### PR TITLE
[FSTORE-1576] Fix built-in transformation functions workflow test and Parallelize transformation function tests

### DIFF
--- a/python/hsfs/builtin_transformations.py
+++ b/python/hsfs/builtin_transformations.py
@@ -43,7 +43,7 @@ def robust_scaler(feature: pd.Series, statistics=feature_statistics) -> pd.Serie
     )
 
 
-@udf(int, drop=["feature"])
+@udf(int, drop=["feature"], mode="pandas")
 def label_encoder(feature: pd.Series, statistics=feature_statistics) -> pd.Series:
     unique_data = sorted([value for value in statistics.feature.unique_values])
     value_to_index = {value: index for index, value in enumerate(unique_data)}
@@ -56,7 +56,7 @@ def label_encoder(feature: pd.Series, statistics=feature_statistics) -> pd.Serie
     )
 
 
-@udf(bool, drop=["feature"])
+@udf(bool, drop=["feature"], mode="pandas")
 def one_hot_encoder(feature: pd.Series, statistics=feature_statistics) -> pd.Series:
     unique_data = [value for value in statistics.feature.unique_values]
 


### PR DESCRIPTION
This PR fixes the `build_in_transformation_functions` load test. 

**Issue:**
- The test was failing with an assertion error when validating values of `train_test_split` because of `Null` values being re turned when the `label_encoder` transformation function was being used.
- Label Encoder and One-hot encoder were decided to be left as `pandas_udf` since they were too complex to be implemented as python functions. However, the execution mode of built-in function isn the `hopsworks-api` was not set correctly. 

**Root Cause:**
When a train test split is created using a random split the training and test dataset created would have their index shuffled. When an input Series is provided to the transformation function it would have the same index as the train/test DataFrame. 

However the `label_encoder` transformation function creates a new pandas series from the input pandas Series, which would cause the transformed Series to have indexes different from the input Series and the train/test Dataframe. 

Pandas tries to align the rows based on index when assigning a Pandas Series to a Pandas Dataframe. Since the transformed output have a different output Pandas when align rows it causing inconsistencies.

**Fix Done:**

- Copied the index of the train/test dataframe to the transformed outputs before assigning it back to the actual dataframe. This fix is similar to the fix done in PR : https://github.com/logicalclocks/hopsworks-api/pull/252/files. This code portion was changed as part if PR : https://github.com/logicalclocks/hopsworks-api/pull/300, which missed out adding this check.
- Corrected execution mode for `one_hot_encoder` and `label_encoder`

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1576

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
