### PR TITLE
[FSTORE-1506][APPEND] Minor fixes for loadtests

### DIFF
--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -286,7 +286,7 @@ class Job:
     def _wait_for_job(self, await_termination=True):
         # If the user passed the wait_for_job option consider it,
         # otherwise use the default True
-        while await_termination:
+        if await_termination:
             executions = self._job_api.last_execution(self)
             if len(executions) > 0:
                 execution = executions[0]


### PR DESCRIPTION
This PR fixes an issue in which `create_train_test_split` infinitely waits in the python client.

**Root Cause**
Issue caused because the while loop in `_wait_for_job` never exits since `_job_api.last_execution` will always provide a value for any already executed job.

**Fix Done**
Removed the while loop in `_wait_for_job` this is unnecessary because the blocking wait is already being performed in inside `_execution_engine.wait_until_finished`

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
