### PR TITLE
[APPEND][FSTORE-1285] Model Dependent Transformations

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1256,7 +1256,7 @@ class Engine:
                 dropped_features.update(tf.hopsworks_udf.dropped_features)
             dataset = pd.concat(
                 [
-                    dataset,
+                    dataset.reset_index(drop=True),
                     tf.hopsworks_udf.get_udf()(
                         *(
                             [
@@ -1264,7 +1264,7 @@ class Engine:
                                 for feature in tf.hopsworks_udf.transformation_features
                             ]
                         )
-                    ),
+                    ).reset_index(drop=True),
                 ],
                 axis=1,
             )


### PR DESCRIPTION
This PR fixes an issue introduced in PR https://github.com/logicalclocks/feature-store-api/pull/1308

Issue : 
Null values were created in the transformed train-test split when the built-in transformation function `label encoder` was used in the feature view.

Root Cause : 
The built in transformation function `label_encoder` returned a newly created pandas Series instead of returning the modified input. The input dataFrame provided to the transformation function contains shuffled indexes when a train-test split is being created. Since a new pandas Series was created within the transformation function the indexes did not match with the input dataFrame. Hence introducing null values when concatenating them together.

Fix Done : 
Reset the index of both the input dataFrame and the output dataFrame before concatenating them.

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
