### PR TITLE
[HWORKS-1620] Set hostname verification off by default in python client

### DIFF
--- a/python/hopsworks/__init__.py
+++ b/python/hopsworks/__init__.py
@@ -273,8 +273,8 @@ def login(
 
 def _handle_ssl_errors(ssl_e):
     raise HopsworksSSLClientError(
-        "Hopsworks certificate verification can be turned on by specifying hopsworks.login(hostname_verification=True) "
-        "or setting the environment variable HOPSWORKS_HOSTNAME_VERIFICATION='True'"
+        "Hopsworks certificate verification can be turned off by specifying hopsworks.login(hostname_verification=False) "
+        "or setting the environment variable HOPSWORKS_HOSTNAME_VERIFICATION='False'"
     ) from ssl_e
 
 

--- a/python/hopsworks/__init__.py
+++ b/python/hopsworks/__init__.py
@@ -81,7 +81,7 @@ def login(
     project: str = None,
     api_key_value: str = None,
     api_key_file: str = None,
-    hostname_verification: bool = True,
+    hostname_verification: bool = False,
     trust_store_path: str = None,
 ) -> project.Project:
     """Connect to [Serverless Hopsworks](https://app.hopsworks.ai) by calling the `hopsworks.login()` function with no arguments.
@@ -273,8 +273,8 @@ def login(
 
 def _handle_ssl_errors(ssl_e):
     raise HopsworksSSLClientError(
-        "Hopsworks certificate verification can be turned off by specifying hopsworks.login(hostname_verification=False) "
-        "or setting the environment variable HOPSWORKS_HOSTNAME_VERIFICATION='False'"
+        "Hopsworks certificate verification can be turned on by specifying hopsworks.login(hostname_verification=True) "
+        "or setting the environment variable HOPSWORKS_HOSTNAME_VERIFICATION='True'"
     ) from ssl_e
 
 


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
