### PR TITLE
[FSTORE-471][APPEND]  Allow transformation functions for label features

### DIFF
--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -190,14 +190,16 @@ class FeatureViewEngine:
             return self._feature_view_api.delete_by_name(name)
 
     def get_training_dataset_schema(
-        self, feature_view: FeatureView, training_dataset_version: int
+        self, feature_view: FeatureView, training_dataset_version: Optional[int] = None
     ):
         """
         Function that returns the schema of the training dataset generated using the feature view.
 
         # Arguments
             feature_view: `FeatureView`. The feature view for which the schema is to be generated.
-            training_dataset_version: `int`. Version of the training dataset for which the schema is to be generated.
+            training_dataset_version: `int`. Specifies the version of the training dataset for which the schema should be generated.
+                By default, this is set to None. However, if the `one_hot_encoder` transformation function is used, the training dataset version must be provided.
+                This is because the schema will then depend on the statistics of the training data used.
 
         # Returns
             `List[training_dataset_feature.TrainingDatasetFeature]`: List of training dataset features objects.
@@ -223,6 +225,11 @@ class FeatureViewEngine:
             )
 
             if statistics_required:
+                if not training_dataset_version:
+                    raise FeatureStoreException(
+                        "The feature view includes the one_hot_encoder transformation function. As a result, the schema of the generated training dataset depends on its statistics. Please specify the version of the training dataset for which the schema should be generated."
+                    )
+
                 # Get transformation functions with correct statistics based on training dataset version.
                 transformation_functions = self._transformation_function_engine.get_ready_to_use_transformation_fns(
                     feature_view=feature_view,

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -3845,15 +3845,16 @@ class FeatureView:
         }
 
     def get_training_dataset_schema(
-        self, training_dataset_version: bool
+        self, training_dataset_version: Optional[int] = None
     ) -> List[training_dataset_feature.TrainingDatasetFeature]:
         """
         Function that returns the schema of the training dataset that is generated from a feature view.
         It provides the schema of the features after all transformation functions have been applied.
 
         # Arguments
-            training_dataset_version: Version of the training dataset for which the schema is to be generated.
-
+            training_dataset_version: Specifies the version of the training dataset for which the schema should be generated.
+                By default, this is set to None. However, if the `one_hot_encoder` transformation function is used, the training dataset version must be provided.
+                This is because the schema will then depend on the statistics of the training data used.
         # Example
             ```python
             schema = feature_view.get_training_dataset_schema(training_dataset_version=1)


### PR DESCRIPTION
This PR fixes a bug introduces as part of PR https://github.com/logicalclocks/hopsworks-api/pull/296

**Issue:**
Training dataset materialization PySpark Job failing with the error. "No statistics available for initializing transformation functions. Training data can be created by `feature_view.create_training_data` or `feature_view.training_data`".

**Root Cause:**

- While materializing training dataset using PySpark Jobs, the metadata of the training dataset are created in the Python Client. Then using `hsfs_utils` the training dataset Spark Job is triggered. 
- Since the meta data is already created in the Python Client the spark Job calls get `_get_training_dataset_metadata` function which in turn calls `get_training_dataset_schema` function. 
- The `get_training_dataset_schema` function requires the training dataset to be materialized since for some cases statistics of the training data is required. Since in this particular case the training dataset is not materialized already it fails.

**Fix Done:**
Ensured that `get_training_dataset_schema` is only called after the training datasets are materialized.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-471

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
