### PR TITLE
Fix istio client url

### DIFF
--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -252,6 +252,7 @@ class ServingApi:
             path_params = self._get_hopsworks_inference_path(
                 _client._project_id, deployment_instance
             )
+            with_base_path_params = True
         else:
             _client = client.istio.get_instance()
             if _client is not None:
@@ -263,16 +264,19 @@ class ServingApi:
                     deployment_instance.name,
                     client.get_knative_domain(),
                 )
+                with_base_path_params = False
             else:
                 # fallback to Hopsworks client
                 _client = client.get_instance()
                 path_params = self._get_hopsworks_inference_path(
                     _client._project_id, deployment_instance
                 )
+                with_base_path_params = True
 
         # send inference request
         return _client._send_request(
-            "POST", path_params, headers=headers, data=json.dumps(data)
+            "POST", path_params, headers=headers, data=json.dumps(data),
+            with_base_path_params=with_base_path_params
         )
 
     def _send_inference_request_via_grpc_protocol(


### PR DESCRIPTION
Deployment predict failed because the url is not correct
```
RestAPIError: Metadata operation error: (url: http://162.19.236.243:32080/hopsworks-api/api/v1/models/irisdeployed:predict). Server response: 
HTTP code: 404, HTTP reason: Not Found, body: b'{"detail":"Not Found"}', error code: , error msg: , user msg: 
```

Change:
the correct url is `http://162.19.236.243:32080/v1/models/irisdeployed:predict` which does not include the base url.

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
