### PR TITLE
[FSTORE-1530] Training Data Materialization using Arrowflight fails with PermissionError when a workflow test run as a Kubernetes Job

### DIFF
--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -29,7 +29,7 @@ import pyarrow._flight
 import pyarrow.flight
 from hopsworks_common import client
 from hopsworks_common.client.exceptions import FeatureStoreException
-from hsfs import feature_group, util
+from hsfs import feature_group
 from hsfs.constructor import query
 from hsfs.core.variable_api import VariableApi
 from hsfs.storage_connector import StorageConnector
@@ -444,9 +444,7 @@ class ArrowFlightClient:
         self, feature_view_obj, training_dataset_obj, query_obj, arrow_flight_config
     ):
         training_dataset = {}
-        training_dataset["fs_name"] = util.strip_feature_store_suffix(
-            training_dataset_obj.feature_store_name
-        )
+        training_dataset["project_name"] = self._client._project_name
         training_dataset["fv_name"] = feature_view_obj.name
         training_dataset["fv_version"] = feature_view_obj.version
         training_dataset["tds_version"] = training_dataset_obj.version


### PR DESCRIPTION
This PR fixes a issue in which training dataset materialization using Arrowflight was throwing a Permission Error

**Root Cause**
When trying to creating training dataset using Arrowflight a request is send from the python client to arrowflight that contains the feature store name along with other parameters. The feature store name is by default cast to into lower case letters before sending. 
Arrowflight then uses this feature store name to construct the path required to access the training dataset directory but the constructed path is incorrect because the feature store name has been casted to lower cases. 
So Arrowflight requests lock access for the parent directories (/Projectto create the provided path which gets rejected because it should not be able to access the directory.

**Fix Done**
Send the unformatted project name to the Arrowflight client during project creation.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1530

Priority for Review: -

Related PRs: https://github.com/logicalclocks/flyingduck/pull/83

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
