### PR TITLE
[FSTORE-1411][APPEND] On-Demand Transformations

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,6 +28,7 @@ jobs:
               - '!python/tests/**/*.py'
             test:
               - 'python/tests/**/*.py'
+              - '!python/tests/test_helpers/transformation_test_helper.py'
 
       - name: install deps
         run: pip install ruff==0.4.2

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -18,6 +18,7 @@ import ast
 import copy
 import inspect
 import json
+import re
 import warnings
 from dataclasses import dataclass
 from datetime import date, datetime, time
@@ -345,7 +346,9 @@ class HopsworksUdf:
         for i, line in enumerate(source_code):
             if line.strip().startswith("def "):
                 signature_start_line = i
-            if signature_start_line is not None and ")" in line:
+            if signature_start_line is not None and re.search(
+                r"\)\s*[->]*.*:$", line.split("#")[0].strip()
+            ):
                 signature_end_line = i
                 break
 

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -347,7 +347,7 @@ class HopsworksUdf:
             if line.strip().startswith("def "):
                 signature_start_line = i
             if signature_start_line is not None and re.search(
-                r"\)\s*[->]*.*:$", line.split("#")[0].strip()
+                r"\)\s*(->.*)?\s*:$", line.split("#")[0].strip()
             ):
                 signature_end_line = i
                 break

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -142,6 +142,7 @@ exclude = [
     "site-packages",
     "venv",
     "java",
+    "transformation_test_helper.py"  # File excluded from ruff formatting to maintain formatting required for tests
 ]
 
 # Same as Black.

--- a/python/tests/test_helpers/transformation_test_helper.py
+++ b/python/tests/test_helpers/transformation_test_helper.py
@@ -46,7 +46,7 @@ def test_function_multiple_argument_with_typehints(arg1: pd.Series, arg2: pd.Ser
 
 def test_function_multiple_argument_with_statistics_and_typehints(
     arg1: pd.Series, arg2: pd.Series, statistics=stats_arg1_arg2
-):
+)                   :
     pass
 
 
@@ -57,13 +57,18 @@ def test_function_multiple_argument_with_mixed_statistics_and_typehints(
 
 
 def test_function_multiple_argument_all_parameter_with_spaces(
-    arg1: pd.Series, arg2, statistics=stats_arg1_arg2
+    arg1: pd.Series,                    arg2,    statistics=stats_arg1_arg2
 ):
     pass
 
 
 def test_function_multiple_argument_all_parameter_multiline(
-    arg1: pd.Series, arg2, arg3, statistics=stats_arg1_arg3
+    arg1: pd.Series,
+    arg2,    
+
+    arg3,
+
+    statistics=stats_arg1_arg3
 ):
     pass
 
@@ -76,6 +81,29 @@ def test_function_multiple_argument_all_parameter_multiline_with_comments(
 ) -> pd.DataFrame:  # Test Comment
     pass
 
+def test_function_transformation_statistics_as_default_one_line(arg1: pd.Series, arg2, statistics=TransformationStatistics("arg1", "arg2")):
+    pass
+
+def test_function_transformation_statistics_as_default_one_line_return_type(arg1: pd.Series, arg2, statistics=TransformationStatistics("arg1", "arg2")) -> pd.Series:
+    pass
+
+def test_function_transformation_statistics_as_default_multiple_line(arg1: pd.Series,
+                                                                    arg2, 
+                                                                    statistics=TransformationStatistics("arg1", "arg2")
+                                                            ):
+    pass
+
+def test_function_transformation_statistics_as_default_multiple_line_return_type_spaces(arg1: pd.Series,
+                                                                    arg2, 
+                                                                    statistics=TransformationStatistics("arg1", "arg2")
+                                                            ) -> pd.Series :
+    pass
+
+def test_function_transformation_statistics_as_default_multiple_line_return_type_no_spaces(arg1: pd.Series,
+                                                                    arg2, 
+                                                                    statistics=TransformationStatistics("arg1", "arg2")
+                                                            )->pd.Series:
+    pass
 
 def test_function_statistics_invalid(arg1: pd.Series, statistics=stats_arg3):
     pass

--- a/python/tests/test_hopswork_udf.py
+++ b/python/tests/test_hopswork_udf.py
@@ -306,7 +306,216 @@ def test_function():
             == "No argument corresponding to statistics parameter 'arg3' present in function definition."
         )
 
-    def test_format_source_code(self):
+    def test_format_source_code_one_argument(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_one_argument,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(test_function_one_argument)
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_one_argument(arg1):
+\t    pass"""
+        )
+
+    def test_format_source_code_one_argument_with_statistics(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_one_argument_with_statistics,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_one_argument_with_statistics
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_one_argument_with_statistics(arg1):
+\t    pass"""
+        )
+
+    def test_format_source_code_one_argument_with_typehints(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_one_argument_with_typehints,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_one_argument_with_typehints
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_one_argument_with_typehints(arg1):
+\t    pass"""
+        )
+
+    def test_format_source_code_one_argument_with_statistics_and_typehints(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_one_argument_with_statistics_and_typehints,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_one_argument_with_statistics_and_typehints
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_one_argument_with_statistics_and_typehints(arg1):
+\t    pass"""
+        )
+
+    def test_format_source_code_multiple_argument(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_multiple_argument,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_multiple_argument
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_multiple_argument(arg1, arg2):
+\t    pass"""
+        )
+
+    def test_format_source_code_multiple_argument_with_statistics(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_multiple_argument_with_statistics,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_multiple_argument_with_statistics
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_multiple_argument_with_statistics(arg1, arg2, arg3):
+\t    pass"""
+        )
+
+    def test_format_source_code_multiple_argument_with_typehints(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_multiple_argument_with_typehints,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_multiple_argument_with_typehints
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_multiple_argument_with_typehints(arg1, arg2):
+\t    pass"""
+        )
+
+    def test_format_source_code_multiple_argument_with_statistics_and_typehints(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_multiple_argument_with_statistics_and_typehints,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_multiple_argument_with_statistics_and_typehints
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_multiple_argument_with_statistics_and_typehints(arg1, arg2):
+\t    pass"""
+        )
+
+    def test_format_source_code_multiple_argument_with_mixed_statistics_and_typehints(
+        self,
+    ):
+        from .test_helpers.transformation_test_helper import (
+            test_function_multiple_argument_with_mixed_statistics_and_typehints,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_multiple_argument_with_mixed_statistics_and_typehints
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_multiple_argument_with_mixed_statistics_and_typehints(arg1, arg2, arg3):
+\t    pass"""
+        )
+
+    def test_format_source_code_multiple_argument_all_parameter_with_spaces(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_multiple_argument_all_parameter_with_spaces,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_multiple_argument_all_parameter_with_spaces
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_multiple_argument_all_parameter_with_spaces(arg1, arg2):
+\t    pass"""
+        )
+
+    def test_format_source_code_multiple_argument_all_parameter_multiline(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_multiple_argument_all_parameter_multiline,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_multiple_argument_all_parameter_multiline
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_multiple_argument_all_parameter_multiline(arg1, arg2, arg3):
+\t    pass"""
+        )
+
+    def test_format_source_code_multiline_with_comments(self):
         from .test_helpers.transformation_test_helper import (
             test_function_multiple_argument_all_parameter_multiline_with_comments,
         )
@@ -322,6 +531,109 @@ def test_function():
         assert (
             formated_source.strip()
             == """def test_function_multiple_argument_all_parameter_multiline_with_comments(arg1, arg2, arg3):
+\t    pass"""
+        )
+
+    def test_format_source_code_transformation_statistics_as_default_one_line(self):
+        from .test_helpers.transformation_test_helper import (
+            test_function_transformation_statistics_as_default_one_line,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_transformation_statistics_as_default_one_line
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_transformation_statistics_as_default_one_line(arg1, arg2):
+\t    pass"""
+        )
+
+    def test_format_source_code_transformation_statistics_as_default_one_line_return_type(
+        self,
+    ):
+        from .test_helpers.transformation_test_helper import (
+            test_function_transformation_statistics_as_default_one_line_return_type,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_transformation_statistics_as_default_one_line_return_type
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_transformation_statistics_as_default_one_line_return_type(arg1, arg2):
+\t    pass"""
+        )
+
+    def test_format_source_code_transformation_statistics_as_default_multiple_line(
+        self,
+    ):
+        from .test_helpers.transformation_test_helper import (
+            test_function_transformation_statistics_as_default_multiple_line,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_transformation_statistics_as_default_multiple_line
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_transformation_statistics_as_default_multiple_line(arg1, arg2):
+\t    pass"""
+        )
+
+    def test_format_source_code_transformation_statistics_as_default_multiple_line_return_type_spaces(
+        self,
+    ):
+        from .test_helpers.transformation_test_helper import (
+            test_function_transformation_statistics_as_default_multiple_line_return_type_spaces,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_transformation_statistics_as_default_multiple_line_return_type_spaces
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_transformation_statistics_as_default_multiple_line_return_type_spaces(arg1, arg2):
+\t    pass"""
+        )
+
+    def test_format_source_code_transformation_statistics_as_default_multiple_line_return_type_no_spaces(
+        self,
+    ):
+        from .test_helpers.transformation_test_helper import (
+            test_function_transformation_statistics_as_default_multiple_line_return_type_no_spaces,
+        )
+
+        function_source = HopsworksUdf._extract_source_code(
+            test_function_transformation_statistics_as_default_multiple_line_return_type_no_spaces
+        )
+
+        formated_source, module_imports = HopsworksUdf._format_source_code(
+            function_source
+        )
+
+        assert (
+            formated_source.strip()
+            == """def test_function_transformation_statistics_as_default_multiple_line_return_type_no_spaces(arg1, arg2):
 \t    pass"""
         )
 


### PR DESCRIPTION
This PR fixes the issue of improper code generated when transformation functions are defined in the format:
```
def test_function_transformation_statistics_as_default_multiple_line(arg1: pd.Series,
                                                                    arg2, 
                                                                    statistics=TransformationStatistics("arg1", "arg2")
                                                            ):
    pass
```

**Root Cause**: 
The end line of a signature was detected by checking if the line ends with `)`. However in the example given above the `TransformationStatistics` is declared with the function signature causing `)` to be present at a line before the signature actually ends.

**Fix Done**:
Use a regex to check for the function signature end. 
- The regex used is `r"\)\s*(->.*)?\s*:$"`
- The expression check if a `:` is  present after `)` and if the line ends with a `:`. It also matches if a `->` and the type is present in between the `)` and `:`. 

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
