### PR TITLE
added testcase for newline in api key

### DIFF
--- a/python/hopsworks/client/auth.py
+++ b/python/hopsworks/client/auth.py
@@ -24,7 +24,7 @@ class BearerAuth(requests.auth.AuthBase):
         self._token = token
 
     def __call__(self, r):
-        r.headers["Authorization"] = "Bearer " + self._token
+        r.headers["Authorization"] = "Bearer " + self._token.strip()
         return r
 
 
@@ -35,5 +35,5 @@ class ApiKeyAuth(requests.auth.AuthBase):
         self._token = token
 
     def __call__(self, r):
-        r.headers["Authorization"] = "ApiKey " + self._token
+        r.headers["Authorization"] = "ApiKey " + self._token.strip()
         return r

--- a/python/tests/hopsworks/test_login.py
+++ b/python/tests/hopsworks/test_login.py
@@ -225,3 +225,10 @@ class TestLogin(TestCase):
             raise e
         finally:
             del os.environ["HOPSWORKS_API_KEY"]
+
+    def test_login_newline_in_api_key(self):
+        try:
+            imaginaryApiKey = "ImaginaryApiKey\n"
+            project = hopsworks.login(api_key_value=imaginaryApiKey)
+        except Exception as e:
+            self.assertNotIn(imaginaryApiKey.strip(), str(e))

--- a/python/tests/hopsworks/test_login.py
+++ b/python/tests/hopsworks/test_login.py
@@ -229,6 +229,6 @@ class TestLogin(TestCase):
     def test_login_newline_in_api_key(self):
         try:
             imaginaryApiKey = "ImaginaryApiKey\n"
-            project = hopsworks.login(api_key_value=imaginaryApiKey)
+            hopsworks.login(api_key_value=imaginaryApiKey)
         except Exception as e:
             self.assertNotIn(imaginaryApiKey.strip(), str(e))


### PR DESCRIPTION
Addition to what is written in [#184](https://github.com/logicalclocks/hopsworks-api/issues/184)

The current implementation of the authorization header results in an edge case where, when the resulting header is deemed invalid from the underlying HTTP library (urllib3), a value error is thrown, which is simply printed. This includes the content of the authorization header (the API key).

By simply stripping any leading or trailing white spaces (which include newlines), this should get rid of the error.

I can also not think of any edge cases where stripping the API key might lead to problems, since only whitespace leading or trailing the actual API key will be removed.

One could make the case that the strip is unnecessary for the bearer token, but my argument for keeping it is that it

1. can not hurt to have it
2. the time complexity of stripping the string once can be disregarded.

Last point:
Why did I choose strip instead of strip? If we believe that a user, while pasting the API key, might make the mistake of entering a newline at the end of the API key, he might also paste a newline at the beginning.