### PR TITLE
[HWORKS-1839] Create fv in master code

### DIFF
--- a/locust_benchmark/create_feature_group.py
+++ b/locust_benchmark/create_feature_group.py
@@ -4,4 +4,5 @@ if __name__ == "__main__":
     hopsworks_client = HopsworksClient()
     fg = hopsworks_client.get_or_create_fg()
     hopsworks_client.insert_data(fg)
+    hopsworks_client.get_or_create_fv()
     hopsworks_client.close()


### PR DESCRIPTION
Creates the locust feature view when creating the feature group. This will prevent the workers to get a race condition creating it.