### PR TITLE
[FSTORE-1507] Python UDF's

### DIFF
--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -51,6 +51,7 @@ from hsfs.core import (
 from hsfs.core import (
     transformation_function_engine as tf_engine_mod,
 )
+from hsfs.hopsworks_udf import UDFExecutionMode
 
 
 if HAS_NUMPY:
@@ -999,43 +1000,91 @@ class VectorServer:
     ) -> dict:
         _logger.debug("Applying On-Demand transformation functions.")
         for tf in self._on_demand_transformation_functions:
-            # Check if feature provided as request parameter if not get it from retrieved feature vector.
-            features = [
-                pd.Series(request_parameter[feature])
-                if feature in request_parameter.keys()
-                else (
-                    pd.Series(
-                        rows[feature]
-                        if (not isinstance(rows[feature], pd.Series))
-                        else rows[feature]
-                    )
+            if (
+                tf.hopsworks_udf.execution_mode.get_current_execution_mode(
+                    inference=True
                 )
-                for feature in tf.hopsworks_udf.transformation_features
-            ]
+                == UDFExecutionMode.PANDAS
+            ):
+                # Check if feature provided as request parameter if not get it from retrieved feature vector.
+                features = [
+                    pd.Series(request_parameter[feature])
+                    if feature in request_parameter.keys()
+                    else (
+                        pd.Series(
+                            rows[feature]
+                            if (not isinstance(rows[feature], pd.Series))
+                            else rows[feature]
+                        )
+                    )
+                    for feature in tf.hopsworks_udf.transformation_features
+                ]
+            else:
+                # No need to cast to pandas Series for Python UDF's
+                features = [
+                    request_parameter[feature]
+                    if feature in request_parameter.keys()
+                    else rows[feature]
+                    for feature in tf.hopsworks_udf.transformation_features
+                ]
+
             on_demand_feature = tf.hopsworks_udf.get_udf(inference=True)(
                 *features
             )  # Get only python compatible UDF irrespective of engine
-
-            rows[on_demand_feature.name] = on_demand_feature.values[0]
+            if (
+                tf.hopsworks_udf.execution_mode.get_current_execution_mode(
+                    inference=True
+                )
+                == UDFExecutionMode.PANDAS
+            ):
+                rows[on_demand_feature.name] = on_demand_feature.values[0]
+            else:
+                rows[tf.output_column_names[0]] = on_demand_feature
         return rows
 
     def apply_model_dependent_transformations(self, rows: Union[dict, pd.DataFrame]):
         _logger.debug("Applying Model-Dependent transformation functions.")
         for tf in self.model_dependent_transformation_functions:
-            features = [
-                pd.Series(rows[feature])
-                if (not isinstance(rows[feature], pd.Series))
-                else rows[feature]
-                for feature in tf.hopsworks_udf.transformation_features
-            ]
+            if (
+                tf.hopsworks_udf.execution_mode.get_current_execution_mode(
+                    inference=True
+                )
+                == UDFExecutionMode.PANDAS
+            ):
+                features = [
+                    pd.Series(rows[feature])
+                    if (not isinstance(rows[feature], pd.Series))
+                    else rows[feature]
+                    for feature in tf.hopsworks_udf.transformation_features
+                ]
+            else:
+                # No need to cast to pandas Series for Python UDF's
+                # print("executing as python udfs")
+                features = [
+                    rows[feature]
+                    for feature in tf.hopsworks_udf.transformation_features
+                ]
             transformed_result = tf.hopsworks_udf.get_udf(inference=True)(
                 *features
             )  # Get only python compatible UDF irrespective of engine
-            if isinstance(transformed_result, pd.Series):
-                rows[transformed_result.name] = transformed_result.values[0]
+
+            if (
+                tf.hopsworks_udf.execution_mode.get_current_execution_mode(
+                    inference=True
+                )
+                == UDFExecutionMode.PANDAS
+            ):
+                if isinstance(transformed_result, pd.Series):
+                    rows[transformed_result.name] = transformed_result.values[0]
+                else:
+                    for col in transformed_result:
+                        rows[col] = transformed_result[col].values[0]
             else:
-                for col in transformed_result:
-                    rows[col] = transformed_result[col].values[0]
+                if isinstance(transformed_result, tuple):
+                    for index, result in enumerate(transformed_result):
+                        rows[tf.output_column_names[index]] = result
+                else:
+                    rows[tf.output_column_names[0]] = transformed_result
         return rows
 
     def apply_transformation(

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1001,9 +1001,7 @@ class VectorServer:
         _logger.debug("Applying On-Demand transformation functions.")
         for tf in self._on_demand_transformation_functions:
             if (
-                tf.hopsworks_udf.execution_mode.get_current_execution_mode(
-                    inference=True
-                )
+                tf.hopsworks_udf.execution_mode.get_current_execution_mode(online=True)
                 == UDFExecutionMode.PANDAS
             ):
                 # Check if feature provided as request parameter if not get it from retrieved feature vector.
@@ -1028,13 +1026,11 @@ class VectorServer:
                     for feature in tf.hopsworks_udf.transformation_features
                 ]
 
-            on_demand_feature = tf.hopsworks_udf.get_udf(inference=True)(
+            on_demand_feature = tf.hopsworks_udf.get_udf(online=True)(
                 *features
             )  # Get only python compatible UDF irrespective of engine
             if (
-                tf.hopsworks_udf.execution_mode.get_current_execution_mode(
-                    inference=True
-                )
+                tf.hopsworks_udf.execution_mode.get_current_execution_mode(online=True)
                 == UDFExecutionMode.PANDAS
             ):
                 rows[on_demand_feature.name] = on_demand_feature.values[0]
@@ -1046,9 +1042,7 @@ class VectorServer:
         _logger.debug("Applying Model-Dependent transformation functions.")
         for tf in self.model_dependent_transformation_functions:
             if (
-                tf.hopsworks_udf.execution_mode.get_current_execution_mode(
-                    inference=True
-                )
+                tf.hopsworks_udf.execution_mode.get_current_execution_mode(online=True)
                 == UDFExecutionMode.PANDAS
             ):
                 features = [
@@ -1064,14 +1058,12 @@ class VectorServer:
                     rows[feature]
                     for feature in tf.hopsworks_udf.transformation_features
                 ]
-            transformed_result = tf.hopsworks_udf.get_udf(inference=True)(
+            transformed_result = tf.hopsworks_udf.get_udf(online=True)(
                 *features
             )  # Get only python compatible UDF irrespective of engine
 
             if (
-                tf.hopsworks_udf.execution_mode.get_current_execution_mode(
-                    inference=True
-                )
+                tf.hopsworks_udf.execution_mode.get_current_execution_mode(online=True)
                 == UDFExecutionMode.PANDAS
             ):
                 if isinstance(transformed_result, pd.Series):

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1012,7 +1012,7 @@ class VectorServer:
                 )
                 for feature in tf.hopsworks_udf.transformation_features
             ]
-            on_demand_feature = tf.hopsworks_udf.get_udf(force_python_udf=True)(
+            on_demand_feature = tf.hopsworks_udf.get_udf(inference=True)(
                 *features
             )  # Get only python compatible UDF irrespective of engine
 
@@ -1028,7 +1028,7 @@ class VectorServer:
                 else rows[feature]
                 for feature in tf.hopsworks_udf.transformation_features
             ]
-            transformed_result = tf.hopsworks_udf.get_udf(force_python_udf=True)(
+            transformed_result = tf.hopsworks_udf.get_udf(inference=True)(
                 *features
             )  # Get only python compatible UDF irrespective of engine
             if isinstance(transformed_result, pd.Series):

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1263,7 +1263,7 @@ class Engine:
         self,
         transformation_functions: List[transformation_function.TransformationFunction],
         dataset: Union[pd.DataFrame, pl.DataFrame],
-        inference_mode: bool = False,
+        online_inference: bool = False,
     ) -> Union[pd.DataFrame, pl.DataFrame]:
         """
         Apply transformation function to the dataframe.
@@ -1304,7 +1304,7 @@ class Engine:
 
             if (
                 hopsworks_udf.execution_mode.get_current_execution_mode(
-                    inference=inference_mode
+                    online=online_inference
                 )
                 == UDFExecutionMode.PANDAS
             ):
@@ -1334,7 +1334,7 @@ class Engine:
         # Raises
             `FeatureStoreException`: If any of the features mentioned in the transformation function is not present in the Feature View.
         """
-        udf = hopsworks_udf.get_udf(inference=False)
+        udf = hopsworks_udf.get_udf(online=False)
         if isinstance(dataframe, pd.DataFrame):
             if len(hopsworks_udf.return_types) > 1:
                 dataframe[hopsworks_udf.output_column_names] = dataframe.apply(
@@ -1398,7 +1398,7 @@ class Engine:
         """
         if len(hopsworks_udf.return_types) > 1:
             dataframe[hopsworks_udf.output_column_names] = hopsworks_udf.get_udf(
-                inference=False
+                online=False
             )(
                 *(
                     [
@@ -1409,7 +1409,7 @@ class Engine:
             )
         else:
             dataframe[hopsworks_udf.output_column_names[0]] = hopsworks_udf.get_udf(
-                inference=False
+                online=False
             )(
                 *(
                     [

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1323,7 +1323,18 @@ class Engine:
         hopsworks_udf: HopsworksUdf,
         dataframe: Union[pd.DataFrame, pl.DataFrame],
     ) -> Union[pd.DataFrame, pl.DataFrame]:
-        udf = hopsworks_udf.get_udf()
+        """
+        Apply a python udf to a dataframe
+
+        # Arguments
+            transformation_functions `List[transformation_function.TransformationFunction]` : List of transformation functions.
+            dataset `Union[pd.DataFrame, pl.DataFrame]`: A pandas or polars dataframe.
+        # Returns
+            `DataFrame`: A pandas dataframe with the transformed data.
+        # Raises
+            `FeatureStoreException`: If any of the features mentioned in the transformation function is not present in the Feature View.
+        """
+        udf = hopsworks_udf.get_udf(inference=False)
         if isinstance(dataframe, pd.DataFrame):
             if len(hopsworks_udf.return_types) > 1:
                 dataframe[hopsworks_udf.output_column_names] = dataframe.apply(
@@ -1381,7 +1392,7 @@ class Engine:
         dataframe = pd.concat(
             [
                 dataframe.reset_index(drop=True),
-                hopsworks_udf.get_udf()(
+                hopsworks_udf.get_udf(inference=False)(
                     *(
                         [
                             dataframe[feature]

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1390,16 +1390,6 @@ class Engine:
             `FeatureStoreException`: If any of the features mentioned in the transformation function is not present in the Feature View.
         """
         if len(hopsworks_udf.return_types) > 1:
-            print(
-                hopsworks_udf.get_udf(inference=False)(
-                    *(
-                        [
-                            dataframe[feature]
-                            for feature in hopsworks_udf.transformation_features
-                        ]
-                    )
-                )
-            )
             dataframe[hopsworks_udf.output_column_names] = hopsworks_udf.get_udf(
                 inference=False
             )(

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1389,9 +1389,8 @@ class Engine:
         # Raises
             `FeatureStoreException`: If any of the features mentioned in the transformation function is not present in the Feature View.
         """
-        dataframe = pd.concat(
-            [
-                dataframe.reset_index(drop=True),
+        if len(hopsworks_udf.return_types) > 1:
+            print(
                 hopsworks_udf.get_udf(inference=False)(
                     *(
                         [
@@ -1399,10 +1398,29 @@ class Engine:
                             for feature in hopsworks_udf.transformation_features
                         ]
                     )
-                ).reset_index(drop=True),
-            ],
-            axis=1,
-        )
+                )
+            )
+            dataframe[hopsworks_udf.output_column_names] = hopsworks_udf.get_udf(
+                inference=False
+            )(
+                *(
+                    [
+                        dataframe[feature]
+                        for feature in hopsworks_udf.transformation_features
+                    ]
+                )
+            )
+        else:
+            dataframe[hopsworks_udf.output_column_names[0]] = hopsworks_udf.get_udf(
+                inference=False
+            )(
+                *(
+                    [
+                        dataframe[feature]
+                        for feature in hopsworks_udf.transformation_features
+                    ]
+                )
+            )
         return dataframe
 
     @staticmethod

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1348,6 +1348,13 @@ class Engine:
                     axis=1,
                     result_type="expand",
                 )
+                if hopsworks_udf.output_column_names[0] in dataframe.columns:
+                    # Overwriting features so reordering dataframe to move overwritten column to the end of the dataframe
+                    cols = dataframe.columns.tolist()
+                    cols.append(
+                        cols.pop(cols.index(hopsworks_udf.output_column_names[0]))
+                    )
+                    dataframe = dataframe[cols]
         else:
             # Dynamically creating lambda function so that we do not need to loop though to extract features required for the udf.
             # This is done because polars 'map_rows' provides rows as tuples to the udf.
@@ -1411,6 +1418,11 @@ class Engine:
                     ]
                 )
             )
+            if hopsworks_udf.output_column_names[0] in dataframe.columns:
+                # Overwriting features so reordering dataframe to move overwritten column to the end of the dataframe
+                cols = dataframe.columns.tolist()
+                cols.append(cols.pop(cols.index(hopsworks_udf.output_column_names[0])))
+                dataframe = dataframe[cols]
         return dataframe
 
     @staticmethod

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -90,6 +90,7 @@ from hsfs.core.constants import (
 from hsfs.core.type_systems import PYARROW_HOPSWORKS_DTYPE_MAPPING
 from hsfs.core.vector_db_client import VectorDbClient
 from hsfs.feature_group import ExternalFeatureGroup, FeatureGroup
+from hsfs.hopsworks_udf import HopsworksUdf, UDFExecutionMode
 from hsfs.training_dataset import TrainingDataset
 from hsfs.training_dataset_feature import TrainingDatasetFeature
 from hsfs.training_dataset_split import TrainingDatasetSplit
@@ -1262,6 +1263,7 @@ class Engine:
         self,
         transformation_functions: List[transformation_function.TransformationFunction],
         dataset: Union[pd.DataFrame, pl.DataFrame],
+        inference_mode: bool = False,
     ) -> Union[pd.DataFrame, pl.DataFrame]:
         """
         Apply transformation function to the dataframe.
@@ -1299,22 +1301,98 @@ class Engine:
                 )
             if tf.hopsworks_udf.dropped_features:
                 dropped_features.update(tf.hopsworks_udf.dropped_features)
-            dataset = pd.concat(
-                [
-                    dataset.reset_index(drop=True),
-                    tf.hopsworks_udf.get_udf()(
-                        *(
-                            [
-                                dataset[feature]
-                                for feature in tf.hopsworks_udf.transformation_features
-                            ]
-                        )
-                    ).reset_index(drop=True),
-                ],
-                axis=1,
-            )
+
+            if (
+                hopsworks_udf.execution_mode.get_current_execution_mode(
+                    inference=inference_mode
+                )
+                == UDFExecutionMode.PANDAS
+            ):
+                dataset = self._apply_pandas_udf(
+                    hopsworks_udf=hopsworks_udf, dataframe=dataset
+                )
+            else:
+                dataset = self._apply_python_udf(
+                    hopsworks_udf=hopsworks_udf, dataframe=dataset
+                )
         dataset = dataset.drop(dropped_features, axis=1)
         return dataset
+
+    def _apply_python_udf(
+        self,
+        hopsworks_udf: HopsworksUdf,
+        dataframe: Union[pd.DataFrame, pl.DataFrame],
+    ) -> Union[pd.DataFrame, pl.DataFrame]:
+        udf = hopsworks_udf.get_udf()
+        if isinstance(dataframe, pd.DataFrame):
+            if len(hopsworks_udf.return_types) > 1:
+                dataframe[hopsworks_udf.output_column_names] = dataframe.apply(
+                    lambda x: udf(*x[hopsworks_udf.transformation_features]),
+                    axis=1,
+                    result_type="expand",
+                )
+            else:
+                dataframe[hopsworks_udf.output_column_names[0]] = dataframe.apply(
+                    lambda x: udf(*x[hopsworks_udf.transformation_features]),
+                    axis=1,
+                    result_type="expand",
+                )
+        else:
+            # Dynamically creating lambda function so that we do not need to loop though to extract features required for the udf.
+            # This is done because polars 'map_rows' provides rows as tuples to the udf.
+            transformation_features = ", ".join(
+                [
+                    f"x[{dataframe.columns.index(feature)}]"
+                    for feature in hopsworks_udf.transformation_features
+                ]
+            )
+            feature_mapping_wrapper = eval(
+                f"lambda x: udf({transformation_features})", locals()
+            )
+            transformed_features = dataframe.map_rows(feature_mapping_wrapper)
+            dataframe = dataframe.with_columns(
+                transformed_features.rename(
+                    dict(
+                        zip(
+                            transformed_features.columns,
+                            hopsworks_udf.output_column_names,
+                        )
+                    )
+                )
+            )
+        return dataframe
+
+    def _apply_pandas_udf(
+        self,
+        hopsworks_udf: HopsworksUdf,
+        dataframe: Union[pd.DataFrame, pl.DataFrame],
+    ) -> Union[pd.DataFrame, pl.DataFrame]:
+        """
+        Apply a pandas udf to a dataframe
+
+        # Arguments
+            transformation_functions `List[transformation_function.TransformationFunction]` : List of transformation functions.
+            dataset `Union[pd.DataFrame, pl.DataFrame]`: A pandas or polars dataframe.
+        # Returns
+            `DataFrame`: A pandas dataframe with the transformed data.
+        # Raises
+            `FeatureStoreException`: If any of the features mentioned in the transformation function is not present in the Feature View.
+        """
+        dataframe = pd.concat(
+            [
+                dataframe.reset_index(drop=True),
+                hopsworks_udf.get_udf()(
+                    *(
+                        [
+                            dataframe[feature]
+                            for feature in hopsworks_udf.transformation_features
+                        ]
+                    )
+                ).reset_index(drop=True),
+            ],
+            axis=1,
+        )
+        return dataframe
 
     @staticmethod
     def get_unique_values(

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -1382,7 +1382,13 @@ class Engine:
                     f"Features {missing_features} specified in the transformation function '{hopsworks_udf.function_name}' are not present in the feature view. Please specify the feature required correctly."
                 )
             if tf.hopsworks_udf.dropped_features:
-                dropped_features.update(tf.hopsworks_udf.dropped_features)
+                dropped_features.update(hopsworks_udf.dropped_features)
+
+            # Add to dropped features if the feature need to overwritten to avoid ambiguous columns.
+            if len(hopsworks_udf.return_types) == 1 and (
+                hopsworks_udf.function_name == hopsworks_udf.output_column_names[0]
+            ):
+                dropped_features.update(hopsworks_udf.output_column_names)
 
             pandas_udf = hopsworks_udf.get_udf()
             output_col_name = hopsworks_udf.output_column_names[0]

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -55,7 +55,7 @@ class UDFExecutionMode(Enum):
         try:
             return UDFExecutionMode[execution_mode.upper()]
         except KeyError as e:
-            raise Exception(
+            raise FeatureStoreException(
                 f"Ivalid execution mode `{execution_mode}` for UDF. Please use `default`, `python` or `pandas` instead."
             ) from e
 

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -605,9 +605,7 @@ def renaming_wrapper(*args):
     df = {self.function_name}(*args)
     if isinstance(df, tuple):
         df = pd.concat(df, axis=1)
-    print(df)
-    df = df.rename(columns = {{df.columns[i]: _output_col_names[i] for i in range(len(df.columns))}})
-    print(df)
+    df.columns = _output_col_names
     for col in _date_time_output_columns:
         if pd.api.types.is_datetime64_any_dtype(df[col]):
             df[col] = convert_timezone(df[col])
@@ -636,7 +634,6 @@ def renaming_wrapper(*args):
         scope = __import__("__main__").__dict__.copy()
         if self.transformation_statistics is not None:
             scope.update({"statistics": self.transformation_statistics})
-        print(self.output_column_names)
         scope.update({"_output_col_names": self.output_column_names})
         scope.update({"_date_time_output_columns": date_time_output_columns})
         # executing code

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -579,7 +579,7 @@ class HopsworksUdf:
         date_time_output_columns = [
             self.output_column_names[ind]
             for ind, ele in enumerate(self.return_types)
-            if ele == "timestamp" or ele == "date"
+            if ele == "timestamp"
         ]
 
         # Function to make transformation function time safe. Defined as a string because it has to be dynamically injected into scope to be executed by spark
@@ -592,7 +592,7 @@ class HopsworksUdf:
             return date_time_col.dt.tz_localize(str(current_timezone))
         else:
             # convert to utc, then localize to system's timezone
-            return date_time_col.dt.tz_localize(None).dt.tz_localize(str(current_timezone))"""
+            return date_time_col.dt.tz_convert('UTC').dt.tz_localize(None).dt.tz_localize(str(current_timezone))"""
 
         # Defining wrapper function that renames the column names to specific names
         if len(self.return_types) > 1:

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -503,9 +503,7 @@ class HopsworksUdf:
         """
         # Check if any output is of date time type.
         date_time_output_index = [
-            ind
-            for ind, ele in enumerate(self.return_types)
-            if ele == "timestamp" or ele == "date"
+            ind for ind, ele in enumerate(self.return_types) if ele == "timestamp"
         ]
 
         # Function that converts the timestamp to localized timezone

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -605,7 +605,9 @@ def renaming_wrapper(*args):
     df = {self.function_name}(*args)
     if isinstance(df, tuple):
         df = pd.concat(df, axis=1)
+    print(df)
     df = df.rename(columns = {{df.columns[i]: _output_col_names[i] for i in range(len(df.columns))}})
+    print(df)
     for col in _date_time_output_columns:
         if pd.api.types.is_datetime64_any_dtype(df[col]):
             df[col] = convert_timezone(df[col])
@@ -634,6 +636,7 @@ def renaming_wrapper(*args):
         scope = __import__("__main__").__dict__.copy()
         if self.transformation_statistics is not None:
             scope.update({"statistics": self.transformation_statistics})
+        print(self.output_column_names)
         scope.update({"_output_col_names": self.output_column_names})
         scope.update({"_date_time_output_columns": date_time_output_columns})
         # executing code

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -622,7 +622,9 @@ def renaming_wrapper(*args):
     df = {self.function_name}(*args)
     df = df.rename(_output_col_names[0])
     if _date_time_output_columns:
-        df = convert_timezone(df)
+        # Set correct type is column is not of datetime type
+        if pd.api.types.is_datetime64_any_dtype(df):
+            df = convert_timezone(df)
     return df"""
             )
 
@@ -863,6 +865,9 @@ def renaming_wrapper(*args):
             dropped_feature_names=dropped_feature_names,
             feature_name_prefix=feature_name_prefix,
             transformation_function_argument_names=transformation_function_argument_names,
+            execution_mode=UDFExecutionMode.from_string(
+                json_decamelized["execution_mode"]
+            ),
         )
 
         # Set transformation features if already set.

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -763,6 +763,7 @@ def renaming_wrapper(*args):
             else None,
             "name": self.function_name,
             "featureNamePrefix": self._feature_name_prefix,
+            "executionMode": self.execution_mode.value,
         }
 
     def json(self) -> str:

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -42,10 +42,10 @@ class UDFExecutionMode(Enum):
     PYTHON = "python"
     PANDAS = "pandas"
 
-    def get_current_execution_mode(self, inference):
-        if self == UDFExecutionMode.DEFAULT and inference:
+    def get_current_execution_mode(self, online):
+        if self == UDFExecutionMode.DEFAULT and online:
             return UDFExecutionMode.PYTHON
-        elif self == UDFExecutionMode.DEFAULT and not inference:
+        elif self == UDFExecutionMode.DEFAULT and not online:
             return UDFExecutionMode.PANDAS
         else:
             return self
@@ -697,7 +697,7 @@ def renaming_wrapper(*args):
             for _ in range(len(self.transformation_statistics.feature.unique_values))
         ]
 
-    def get_udf(self, inference: bool = False) -> Callable:
+    def get_udf(self, online: bool = False) -> Callable:
         """
         Function that checks the current engine type, execution type and returns the appropriate UDF.
 
@@ -719,10 +719,10 @@ def renaming_wrapper(*args):
         """
 
         if (
-            self.execution_mode.get_current_execution_mode(inference)
+            self.execution_mode.get_current_execution_mode(online)
             == UDFExecutionMode.PANDAS
         ):
-            if engine.get_type() in ["python", "training"] or inference:
+            if engine.get_type() in ["python", "training"] or online:
                 return self.pandas_udf_wrapper()
             else:
                 from pyspark.sql.functions import pandas_udf
@@ -732,10 +732,10 @@ def renaming_wrapper(*args):
                     returnType=self._create_pandas_udf_return_schema_from_list(),
                 )
         elif (
-            self.execution_mode.get_current_execution_mode(inference)
+            self.execution_mode.get_current_execution_mode(online)
             == UDFExecutionMode.PYTHON
         ):
-            if engine.get_type() in ["python", "training"] or inference:
+            if engine.get_type() in ["python", "training"] or online:
                 # Renaming into correct column names done within Python engine since a wrapper does not work for polars dataFrames.
                 return self.python_udf_wrapper(rename_outputs=False)
             else:

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -524,9 +524,9 @@ class HopsworksUdf:
 
         # Start wrapper function generation
         code = (
-            self._module_imports + "\n" + convert_timstamp_function
-            if date_time_output_index
-            else "\n"
+            self._module_imports
+            + "\n"
+            + (convert_timstamp_function + "\n" if date_time_output_index else "\n")
             + "def wrapper(*args):\n"
             + f"   {self._formatted_function_source}\n"
             + f"   transformed_features = {self.function_name}(*args)\n"
@@ -560,6 +560,7 @@ class HopsworksUdf:
 
         # executing code
         exec(code, scope)
+        print(code)
 
         # returning executed function object
         return eval("wrapper", scope)

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -764,7 +764,7 @@ def renaming_wrapper(*args):
             else None,
             "name": self.function_name,
             "featureNamePrefix": self._feature_name_prefix,
-            "executionMode": self.execution_mode.value,
+            "executionMode": self.execution_mode.value.upper(),
         }
 
     def json(self) -> str:

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -510,16 +510,19 @@ class HopsworksUdf:
 
         # Function that converts the timestamp to localized timezone
         convert_timstamp_function = (
-            "from datetime import datetime\n"
+            "from datetime import datetime, timezone\n"
             + "import tzlocal\n"
             + "def convert_timezone(date_time_obj : datetime):\n"
             + "   current_timezone = tzlocal.get_localzone()\n"
-            + "   if date_time_obj.tzinfo is None:\n"
-            + "   # if timestamp is timezone unaware, make sure it's localized to the system's timezone.\n"
-            + "   # otherwise, spark will implicitly convert it to the system's timezone.\n"
-            "      return date_time_obj.replace(tzinfo=current_timezone)\n"
+            + "   if date_time_obj and isinstance(date_time_obj, datetime):\n"
+            + "      if date_time_obj.tzinfo is None:\n"
+            + "      # if timestamp is timezone unaware, make sure it's localized to the system's timezone.\n"
+            + "      # otherwise, spark will implicitly convert it to the system's timezone.\n"
+            + "         return date_time_obj.replace(tzinfo=current_timezone)\n"
+            + "      else:\n"
+            + "         return date_time_obj.astimezone(timezone.utc).replace(tzinfo=current_timezone)\n"
             + "   else:\n"
-            + "      return date_time_obj.astimezone(timezone.utc).replace(tzinfo=current_timezone)\n"
+            + "      return None\n"
         )
 
         # Start wrapper function generation
@@ -560,7 +563,6 @@ class HopsworksUdf:
 
         # executing code
         exec(code, scope)
-        print(code)
 
         # returning executed function object
         return eval("wrapper", scope)

--- a/python/hsfs/transformation_function.py
+++ b/python/hsfs/transformation_function.py
@@ -237,6 +237,25 @@ class TransformationFunction:
         # Returns
             `List[str]`: List of feature names for the transformed columns
         """
+        # If function name matches the name of an input feature and the transformation function only returns one output feature then
+        # then the transformed output feature would have the same name as the input feature. i.e the input feature will get overwritten.
+        if (
+            len(self._hopsworks_udf.return_types) == 1
+            and any(
+                [
+                    self.hopsworks_udf.function_name
+                    == transformation_feature.feature_name
+                    for transformation_feature in self.hopsworks_udf._transformation_features
+                ]
+            )
+            and (
+                not self.hopsworks_udf.dropped_features
+                or self.hopsworks_udf.function_name
+                not in self.hopsworks_udf.dropped_features
+            )
+        ):
+            return [self.hopsworks_udf.function_name]
+
         if self.transformation_type == TransformationType.MODEL_DEPENDENT:
             _BASE_COLUMN_NAME = f'{self._hopsworks_udf.function_name}_{"_".join(self._hopsworks_udf.transformation_features)}_'
             if len(self._hopsworks_udf.return_types) > 1:

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -2602,7 +2602,7 @@ class TestPython:
         # Assert
         assert result == file
 
-    def test_apply_transformation_function_pandas(self, mocker):
+    def test_apply_transformation_function_udf_default_mode(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
         hopsworks_common.connection._hsfs_engine_type = "python"
@@ -2642,7 +2642,89 @@ class TestPython:
         assert result["plus_one_tf_name_"][0] == 2
         assert result["plus_one_tf_name_"][1] == 3
 
-    def test_apply_transformation_function_multiple_output(self, mocker):
+    def test_apply_transformation_function_udf_pandas_mode(self, mocker):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf(int, mode="pandas")
+        def plus_one(col1):
+            return col1 + 1
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_one("tf_name")],
+        )
+
+        df = pd.DataFrame(data={"tf_name": [1, 2]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert len(result["plus_one_tf_name_"]) == 2
+        assert result["plus_one_tf_name_"][0] == 2
+        assert result["plus_one_tf_name_"][1] == 3
+
+    def test_apply_transformation_function_udf_python_mode(self, mocker):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf(int, mode="python")
+        def plus_one(col1):
+            return col1 + 1
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_one("tf_name")],
+        )
+
+        df = pd.DataFrame(data={"tf_name": [1, 2]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert len(result["plus_one_tf_name_"]) == 2
+        assert result["plus_one_tf_name_"][0] == 2
+        assert result["plus_one_tf_name_"][1] == 3
+
+    def test_apply_transformation_function_multiple_output_udf_default_mode(
+        self, mocker
+    ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
         hopsworks_common.connection._hsfs_engine_type = "python"
@@ -2685,7 +2767,99 @@ class TestPython:
         assert result["plus_two_col1_1"][0] == 3
         assert result["plus_two_col1_1"][1] == 4
 
-    def test_apply_transformation_function_multiple_input_output(self, mocker):
+    def test_apply_transformation_function_multiple_output_udf_python_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf([int, int], drop=["col1"], mode="python")
+        def plus_two(col1):
+            return col1 + 1, col1 + 2
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_two],
+        )
+
+        df = pd.DataFrame(data={"col1": [1, 2], "col2": [10, 11]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert all(result.columns == ["col2", "plus_two_col1_0", "plus_two_col1_1"])
+        assert len(result) == 2
+        assert result["plus_two_col1_0"][0] == 2
+        assert result["plus_two_col1_0"][1] == 3
+        assert result["plus_two_col1_1"][0] == 3
+        assert result["plus_two_col1_1"][1] == 4
+
+    def test_apply_transformation_function_multiple_output_udf_pandas_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf([int, int], drop=["col1"], mode="pandas")
+        def plus_two(col1):
+            return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col1 + 2})
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_two],
+        )
+
+        df = pd.DataFrame(data={"col1": [1, 2], "col2": [10, 11]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert all(result.columns == ["col2", "plus_two_col1_0", "plus_two_col1_1"])
+        assert len(result) == 2
+        assert result["plus_two_col1_0"][0] == 2
+        assert result["plus_two_col1_0"][1] == 3
+        assert result["plus_two_col1_1"][0] == 3
+        assert result["plus_two_col1_1"][1] == 4
+
+    def test_apply_transformation_function_multiple_input_output_udf_default_mode(
+        self, mocker
+    ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
 
@@ -2736,7 +2910,115 @@ class TestPython:
         assert result["plus_two_col1_col2_1"][0] == 12
         assert result["plus_two_col1_col2_1"][1] == 13
 
-    def test_apply_transformation_function_multiple_input_output_drop_all(self, mocker):
+    def test_apply_transformation_function_multiple_input_output_udf_pandas_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf([int, int], mode="pandas")
+        def plus_two(col1, col2):
+            return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col2 + 2})
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_two],
+        )
+
+        df = pd.DataFrame(data={"col1": [1, 2], "col2": [10, 11]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert all(
+            result.columns
+            == ["col1", "col2", "plus_two_col1_col2_0", "plus_two_col1_col2_1"]
+        )
+        assert len(result) == 2
+        assert result["col1"][0] == 1
+        assert result["col1"][1] == 2
+        assert result["col2"][0] == 10
+        assert result["col2"][1] == 11
+        assert result["plus_two_col1_col2_0"][0] == 2
+        assert result["plus_two_col1_col2_0"][1] == 3
+        assert result["plus_two_col1_col2_1"][0] == 12
+        assert result["plus_two_col1_col2_1"][1] == 13
+
+    def test_apply_transformation_function_multiple_input_output_udf_python_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf([int, int], mode="python")
+        def plus_two(col1, col2):
+            return col1 + 1, col2 + 2
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_two],
+        )
+
+        df = pd.DataFrame(data={"col1": [1, 2], "col2": [10, 11]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert all(
+            result.columns
+            == ["col1", "col2", "plus_two_col1_col2_0", "plus_two_col1_col2_1"]
+        )
+        assert len(result) == 2
+        assert result["col1"][0] == 1
+        assert result["col1"][1] == 2
+        assert result["col2"][0] == 10
+        assert result["col2"][1] == 11
+        assert result["plus_two_col1_col2_0"][0] == 2
+        assert result["plus_two_col1_col2_0"][1] == 3
+        assert result["plus_two_col1_col2_1"][0] == 12
+        assert result["plus_two_col1_col2_1"][1] == 13
+
+    def test_apply_transformation_function_multiple_input_output_drop_all_udf_default_mode(
+        self, mocker
+    ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
 
@@ -2780,7 +3062,99 @@ class TestPython:
         assert result["plus_two_col1_col2_1"][0] == 12
         assert result["plus_two_col1_col2_1"][1] == 13
 
-    def test_apply_transformation_function_multiple_input_output_drop_some(
+    def test_apply_transformation_function_multiple_input_output_drop_all_udf_python_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf([int, int], drop=["col1", "col2"], mode="python")
+        def plus_two(col1, col2):
+            return col1 + 1, col2 + 2
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_two],
+        )
+
+        df = pd.DataFrame(data={"col1": [1, 2], "col2": [10, 11]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert all(result.columns == ["plus_two_col1_col2_0", "plus_two_col1_col2_1"])
+        assert len(result) == 2
+        assert result["plus_two_col1_col2_0"][0] == 2
+        assert result["plus_two_col1_col2_0"][1] == 3
+        assert result["plus_two_col1_col2_1"][0] == 12
+        assert result["plus_two_col1_col2_1"][1] == 13
+
+    def test_apply_transformation_function_multiple_input_output_drop_all_udf_pandas_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf([int, int], drop=["col1", "col2"], mode="pandas")
+        def plus_two(col1, col2):
+            return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col2 + 2})
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_two],
+        )
+
+        df = pd.DataFrame(data={"col1": [1, 2], "col2": [10, 11]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert all(result.columns == ["plus_two_col1_col2_0", "plus_two_col1_col2_1"])
+        assert len(result) == 2
+        assert result["plus_two_col1_col2_0"][0] == 2
+        assert result["plus_two_col1_col2_0"][1] == 3
+        assert result["plus_two_col1_col2_1"][0] == 12
+        assert result["plus_two_col1_col2_1"][1] == 13
+
+    def test_apply_transformation_function_multiple_input_output_drop_some_udf_default_mode(
         self, mocker
     ):
         # Arrange
@@ -2830,11 +3204,111 @@ class TestPython:
         assert result["plus_two_col1_col2_1"][0] == 12
         assert result["plus_two_col1_col2_1"][1] == 13
 
+    def test_apply_transformation_function_multiple_input_output_drop_some_udf_python_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf([int, int], drop=["col1"], mode="python")
+        def plus_two(col1, col2):
+            return col1 + 1, col2 + 2
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_two],
+        )
+
+        df = pd.DataFrame(data={"col1": [1, 2], "col2": [10, 11]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert all(
+            result.columns == ["col2", "plus_two_col1_col2_0", "plus_two_col1_col2_1"]
+        )
+        assert len(result) == 2
+        assert result["col2"][0] == 10
+        assert result["col2"][1] == 11
+        assert result["plus_two_col1_col2_0"][0] == 2
+        assert result["plus_two_col1_col2_0"][1] == 3
+        assert result["plus_two_col1_col2_1"][0] == 12
+        assert result["plus_two_col1_col2_1"][1] == 13
+
+    def test_apply_transformation_function_multiple_input_output_drop_some_udf_pandas_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf([int, int], drop=["col1"], mode="pandas")
+        def plus_two(col1, col2):
+            return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col2 + 2})
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_two],
+        )
+
+        df = pd.DataFrame(data={"col1": [1, 2], "col2": [10, 11]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert all(
+            result.columns == ["col2", "plus_two_col1_col2_0", "plus_two_col1_col2_1"]
+        )
+        assert len(result) == 2
+        assert result["col2"][0] == 10
+        assert result["col2"][1] == 11
+        assert result["plus_two_col1_col2_0"][0] == 2
+        assert result["plus_two_col1_col2_0"][1] == 3
+        assert result["plus_two_col1_col2_1"][0] == 12
+        assert result["plus_two_col1_col2_1"][1] == 13
+
     @pytest.mark.skipif(
         not HAS_POLARS,
         reason="Polars is not installed.",
     )
-    def test_apply_transformation_function_polars(self, mocker):
+    def test_apply_transformation_function_polars_udf_default_mode(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
 
@@ -2842,6 +3316,88 @@ class TestPython:
         python_engine = python.Engine()
 
         @udf(int)
+        def plus_one(col1):
+            return col1 + 1
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_one("tf_name")],
+        )
+
+        df = pl.DataFrame(data={"tf_name": [1, 2]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert len(result["plus_one_tf_name_"]) == 2
+        assert result["plus_one_tf_name_"][0] == 2
+        assert result["plus_one_tf_name_"][1] == 3
+
+    def test_apply_transformation_function_polars_udf_python_mode(self, mocker):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf(int, mode="python")
+        def plus_one(col1):
+            return col1 + 1
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("id"), feature.Feature("tf_name")],
+            id=11,
+            stream=False,
+        )
+
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg.select_all(),
+            featurestore_id=99,
+            transformation_functions=[plus_one("tf_name")],
+        )
+
+        df = pl.DataFrame(data={"tf_name": [1, 2]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert len(result["plus_one_tf_name_"]) == 2
+        assert result["plus_one_tf_name_"][0] == 2
+        assert result["plus_one_tf_name_"][1] == 3
+
+    def test_apply_transformation_function_polars_udf_pandas_mode(self, mocker):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+
+        hopsworks_common.connection._hsfs_engine_type = "python"
+        python_engine = python.Engine()
+
+        @udf(int, mode="pandas")
         def plus_one(col1):
             return col1 + 1
 

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -3349,6 +3349,10 @@ class TestPython:
         assert result["plus_one_tf_name_"][0] == 2
         assert result["plus_one_tf_name_"][1] == 3
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_apply_transformation_function_polars_udf_python_mode(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
@@ -3390,6 +3394,10 @@ class TestPython:
         assert result["plus_one_tf_name_"][0] == 2
         assert result["plus_one_tf_name_"][1] == 3
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_apply_transformation_function_polars_udf_pandas_mode(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")

--- a/python/tests/engine/test_python_spark_transformation_functions.py
+++ b/python/tests/engine/test_python_spark_transformation_functions.py
@@ -90,7 +90,6 @@ class TestPythonSparkTransformationFunctions:
         pd.testing.assert_frame_equal(
             result, expected_df, check_dtype=False, check_exact=True
         )
-        # assert np.all(result.values == expected_df.values)
 
     def _validate_on_spark_engine(
         self, td, spark_df, expected_spark_df, transformation_functions
@@ -1092,17 +1091,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", TimestampType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1640995200),
-                    datetime.datetime.utcfromtimestamp(1640995201),
-                ],
+                "col_0": [1640995200, 1640995201],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -1122,10 +1118,8 @@ class TestPythonSparkTransformationFunctions:
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
-                    datetime.datetime.utcfromtimestamp(1640995200)
-                    + datetime.timedelta(milliseconds=1),
-                    datetime.datetime.utcfromtimestamp(1640995201)
-                    + datetime.timedelta(milliseconds=1),
+                    datetime.datetime.utcfromtimestamp(1640995201),
+                    datetime.datetime.utcfromtimestamp(1640995202),
                 ],
             }
         )
@@ -1142,9 +1136,7 @@ class TestPythonSparkTransformationFunctions:
         # Arrange
         @udf(datetime.datetime, drop="col_0")
         def tf_fun(col_0):
-            import datetime
-
-            return col_0 + datetime.timedelta(milliseconds=1)
+            return pd.to_datetime(col_0 + 1, unit="s")
 
         td = self._create_training_dataset()
         transformation_functions = [
@@ -1170,17 +1162,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", TimestampType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1640995200),
-                    datetime.datetime.utcfromtimestamp(1640995201),
-                ],
+                "col_0": [1640995200, 1640995201],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -1199,10 +1188,8 @@ class TestPythonSparkTransformationFunctions:
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
-                    datetime.datetime.utcfromtimestamp(1640995200)
-                    + datetime.timedelta(milliseconds=1),
-                    datetime.datetime.utcfromtimestamp(1640995201)
-                    + datetime.timedelta(milliseconds=1),
+                    datetime.datetime.utcfromtimestamp(1640995201),
+                    datetime.datetime.utcfromtimestamp(1640995202),
                 ],
             }
         )
@@ -1221,7 +1208,7 @@ class TestPythonSparkTransformationFunctions:
         def tf_fun(col_0) -> datetime.datetime:
             import datetime
 
-            return (col_0 + datetime.timedelta(milliseconds=1)).dt.tz_localize(
+            return pd.to_datetime(col_0 + 1, unit="s").dt.tz_localize(
                 datetime.timezone.utc
             )
 
@@ -1243,7 +1230,6 @@ class TestPythonSparkTransformationFunctions:
         )
 
     def test_apply_plus_one_datetime_no_tz_python(self, mocker):
-        # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
         spark_engine = spark.Engine()
 
@@ -1276,10 +1262,8 @@ class TestPythonSparkTransformationFunctions:
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
-                    datetime.datetime.utcfromtimestamp(1640995200)
-                    + datetime.timedelta(milliseconds=1),
-                    datetime.datetime.utcfromtimestamp(1640995201)
-                    + datetime.timedelta(milliseconds=1),
+                    datetime.datetime.utcfromtimestamp(1640995201),
+                    datetime.datetime.utcfromtimestamp(1640995202),
                 ],
             }
         )
@@ -1294,13 +1278,9 @@ class TestPythonSparkTransformationFunctions:
         )
 
         # Arrange
-        @udf(datetime.datetime, drop="col_0", mode="python")
+        @udf(datetime.datetime, drop="col_0", mode="pandas")
         def tf_fun(col_0):
-            import datetime
-
-            return datetime.datetime.utcfromtimestamp(col_0) + datetime.timedelta(
-                milliseconds=1
-            )
+            return pd.to_datetime(col_0 + 1, unit="s")
 
         td = self._create_training_dataset()
         transformation_functions = [
@@ -1481,17 +1461,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", TimestampType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1640995200),
-                    datetime.datetime.utcfromtimestamp(1640995201),
-                ],
+                "col_0": [1640995200, 1640995201],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -1510,10 +1487,8 @@ class TestPythonSparkTransformationFunctions:
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
-                    datetime.datetime.utcfromtimestamp(1640995200)
-                    + datetime.timedelta(milliseconds=1),
-                    datetime.datetime.utcfromtimestamp(1640995201)
-                    + datetime.timedelta(milliseconds=1),
+                    datetime.datetime.utcfromtimestamp(1640995201),
+                    datetime.datetime.utcfromtimestamp(1640995202),
                 ],
             }
         )
@@ -1532,7 +1507,7 @@ class TestPythonSparkTransformationFunctions:
         def tf_fun(col_0) -> datetime.datetime:
             import datetime
 
-            return (col_0 + datetime.timedelta(milliseconds=1)).dt.tz_localize(
+            return pd.to_datetime(col_0 + 1, unit="s").dt.tz_localize(
                 datetime.timezone.utc
             )
 
@@ -1560,17 +1535,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", TimestampType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1640995200),
-                    datetime.datetime.utcfromtimestamp(1640995201),
-                ],
+                "col_0": [1640995200, 1640995201],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -1590,10 +1562,8 @@ class TestPythonSparkTransformationFunctions:
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
-                    datetime.datetime.utcfromtimestamp(1640995200)
-                    + datetime.timedelta(milliseconds=1),
-                    datetime.datetime.utcfromtimestamp(1640995201)
-                    + datetime.timedelta(milliseconds=1),
+                    datetime.datetime.utcfromtimestamp(1641024001),
+                    datetime.datetime.utcfromtimestamp(1641024002),
                 ],
             }
         )
@@ -1610,12 +1580,10 @@ class TestPythonSparkTransformationFunctions:
         # Arrange
         @udf(datetime.datetime, drop="col_0")
         def tf_fun(col_0) -> datetime.datetime:
-            import datetime
-
             import pytz
 
             pdt = pytz.timezone("US/Pacific")
-            return (col_0 + datetime.timedelta(milliseconds=1)).dt.tz_localize(pdt)
+            return pd.to_datetime(col_0 + 1, unit="s").dt.tz_localize(pdt)
 
         td = self._create_training_dataset()
         transformation_functions = [
@@ -1717,17 +1685,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", TimestampType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1640995200),
-                    datetime.datetime.utcfromtimestamp(1640995201),
-                ],
+                "col_0": [1640995200, 1640995201],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -1747,10 +1712,8 @@ class TestPythonSparkTransformationFunctions:
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
-                    datetime.datetime.utcfromtimestamp(1640995200)
-                    + datetime.timedelta(milliseconds=1),
-                    datetime.datetime.utcfromtimestamp(1640995201)
-                    + datetime.timedelta(milliseconds=1),
+                    datetime.datetime.utcfromtimestamp(1641024001),
+                    datetime.datetime.utcfromtimestamp(1641024002),
                 ],
             }
         )
@@ -1767,12 +1730,10 @@ class TestPythonSparkTransformationFunctions:
         # Arrange
         @udf(datetime.datetime, drop="col_0", mode="pandas")
         def tf_fun(col_0) -> datetime.datetime:
-            import datetime
-
             import pytz
 
             pdt = pytz.timezone("US/Pacific")
-            return (col_0 + datetime.timedelta(milliseconds=1)).dt.tz_localize(pdt)
+            return pd.to_datetime(col_0 + 1, unit="s").dt.tz_localize(pdt)
 
         td = self._create_training_dataset()
         transformation_functions = [
@@ -1798,17 +1759,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", TimestampType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1640995200),
-                    datetime.datetime.utcfromtimestamp(1640995201),
-                ],
+                "col_0": [1640995200, 1640995201],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -1829,8 +1787,7 @@ class TestPythonSparkTransformationFunctions:
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
                     None,
-                    datetime.datetime.utcfromtimestamp(1640995201)
-                    + datetime.timedelta(milliseconds=1),
+                    datetime.datetime.utcfromtimestamp(1640995202),
                 ],
             }
         )
@@ -1847,12 +1804,8 @@ class TestPythonSparkTransformationFunctions:
         # Arrange
         @udf(datetime.datetime, drop=["col_0"])
         def tf_fun(col_0) -> datetime.datetime:
-            import datetime
-
             return pd.Series(
-                None
-                if data == datetime.datetime.utcfromtimestamp(1640995200)
-                else data + datetime.timedelta(milliseconds=1)
+                None if data == 1640995200 else pd.to_datetime(data + 1, unit="s")
                 for data in col_0
             )
 
@@ -1954,17 +1907,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", TimestampType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1640995200),
-                    datetime.datetime.utcfromtimestamp(1640995201),
-                ],
+                "col_0": [1640995200, 1640995201],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -1985,8 +1935,7 @@ class TestPythonSparkTransformationFunctions:
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
                     None,
-                    datetime.datetime.utcfromtimestamp(1640995201)
-                    + datetime.timedelta(milliseconds=1),
+                    datetime.datetime.utcfromtimestamp(1640995202),
                 ],
             }
         )
@@ -2003,12 +1952,8 @@ class TestPythonSparkTransformationFunctions:
         # Arrange
         @udf(datetime.datetime, drop=["col_0"], mode="pandas")
         def tf_fun(col_0) -> datetime.datetime:
-            import datetime
-
             return pd.Series(
-                None
-                if data == datetime.datetime.utcfromtimestamp(1640995200)
-                else data + datetime.timedelta(milliseconds=1)
+                None if data == 1640995200 else pd.to_datetime(data + 1, unit="s")
                 for data in col_0
             )
 
@@ -2036,17 +1981,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", DateType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1641045600).date(),
-                    datetime.datetime.utcfromtimestamp(1641132000).date(),
-                ],
+                "col_0": [1641045600, 1641132000],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -2065,10 +2007,8 @@ class TestPythonSparkTransformationFunctions:
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
-                    datetime.datetime.utcfromtimestamp(1641045600).date()
-                    + datetime.timedelta(days=1),
-                    datetime.datetime.utcfromtimestamp(1641132000).date()
-                    + datetime.timedelta(days=1),
+                    datetime.datetime.utcfromtimestamp(1641045601).date(),
+                    datetime.datetime.utcfromtimestamp(1641132001).date(),
                 ],
             }
         )
@@ -2079,9 +2019,7 @@ class TestPythonSparkTransformationFunctions:
         # Arrange
         @udf(datetime.date, drop=["col_0"])
         def tf_fun(col_0):
-            import datetime
-
-            return col_0 + datetime.timedelta(days=1)
+            return pd.to_datetime(col_0 + 1, unit="s").dt.date
 
         td = self._create_training_dataset()
         transformation_functions = [
@@ -2174,17 +2112,14 @@ class TestPythonSparkTransformationFunctions:
 
         schema = StructType(
             [
-                StructField("col_0", DateType(), True),
+                StructField("col_0", IntegerType(), True),
                 StructField("col_1", StringType(), True),
                 StructField("col_2", BooleanType(), True),
             ]
         )
         df = pd.DataFrame(
             data={
-                "col_0": [
-                    datetime.datetime.utcfromtimestamp(1641045600).date(),
-                    datetime.datetime.utcfromtimestamp(1641132000).date(),
-                ],
+                "col_0": [1641045600, 1641132000],
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
             }
@@ -2203,10 +2138,8 @@ class TestPythonSparkTransformationFunctions:
                 "col_1": ["test_1", "test_2"],
                 "col_2": [True, False],
                 "tf_fun_col_0_": [
-                    datetime.datetime.utcfromtimestamp(1641045600).date()
-                    + datetime.timedelta(days=1),
-                    datetime.datetime.utcfromtimestamp(1641132000).date()
-                    + datetime.timedelta(days=1),
+                    datetime.datetime.utcfromtimestamp(1641045601).date(),
+                    datetime.datetime.utcfromtimestamp(1641132001).date(),
                 ],
             }
         )
@@ -2217,9 +2150,7 @@ class TestPythonSparkTransformationFunctions:
         # Arrange
         @udf(datetime.date, drop=["col_0"], mode="pandas")
         def tf_fun(col_0):
-            import datetime
-
-            return col_0 + datetime.timedelta(days=1)
+            return pd.to_datetime(col_0 + 1, unit="s").dt.date
 
         td = self._create_training_dataset()
         transformation_functions = [

--- a/python/tests/engine/test_python_spark_transformation_functions.py
+++ b/python/tests/engine/test_python_spark_transformation_functions.py
@@ -85,7 +85,7 @@ class TestPythonSparkTransformationFunctions:
             transformation_functions=transformation_functions,
             dataset=df,
         )
-
+        print(result)
         assert list(result.columns) == list(expected_df.columns)
         assert list(result.dtypes) == list(expected_df.dtypes)
         assert result.equals(expected_df)
@@ -163,6 +163,7 @@ class TestPythonSparkTransformationFunctions:
             "statisticsArgumentNames": ["feature"],
             "name": "min_max_scaler",
             "droppedArgumentNames": ["feature"],
+            "executionMode": "default",
         }
 
         tf_fun = HopsworksUdf.from_response_json(udf_response)
@@ -306,6 +307,7 @@ class TestPythonSparkTransformationFunctions:
             "statisticsArgumentNames": ["feature"],
             "name": "standard_scaler",
             "droppedArgumentNames": ["feature"],
+            "executionMode": "default",
         }
 
         tf_fun = HopsworksUdf.from_response_json(udf_response)
@@ -453,6 +455,7 @@ class TestPythonSparkTransformationFunctions:
             "statisticsArgumentNames": ["feature"],
             "name": "robust_scaler",
             "droppedArgumentNames": ["feature"],
+            "executionMode": "default",
         }
 
         tf_fun = HopsworksUdf.from_response_json(udf_response)

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -4543,7 +4543,7 @@ class TestSpark:
         assert mock_spark_engine_save_dataframe.call_count == 1
         assert mock_spark_read.format.call_count == 1
 
-    def test_apply_transformation_function_single_output(self, mocker):
+    def test_apply_transformation_function_single_output_udf_default_mode(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
         hopsworks_common.connection._hsfs_engine_type = "spark"
@@ -4604,7 +4604,131 @@ class TestSpark:
         assert result.schema == expected_spark_df.schema
         assert result.collect() == expected_spark_df.collect()
 
-    def test_apply_transformation_function_multiple_output(self, mocker):
+    def test_apply_transformation_function_single_output_udf_python_mode(self, mocker):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf(int, drop=["col1"], mode="python")
+        def plus_one(col1):
+            return col1 + 1
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=plus_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=BooleanType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [True, False]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_1": ["test_1", "test_2"],
+                "col_2": [True, False],
+                "plus_one_col_0_": [2, 3],
+            }
+        )  # todo why it doesnt return int?
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_single_output_udf_pandas_mode(self, mocker):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf(int, drop=["col1"], mode="pandas")
+        def plus_one(col1):
+            return col1 + 1
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=plus_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=BooleanType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [True, False]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_1": ["test_1", "test_2"],
+                "col_2": [True, False],
+                "plus_one_col_0_": [2, 3],
+            }
+        )  # todo why it doesnt return int?
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_output_udf_default_mode(
+        self, mocker
+    ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
         hopsworks_common.connection._hsfs_engine_type = "spark"
@@ -4666,7 +4790,137 @@ class TestSpark:
         assert result.schema == expected_spark_df.schema
         assert result.collect() == expected_spark_df.collect()
 
-    def test_apply_transformation_function_multiple_input_output(self, mocker):
+    def test_apply_transformation_function_multiple_output_udf_pandas_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf([int, int], drop=["col1"], mode="pandas")
+        def plus_two(col1):
+            return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col1 + 2})
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=plus_two,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=BooleanType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [True, False]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_1": ["test_1", "test_2"],
+                "col_2": [True, False],
+                "plus_two_col_0_0": [2, 3],
+                "plus_two_col_0_1": [3, 4],
+            }
+        )  # todo why it doesnt return int?
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_output_udf_python_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf([int, int], drop=["col1"], mode="python")
+        def plus_two(col1):
+            return col1 + 1, col1 + 2
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=plus_two,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=BooleanType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [True, False]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_1": ["test_1", "test_2"],
+                "col_2": [True, False],
+                "plus_two_col_0_0": [2, 3],
+                "plus_two_col_0_1": [3, 4],
+            }
+        )  # todo why it doesnt return int?
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_input_output_udf_default_mode(
+        self, mocker
+    ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
         hopsworks_common.connection._hsfs_engine_type = "spark"
@@ -4729,7 +4983,137 @@ class TestSpark:
         assert result.schema == expected_spark_df.schema
         assert result.collect() == expected_spark_df.collect()
 
-    def test_apply_transformation_function_multiple_input_output_drop_some(
+    def test_apply_transformation_function_multiple_input_output_udf_python_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf([int, int], mode="python")
+        def test(col1, col2):
+            return col1 + 1, col2 + 2
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=test,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=IntegerType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0", "col_2")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [10, 11]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_0": [1, 2],
+                "col_1": ["test_1", "test_2"],
+                "col_2": [10, 11],
+                "test_col_0_col_2_0": [2, 3],
+                "test_col_0_col_2_1": [12, 13],
+            }
+        )
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_input_output_udf_pandas_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf([int, int], mode="pandas")
+        def test(col1, col2):
+            return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col2 + 2})
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=test,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=IntegerType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0", "col_2")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [10, 11]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_0": [1, 2],
+                "col_1": ["test_1", "test_2"],
+                "col_2": [10, 11],
+                "test_col_0_col_2_0": [2, 3],
+                "test_col_0_col_2_1": [12, 13],
+            }
+        )
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_input_output_drop_some_udf_default_mode(
         self, mocker
     ):
         # Arrange
@@ -4793,7 +5177,137 @@ class TestSpark:
         assert result.schema == expected_spark_df.schema
         assert result.collect() == expected_spark_df.collect()
 
-    def test_apply_transformation_function_multiple_input_output_drop_all(self, mocker):
+    def test_apply_transformation_function_multiple_input_output_drop_some_udf_pandas_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf([int, int], drop=["col1"], mode="pandas")
+        def test(col1, col2):
+            return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col2 + 2})
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=test,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=IntegerType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0", "col_2")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [10, 11]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_1": ["test_1", "test_2"],
+                "col_2": [10, 11],
+                "test_col_0_col_2_0": [2, 3],
+                "test_col_0_col_2_1": [12, 13],
+            }
+        )
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_input_output_drop_some_udf_python_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf([int, int], drop=["col1"], mode="python")
+        def test(col1, col2):
+            return col1 + 1, col2 + 2
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=test,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=IntegerType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0", "col_2")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [10, 11]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_1": ["test_1", "test_2"],
+                "col_2": [10, 11],
+                "test_col_0_col_2_0": [2, 3],
+                "test_col_0_col_2_1": [12, 13],
+            }
+        )
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_input_output_drop_all_udf_default_mode(
+        self, mocker
+    ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
         hopsworks_common.connection._hsfs_engine_type = "spark"
@@ -4802,6 +5316,132 @@ class TestSpark:
         @udf([int, int], drop=["col1", "col2"])
         def test(col1, col2):
             return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col2 + 2})
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=test,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=IntegerType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0", "col_2")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [10, 11]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_1": ["test_1", "test_2"],
+                "test_col_0_col_2_0": [2, 3],
+                "test_col_0_col_2_1": [12, 13],
+            }
+        )  # todo why it doesnt return int?
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_input_output_drop_all_udf_pandas_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf([int, int], drop=["col1", "col2"], mode="pandas")
+        def test(col1, col2):
+            return pd.DataFrame({"new_col1": col1 + 1, "new_col2": col2 + 2})
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=test,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        f = feature.Feature(name="col_0", type=IntegerType(), index=0)
+        f1 = feature.Feature(name="col_1", type=StringType(), index=1)
+        f2 = feature.Feature(name="col_2", type=IntegerType(), index=1)
+        features = [f, f1, f2]
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=features,
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0", "col_2")],
+        )
+
+        d = {"col_0": [1, 2], "col_1": ["test_1", "test_2"], "col_2": [10, 11]}
+        df = pd.DataFrame(data=d)
+
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        expected_df = pd.DataFrame(
+            data={
+                "col_1": ["test_1", "test_2"],
+                "test_col_0_col_2_0": [2, 3],
+                "test_col_0_col_2_1": [12, 13],
+            }
+        )  # todo why it doesnt return int?
+
+        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
+
+        # Act
+        result = spark_engine._apply_transformation_function(
+            transformation_functions=fv.transformation_functions,
+            dataset=spark_df,
+        )
+        # Assert
+        assert result.schema == expected_spark_df.schema
+        assert result.collect() == expected_spark_df.collect()
+
+    def test_apply_transformation_function_multiple_input_output_drop_all_udf_python_mode(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client.get_instance")
+        engine._engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf([int, int], drop=["col1", "col2"], mode="python")
+        def test(col1, col2):
+            return col1 + 1, col2 + 2
 
         tf = transformation_function.TransformationFunction(
             99,

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -4607,7 +4607,7 @@ class TestSpark:
     def test_apply_transformation_function_single_output_udf_python_mode(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf(int, drop=["col1"], mode="python")
@@ -4668,7 +4668,7 @@ class TestSpark:
     def test_apply_transformation_function_single_output_udf_pandas_mode(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf(int, drop=["col1"], mode="pandas")
@@ -4795,7 +4795,7 @@ class TestSpark:
     ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf([int, int], drop=["col1"], mode="pandas")
@@ -4859,7 +4859,7 @@ class TestSpark:
     ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf([int, int], drop=["col1"], mode="python")
@@ -4988,7 +4988,7 @@ class TestSpark:
     ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf([int, int], mode="python")
@@ -5053,7 +5053,7 @@ class TestSpark:
     ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf([int, int], mode="pandas")
@@ -5182,7 +5182,7 @@ class TestSpark:
     ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf([int, int], drop=["col1"], mode="pandas")
@@ -5246,7 +5246,7 @@ class TestSpark:
     ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf([int, int], drop=["col1"], mode="python")
@@ -5373,7 +5373,7 @@ class TestSpark:
     ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf([int, int], drop=["col1", "col2"], mode="pandas")
@@ -5436,7 +5436,7 @@ class TestSpark:
     ):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")
-        engine._engine_type = "spark"
+        hopsworks_common.connection._hsfs_engine_type = "spark"
         spark_engine = spark.Engine()
 
         @udf([int, int], drop=["col1", "col2"], mode="python")

--- a/python/tests/fixtures/feature_group_fixtures.json
+++ b/python/tests/fixtures/feature_group_fixtures.json
@@ -695,7 +695,8 @@
             "name": "add_two",
             "outputTypes":["double"],
             "transformationFeatures":["data"],
-            "dropped_argument_names":["data1"]
+            "droppedArgumentNames":["data1"],
+            "executionMode":"default"
           }
         },
         {
@@ -707,7 +708,8 @@
             "name": "add_one_fs",
             "outputTypes":["double"],
             "transformationFeatures":["col1"],
-            "dropped_argument_names":["data1"]
+            "droppedArgumentNames":["data1"],
+            "executionMode":"default"
           }
         }
     ],

--- a/python/tests/fixtures/feature_view_fixtures.json
+++ b/python/tests/fixtures/feature_view_fixtures.json
@@ -694,7 +694,8 @@
               "name": "add_mean_fs",
               "outputTypes":["double"],
               "transformationFeatures":["data"],
-              "statisticsArgumentNames":["data1"]
+              "statisticsArgumentNames":["data1"],
+              "executionMode":"default"
             }
           },
           {
@@ -705,7 +706,8 @@
               "sourceCode": "\n@udf(float)\ndef add_one_fs(data1 : pd.Series):\n    return data1 + 1\n",
               "name": "add_one_fs",
               "outputTypes":["double"],
-              "transformationFeatures":["col1"]
+              "transformationFeatures":["col1"],
+              "executionMode":"default"
             }
           }
       ],
@@ -935,7 +937,8 @@
                 "outputTypes":["double"],
                 "transformationFeatures":["data"],
                 "statisticsArgumentNames":["data1"],
-                "dropped_argument_names":["data1"]
+                "dropped_argument_names":["data1"],
+                "executionMode":"default"
               }
             },
             {
@@ -947,7 +950,8 @@
                 "name": "add_one_fs",
                 "outputTypes":["double"],
                 "transformationFeatures":["col1"],
-                "dropped_argument_names":["data1"]
+                "dropped_argument_names":["data1"],
+                "executionMode":"default"
               }
             }
         ],

--- a/python/tests/fixtures/training_dataset_feature_fixtures.json
+++ b/python/tests/fixtures/training_dataset_feature_fixtures.json
@@ -79,7 +79,8 @@
             "name": "add_one_fs",
             "outputTypes":["double"],
             "transformationFeatures":["col1"],
-            "dropped_argument_names":["data1"]
+            "dropped_argument_names":["data1"],
+            "executionMode":"default"
           }
         },
         "featuregroup": {

--- a/python/tests/fixtures/transformation_function_fixtures.json
+++ b/python/tests/fixtures/transformation_function_fixtures.json
@@ -9,7 +9,8 @@
         "name": "add_one_fs",
         "outputTypes":["double"],
         "transformationFeatures":["col1"],
-        "dropped_argument_names":["data1"]
+        "dropped_argument_names":["data1"],
+        "executionMode":"default"
       }
     }
   },
@@ -24,7 +25,8 @@
         "outputTypes":["double"],
         "transformationFeatures":["data"],
         "statisticsArgumentNames":["data1"],
-        "dropped_argument_names":["data1"]
+        "dropped_argument_names":["data1"],
+        "executionMode":"default"
       }
     }
   },
@@ -39,7 +41,8 @@
         "outputTypes":["string"],
         "transformationFeatures":["feature1", "feature2", "feature3"],
         "statisticsArgumentNames":["data1", "data2"],
-        "dropped_argument_names":["data1", "data2", "data3"]
+        "dropped_argument_names":["data1", "data2", "data3"],
+        "executionMode":"default"
       }
     }
   },
@@ -54,7 +57,8 @@
         "outputTypes":["string", "double"],
         "transformationFeatures":["feature1", "feature2", "feature3"],
         "statisticsArgumentNames":["data1", "data2"],
-        "dropped_argument_names":["data1", "data2", "data3"]
+        "dropped_argument_names":["data1", "data2", "data3"],
+        "executionMode":"default"
       }
     }
   },
@@ -72,7 +76,8 @@
             "outputTypes":["double"],
             "transformationFeatures":["data"],
             "statisticsArgumentNames":["data1"],
-            "dropped_argument_names":["data1"]
+            "dropped_argument_names":["data1"],
+            "executionMode":"default"
           }
         },
         {
@@ -84,7 +89,8 @@
             "name": "add_one_fs",
             "outputTypes":["double"],
             "transformationFeatures":["col1"],
-            "dropped_argument_names":["data1"]
+            "dropped_argument_names":["data1"],
+            "executionMode":"default"
           }
         }
       ]
@@ -104,7 +110,8 @@
             "outputTypes":["double"],
             "transformationFeatures":["data"],
             "statisticsArgumentNames":["data1"],
-            "dropped_argument_names":["data1"]
+            "dropped_argument_names":["data1"],
+            "executionMode":"default"
           }
         }
       ]

--- a/python/tests/test_hopswork_udf.py
+++ b/python/tests/test_hopswork_udf.py
@@ -18,7 +18,6 @@ from datetime import date, datetime, time
 
 import pandas as pd
 import pytest
-from hsfs import engine
 from hsfs.client.exceptions import FeatureStoreException
 from hsfs.hopsworks_udf import (
     HopsworksUdf,
@@ -864,7 +863,7 @@ def test_function():
         assert result.values.tolist() == [[2, 12], [3, 22], [4, 32], [5, 42]]
 
     def test_get_udf_spark_engine_default_mode_training(self, mocker):
-        engine._engine_type = "spark"
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
 
         @udf(return_type=int)
         def test(feature):
@@ -883,7 +882,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 0
 
     def test_get_udf_spark_engine_default_mode_inference(self, mocker):
-        engine._engine_type = "spark"
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
 
         @udf(return_type=int)
         def test(feature):
@@ -902,7 +901,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 1
 
     def test_get_udf_spark_engine_python_mode_training(self, mocker):
-        engine._engine_type = "spark"
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
 
         @udf(return_type=int, mode="python")
         def test(feature):
@@ -921,7 +920,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 1
 
     def test_get_udf_spark_engine_python_mode_inference(self, mocker):
-        engine._engine_type = "spark"
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
 
         @udf(return_type=int, mode="python")
         def test(feature):
@@ -940,7 +939,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 1
 
     def test_get_udf_spark_engine_pandas_mode_training(self, mocker):
-        engine._engine_type = "spark"
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
 
         @udf(return_type=int, mode="pandas")
         def test(feature):
@@ -959,7 +958,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 0
 
     def test_get_udf_spark_engine_pandas_mode_inference(self, mocker):
-        engine._engine_type = "spark"
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
 
         @udf(return_type=int, mode="pandas")
         def test(feature):
@@ -978,7 +977,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 0
 
     def test_get_udf_python_engine_default_mode_training(self, mocker):
-        engine._engine_type = "python"
+        mocker.patch("hsfs.engine.get_type", return_value="python")
 
         @udf(return_type=int)
         def test(feature):
@@ -997,7 +996,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 0
 
     def test_get_udf_python_engine_default_mode_inference(self, mocker):
-        engine._engine_type = "python"
+        mocker.patch("hsfs.engine.get_type", return_value="python")
 
         @udf(return_type=int)
         def test(feature):
@@ -1016,7 +1015,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 1
 
     def test_get_udf_python_engine_python_mode_training(self, mocker):
-        engine._engine_type = "python"
+        mocker.patch("hsfs.engine.get_type", return_value="python")
 
         @udf(return_type=int, mode="python")
         def test(feature):
@@ -1035,7 +1034,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 1
 
     def test_get_udf_python_engine_python_mode_inference(self, mocker):
-        engine._engine_type = "python"
+        mocker.patch("hsfs.engine.get_type", return_value="python")
 
         @udf(return_type=int, mode="python")
         def test(feature):
@@ -1054,7 +1053,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 1
 
     def test_get_udf_python_engine_pandas_mode_training(self, mocker):
-        engine._engine_type = "python"
+        mocker.patch("hsfs.engine.get_type", return_value="python")
 
         @udf(return_type=int, mode="pandas")
         def test(feature):
@@ -1073,7 +1072,7 @@ def test_function():
         assert python_wrapper_mocker.call_count == 0
 
     def test_get_udf_python_engine_pandas_mode_inference(self, mocker):
-        engine._engine_type = "python"
+        mocker.patch("hsfs.engine.get_type", return_value="python")
 
         @udf(return_type=int, mode="pandas")
         def test(feature):

--- a/python/tests/test_hopswork_udf.py
+++ b/python/tests/test_hopswork_udf.py
@@ -874,7 +874,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=False)
+        _ = test.get_udf(online=False)
 
         assert pandas_udf_mocker.call_count == 1
         assert python_udf_mocker.call_count == 0
@@ -893,7 +893,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=True)
+        _ = test.get_udf(online=True)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0
@@ -912,7 +912,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=False)
+        _ = test.get_udf(online=False)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 1
@@ -931,7 +931,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=True)
+        _ = test.get_udf(online=True)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0
@@ -950,7 +950,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=False)
+        _ = test.get_udf(online=False)
 
         assert pandas_udf_mocker.call_count == 1
         assert python_udf_mocker.call_count == 0
@@ -969,7 +969,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=True)
+        _ = test.get_udf(online=True)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0
@@ -988,7 +988,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=False)
+        _ = test.get_udf(online=False)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0
@@ -1007,7 +1007,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=True)
+        _ = test.get_udf(online=True)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0
@@ -1026,7 +1026,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=False)
+        _ = test.get_udf(online=False)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0
@@ -1045,7 +1045,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=True)
+        _ = test.get_udf(online=True)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0
@@ -1064,7 +1064,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=False)
+        _ = test.get_udf(online=False)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0
@@ -1083,7 +1083,7 @@ def test_function():
         pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
         python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
 
-        _ = test.get_udf(inference=True)
+        _ = test.get_udf(online=True)
 
         assert pandas_udf_mocker.call_count == 0
         assert python_udf_mocker.call_count == 0

--- a/python/tests/test_hopswork_udf.py
+++ b/python/tests/test_hopswork_udf.py
@@ -739,7 +739,7 @@ def test_function():
             return col1 + 1
 
         test_func.output_column_names = ["test_func_col1_"]
-        renaming_wrapper_function = test_func.hopsworksUdf_wrapper()
+        renaming_wrapper_function = test_func.pandas_udf_wrapper()
 
         result = renaming_wrapper_function(test_dataframe["col1"])
 
@@ -755,7 +755,7 @@ def test_function():
             "test_func_col1_col2_0",
             "test_func_col1_col2_1",
         ]
-        renaming_wrapper_function = test_func.hopsworksUdf_wrapper()
+        renaming_wrapper_function = test_func.pandas_udf_wrapper()
 
         test_dataframe = pd.DataFrame(
             {"column1": [1, 2, 3, 4], "column2": [10, 20, 30, 40]}

--- a/python/tests/test_hopswork_udf.py
+++ b/python/tests/test_hopswork_udf.py
@@ -18,11 +18,56 @@ from datetime import date, datetime, time
 
 import pandas as pd
 import pytest
+from hsfs import engine
 from hsfs.client.exceptions import FeatureStoreException
-from hsfs.hopsworks_udf import HopsworksUdf, TransformationFeature, udf
+from hsfs.hopsworks_udf import (
+    HopsworksUdf,
+    TransformationFeature,
+    UDFExecutionMode,
+    udf,
+)
 
 
 class TestHopsworksUdf:
+    def test_udf_creation_invalid_execution_mode(self):
+        with pytest.raises(FeatureStoreException) as exception:
+
+            @udf(return_type=int, mode="invalid")
+            def test(feature):
+                pass
+
+        assert (
+            str(exception.value)
+            == "Ivalid execution mode `invalid` for UDF. Please use `default`, `python` or `pandas` instead."
+        )
+
+    def test_udf_creation_default_execution_mode(self):
+        @udf(return_type=int)
+        def test(feature):
+            pass
+
+        assert test.execution_mode == UDFExecutionMode.DEFAULT
+
+        @udf(return_type=int, mode="default")
+        def test1(feature):
+            pass
+
+        assert test1.execution_mode == UDFExecutionMode.DEFAULT
+
+    def test_udf_creation_python_execution_mode(self):
+        @udf(return_type=int, mode="python")
+        def test(feature):
+            pass
+
+        assert test.execution_mode == UDFExecutionMode.PYTHON
+
+    def test_udf_creation_pandas_execution_mode(self):
+        @udf(return_type=int, mode="pandas")
+        def test(feature):
+            pass
+
+        assert test.execution_mode == UDFExecutionMode.PANDAS
+
     def test_validate_and_convert_output_types_one_elements(self):
         assert HopsworksUdf._validate_and_convert_output_types([int]) == ["bigint"]
 
@@ -731,7 +776,7 @@ def test_function():
             == "`test_func_col1_0` bigint, `test_func_col1_1` double, `test_func_col1_2` string, `test_func_col1_3` date, `test_func_col1_4` timestamp, `test_func_col1_5` timestamp, `test_func_col1_6` boolean"
         )
 
-    def test_hopsworks_wrapper_single_output(self):
+    def test_pandas_udf_wrapper_single_output(self):
         test_dataframe = pd.DataFrame({"col1": [1, 2, 3, 4]})
 
         @udf(int)
@@ -746,7 +791,23 @@ def test_function():
         assert result.name == "test_func_col1_"
         assert result.values.tolist() == [2, 3, 4, 5]
 
-    def test_hopsworks_wrapper_multiple_output(self):
+    def test_python_udf_wrapper_single_output(self):
+        test_dataframe = pd.DataFrame({"col1": [1, 2, 3, 4]})
+
+        @udf(int)
+        def test_func(col1):
+            return col1 + 1
+
+        test_func.output_column_names = ["test_func_col1_"]
+        wrapper_function = test_func.python_udf_wrapper(rename_outputs=False)
+
+        result = test_dataframe.apply(
+            lambda x: wrapper_function(x["col1"]), axis=1, result_type="expand"
+        )
+
+        assert result.values.tolist() == [2, 3, 4, 5]
+
+    def test_pandas_udf_wrapper_multiple_output(self):
         @udf([int, float])
         def test_func(col1, col2):
             return pd.DataFrame({"out1": col1 + 1, "out2": col2 + 2})
@@ -767,6 +828,268 @@ def test_function():
 
         assert all(result.columns == ["test_func_col1_col2_0", "test_func_col1_col2_1"])
         assert result.values.tolist() == [[2, 12], [3, 22], [4, 32], [5, 42]]
+
+    def test_python_udf_wrapper_multiple_output(self):
+        @udf([int, float], mode="python")
+        def test_func(col1, col2):
+            return col1 + 1, col2 + 2
+
+        test_func.output_column_names = [
+            "test_func_col1_col2_0",
+            "test_func_col1_col2_1",
+        ]
+        wrapper_function = test_func.python_udf_wrapper(rename_outputs=False)
+
+        test_dataframe = pd.DataFrame(
+            {"column1": [1, 2, 3, 4], "column2": [10, 20, 30, 40]}
+        )
+
+        result = test_dataframe.apply(
+            lambda x: wrapper_function(x["column1"], x["column2"]),
+            axis=1,
+            result_type="expand",
+        )
+
+        assert result.values.tolist() == [[2, 12], [3, 22], [4, 32], [5, 42]]
+
+        renaming_wrapper_function = test_func.python_udf_wrapper(rename_outputs=True)
+
+        result = test_dataframe.apply(
+            lambda x: renaming_wrapper_function(x["column1"], x["column2"]),
+            axis=1,
+            result_type="expand",
+        )
+
+        assert all(result.columns == ["test_func_col1_col2_0", "test_func_col1_col2_1"])
+        assert result.values.tolist() == [[2, 12], [3, 22], [4, 32], [5, 42]]
+
+    def test_get_udf_spark_engine_default_mode_training(self, mocker):
+        engine._engine_type = "spark"
+
+        @udf(return_type=int)
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=False)
+
+        assert pandas_udf_mocker.call_count == 1
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 1
+        assert python_wrapper_mocker.call_count == 0
+
+    def test_get_udf_spark_engine_default_mode_inference(self, mocker):
+        engine._engine_type = "spark"
+
+        @udf(return_type=int)
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=True)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 0
+        assert python_wrapper_mocker.call_count == 1
+
+    def test_get_udf_spark_engine_python_mode_training(self, mocker):
+        engine._engine_type = "spark"
+
+        @udf(return_type=int, mode="python")
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=False)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 1
+        assert pandas_wrapper_mocker.call_count == 0
+        assert python_wrapper_mocker.call_count == 1
+
+    def test_get_udf_spark_engine_python_mode_inference(self, mocker):
+        engine._engine_type = "spark"
+
+        @udf(return_type=int, mode="python")
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=True)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 0
+        assert python_wrapper_mocker.call_count == 1
+
+    def test_get_udf_spark_engine_pandas_mode_training(self, mocker):
+        engine._engine_type = "spark"
+
+        @udf(return_type=int, mode="pandas")
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=False)
+
+        assert pandas_udf_mocker.call_count == 1
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 1
+        assert python_wrapper_mocker.call_count == 0
+
+    def test_get_udf_spark_engine_pandas_mode_inference(self, mocker):
+        engine._engine_type = "spark"
+
+        @udf(return_type=int, mode="pandas")
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=True)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 1
+        assert python_wrapper_mocker.call_count == 0
+
+    def test_get_udf_python_engine_default_mode_training(self, mocker):
+        engine._engine_type = "python"
+
+        @udf(return_type=int)
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=False)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 1
+        assert python_wrapper_mocker.call_count == 0
+
+    def test_get_udf_python_engine_default_mode_inference(self, mocker):
+        engine._engine_type = "python"
+
+        @udf(return_type=int)
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=True)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 0
+        assert python_wrapper_mocker.call_count == 1
+
+    def test_get_udf_python_engine_python_mode_training(self, mocker):
+        engine._engine_type = "python"
+
+        @udf(return_type=int, mode="python")
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=False)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 0
+        assert python_wrapper_mocker.call_count == 1
+
+    def test_get_udf_python_engine_python_mode_inference(self, mocker):
+        engine._engine_type = "python"
+
+        @udf(return_type=int, mode="python")
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=True)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 0
+        assert python_wrapper_mocker.call_count == 1
+
+    def test_get_udf_python_engine_pandas_mode_training(self, mocker):
+        engine._engine_type = "python"
+
+        @udf(return_type=int, mode="pandas")
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=False)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 1
+        assert python_wrapper_mocker.call_count == 0
+
+    def test_get_udf_python_engine_pandas_mode_inference(self, mocker):
+        engine._engine_type = "python"
+
+        @udf(return_type=int, mode="pandas")
+        def test(feature):
+            pass
+
+        pandas_udf_mocker = mocker.patch("pyspark.sql.functions.pandas_udf")
+        python_udf_mocker = mocker.patch("pyspark.sql.functions.udf")
+        pandas_wrapper_mocker = mocker.patch.object(test, "pandas_udf_wrapper")
+        python_wrapper_mocker = mocker.patch.object(test, "python_udf_wrapper")
+
+        _ = test.get_udf(inference=True)
+
+        assert pandas_udf_mocker.call_count == 0
+        assert python_udf_mocker.call_count == 0
+        assert pandas_wrapper_mocker.call_count == 1
+        assert python_wrapper_mocker.call_count == 0
 
     def test_HopsworkUDf_call_one_argument(self):
         @udf(int)


### PR DESCRIPTION
This PR adds support for 
- Python UDF's in transformation functions as discussed in design document (https://hopsworks.atlassian.net/wiki/spaces/FST/pages/555221020/Python+UDF+and+Pandas+UDF+s+in+Transformation+Functions).
- Adds support for overwriting features with transformed features for one-to-one and many-to-one transformations. A feature would be overwritten with the transformed feature if the transformation function name matches any of the features passed as input to the transformation function. This is only supported for transformation function returning one transformed features.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1507

Priority for Review: -

Related PRs: 
https://github.com/logicalclocks/hopsworks-ee/pull/1950
https://github.com/logicalclocks/loadtest/pull/453

**How Has This Been Tested?**

- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
