### PR TITLE
[FSTORE-1605] Add “global” path field in the storage connector

### DIFF
--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
@@ -125,6 +125,9 @@ public abstract class StorageConnector {
     protected String bucket;
 
     @Getter @Setter
+    protected String path;
+
+    @Getter @Setter
     protected String region;
 
     @Getter @Setter
@@ -138,7 +141,9 @@ public abstract class StorageConnector {
 
     @JsonIgnore
     public String getPath(String subPath) {
-      return "s3://" + bucket + "/"  + (Strings.isNullOrEmpty(subPath) ? "" : subPath);
+      return "s3://" + bucket
+          + (Strings.isNullOrEmpty(path) ? "" : "/" + path) + "/"
+          + (Strings.isNullOrEmpty(subPath) ? "" : subPath);
     }
 
     @Override

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/TestStorageConnector.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/TestStorageConnector.java
@@ -19,6 +19,7 @@ package com.logicalclocks.hsfs.spark;
 
 import com.logicalclocks.hsfs.FeatureStoreException;
 import com.logicalclocks.hsfs.StorageConnectorType;
+import com.logicalclocks.hsfs.StorageConnector.S3Connector;
 import com.logicalclocks.hsfs.metadata.HopsworksClient;
 import com.logicalclocks.hsfs.metadata.HopsworksHttpClient;
 import com.logicalclocks.hsfs.metadata.Option;
@@ -244,6 +245,33 @@ public class TestStorageConnector {
       Assertions.assertEquals("s3://"+s3Connector.getBucket()+"/", pathArg.getValue());
       // reset
       SparkEngine.setInstance(null);
+    }
+
+    @Test
+    void testGetPath() throws FeatureStoreException, IOException {
+      // Arrange
+      S3Connector connector = new S3Connector();
+      connector.setBucket("testBucket");
+
+      // Act
+      String path = connector.getPath("some/location");
+
+      // Assert
+      Assertions.assertEquals("s3://testBucket/some/location", path);
+    }
+
+    @Test
+    void testGetPathStorageConnectorWithPath() throws FeatureStoreException, IOException {
+      // Arrange
+      S3Connector connector = new S3Connector();
+      connector.setBucket("testBucket");
+      connector.setPath("abc/def");
+
+      // Act
+      String path = connector.getPath("some/location");
+
+      // Assert
+      Assertions.assertEquals("s3://testBucket/abc/def/some/location", path);
     }
   }
 

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -18,11 +18,11 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import posixpath
 import re
 import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, TypeVar, Union
-import posixpath
 
 import humps
 import pandas as pd

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -276,6 +276,7 @@ class S3Connector(StorageConnector):
         server_encryption_algorithm: Optional[str] = None,
         server_encryption_key: Optional[str] = None,
         bucket: Optional[str] = None,
+        path: Optional[str] = None,
         region: Optional[str] = None,
         session_token: Optional[str] = None,
         iam_role: Optional[str] = None,
@@ -290,6 +291,7 @@ class S3Connector(StorageConnector):
         self._server_encryption_algorithm = server_encryption_algorithm
         self._server_encryption_key = server_encryption_key
         self._bucket = bucket
+        self._path = path
         self._region = region
         self._session_token = session_token
         self._iam_role = iam_role
@@ -340,7 +342,7 @@ class S3Connector(StorageConnector):
     @property
     def path(self) -> Optional[str]:
         """If the connector refers to a path (e.g. S3) - return the path of the connector"""
-        return "s3://" + self._bucket
+        return "s3://" + self._bucket + ("/" + self._path if self._path else "")
 
     @property
     def arguments(self) -> Optional[Dict[str, Any]]:

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -22,6 +22,7 @@ import re
 import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, TypeVar, Union
+import posixpath
 
 import humps
 import pandas as pd
@@ -342,7 +343,7 @@ class S3Connector(StorageConnector):
     @property
     def path(self) -> Optional[str]:
         """If the connector refers to a path (e.g. S3) - return the path of the connector"""
-        return os.path.join("s3://" + self._bucket, *os.path.split(self._path if self._path else ""))
+        return posixpath.join("s3://" + self._bucket, *os.path.split(self._path if self._path else ""))
 
     @property
     def arguments(self) -> Optional[Dict[str, Any]]:
@@ -435,7 +436,7 @@ class S3Connector(StorageConnector):
         )
 
     def _get_path(self, sub_path: str) -> str:
-        return os.path.join(self.path, *os.path.split(sub_path))
+        return posixpath.join(self.path, *os.path.split(sub_path))
 
 
 class RedshiftConnector(StorageConnector):

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -342,7 +342,7 @@ class S3Connector(StorageConnector):
     @property
     def path(self) -> Optional[str]:
         """If the connector refers to a path (e.g. S3) - return the path of the connector"""
-        return "s3://" + self._bucket + ("/" + self._path if self._path else "")
+        return os.path.join("s3://" + self._bucket, *os.path.split(self._path if self._path else ""))
 
     @property
     def arguments(self) -> Optional[Dict[str, Any]]:
@@ -435,7 +435,7 @@ class S3Connector(StorageConnector):
         )
 
     def _get_path(self, sub_path: str) -> str:
-        return os.path.join(self.path, sub_path)
+        return os.path.join(self.path, *os.path.split(sub_path))
 
 
 class RedshiftConnector(StorageConnector):

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -113,9 +113,21 @@ class TestS3Connector:
         )
         sc.read(data_format="csv")
         # assert
-        assert "" == mock_engine_read.call_args[0][3]
+        assert "s3://test-bucket" in mock_engine_read.call_args[0][3]
 
     def test_get_path(self, mocker):
+        mocker.patch("hsfs.engine.get_instance", return_value=spark.Engine())
+        sc = storage_connector.S3Connector(
+            id=1, name="test_connector", featurestore_id=1, bucket="test-bucket"
+        )
+
+        # act
+        result = sc._get_path("some/location")
+
+        # assert
+        assert "s3://test-bucket/some/location" == result
+
+    def test_get_path_storage_connector_with_path(self, mocker):
         mocker.patch("hsfs.engine.get_instance", return_value=spark.Engine())
         sc = storage_connector.S3Connector(
             id=1, name="test_connector", featurestore_id=1, bucket="test-bucket", path="abc/def"

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -113,7 +113,19 @@ class TestS3Connector:
         )
         sc.read(data_format="csv")
         # assert
-        assert "s3://test-bucket" in mock_engine_read.call_args[0][3]
+        assert "" == mock_engine_read.call_args[0][3]
+    
+    def test_get_path(self, mocker):
+        mocker.patch("hsfs.engine.get_instance", return_value=spark.Engine())
+        sc = storage_connector.S3Connector(
+            id=1, name="test_connector", featurestore_id=1, bucket="test-bucket", path="abc/def"
+        )
+
+        # act
+        result = sc._get_path("some/location")
+
+        # assert
+        assert "s3://test-bucket/abc/def/some/location" == result
 
 
 class TestRedshiftConnector:

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -114,7 +114,7 @@ class TestS3Connector:
         sc.read(data_format="csv")
         # assert
         assert "" == mock_engine_read.call_args[0][3]
-    
+
     def test_get_path(self, mocker):
         mocker.patch("hsfs.engine.get_instance", return_value=spark.Engine())
         sc = storage_connector.S3Connector(


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
