### PR TITLE
[FSTORE-1411][APPEND] On-Demand Transformations

### DIFF
--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -14,7 +14,6 @@
 #
 from __future__ import annotations
 
-import copy
 import warnings
 from typing import List
 
@@ -263,7 +262,7 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
     def _update_features_metadata(self, feature_group: fg.FeatureGroup, features):
         # perform changes on copy in case the update fails, so we don't leave
         # the user object in corrupted state
-        copy_feature_group: fg.FeatureGroup = copy.deepcopy(feature_group)
+        copy_feature_group = fg.FeatureGroup.from_response_json(feature_group.to_dict())
         copy_feature_group.features = features
         self._feature_group_api.update_metadata(
             feature_group, copy_feature_group, "updateMetadata"

--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -14,6 +14,7 @@
 #
 from __future__ import annotations
 
+import copy
 import warnings
 from typing import List
 
@@ -259,10 +260,10 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
             read_options,
         )
 
-    def _update_features_metadata(self, feature_group, features):
+    def _update_features_metadata(self, feature_group: fg.FeatureGroup, features):
         # perform changes on copy in case the update fails, so we don't leave
         # the user object in corrupted state
-        copy_feature_group = fg.FeatureGroup.from_response_json(feature_group.to_dict())
+        copy_feature_group: fg.FeatureGroup = copy.deepcopy(feature_group)
         copy_feature_group.features = features
         self._feature_group_api.update_metadata(
             feature_group, copy_feature_group, "updateMetadata"

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3554,7 +3554,9 @@ class FeatureGroup(FeatureGroupBase):
             "topicName": self.topic_name,
             "notificationTopicName": self.notification_topic_name,
             "deprecated": self.deprecated,
-            "transformationFunctions": self._transformation_functions,
+            "transformationFunctions": [
+                tf.to_dict() for tf in self._transformation_functions
+            ],
         }
         if self._online_config:
             fg_meta_dict["onlineConfig"] = self._online_config.to_dict()

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -315,7 +315,7 @@ class HopsworksUdf:
         except FileNotFoundError:
             module_imports = [""]
             warnings.warn(
-                "Cannot extract imported dependencies for the function module. Please make sure to import all dependencies for the UDF inside the function.",
+                "Cannot extract imported dependencies for the UDF from the module in which it is defined. Please make sure to import all dependencies for the UDF inside the function.",
                 stacklevel=2,
             )
 

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -657,7 +657,7 @@ def renaming_wrapper(*args):
                 dropped_feature.strip()
                 for dropped_feature in json_decamelized["dropped_argument_names"]
             ]
-            if "dropped_argument_names" in json_decamelized
+            if json_decamelized.get("dropped_argument_names", None)
             else None
         )
         transformation_function_argument_names = (
@@ -667,7 +667,7 @@ def renaming_wrapper(*args):
                     "transformation_function_argument_names"
                 ]
             ]
-            if "transformation_function_argument_names" in json_decamelized
+            if json_decamelized.get("transformation_function_argument_names", None)
             else None
         )
         statistics_features = (
@@ -675,7 +675,7 @@ def renaming_wrapper(*args):
                 feature.strip()
                 for feature in json_decamelized["statistics_argument_names"]
             ]
-            if "statistics_argument_names" in json_decamelized
+            if json_decamelized.get("statistics_argument_names", None)
             else None
         )
 

--- a/python/hsfs/transformation_function.py
+++ b/python/hsfs/transformation_function.py
@@ -227,7 +227,7 @@ class TransformationFunction:
             "id": self._id,
             "version": self._version,
             "featurestoreId": self._featurestore_id,
-            "hopsworksUdf": self._hopsworks_udf,
+            "hopsworksUdf": self._hopsworks_udf.to_dict(),
         }
 
     def _get_output_column_names(self) -> str:


### PR DESCRIPTION
This PR fixes an issue in which update `feature_group.update_feature_description` fails if the feature group has an on-demand transformation function.

**Root Cause:**

- The `update_feature_description` function creates a copy of the feature group with the function `FeaureGroup.from_response_json(feature_group.to_dict())`.
- However this does not convert the "_transformation_function_" in the feature group also to a dict making the feature group dictionary contain a class object for  "_transformation_function_". 
- This causes the `from_response_json` function to fail as it expects a dictionary of string elements.

**Fix Done:**
Use `deepcopy` to create the copy of the object

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
