### PR TITLE
[HWORKS-1565][APPEND] Make sure the spark program exits after completion

### DIFF
--- a/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
+++ b/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
@@ -132,15 +132,6 @@ public class MainClass {
       }
       if (!success) {
         System.exit(1);
-        LOGGER.info("Closing spark session...");
-        try {
-          SparkEngine.getInstance().closeSparkSession();
-        } catch (Exception e) {
-          LOGGER.error("Error closing spark session", e);
-        }
-        if (!success) {
-          System.exit(1);
-        }
       }
     }
     System.exit(0);

--- a/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
+++ b/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
@@ -121,8 +121,7 @@ public class MainClass {
         SparkEngine.getInstance().streamToHudiTable(streamFeatureGroup, writeOptions);
       }
       success = true;
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       e.printStackTrace();
     } finally {
       LOGGER.info("Closing spark session...");
@@ -146,5 +145,4 @@ public class MainClass {
     }
     System.exit(0);
   }
-}
 }

--- a/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
+++ b/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
@@ -121,6 +121,9 @@ public class MainClass {
         SparkEngine.getInstance().streamToHudiTable(streamFeatureGroup, writeOptions);
       }
       success = true;
+    }
+    catch (Exception e) {
+      e.printStackTrace();
     } finally {
       LOGGER.info("Closing spark session...");
       try {
@@ -130,8 +133,18 @@ public class MainClass {
       }
       if (!success) {
         System.exit(1);
+        LOGGER.info("Closing spark session...");
+        try {
+          SparkEngine.getInstance().closeSparkSession();
+        } catch (Exception e) {
+          LOGGER.error("Error closing spark session", e);
+        }
+        if (!success) {
+          System.exit(1);
+        }
       }
     }
     System.exit(0);
   }
+}
 }

--- a/utils/python/hsfs_utils.py
+++ b/utils/python/hsfs_utils.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from datetime import datetime
 from typing import Any, Dict
+import traceback
 
 import fsspec.implementations.arrow as pfs
 
@@ -304,6 +305,9 @@ if __name__ == "__main__":
             run_feature_monitoring(job_conf)
 
         success = True
+    except Exception:
+        # Printing stack trace of exception so that logs are not lost.
+        print(traceback.format_exc())
     finally:
         if spark is not None:
             try:


### PR DESCRIPTION
This PR fixes the issue in which exceptions are lost if a spark Job Fails.

Root Cause:
PR https://github.com/logicalclocks/hopsworks-api/pull/275 added a `system.exit(1)` to kill the Kubernetes pod in case of spark Job Failure. However this causes the exception logs to be lost since they are not re-raised after the finally block.

https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions

Fix Done: 
As a temporary fix the exceptions before calling System.exit(1). Jira ticket has been created for further investigation of the need for a System.exit

 
JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
