### PR TITLE
[FSTORE-1484] External Fraud batch Validation workflow test failing with `transformation_functions` not found in feature group

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -761,7 +761,8 @@ class Engine:
         online_write_options: Dict[str, Any],
         validation_id: Optional[int] = None,
     ) -> Optional[job.Job]:
-        if feature_group.transformation_functions:
+        # Currently on-demand transformation functions not supported in external feature groups.
+        if not isinstance(feature_group, ExternalFeatureGroup) and feature_group.transformation_functions:
             dataframe = self._apply_transformation_function(
                 feature_group.transformation_functions, dataframe
             )

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -357,7 +357,8 @@ class Engine:
         validation_id=None,
     ):
         try:
-            if feature_group.transformation_functions:
+            # Currently on-demand transformation functions not supported in external feature groups.
+            if not isinstance(feature_group, fg_mod.ExternalFeatureGroup) and feature_group.transformation_functions:
                 dataframe = self._apply_transformation_function(
                     feature_group.transformation_functions, dataframe
                 )


### PR DESCRIPTION
This PR fixes a load test for external fraud batch data validation.

**Issue**:
 Inserting into external feature groups causes [AttributeError: `FeatureGroup` object has no attribute `transformation_functions`. If you are trying to access a feature, fall back on using the `get_feature` method.](https://jenkins.hops.works/job/freestyle_report_kube_loadtests/19/testReport/workflows.feature_store.python_driver/test_external_fraud_batch_data_validation/test_workflow/)

**Root Cause**: 
Inserting into feature group currently applies transformations function, but external feature groups do not support on-demand transformations.

**Fix Done**: 
Prevent application of transformation function during insert in external feature groups. 

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1494

Priority for Review: -

Related PRs: 

**How Has This Been Tested?**

- [ ] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
