### PR TITLE
[HWORKS-1304] Secret API documentation says you need to provide email…

### DIFF
--- a/python/hopsworks/core/secret_api.py
+++ b/python/hopsworks/core/secret_api.py
@@ -50,7 +50,7 @@ class SecretsApi:
 
         # Arguments
             name: Name of the secret.
-            owner: email of the owner for a secret shared with the current project.
+            owner: username of the owner for a secret shared with the current project. Users can find their username in the Account Settings > Profile section.
         # Returns
             `Secret`: The Secret object
         # Raises


### PR DESCRIPTION
… to get shared ticket, but you should provide username instead