### PR TITLE
[FSTORE-1411-APPEND] On-Demand Transformation Functions

### DIFF
--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -100,7 +100,11 @@ class VectorServer:
         self._untransformed_feature_vector_col_name = [
             feat.name
             for feat in features
-            if not (feat.label or feat.training_helper_column or feat.on_demand_transformation_function)
+            if not (
+                feat.label
+                or feat.training_helper_column
+                or feat.on_demand_transformation_function
+            )
         ]
         self._on_demand_feature_vector_col_name = [
             feat.name
@@ -316,7 +320,7 @@ class VectorServer:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: bool=True,
+        transform: bool = True,
         request_parameters: Optional[Dict[str, Any]] = None,
     ) -> Union[pd.DataFrame, pl.DataFrame, np.ndarray, List[Any], Dict[str, Any]]:
         """Assembles serving vector from online feature store."""
@@ -359,7 +363,7 @@ class VectorServer:
             inference_helper=False,
             return_type=return_type,
             transform=transform,
-            on_demand_feature=transform
+            on_demand_feature=transform,
         )
 
     def get_feature_vectors(
@@ -374,7 +378,7 @@ class VectorServer:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: bool=True,
+        transform: bool = True,
     ) -> Union[pd.DataFrame, pl.DataFrame, np.ndarray, List[Any], List[Dict[str, Any]]]:
         """Assembles serving vector from online feature store."""
         if passed_features is None:
@@ -487,7 +491,7 @@ class VectorServer:
             inference_helper=False,
             return_type=return_type,
             transform=transform,
-            on_demand_feature=transform
+            on_demand_feature=transform,
         )
 
     def assemble_feature_vector(
@@ -563,7 +567,7 @@ class VectorServer:
     def _check_feature_vectors_type_and_convert_to_dict(
         self,
         feature_vectors: Union[List[Any], List[List[Any]], pd.DataFrame, pl.DataFrame],
-        on_demand_features : bool = False,
+        on_demand_features: bool = False,
     ) -> Tuple[Dict[str, Any], Literal["pandas", "polars", "list"]]:
         """
         Function that converts an input feature vector into a list of dictionaries.
@@ -591,13 +595,19 @@ class VectorServer:
             ):
                 return_type = "list"
                 feature_vectors = [
-                    self.get_untransformed_features_map(feature_vector, on_demand_features=on_demand_features)
+                    self.get_untransformed_features_map(
+                        feature_vector, on_demand_features=on_demand_features
+                    )
                     for feature_vector in feature_vectors
                 ]
 
             else:
                 return_type = "list"
-                feature_vectors = [self.get_untransformed_features_map(feature_vectors, on_demand_features=on_demand_features)]
+                feature_vectors = [
+                    self.get_untransformed_features_map(
+                        feature_vectors, on_demand_features=on_demand_features
+                    )
+                ]
 
         else:
             raise exceptions.FeatureStoreException(
@@ -626,7 +636,9 @@ class VectorServer:
             return feature_vectors
 
         feature_vectors, return_type = (
-            self._check_feature_vectors_type_and_convert_to_dict(feature_vectors, on_demand_features=True)
+            self._check_feature_vectors_type_and_convert_to_dict(
+                feature_vectors, on_demand_features=True
+            )
         )
         transformed_feature_vectors = []
         for feature_vector in feature_vectors:
@@ -716,10 +728,12 @@ class VectorServer:
             inference_helper=False,
             return_type=return_type,
             transform=False,
-            on_demand_feature=True
+            on_demand_feature=True,
         )
 
-    def get_untransformed_features_map(self, features : List[Any], on_demand_features : bool = False) -> Dict[str, Any]:
+    def get_untransformed_features_map(
+        self, features: List[Any], on_demand_features: bool = False
+    ) -> Dict[str, Any]:
         """
         Function that accepts a feature vectors as a list and returns the untransformed features as a dict that maps
         feature names to their values
@@ -759,7 +773,7 @@ class VectorServer:
         inference_helper: bool,
         return_type: Union[Literal["list", "dict", "numpy", "pandas", "polars"]],
         transform: bool = False,
-        on_demand_feature: bool=False
+        on_demand_feature: bool = False,
     ) -> Union[
         pd.DataFrame,
         pl.DataFrame,
@@ -839,7 +853,7 @@ class VectorServer:
                 inference_helper=True,
                 return_type=return_type,
                 transform=False,
-                on_demand_feature=False
+                on_demand_feature=False,
             )
         return self.handle_feature_vector_return_type(
             self.sql_client.get_inference_helper_vector(entry),
@@ -847,7 +861,7 @@ class VectorServer:
             inference_helper=True,
             return_type=return_type,
             transform=False,
-            on_demand_feature=False
+            on_demand_feature=False,
         )
 
     def get_inference_helpers(
@@ -897,7 +911,7 @@ class VectorServer:
             inference_helper=True,
             return_type=return_type,
             transform=False,
-            on_demand_feature=False
+            on_demand_feature=False,
         )
 
     def which_client_and_ensure_initialised(

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -511,7 +511,7 @@ class FeatureView:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transformed: Optional[bool] = True,
+        transform: Optional[bool] = True,
         request_parameters: Optional[Dict[str, Any]] = None,
     ) -> Union[List[Any], pd.DataFrame, np.ndarray, pl.DataFrame]:
         """Returns assembled feature vector from online feature store.
@@ -613,7 +613,7 @@ class FeatureView:
             vector_db_features=vector_db_features,
             force_rest_client=force_rest_client,
             force_sql_client=force_sql_client,
-            transformed=transformed,
+            transform=transform,
             request_parameters=request_parameters,
         )
 
@@ -626,7 +626,7 @@ class FeatureView:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transformed: Optional[bool] = True,
+        transform: Optional[bool] = True,
         request_parameters: Optional[List[Dict[str, Any]]] = None,
     ) -> Union[List[List[Any]], pd.DataFrame, np.ndarray, pl.DataFrame]:
         """Returns assembled feature vectors in batches from online feature store.
@@ -728,7 +728,7 @@ class FeatureView:
             vector_db_features=vector_db_features,
             force_rest_client=force_rest_client,
             force_sql_client=force_sql_client,
-            transformed=transformed,
+            transform=transform,
             request_parameters=request_parameters,
         )
 
@@ -3941,7 +3941,7 @@ class FeatureView:
         self._transformation_functions = transformation_functions
 
     @property
-    def model_dependent_tranformation_functions(self) -> Dict["str", Callable]:
+    def model_dependent_transformations(self) -> Dict["str", Callable]:
         """Get Model-Dependent transformations as a dictionary mapping transformed feature names to transformation function"""
         return {
             transformation_function.hopsworks_udf.output_column_names[
@@ -3951,7 +3951,7 @@ class FeatureView:
         }
 
     @property
-    def on_demand_tranformation_functions(self) -> Dict["str", Callable]:
+    def on_demand_transformations(self) -> Dict["str", Callable]:
         """Get On-Demand transformations as a dictionary mapping on-demand feature names to transformation function"""
         return {
             feature.on_demand_transformation_function.hopsworks_udf.function_name: feature.on_demand_transformation_function.hopsworks_udf.get_udf()

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -4021,16 +4021,18 @@ class FeatureView:
     def logging_enabled(self, logging_enabled) -> None:
         self._logging_enabled = logging_enabled
 
+    @property
     def transformed_features(self) -> List[str]:
         """Name of features of a feature view after transformation functions have been applied"""
-        transformation_features = set()
+        dropped_features = set()
         transformed_column_names = []
         for tf in self.transformation_functions:
             transformed_column_names.extend(tf.output_column_names)
-            transformation_features.update(tf.hopsworks_udf.transformation_features)
+            if tf.hopsworks_udf.dropped_features:
+                dropped_features.update(tf.hopsworks_udf.dropped_features)
 
         return [
             feature.name
             for feature in self.features
-            if feature.name not in transformation_features
+            if feature.name not in dropped_features
         ] + transformed_column_names

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -916,7 +916,7 @@ def renaming_wrapper(*args):
     def output_column_names(self, output_col_names: Union[str, List[str]]) -> None:
         if not isinstance(output_col_names, List):
             output_col_names = [output_col_names]
-        if len(output_col_names) != len(self.return_types):
+        if not output_col_names and len(output_col_names) != len(self.return_types):
             raise FeatureStoreException(
                 f"Provided names for output columns does not match the number of columns returned from the UDF. Please provide {len(self.return_types)} names."
             )

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -669,7 +669,7 @@ def renaming_wrapper(*args):
             "statisticsArgumentNames": self._statistics_argument_names
             if self.statistics_required
             else None,
-            "name": self._function_name,
+            "name": self.function_name,
             "featureNamePrefix": self._feature_name_prefix,
         }
 

--- a/python/hsfs/training_dataset_feature.py
+++ b/python/hsfs/training_dataset_feature.py
@@ -66,7 +66,7 @@ class TrainingDatasetFeature:
             "trainingHelperColumn": self._training_helper_column,
             "featureGroupFeatureName": self._feature_group_feature_name,
             "featuregroup": self._feature_group,
-            "transformation_function": self.on_demand_transformation_function,
+            "transformationFunction": self.on_demand_transformation_function,
         }
 
     @classmethod

--- a/python/hsfs/training_dataset_feature.py
+++ b/python/hsfs/training_dataset_feature.py
@@ -66,7 +66,7 @@ class TrainingDatasetFeature:
             "trainingHelperColumn": self._training_helper_column,
             "featureGroupFeatureName": self._feature_group_feature_name,
             "featuregroup": self._feature_group,
-            "transformation_function": self._on_demand_transformation_function,
+            "transformation_function": self.on_demand_transformation_function,
         }
 
     @classmethod


### PR DESCRIPTION
This PR fixes some bugs introduced from https://github.com/logicalclocks/feature-store-api/pull/1371

** Changes Done ** 
1. Updated check while to set `output_column_names` for `hopsworks_udf` so that it does not set the `output_column_names` if it is empty which can be a possibility when the udf is not attached to a feature view or feature group. Output column names can only be generated when udf is known to be On-Demand (attached to feature group) or Model Dependent (attached to feature view).

2. Changed argument name `transformed` into `transform` as per review comments obtained here (https://github.com/logicalclocks/logicalclocks.github.io/pull/397).

3. Updated vector to have variable `_on_demand_feature_vector_col_name` which store the untransformed and on demand features as a list. This is required to genreate pandas and polars dataframe with correct column names after `compute_on_demand_features`.

4. Added back changes missed during merge from `hopsworks-api` to `feature-store-api`.

JIRA Issue: -

Priority for Review: -

Related PRs: 
https://github.com/logicalclocks/feature-store-api/pull/1371
https://github.com/logicalclocks/hopsworks-ee/pull/1862
https://github.com/logicalclocks/loadtest/pull/394

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
