### PR TITLE
[FSTORE-1606] Allow ´entries´ to be None while retrieving feature vectors from a feature view with only on-demand features

### DIFF
--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -416,8 +416,9 @@ class VectorServer:
             request_parameters is None
             or len(request_parameters) == 0
             or isinstance(request_parameters, dict)
-            or (not entries or (entries and len(request_parameters) == len(entries)))
-        ), "Request Parameters should be a Dictionary, None, empty or have the same length as the entries when entires is not None or empty."
+            or not entries
+            or len(request_parameters) == len(entries)
+        ), "Request Parameters should be a Dictionary, None, empty or have the same length as the entries if they are not None or empty."
 
         online_client_choice = self.which_client_and_ensure_initialised(
             force_rest_client=force_rest_client, force_sql_client=force_sql_client
@@ -1611,7 +1612,7 @@ class VectorServer:
 
     @property
     def _all_features_on_demand(self) -> bool:
-        """True if all features in the feature view is on-demand."""
+        """True if all features in the feature view are on-demand."""
         if self.__all_features_on_demand is None:
             self.__all_features_on_demand = all(
                 feature.on_demand_transformation_function for feature in self._features

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -520,7 +520,7 @@ class FeatureView:
 
     def get_feature_vector(
         self,
-        entry: Dict[str, Any],
+        entry: Optional[Dict[str, Any]] = None,
         passed_features: Optional[Dict[str, Any]] = None,
         external: Optional[bool] = None,
         return_type: Literal["list", "polars", "numpy", "pandas"] = "list",
@@ -635,7 +635,7 @@ class FeatureView:
 
     def get_feature_vectors(
         self,
-        entry: List[Dict[str, Any]],
+        entry: Optional[List[Dict[str, Any]]] = None,
         passed_features: Optional[List[Dict[str, Any]]] = None,
         external: Optional[bool] = None,
         return_type: Literal["list", "polars", "numpy", "pandas"] = "list",


### PR DESCRIPTION
This PR fixes an issue in which dummy data needs to be provided using `entires` to the function `get_feature_vector` while retrieving feature vectors from a feature view with only on-demand features. 

**Issue:**
User have to always provide `entires` in the function `get_feature_vector` when reading feature vectors from a feature view. 

In the use case in which a feature view contains only on-demand features,  all features are computed while retrieving feature vectors using provided request parameter. Hence `entries` is not a mandatory parameter.

**Fix Done:**
Made `entries` into an optional parameter in cases where the feature view contains only on-demand features.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1606

Priority for Review: -

Related PRs: https://github.com/logicalclocks/loadtest/pull/485

**How Has This Been Tested?**

- [ ] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
