### PR TITLE
[FSTORE-1411-APPEND] On-Demand Transformations

### DIFF
--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -713,6 +713,14 @@ def renaming_wrapper(*args):
             if "dropped_argument_names" in json_decamelized
             else None
         )
+        transformation_function_argument_names = (
+            [
+                arg_name.strip()
+                for arg_name in json_decamelized["transformation_function_argument_names"]
+            ]
+            if "transformation_function_argument_names" in json_decamelized
+            else None
+        )
         statistics_features = (
             [
                 feature.strip()
@@ -762,6 +770,7 @@ def renaming_wrapper(*args):
             dropped_argument_names=dropped_argument_names,
             dropped_feature_names=dropped_feature_names,
             feature_name_prefix=feature_name_prefix,
+            transformation_function_argument_names=transformation_function_argument_names
         )
 
         # Set transformation features if already set.


### PR DESCRIPTION
This PR fixes a bug introduced by the PR https://github.com/logicalclocks/feature-store-api/pull/1371

Issue - Transformation function read from feature store directly using the `get_transformation_function` causing a exception in the backend because the column  `transformation_function_argument_names` is not set.

Root Cause - Issue caused by `transformation_function_argument_names` not being set in `from_response_json`. This cause transformation function read from the backend to not the `transformation_function_argument_names` which in turn causes the DTO to not have it.

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
