### PR TITLE
[FSTORE-1533] Importing hopsworks fails due to core dump while importing polars

### DIFF
--- a/python/hopsworks_common/core/constants.py
+++ b/python/hopsworks_common/core/constants.py
@@ -49,9 +49,9 @@ HAS_NUMPY: bool = importlib.util.find_spec("numpy") is not None
 HAS_POLARS: bool = importlib.util.find_spec("polars") is not None
 polars_not_installed_message = (
     "Polars package not found. "
-    "If you want to use Polars with Hopsworks you can install the corresponding extras "
-    """`pip install hopsworks[polars]` or `pip install "hopsworks[polars]"` if using zsh. """
-    "You can also install polars directly in your environment e.g `pip install polars`. "
+    "If you want to use Polars with Hopsworks you can install the corresponding extra via "
+    """'`pip install "hopsworks[polars]"`. '"""
+    "You can also install polars directly in your environment with `pip install polars`. "
     "You will need to restart your kernel if applicable."
 )
 

--- a/python/hopsworks_common/core/constants.py
+++ b/python/hopsworks_common/core/constants.py
@@ -47,6 +47,13 @@ HAS_ARROW: bool = importlib.util.find_spec("pyarrow") is not None
 HAS_PANDAS: bool = importlib.util.find_spec("pandas") is not None
 HAS_NUMPY: bool = importlib.util.find_spec("numpy") is not None
 HAS_POLARS: bool = importlib.util.find_spec("polars") is not None
+polars_not_installed_message = (
+    "Polars package not found. "
+    "If you want to use Polars with Hopsworks you can install the corresponding extras "
+    """`pip install hopsworks[polars]` or `pip install "hopsworks[polars]"` if using zsh. """
+    "You can also install polars directly in your environment e.g `pip install polars`. "
+    "You will need to restart your kernel if applicable."
+)
 
 # SQL packages
 HAS_SQLALCHEMY: bool = importlib.util.find_spec("sqlalchemy") is not None

--- a/python/hopsworks_common/core/type_systems.py
+++ b/python/hopsworks_common/core/type_systems.py
@@ -26,8 +26,8 @@ from hopsworks_common.core.constants import (
     HAS_ARROW,
     HAS_PANDAS,
     HAS_POLARS,
-    polars_not_installed_message,
 )
+from hopsworks_common.decorators import uses_polars
 
 
 if TYPE_CHECKING:
@@ -200,12 +200,10 @@ def cast_pandas_column_to_offline_type(
             return feature_column  # handle gracefully, just return the column as-is
 
 
+@uses_polars
 def cast_polars_column_to_offline_type(
     feature_column: pl.Series, offline_type: str
 ) -> pl.Series:
-    if not HAS_POLARS:
-        raise ModuleNotFoundError(polars_not_installed_message)
-
     offline_type = offline_type.lower()
     if offline_type == "timestamp":
         # convert (if tz!=UTC) to utc, then make timezone unaware
@@ -240,10 +238,7 @@ def cast_column_to_offline_type(
 ) -> pd.Series:
     if isinstance(feature_column, pd.Series):
         return cast_pandas_column_to_offline_type(feature_column, offline_type.lower())
-    elif isinstance(feature_column, pl.Series):
-        if not HAS_POLARS:
-            raise ModuleNotFoundError(polars_not_installed_message)
-
+    elif HAS_POLARS and isinstance(feature_column, pl.Series):
         return cast_polars_column_to_offline_type(feature_column, offline_type.lower())
 
 

--- a/python/hopsworks_common/core/type_systems.py
+++ b/python/hopsworks_common/core/type_systems.py
@@ -22,7 +22,12 @@ import decimal
 from typing import TYPE_CHECKING, Literal, Union
 
 import pytz
-from hopsworks_common.core.constants import HAS_ARROW, HAS_PANDAS, HAS_POLARS
+from hopsworks_common.core.constants import (
+    HAS_ARROW,
+    HAS_PANDAS,
+    HAS_POLARS,
+    polars_not_installed_message,
+)
 
 
 if TYPE_CHECKING:
@@ -198,6 +203,9 @@ def cast_pandas_column_to_offline_type(
 def cast_polars_column_to_offline_type(
     feature_column: pl.Series, offline_type: str
 ) -> pl.Series:
+    if not HAS_POLARS:
+        raise ModuleNotFoundError(polars_not_installed_message)
+
     offline_type = offline_type.lower()
     if offline_type == "timestamp":
         # convert (if tz!=UTC) to utc, then make timezone unaware
@@ -233,6 +241,9 @@ def cast_column_to_offline_type(
     if isinstance(feature_column, pd.Series):
         return cast_pandas_column_to_offline_type(feature_column, offline_type.lower())
     elif isinstance(feature_column, pl.Series):
+        if not HAS_POLARS:
+            raise ModuleNotFoundError(polars_not_installed_message)
+
         return cast_polars_column_to_offline_type(feature_column, offline_type.lower())
 
 

--- a/python/hopsworks_common/decorators.py
+++ b/python/hopsworks_common/decorators.py
@@ -21,7 +21,9 @@ import os
 
 from hopsworks_common.core.constants import (
     HAS_GREAT_EXPECTATIONS,
+    HAS_POLARS,
     great_expectations_not_installed_message,
+    polars_not_installed_message,
 )
 
 
@@ -81,6 +83,16 @@ def uses_great_expectations(f):
     def g(*args, **kwds):
         if not HAS_GREAT_EXPECTATIONS:
             raise ModuleNotFoundError(great_expectations_not_installed_message)
+        return f(*args, **kwds)
+
+    return g
+
+
+def uses_polars(f):
+    @functools.wraps(f)
+    def g(*args, **kwds):
+        if not HAS_POLARS:
+            raise ModuleNotFoundError(polars_not_installed_message)
         return f(*args, **kwds)
 
     return g

--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -23,18 +23,22 @@ import warnings
 from functools import wraps
 from typing import Any, Dict, Optional, Union
 
-import polars as pl
 import pyarrow
 import pyarrow._flight
 import pyarrow.flight
 from hopsworks_common import client
 from hopsworks_common.client.exceptions import FeatureStoreException
+from hopsworks_common.core.constants import HAS_POLARS, polars_not_installed_message
 from hsfs import feature_group
 from hsfs.constructor import query
 from hsfs.core.variable_api import VariableApi
 from hsfs.storage_connector import StorageConnector
 from pyarrow.flight import FlightServerError
 from retrying import retry
+
+
+if HAS_POLARS:
+    import polars as pl
 
 
 _logger = logging.getLogger(__name__)
@@ -397,6 +401,8 @@ class ArrowFlightClient:
         reader = self._connection.do_get(info.endpoints[0].ticket, options)
         _logger.debug("Dataset fetched. Converting to dataframe %s.", dataframe_type)
         if dataframe_type.lower() == "polars":
+            if not HAS_POLARS:
+                raise ModuleNotFoundError(polars_not_installed_message)
             return pl.from_arrow(reader.read_all())
         else:
             return reader.read_pandas()

--- a/python/hsfs/core/transformation_function_engine.py
+++ b/python/hsfs/core/transformation_function_engine.py
@@ -15,12 +15,15 @@
 #
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set, TypeVar, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, TypeVar, Union
 
 import pandas as pd
-import polars as pl
 from hsfs import feature_view, statistics, training_dataset, transformation_function
 from hsfs.core import transformation_function_api
+
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 class TransformationFunctionEngine:

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -52,11 +52,11 @@ import boto3
 import hsfs
 import numpy as np
 import pandas as pd
-import polars as pl
 import pyarrow as pa
 from botocore.response import StreamingBody
 from hopsworks_common import client
 from hopsworks_common.client.exceptions import FeatureStoreException
+from hopsworks_common.core.constants import HAS_POLARS, polars_not_installed_message
 from hsfs import (
     feature,
     feature_view,
@@ -108,6 +108,9 @@ if HAS_SQLALCHEMY:
 
 if HAS_PANDAS:
     from hsfs.core.type_systems import convert_pandas_dtype_to_offline_type
+
+if HAS_POLARS:
+    import polars as pl
 
 _logger = logging.getLogger(__name__)
 
@@ -214,6 +217,8 @@ class Engine:
             if "sqlalchemy" in str(type(mysql_conn)):
                 sql_query = sql.text(sql_query)
             if dataframe_type.lower() == "polars":
+                if not HAS_POLARS:
+                    raise ModuleNotFoundError(polars_not_installed_message)
                 result_df = pl.read_database(sql_query, mysql_conn)
             else:
                 result_df = pd.read_sql(sql_query, mysql_conn)
@@ -247,6 +252,8 @@ class Engine:
                 )
             )
         if dataframe_type.lower() == "polars":
+            if not HAS_POLARS:
+                raise ModuleNotFoundError(polars_not_installed_message)
             # Below check performed since some files materialized when creating training data are empty
             # If empty dataframe is in df_list then polars cannot concatenate df_list due to schema mismatch
             # However if the entire split contains only empty files which can occur when the data size is very small then one of the empty dataframe is return so that the column names can be accessed.
@@ -281,6 +288,8 @@ class Engine:
     def _read_polars(
         self, data_format: Literal["csv", "tsv", "parquet"], obj: Any
     ) -> pl.DataFrame:
+        if not HAS_POLARS:
+            raise ModuleNotFoundError(polars_not_installed_message)
         if data_format.lower() == "csv":
             return pl.read_csv(obj)
         elif data_format.lower() == "tsv":
@@ -454,6 +463,8 @@ class Engine:
         results = VectorDbClient.read_feature_group(feature_group, n)
         feature_names = [f.name for f in feature_group.features]
         if dataframe_type == "polars":
+            if not HAS_POLARS:
+                raise ModuleNotFoundError(polars_not_installed_message)
             df = pl.DataFrame(results, schema=feature_names)
         else:
             df = pd.DataFrame(results, columns=feature_names, index=None)
@@ -513,7 +524,9 @@ class Engine:
         exact_uniqueness: bool = True,
     ) -> str:
         # TODO: add statistics for correlations, histograms and exact_uniqueness
-        if isinstance(df, pl.DataFrame) or isinstance(df, pl.dataframe.frame.DataFrame):
+        if HAS_POLARS and (
+            isinstance(df, pl.DataFrame) or isinstance(df, pl.dataframe.frame.DataFrame)
+        ):
             arrow_schema = df.to_arrow().schema
         else:
             arrow_schema = pa.Schema.from_pandas(df, preserve_index=False)
@@ -526,8 +539,9 @@ class Engine:
                 or pa.types.is_large_list(field.type)
                 or pa.types.is_struct(field.type)
             ) and PYARROW_HOPSWORKS_DTYPE_MAPPING[field.type] in ["timestamp", "date"]:
-                if isinstance(df, pl.DataFrame) or isinstance(
-                    df, pl.dataframe.frame.DataFrame
+                if HAS_POLARS and (
+                    isinstance(df, pl.DataFrame)
+                    or isinstance(df, pl.dataframe.frame.DataFrame)
                 ):
                     df = df.with_columns(pl.col(field.name).cast(pl.String))
                 else:
@@ -546,8 +560,9 @@ class Engine:
             stats[col] = df[col].describe().to_dict()
         final_stats = []
         for col in relevant_columns:
-            if isinstance(df, pl.DataFrame) or isinstance(
-                df, pl.dataframe.frame.DataFrame
+            if HAS_POLARS and (
+                isinstance(df, pl.DataFrame)
+                or isinstance(df, pl.dataframe.frame.DataFrame)
             ):
                 stats[col] = dict(zip(stats["statistic"], stats[col]))
             # set data type
@@ -632,8 +647,9 @@ class Engine:
     ) -> great_expectations.core.ExpectationSuiteValidationResult:
         # This conversion might cause a bottleneck in performance when using polars with greater expectations.
         # This patch is done becuase currently great_expecatations does not support polars, would need to be made proper when support added.
-        if isinstance(dataframe, pl.DataFrame) or isinstance(
-            dataframe, pl.dataframe.frame.DataFrame
+        if HAS_POLARS and (
+            isinstance(dataframe, pl.DataFrame)
+            or isinstance(dataframe, pl.dataframe.frame.DataFrame)
         ):
             warnings.warn(
                 "Currently Great Expectations does not support Polars dataframes. This operation will convert to Pandas dataframe that can be slow.",
@@ -654,10 +670,12 @@ class Engine:
     def convert_to_default_dataframe(
         self, dataframe: Union[pd.DataFrame, pl.DataFrame, pl.dataframe.frame.DataFrame]
     ) -> Optional[pd.DataFrame]:
-        if (
-            isinstance(dataframe, pd.DataFrame)
-            or isinstance(dataframe, pl.DataFrame)
-            or isinstance(dataframe, pl.dataframe.frame.DataFrame)
+        if isinstance(dataframe, pd.DataFrame) or (
+            HAS_POLARS
+            and (
+                isinstance(dataframe, pl.DataFrame)
+                or isinstance(dataframe, pl.dataframe.frame.DataFrame)
+            )
         ):
             upper_case_features = [
                 col for col in dataframe.columns if any(re.finditer("[A-Z]", col))
@@ -700,7 +718,7 @@ class Engine:
                     dataframe_copy[col].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
                 ):
                     dataframe_copy[col] = dataframe_copy[col].dt.tz_convert(None)
-                elif isinstance(dataframe_copy[col].dtype, pl.Datetime):
+                elif HAS_POLARS and isinstance(dataframe_copy[col].dtype, pl.Datetime):
                     dataframe_copy = dataframe_copy.with_columns(
                         pl.col(col).dt.replace_time_zone(None)
                     )
@@ -725,8 +743,10 @@ class Engine:
                 feature_type_map[_feature.name] = _feature.type
         if isinstance(dataframe, pd.DataFrame):
             arrow_schema = pa.Schema.from_pandas(dataframe, preserve_index=False)
-        elif isinstance(dataframe, pl.DataFrame) or isinstance(
-            dataframe, pl.dataframe.frame.DataFrame
+        elif (
+            HAS_POLARS
+            and isinstance(dataframe, pl.DataFrame)
+            or isinstance(dataframe, pl.dataframe.frame.DataFrame)
         ):
             arrow_schema = dataframe.to_arrow().schema
         features = []
@@ -999,13 +1019,16 @@ class Engine:
             groups += [i] * int(df_size * split.percentage)
         groups += [len(splits) - 1] * (df_size - len(groups))
         random.shuffle(groups)
-        if isinstance(df, pl.DataFrame) or isinstance(df, pl.dataframe.frame.DataFrame):
+        if HAS_POLARS and (
+            isinstance(df, pl.DataFrame) or isinstance(df, pl.dataframe.frame.DataFrame)
+        ):
             df = df.with_columns(pl.Series(name=split_column, values=groups))
         else:
             df[split_column] = groups
         for i, split in enumerate(splits):
-            if isinstance(df, pl.DataFrame) or isinstance(
-                df, pl.dataframe.frame.DataFrame
+            if HAS_POLARS and (
+                isinstance(df, pl.DataFrame)
+                or isinstance(df, pl.dataframe.frame.DataFrame)
             ):
                 split_df = df.filter(pl.col(split_column) == i).drop(split_column)
             else:
@@ -1121,6 +1144,8 @@ class Engine:
         if dataframe_type.lower() in ["default", "pandas"]:
             return dataframe
         if dataframe_type.lower() == "polars":
+            if not HAS_POLARS:
+                raise ModuleNotFoundError(polars_not_installed_message)
             if not (
                 isinstance(dataframe, pl.DataFrame) or isinstance(dataframe, pl.Series)
             ):
@@ -1220,8 +1245,9 @@ class Engine:
         """
         dropped_features = set()
 
-        if isinstance(dataset, pl.DataFrame) or isinstance(
-            dataset, pl.dataframe.frame.DataFrame
+        if HAS_POLARS and (
+            isinstance(dataset, pl.DataFrame)
+            or isinstance(dataset, pl.dataframe.frame.DataFrame)
         ):
             # Converting polars dataframe to pandas because currently we support only pandas UDF's as transformation functions.
             if HAS_ARROW:

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -57,6 +57,7 @@ from botocore.response import StreamingBody
 from hopsworks_common import client
 from hopsworks_common.client.exceptions import FeatureStoreException
 from hopsworks_common.core.constants import HAS_POLARS, polars_not_installed_message
+from hopsworks_common.decorators import uses_great_expectations, uses_polars
 from hsfs import (
     feature,
     feature_view,
@@ -88,7 +89,6 @@ from hsfs.core.constants import (
     HAS_SQLALCHEMY,
 )
 from hsfs.core.vector_db_client import VectorDbClient
-from hsfs.decorators import uses_great_expectations
 from hsfs.feature_group import ExternalFeatureGroup, FeatureGroup
 from hsfs.training_dataset import TrainingDataset
 from hsfs.training_dataset_feature import TrainingDatasetFeature
@@ -285,6 +285,7 @@ class Engine:
                 )
             )
 
+    @uses_polars
     def _read_polars(
         self, data_format: Literal["csv", "tsv", "parquet"], obj: Any
     ) -> pl.DataFrame:

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -36,13 +36,13 @@ from typing import (
 
 if TYPE_CHECKING:
     import great_expectations
+    import polars as pl
 
 import avro.schema
 import hsfs.expectation_suite
 import humps
 import numpy as np
 import pandas as pd
-import polars as pl
 from hopsworks_common.client.exceptions import FeatureStoreException, RestAPIError
 from hsfs import (
     engine,

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -36,7 +36,6 @@ from typing import (
 
 if TYPE_CHECKING:
     import great_expectations
-    import polars as pl
 
 import avro.schema
 import hsfs.expectation_suite
@@ -44,6 +43,7 @@ import humps
 import numpy as np
 import pandas as pd
 from hopsworks_common.client.exceptions import FeatureStoreException, RestAPIError
+from hopsworks_common.core.constants import HAS_POLARS
 from hsfs import (
     engine,
     feature,
@@ -103,6 +103,9 @@ if HAS_GREAT_EXPECTATIONS:
 
 if HAS_CONFLUENT_KAFKA:
     import confluent_kafka
+
+if HAS_POLARS:
+    import polars as pl
 
 
 _logger = logging.getLogger(__name__)

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 import humps
 import numpy as np
 import pandas as pd
+from hopsworks_common.core.constants import HAS_POLARS
 from hsfs import (
     expectation_suite,
     feature,
@@ -52,7 +53,7 @@ from hsfs.statistics_config import StatisticsConfig
 from hsfs.transformation_function import TransformationFunction
 
 
-if TYPE_CHECKING:
+if HAS_POLARS:
     import polars as pl
 
 

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -18,12 +18,11 @@ from __future__ import annotations
 
 import datetime
 import warnings
-from typing import Any, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
 
 import humps
 import numpy as np
 import pandas as pd
-import polars as pl
 from hsfs import (
     expectation_suite,
     feature,
@@ -51,6 +50,10 @@ from hsfs.hopsworks_udf import HopsworksUdf
 from hsfs.online_config import OnlineConfig
 from hsfs.statistics_config import StatisticsConfig
 from hsfs.transformation_function import TransformationFunction
+
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 @typechecked

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -76,25 +76,22 @@ from hsfs.transformation_function import TransformationFunction, TransformationT
 from hsml.model import Model
 
 
+TrainingDatasetDataFrameTypes = Union[
+    pd.DataFrame,
+    TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
+    TypeVar("pyspark.RDD"),  # noqa: F821
+    np.ndarray,
+    List[List[Any]],
+]
+
 if HAS_POLARS:
     import polars as pl
 
     TrainingDatasetDataFrameTypes = Union[
-        pd.DataFrame,
-        TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
-        TypeVar("pyspark.RDD"),  # noqa: F821
-        np.ndarray,
-        List[List[Any]],
+        TrainingDatasetDataFrameTypes,
         pl.DataFrame,
     ]
-else:
-    TrainingDatasetDataFrameTypes = Union[
-        pd.DataFrame,
-        TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
-        TypeVar("pyspark.RDD"),  # noqa: F821
-        np.ndarray,
-        List[List[Any]],
-    ]
+
 
 SplineDataFrameTypes = Union[
     pd.DataFrame,

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -20,6 +20,7 @@ import logging
 import warnings
 from datetime import date, datetime
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -35,7 +36,6 @@ from typing import (
 import humps
 import numpy as np
 import pandas as pd
-import polars as pl
 from hopsworks_common.client.exceptions import FeatureStoreException
 from hsfs import (
     feature_group,
@@ -76,25 +76,29 @@ from hsfs.transformation_function import TransformationFunction, TransformationT
 from hsml.model import Model
 
 
+if TYPE_CHECKING:
+    import polars as pl
+
+    TrainingDatasetDataFrameTypes = Union[
+        pd.DataFrame,
+        TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
+        TypeVar("pyspark.RDD"),  # noqa: F821
+        np.ndarray,
+        List[List[Any]],
+        pl.DataFrame,
+    ]
+
+    SplineDataFrameTypes = Union[
+        pd.DataFrame,
+        TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
+        TypeVar("pyspark.RDD"),  # noqa: F821
+        np.ndarray,
+        List[List[Any]],
+        TypeVar("SplineGroup"),  # noqa: F821
+    ]
+
+
 _logger = logging.getLogger(__name__)
-
-TrainingDatasetDataFrameTypes = Union[
-    pd.DataFrame,
-    TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
-    TypeVar("pyspark.RDD"),  # noqa: F821
-    np.ndarray,
-    List[List[Any]],
-    pl.DataFrame,
-]
-
-SplineDataFrameTypes = Union[
-    pd.DataFrame,
-    TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
-    TypeVar("pyspark.RDD"),  # noqa: F821
-    np.ndarray,
-    List[List[Any]],
-    TypeVar("SplineGroup"),  # noqa: F821
-]
 
 
 @typechecked

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -20,7 +20,6 @@ import logging
 import warnings
 from datetime import date, datetime
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -37,6 +36,7 @@ import humps
 import numpy as np
 import pandas as pd
 from hopsworks_common.client.exceptions import FeatureStoreException
+from hopsworks_common.core.constants import HAS_POLARS
 from hsfs import (
     feature_group,
     storage_connector,
@@ -76,7 +76,7 @@ from hsfs.transformation_function import TransformationFunction, TransformationT
 from hsml.model import Model
 
 
-if TYPE_CHECKING:
+if HAS_POLARS:
     import polars as pl
 
     TrainingDatasetDataFrameTypes = Union[
@@ -87,15 +87,23 @@ if TYPE_CHECKING:
         List[List[Any]],
         pl.DataFrame,
     ]
-
-    SplineDataFrameTypes = Union[
+else:
+    TrainingDatasetDataFrameTypes = Union[
         pd.DataFrame,
         TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
         TypeVar("pyspark.RDD"),  # noqa: F821
         np.ndarray,
         List[List[Any]],
-        TypeVar("SplineGroup"),  # noqa: F821
     ]
+
+SplineDataFrameTypes = Union[
+    pd.DataFrame,
+    TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
+    TypeVar("pyspark.RDD"),  # noqa: F821
+    np.ndarray,
+    List[List[Any]],
+    TypeVar("SplineGroup"),  # noqa: F821
+]
 
 
 _logger = logging.getLogger(__name__)

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -21,17 +21,18 @@ import os
 import re
 import warnings
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 import humps
 import numpy as np
 import pandas as pd
 from hopsworks_common import client
+from hopsworks_common.core.constants import HAS_POLARS
 from hsfs import engine
 from hsfs.core import storage_connector_api
 
 
-if TYPE_CHECKING:
+if HAS_POLARS:
     import polars as pl
 
 _logger = logging.getLogger(__name__)

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -21,16 +21,18 @@ import os
 import re
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
 
 import humps
 import numpy as np
 import pandas as pd
-import polars as pl
 from hopsworks_common import client
 from hsfs import engine
 from hsfs.core import storage_connector_api
 
+
+if TYPE_CHECKING:
+    import polars as pl
 
 _logger = logging.getLogger(__name__)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "fsspec",
     "retrying",
     "hopsworks_aiomysql[sa]==0.2.1",
-    "polars>=0.20.18,<=0.21.0",
     "opensearch-py>=1.1.0,<=2.4.2",
     "tqdm",
     "grpcio>=1.49.1,<2.0.0",         # ^1.49.1
@@ -87,6 +86,7 @@ dev-pandas1 = [
     "sqlalchemy<=1.4.48",
 ]
 dev = ["hopsworks[dev-no-opt,great-expectations]"]
+polars=["polars>=0.20.18,<=0.21.0"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -85,7 +85,7 @@ dev-pandas1 = [
     "pandas<=1.5.3",
     "sqlalchemy<=1.4.48",
 ]
-dev = ["hopsworks[dev-no-opt,great-expectation,polars]"]
+dev = ["hopsworks[dev-no-opt,great-expectations,polars]"]
 polars=["polars>=0.20.18,<=0.21.0"]
 
 [build-system]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -85,7 +85,7 @@ dev-pandas1 = [
     "pandas<=1.5.3",
     "sqlalchemy<=1.4.48",
 ]
-dev = ["hopsworks[dev-no-opt,great-expectations]"]
+dev = ["hopsworks[dev-no-opt,great-expectation,polars]"]
 polars=["polars>=0.20.18,<=0.21.0"]
 
 [build-system]

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -19,9 +19,9 @@ from datetime import date, datetime
 import hopsworks_common
 import numpy as np
 import pandas as pd
-import polars as pl
 import pyarrow as pa
 import pytest
+from hopsworks_common.core.constants import HAS_POLARS
 from hsfs import (
     feature,
     feature_group,
@@ -39,7 +39,11 @@ from hsfs.engine import python
 from hsfs.expectation_suite import ExpectationSuite
 from hsfs.hopsworks_udf import udf
 from hsfs.training_dataset_feature import TrainingDatasetFeature
-from polars.testing import assert_frame_equal as polars_assert_frame_equal
+
+
+if HAS_POLARS:
+    import polars as pl
+    from polars.testing import assert_frame_equal as polars_assert_frame_equal
 
 
 hopsworks_common.connection._hsfs_engine_type = "python"
@@ -252,6 +256,10 @@ class TestPython:
         assert isinstance(dataframe, pd.DataFrame)
         assert len(dataframe) == 0
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_hopsfs_connector_empty_dataframe_polars(self, mocker):
         # Arrange
 
@@ -403,6 +411,10 @@ class TestPython:
         assert mock_pandas_read_csv.call_count == 0
         assert mock_pandas_read_parquet.call_count == 0
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_polars_csv(self, mocker):
         # Arrange
         mock_pandas_read_csv = mocker.patch("polars.read_csv")
@@ -417,6 +429,10 @@ class TestPython:
         assert mock_pandas_read_csv.call_count == 1
         assert mock_pandas_read_parquet.call_count == 0
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_polars_tsv(self, mocker):
         # Arrange
         mock_pandas_read_csv = mocker.patch("polars.read_csv")
@@ -431,6 +447,10 @@ class TestPython:
         assert mock_pandas_read_csv.call_count == 1
         assert mock_pandas_read_parquet.call_count == 0
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_polars_parquet(self, mocker):
         # Arrange
         mock_pandas_read_csv = mocker.patch("polars.read_csv")
@@ -448,6 +468,10 @@ class TestPython:
         assert mock_pandas_read_csv.call_count == 0
         assert mock_pandas_read_parquet.call_count == 1
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_polars_other(self, mocker):
         # Arrange
         mock_pandas_read_csv = mocker.patch("polars.read_csv")
@@ -885,6 +909,10 @@ class TestPython:
         )
         assert mock_python_engine_convert_pandas_statistics.call_count == 3
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_profile_polars(self, mocker):
         # Arrange
         mock_python_engine_convert_pandas_statistics = mocker.patch(
@@ -923,6 +951,10 @@ class TestPython:
         )
         assert mock_python_engine_convert_pandas_statistics.call_count == 3
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_profile_polars_with_null_column(self, mocker):
         # Arrange
         mock_python_engine_convert_pandas_statistics = mocker.patch(
@@ -1261,6 +1293,10 @@ class TestPython:
             "Feature names are sanitized to use underscore '_' in the feature store."
         )
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_convert_to_default_dataframe_polars(self, mocker):
         # Arrange
         mock_warnings = mocker.patch("warnings.warn")
@@ -1327,6 +1363,10 @@ class TestPython:
         assert result[0].name == "col1"
         assert result[1].name == "col2"
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_parse_schema_feature_group_polars(self, mocker):
         # Arrange
         mocker.patch("hsfs.core.type_systems.convert_pandas_dtype_to_offline_type")
@@ -1648,6 +1688,10 @@ class TestPython:
         assert isinstance(result_df, pd.DataFrame)
         assert result_df_split is None
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_split_labels_dataframe_type_polars(self):
         # Arrange
         python_engine = python.Engine()
@@ -1743,6 +1787,10 @@ class TestPython:
         assert isinstance(result_df, pd.DataFrame)
         assert isinstance(result_df_split, pd.Series)
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_split_labels_labels_dataframe_type_polars(self):
         # Arrange
         python_engine = python.Engine()
@@ -2416,6 +2464,10 @@ class TestPython:
         # Assert
         assert str(result) == "   col1  col2\n0     1     3\n1     2     4"
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_return_dataframe_type_polars(self):
         # Arrange
         python_engine = python.Engine()
@@ -2778,6 +2830,10 @@ class TestPython:
         assert result["plus_two_col1_col2_1"][0] == 12
         assert result["plus_two_col1_col2_1"][1] == 13
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_apply_transformation_function_polars(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,4 +8,5 @@ mkdocs-jupyter==0.24.3
 markdown==3.6
 pymdown-extensions==10.7.1
 mkdocs-macros-plugin==1.0.4
+polars==0.20.31
 mkdocs-minify-plugin>=0.2.0


### PR DESCRIPTION
This PR fixes an issue in which hopworks is not importable because Polars throws a "" due to AVX instructions being unavailable.

https://github.com/pola-rs/polars?tab=readme-ov-file#legacy 

Fix Done: 
Make polars a optional dependency. The changes being done resembles the changes done for 3.8 (https://github.com/logicalclocks/feature-store-api/pull/1379)


JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1533

Related PRs: 
https://github.com/logicalclocks/feature-store-api/pull/1379
https://github.com/logicalclocks/loadtest/pull/459
https://github.com/logicalclocks/docker-images/pull/437


**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
