### PR TITLE
[FSTORE-471] Allow transformation functions for label features

### DIFF
--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -1103,9 +1103,9 @@ class FeatureViewEngine:
         td_predictions_names = set([feature.name for feature in td_predictions])
         if transformed:
             td_features = [
-                feature_name
-                for feature_name in training_dataset_schema
-                if feature_name not in td_predictions_names
+                feature.name
+                for feature in training_dataset_schema
+                if feature.name not in td_predictions_names
             ]
         else:
             td_features = [

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -3856,7 +3856,7 @@ class FeatureView:
 
         # Example
             ```python
-            schema = feature_view.get_schema(training_dataset_version=1)
+            schema = feature_view.get_training_dataset_schema(training_dataset_version=1)
             ```
 
         # Returns
@@ -3865,7 +3865,9 @@ class FeatureView:
         # Raises
             `ValueError` if the  training dataset version provided cannot be found.
         """
-        return self._feature_view_engine.get_schema(self, training_dataset_version)
+        return self._feature_view_engine.get_training_dataset_schema(
+            self, training_dataset_version
+        )
 
     @property
     def id(self) -> int:
@@ -4060,40 +4062,6 @@ class FeatureView:
     @logging_enabled.setter
     def logging_enabled(self, logging_enabled) -> None:
         self._logging_enabled = logging_enabled
-
-    @property
-    def transformed_features(self) -> List[str]:
-        """Names of features in the latest training dataset version generated from the feature view after transformation functions have been applied"""
-        dropped_features = set()
-        transformed_column_names = []
-        for tf in self.transformation_functions:
-            if self.labels not in tf.hopsworks_udf.transformation_features:
-                transformed_column_names.extend(tf.output_column_names)
-                if tf.hopsworks_udf.dropped_features:
-                    dropped_features.update(tf.hopsworks_udf.dropped_features)
-
-        return [
-            feature.name
-            for feature in self.features
-            if feature.name not in dropped_features
-        ] + transformed_column_names
-
-    @property
-    def transformed_labels(self) -> List[str]:
-        """Names of labels in the latest training dataset version generated from the feature view after transformation functions have been applied"""
-        dropped_features = set()
-        transformed_column_names = []
-        for tf in self.transformation_functions:
-            if any(
-                label in tf.hopsworks_udf.transformation_features
-                for label in self.labels
-            ):
-                transformed_column_names.extend(tf.output_column_names)
-                if tf.hopsworks_udf.dropped_features:
-                    dropped_features.update(tf.hopsworks_udf.dropped_features)
-        return [
-            label for label in self.labels if label not in dropped_features
-        ] + transformed_column_names
 
     @property
     def feature_logging(self) -> Optional[FeatureLogging]:

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -3844,6 +3844,29 @@ class FeatureView:
             "type": "featureViewDTO",
         }
 
+    def get_training_dataset_schema(
+        self, training_dataset_version: bool
+    ) -> List[training_dataset_feature.TrainingDatasetFeature]:
+        """
+        Function that returns the schema of the training dataset that is generated from a feature view.
+        It provides the schema of the features after all transformation functions have been applied.
+
+        # Arguments
+            training_dataset_version: Version of the training dataset for which the schema is to be generated.
+
+        # Example
+            ```python
+            schema = feature_view.get_schema(training_dataset_version=1)
+            ```
+
+        # Returns
+            `List[training_dataset_feature.TrainingDatasetFeature]`: List of training dataset features objects.
+
+        # Raises
+            `ValueError` if the  training dataset version provided cannot be found.
+        """
+        return self._feature_view_engine.get_schema(self, training_dataset_version)
+
     @property
     def id(self) -> int:
         """Feature view id."""
@@ -3978,12 +4001,12 @@ class FeatureView:
 
     @property
     def schema(self) -> List[training_dataset_feature.TrainingDatasetFeature]:
-        """Feature view schema."""
+        """Schema of untransformed features in the Feature view."""
         return self._features
 
     @property
     def features(self) -> List[training_dataset_feature.TrainingDatasetFeature]:
-        """Feature view schema. (alias)"""
+        """Schema of untransformed features in the Feature view. (alias)"""
         return self._features
 
     @schema.setter
@@ -4040,18 +4063,36 @@ class FeatureView:
 
     @property
     def transformed_features(self) -> List[str]:
-        """Name of features of a feature view after transformation functions have been applied"""
+        """Names of features in the latest training dataset version generated from the feature view after transformation functions have been applied"""
         dropped_features = set()
         transformed_column_names = []
         for tf in self.transformation_functions:
-            transformed_column_names.extend(tf.output_column_names)
-            if tf.hopsworks_udf.dropped_features:
-                dropped_features.update(tf.hopsworks_udf.dropped_features)
+            if self.labels not in tf.hopsworks_udf.transformation_features:
+                transformed_column_names.extend(tf.output_column_names)
+                if tf.hopsworks_udf.dropped_features:
+                    dropped_features.update(tf.hopsworks_udf.dropped_features)
 
         return [
             feature.name
             for feature in self.features
             if feature.name not in dropped_features
+        ] + transformed_column_names
+
+    @property
+    def transformed_labels(self) -> List[str]:
+        """Names of labels in the latest training dataset version generated from the feature view after transformation functions have been applied"""
+        dropped_features = set()
+        transformed_column_names = []
+        for tf in self.transformation_functions:
+            if any(
+                label in tf.hopsworks_udf.transformation_features
+                for label in self.labels
+            ):
+                transformed_column_names.extend(tf.output_column_names)
+                if tf.hopsworks_udf.dropped_features:
+                    dropped_features.update(tf.hopsworks_udf.dropped_features)
+        return [
+            label for label in self.labels if label not in dropped_features
         ] + transformed_column_names
 
     @property

--- a/python/hsfs/training_dataset_feature.py
+++ b/python/hsfs/training_dataset_feature.py
@@ -151,4 +151,8 @@ class TrainingDatasetFeature:
         return self._feature_group_feature_name
 
     def __repr__(self):
-        return f"Training Dataset Feature({self._name!r}, {self._type!r}, {self._index!r}, {self._label}, {self._feature_group_feature_name}, {self._feature_group.id!r}, {self.on_demand_transformation_function})"
+        if self._feature_group:
+            return f"Training Dataset Feature({self._name!r}, {self._type!r}, {self._index!r}, {self._label}, {self._feature_group_feature_name}, {self._feature_group.id!r}, {self.on_demand_transformation_function})"
+        else:
+            # Feature group will be empty and index will be null if the training dataset feature is generated using model dependent transformations.
+            return f"Training Dataset Feature({self._name!r}, {self._type!r}, {self._index!r}, {self._label}, {self.on_demand_transformation_function})"


### PR DESCRIPTION
This PR adds support for adding transformation function to labels in the feature view.
 
**Changes done**
- Added property `transformation_labels` which provide names of labels after transformation functions have been applied to it.
- Added function `get_training_dataset_schema` which provide the schema of the features for a specific training dataset version.  Training dataset schema can only be generated after creation of a training dataset because the schema can vary based on training dataset statistics if the transformation `one_hot_encoder` is applied.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-471

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
