### PR TITLE
Fix doc headers in the Hopsworks API documentation

### DIFF
--- a/docs/js/dropdown.js
+++ b/docs/js/dropdown.js
@@ -1,2 +1,2 @@
-document.getElementsByClassName("md-tabs__link")[7].style.display = "none";
-document.getElementsByClassName("md-tabs__link")[9].style.display = "none";
+document.getElementsByClassName("md-tabs__link")[6].style.display = "none";
+document.getElementsByClassName("md-tabs__link")[8].style.display = "none";

--- a/docs/js/inject-api-links.js
+++ b/docs/js/inject-api-links.js
@@ -20,7 +20,6 @@ window.addEventListener("DOMContentLoaded", function () {
         document.getElementsByClassName("md-tabs__link")[3].href = "https://docs.hopsworks.ai/" + majorVersion + "/concepts/hopsworks/";
         document.getElementsByClassName("md-tabs__link")[4].href = "https://docs.hopsworks.ai/" + majorVersion + "/user_guides/";
         document.getElementsByClassName("md-tabs__link")[5].href = "https://docs.hopsworks.ai/" + majorVersion + "/setup_installation/aws/getting_started/";
-        document.getElementsByClassName("md-tabs__link")[6].href = "https://docs.hopsworks.ai/" + majorVersion + "/admin/";
         // Version API dropdown
         document.getElementById("hopsworks_api_link").href = "https://docs.hopsworks.ai/hopsworks-api/" + majorVersion + "/generated/api/login/";
         document.getElementById("hsfs_javadoc_link").href = "https://docs.hopsworks.ai/hopsworks-api/" + majorVersion + "/javadoc";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,9 +14,8 @@ nav:
   - Tutorials: https://docs.hopsworks.ai/
   - Concepts: https://docs.hopsworks.ai/
   - Guides: https://docs.hopsworks.ai/
-  - Setup and Installation: https://docs.hopsworks.ai/
-  - Administration: https://docs.hopsworks.ai/
-  - API<div class="dropdown"><button class="dropbtn"> API </button> <div id="myDropdown" class="dropdown-content"> <a id="hopsworks_api_link" href="https://docs.hopsworks.ai/hopsworks-api/latest">Python API</a> <a id="hsfs_javadoc_link" href="https://docs.hopsworks.ai/hopsworks-api/latest/javadoc">Feature Store JavaDoc</a> </div></div>:
+  - Setup and Administration: https://docs.hopsworks.ai/
+  - API<div class="dropdown"><button class="dropbtn"> API </button> <div id="myDropdown" class="dropdown-content"> <a id="hopsworks_api_link" href="https://docs.hopsworks.ai/hopsworks-api/latest">Hopsworks API</a> <a id="hsfs_javadoc_link" href="https://docs.hopsworks.ai/hopsworks-api/latest/javadoc">Feature Store JavaDoc</a> </div></div>:
     - Login: generated/api/login.md
     - Platform API:
       - Connection: generated/api/connection.md


### PR DESCRIPTION
The headers in the main documentation are different than the headers in the Hopsworks API documentation. In particular:
- Setup and Installation and Administration have been merged into: Setup and Administration
- Python API has been renamed to Hopsworks API

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
