### PR TITLE
[FSTORE-1540] Enforce releasing lock on mysql table after reading feature values from online store

### DIFF
--- a/python/hsfs/core/online_store_sql_engine.py
+++ b/python/hsfs/core/online_store_sql_engine.py
@@ -601,18 +601,16 @@ class OnlineStoreSqlClient:
                 for key in prepared_statements
             ]
             # Run the queries in parallel using asyncio.gather
-            results = await asyncio.gather(*tasks)
+            results = await asyncio.wait_for(
+                asyncio.gather(*tasks),
+                timeout=self.connection_options.get("query_timeout", 120),
+            )
         except asyncio.CancelledError as e:
             _logger.error(f"Failed executing prepared statements: {e}")
             raise e
-        finally:
-            # close connection pool
-            self._connection_pool.close()
-            try:
-                # await with timeout of 120 seconds
-                await asyncio.wait_for(self._connection_pool.wait_closed(), timeout=120)
-            except asyncio.TimeoutError as e:
-                _logger.error(f"Connection pool did not close within time limit: {e}")
+        except asyncio.TimeoutError as e:
+            _logger.error(f"Query timed out: {e}")
+            raise e
 
         # Create a dict of results with the prepared statement index as key
         results_dict = {}

--- a/python/hsfs/core/online_store_sql_engine.py
+++ b/python/hsfs/core/online_store_sql_engine.py
@@ -603,7 +603,9 @@ class OnlineStoreSqlClient:
             # Run the queries in parallel using asyncio.gather
             results = await asyncio.wait_for(
                 asyncio.gather(*tasks),
-                timeout=self.connection_options.get("query_timeout", 120),
+                timeout=self.connection_options.get("query_timeout", 120)
+                if self.connection_options
+                else 120,
             )
         except asyncio.CancelledError as e:
             _logger.error(f"Failed executing prepared statements: {e}")

--- a/python/hsfs/core/util_sql.py
+++ b/python/hsfs/core/util_sql.py
@@ -100,6 +100,9 @@ async def create_async_engine(
         else:
             hostname = url.host
 
+    if options is None:
+        options = {}
+
     # create a aiomysql connection pool
     pool = await async_create_engine(
         host=hostname,
@@ -108,12 +111,9 @@ async def create_async_engine(
         password=online_options["password"],
         db=url.database,
         loop=loop,
-        minsize=(
-            options.get("minsize", default_min_size) if options else default_min_size
-        ),
-        maxsize=(
-            options.get("maxsize", default_min_size) if options else default_min_size
-        ),
-        pool_recycle=(options.get("pool_recycle", -1) if options else -1),
+        minsize=options.get("minsize", default_min_size),
+        maxsize=options.get("maxsize", default_min_size),
+        pool_recycle=options.get("pool_recycle", -1),
+        autocommit=options.get("autocommit", True),
     )
     return pool


### PR DESCRIPTION
This PR aims to solve the issue caused by get_feature_vector locking the mysql table of the online store. By setting autocommit to false as default, connection were defaulting to repeated_read causing a lock on the underlying table, preventing deletion of the table and therefore the corresponding Feature Group.

This PR reverts the temporary hack closing connections on every call to unblock downstream tests.

This PR is intended to be minimal in scope to limit breaking existing code path. Further cleanup will be forthcoming

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
