### PR TITLE
[FSTORE-1567] Fix login error messages

### DIFF
--- a/python/hopsworks_common/connection.py
+++ b/python/hopsworks_common/connection.py
@@ -457,7 +457,8 @@ class Connection:
         """
         from hsfs import engine
 
-        OpenSearchClientSingleton().close()
+        if OpenSearchClientSingleton._instance:
+            OpenSearchClientSingleton().close()
         client.stop()
         engine.stop()
         self._feature_store_api = None


### PR DESCRIPTION
At the moment the last shown error is something like “client doesn’t have `_project_id`“, and to find the real cause of the error one has to scroll up to a REST error. The REST error should be shown as the last error instead (we should fail earlier).

JIRA Issue: FSTORE-1567

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
