### PR TITLE
[FSTORE-1499] Recreate training dataset and feature monitoring load test failing with `transformation_functions` not found in feature group

### DIFF
--- a/python/hsfs/core/monitoring_window_config_engine.py
+++ b/python/hsfs/core/monitoring_window_config_engine.py
@@ -256,14 +256,10 @@ class MonitoringWindowConfigEngine:
             == mwc.WindowConfigType.TRAINING_DATASET
             and isinstance(entity, feature_view.FeatureView)
         ):
-            td_meta = entity._feature_view_engine._get_training_dataset_metadata(
-                entity,
-                training_dataset_version=monitoring_window_config.training_dataset_version,
-            )
             before_transformation = (
                 feature_name is not None
-                and td_meta.transformation_functions is not None
-                and feature_name in td_meta.transformation_functions.keys()
+                and entity.transformation_functions is not None
+                and feature_name in {transformation_feature for transformation_function in entity.transformation_functions for transformation_feature in transformation_function.hopsworks_udf.transformation_features}
             )
             registered_stats = entity.get_training_dataset_statistics(
                 training_dataset_version=monitoring_window_config.training_dataset_version,

--- a/python/hsfs/core/monitoring_window_config_engine.py
+++ b/python/hsfs/core/monitoring_window_config_engine.py
@@ -259,7 +259,12 @@ class MonitoringWindowConfigEngine:
             before_transformation = (
                 feature_name is not None
                 and entity.transformation_functions is not None
-                and feature_name in {transformation_feature for transformation_function in entity.transformation_functions for transformation_feature in transformation_function.hopsworks_udf.transformation_features}
+                and feature_name
+                in {
+                    transformation_feature
+                    for transformation_function in entity.transformation_functions
+                    for transformation_feature in transformation_function.hopsworks_udf.transformation_features
+                }
             )
             registered_stats = entity.get_training_dataset_statistics(
                 training_dataset_version=monitoring_window_config.training_dataset_version,

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1052,6 +1052,7 @@ class Engine:
         if (
             arrow_flight_client.is_query_supported(dataset, user_write_options)
             and len(training_dataset.splits) == 0
+            and feature_view_obj
             and len(feature_view_obj.transformation_functions) == 0
             and training_dataset.data_format == "parquet"
         ):

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1052,7 +1052,7 @@ class Engine:
         if (
             arrow_flight_client.is_query_supported(dataset, user_write_options)
             and len(training_dataset.splits) == 0
-            and len(training_dataset.transformation_functions) == 0
+            and len(feature_view_obj.transformation_functions) == 0
             and training_dataset.data_format == "parquet"
         ):
             query_obj, _ = dataset._prep_read(False, user_write_options)


### PR DESCRIPTION
This PR fixes a load tests : [recreate_training_data](https://jenkins.hops.works/job/freestyle_report_kube_loadtests/34/testReport/workflows.feature_store.python_driver/test_recreate_training_data/test_training_data/) and [feature_monitoring](https://jenkins.hops.works/job/freestyle_report_kube_loadtests/34/testReport/workflows.feature_store.pyspark_driver/test_feature_monitoring/test_pyspark_feature_monitoring/)


**Issue**:
1. Creating training dataset without any transformations with arrow-flight enable causes 'TrainingDataset' object has no attribute 'transformation_functions'.
2. Running feature monitoring  causes 'TrainingDataset' object has no attribute 'transformation_functions'.

**Root Cause**:
1. Transformation functions were implemented earlier as part of `TrainingDataset` object but was moved into the `FeatureView` object. So these issue were caused due to the checks not ported from `TrainingDataset` to `FeatureView` object.

**Fix Done**:
Ported checks to using FeatureView object.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1499

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
