### PR TITLE
[FSTORE-1533] Importing hopsworks fails due to core dump while importing polars

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,5 +6,5 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hopsworks</artifactId>
-    <version>3.8.0-RC0</version>
+    <version>3.8.0-RC1</version>
 </project>

--- a/python/hopsworks/version.py
+++ b/python/hopsworks/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "3.8.0rc0"
+__version__ = "3.8.0rc1"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "hsfs[python]==3.8.0rc0",
+    "hsfs[python]==3.8.0rc1",
     "hsml==3.8.0rc0",
     "pyhumps==1.6.1",
     "requests",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "tqdm",
 ]
 
+polars=["polars>=0.20.18,<=0.21.0"]
+
 [project.optional-dependencies]
 dev = [ "ruff", "pytest"]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -33,10 +33,10 @@ dependencies = [
     "tqdm",
 ]
 
-polars=["polars>=0.20.18,<=0.21.0"]
 
 [project.optional-dependencies]
 dev = [ "ruff", "pytest"]
+polars=["polars>=0.20.18,<=0.21.0"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -9,3 +9,4 @@ markdown==3.6
 pymdown-extensions==10.7.1
 mkdocs-macros-plugin==1.0.4
 mkdocs-minify-plugin>=0.2.0
+polars==0.20.31


### PR DESCRIPTION
This PR fixes an issue in which hopworks is not importable because Polars throws a `Illegal instruction (core dumped)` due to AVX instructions being unavailable.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1533

Priority for Review: -

Related PRs: 
https://github.com/logicalclocks/feature-store-api/pull/1379
https://github.com/logicalclocks/loadtest/pull/454

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
