### PR TITLE
[FSTORE-1672] Allow multiple on-demand features to be returned from an on-demand transformation function and allow passing of local variables to a transformation function

### DIFF
--- a/docs/templates/api/hopsworks_udf.md
+++ b/docs/templates/api/hopsworks_udf.md
@@ -6,6 +6,10 @@
 
 {{hopsworks_udf_properties}}
 
+## Methods
+
+{{hopsworks_udf_methods}}
+
 ## TransformationFeature
 
 {{transformation_feature}}

--- a/python/auto_doc.py
+++ b/python/auto_doc.py
@@ -451,6 +451,15 @@ PAGES = {
         "hopsworks_udf_properties": keras_autodoc.get_properties(
             "hsfs.hopsworks_udf.HopsworksUdf"
         ),
+        "hopsworks_udf_methods": keras_autodoc.get_methods(
+            "hsfs.hopsworks_udf.HopsworksUdf",
+            exclude=[
+                "update_return_type_one_hot",
+                "python_udf_wrapper",
+                "pandas_udf_wrapper",
+                "get_udf",
+            ],
+        ),
         "transformation_feature": ["hsfs.hopsworks_udf.TransformationFeature"],
     },
     "api/transformation_statistics.md": {

--- a/python/hopsworks_common/constants.py
+++ b/python/hopsworks_common/constants.py
@@ -70,6 +70,14 @@ class OPENSEARCH_CONFIG:
     CA_CERTS = "ca_certs"
 
 
+class FEATURES:
+    """
+    Class that stores constants about a feature.
+    """
+
+    MAX_LENGTH_NAME = 63
+
+
 class KAFKA_SSL_CONFIG:
     """
     Kafka SSL constant strings for configuration

--- a/python/hsfs/core/feature_monitoring_config.py
+++ b/python/hsfs/core/feature_monitoring_config.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import humps
 from hopsworks_common.client.exceptions import FeatureStoreException
+from hopsworks_common.constants import FEATURES
 from hsfs import util
 from hsfs.core import (
     feature_monitoring_config_engine,
@@ -34,7 +35,6 @@ from hsfs.core.feature_monitoring_result import FeatureMonitoringResult
 from hsfs.core.job_schedule import JobSchedule
 
 
-MAX_LENGTH_NAME = 63
 MAX_LENGTH_DESCRIPTION = 2000
 
 
@@ -686,8 +686,10 @@ class FeatureMonitoringConfig:
             raise AttributeError("The name of a registered config is read-only.")
         elif not isinstance(name, str):
             raise TypeError("name must be of type str")
-        if len(name) > MAX_LENGTH_NAME:
-            raise ValueError("name must be less than {MAX_LENGTH_NAME} characters.")
+        if len(name) > FEATURES.MAX_LENGTH_NAME:
+            raise ValueError(
+                "name must be less than {FEATURES.MAX_LENGTH_NAME} characters."
+            )
         self._name = name
 
     @property

--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import humps
 from hopsworks_common.client.exceptions import FeatureStoreException
+from hopsworks_common.constants import FEATURES
 from hsfs import engine, util
 from hsfs.core.feature_descriptive_statistics import FeatureDescriptiveStatistics
 from hsfs.decorators import typechecked
@@ -146,7 +147,9 @@ class HopsworksUdf:
         transformation_function_argument_names : `Optional[List[TransformationFeature]]`. The argument names of the transformation function.
         dropped_argument_names : `Optional[List[str]]`. The arguments to be dropped from the finial DataFrame after the transformation functions are applied.
         dropped_feature_names : `Optional[List[str]]`. The feature name corresponding to the arguments names that are dropped
-        feature_name_prefix: `Optional[str]` = None. Prefixes if any used in the feature view.
+        feature_name_prefix: `Optional[str]`. Prefixes if any used in the feature view.
+        output_column_names: `Optional[List[str]]`. The names of the output columns returned from the transformation function.
+        generate_output_col_names: `Optional[bool]`. Generate default output column names for the transformation function. Default's to True.
     """
 
     # Mapping for converting python types to spark types - required for creating pandas UDF's.
@@ -173,6 +176,8 @@ class HopsworksUdf:
         dropped_argument_names: Optional[List[str]] = None,
         dropped_feature_names: Optional[List[str]] = None,
         feature_name_prefix: Optional[str] = None,
+        output_column_names: Optional[str] = None,
+        generate_output_col_names: bool = True,
     ):
         self._return_types: List[str] = HopsworksUdf._validate_and_convert_output_types(
             return_types
@@ -191,6 +196,12 @@ class HopsworksUdf:
             if isinstance(func, Callable)
             else func
         )
+
+        # The parameter `output_column_names` is initialized lazily.
+        # It is only initialized if the output column names are retrieved from the backend or explicitly specified using the `alias` function or is initialized with default column names if the UDF is accessed from a transformation function.
+        # Output column names are only stored in the backend when a model dependent or on demand transformation function is created using the defined UDF.
+        self._output_column_names: List[str] = []
+
         if not transformation_features:
             # New transformation function being declared so extract source code from function
             self._transformation_features: List[TransformationFeature] = (
@@ -211,6 +222,7 @@ class HopsworksUdf:
                 )
             )
             self._dropped_features = self._dropped_argument_names
+
         else:
             self._transformation_features = transformation_features
             self._transformation_function_argument_names = (
@@ -222,6 +234,9 @@ class HopsworksUdf:
                 if dropped_feature_names
                 else dropped_argument_names
             )
+            self._output_column_names = (
+                output_column_names if output_column_names else []
+            )
 
         self._formatted_function_source, self._module_imports = (
             HopsworksUdf._format_source_code(self._function_source)
@@ -229,7 +244,9 @@ class HopsworksUdf:
 
         self._statistics: Optional[TransformationStatistics] = None
 
-        self._output_column_names: List[str] = []
+        # Denote if the output feature names have to be generated.
+        # Set to `False` if the output column names are saved in the backend and the udf is constructed from it using `from_response_json` function or if user has specified the output feature names using the `alias`` function.
+        self._generate_output_col_name: bool = generate_output_col_names
 
     @staticmethod
     def _validate_and_convert_drop_features(
@@ -691,6 +708,47 @@ def renaming_wrapper(*args):
         udf.dropped_features = updated_dropped_features
         return udf
 
+    def alias(self, *args: str):
+        """
+        Set the names of the transformed features output by the UDF.
+        """
+        if len(args) == 1 and isinstance(args[0], list):
+            # If a single list is passed, use it directly
+            output_col_names = args[0]
+        else:
+            # Otherwise, use the individual arguments as a list
+            output_col_names = list(args)
+        if any(
+            not isinstance(output_col_name, str) for output_col_name in output_col_names
+        ):
+            raise FeatureStoreException(
+                f"Invalid output feature names provided for the transformation function '{repr(self)}'. Please ensure all arguments are strings."
+            )
+
+        self._generate_output_col_name = False
+        self.output_column_names = output_col_names
+
+        return self
+
+    def _validate_output_col_name(self, output_col_names):
+        if any(
+            len(output_col_name) > FEATURES.MAX_LENGTH_NAME
+            for output_col_name in output_col_names
+        ):
+            raise FeatureStoreException(
+                f"Invalid output feature names specified for the transformation function '{repr(self)}'. Please provide names shorter than {FEATURES.MAX_LENGTH_NAME} characters."
+            )
+
+        if len(output_col_names) != len(set(output_col_names)):
+            raise FeatureStoreException(
+                f"Duplicate output feature names provided for the transformation function '{repr(self)}'. Please ensure all arguments names are unique."
+            )
+
+        if output_col_names and len(output_col_names) != len(self.return_types):
+            raise FeatureStoreException(
+                f"The number of output feature names provided does not match the number of features returned by the transformation function '{repr(self)}'. Pease provide exactly {len(self.return_types)} feature name(s) to match the output."
+            )
+
     def update_return_type_one_hot(self):
         self._return_types = [
             self._return_types[0]
@@ -765,6 +823,7 @@ def renaming_wrapper(*args):
             "name": self.function_name,
             "featureNamePrefix": self._feature_name_prefix,
             "executionMode": self.execution_mode.value.upper(),
+            "outputColumnNames": self.output_column_names,
         }
 
     def json(self) -> str:
@@ -826,6 +885,12 @@ def renaming_wrapper(*args):
             else None
         )
 
+        output_column_names = (
+            [feature.strip() for feature in json_decamelized["output_column_names"]]
+            if json_decamelized.get("output_column_names", None)
+            else None
+        )
+
         # Reconstructing statistics arguments.
         arg_list, _, _, _ = HopsworksUdf._parse_function_signature(function_source_code)
 
@@ -858,7 +923,7 @@ def renaming_wrapper(*args):
                 for arg_index in range(len(arg_list))
             ]
 
-        hopsworks_udf = cls(
+        hopsworks_udf: HopsworksUdf = cls(
             func=function_source_code,
             return_types=output_types,
             name=function_name,
@@ -870,6 +935,8 @@ def renaming_wrapper(*args):
             execution_mode=UDFExecutionMode.from_string(
                 json_decamelized["execution_mode"]
             ),
+            output_column_names=output_column_names,
+            generate_output_col_names=not output_column_names,  # Do not generate output column names if they are retrieved from the back
         )
 
         # Set transformation features if already set.
@@ -998,12 +1065,8 @@ def renaming_wrapper(*args):
     def output_column_names(self, output_col_names: Union[str, List[str]]) -> None:
         if not isinstance(output_col_names, List):
             output_col_names = [output_col_names]
-        if not output_col_names and len(output_col_names) != len(self.return_types):
-            raise FeatureStoreException(
-                f"Provided names for output columns does not match the number of columns returned from the UDF. Please provide {len(self.return_types)} names."
-            )
-        else:
-            self._output_column_names = output_col_names
+        self._validate_output_col_name(output_col_names)
+        self._output_column_names = output_col_names
 
     def __repr__(self):
         return f'{self.function_name}({", ".join(self.transformation_features)})'

--- a/python/hsfs/transformation_function.py
+++ b/python/hsfs/transformation_function.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import humps
 from hopsworks_common.client.exceptions import FeatureStoreException
+from hopsworks_common.constants import FEATURES
 from hsfs import util
 from hsfs.core import transformation_function_engine
 from hsfs.core.feature_descriptive_statistics import FeatureDescriptiveStatistics
@@ -78,11 +79,16 @@ class TransformationFunction:
                 "Please use the hopsworks_udf decorator when defining transformation functions."
             )
 
-        self._hopsworks_udf: HopsworksUdf = hopsworks_udf
+        self.__hopsworks_udf: HopsworksUdf = hopsworks_udf
         TransformationFunction._validate_transformation_type(
             transformation_type=transformation_type, hopsworks_udf=hopsworks_udf
         )
         self.transformation_type = transformation_type
+
+        if self.__hopsworks_udf._generate_output_col_name:
+            # Reset output column names so that they would be regenerated.
+            # Handles the use case in which the same UDF is used to define both on-demand and model dependent transformations.
+            self.__hopsworks_udf._output_column_names = []
 
     def save(self) -> None:
         """Save a transformation function into the backend.
@@ -152,11 +158,8 @@ class TransformationFunction:
         """
         # Deep copy so that the same transformation function can be used to create multiple new transformation function with different features.
         transformation = copy.deepcopy(self)
-        transformation._hopsworks_udf = transformation._hopsworks_udf(*features)
-        # Regenerate output column names when setting new transformation features.
-        transformation._hopsworks_udf.output_column_names = (
-            transformation._get_output_column_names()
-        )
+        transformation.__hopsworks_udf = transformation.__hopsworks_udf(*features)
+
         return transformation
 
     @classmethod
@@ -227,8 +230,16 @@ class TransformationFunction:
             "id": self._id,
             "version": self._version,
             "featurestoreId": self._featurestore_id,
-            "hopsworksUdf": self._hopsworks_udf.to_dict(),
+            "hopsworksUdf": self.hopsworks_udf.to_dict(),
         }
+
+    def alias(self, *args: str):
+        """
+        Set the names of the transformed features output by the transformation function.
+        """
+        self.__hopsworks_udf.alias(*args)
+
+        return self
 
     def _get_output_column_names(self) -> str:
         """
@@ -240,33 +251,43 @@ class TransformationFunction:
         # If function name matches the name of an input feature and the transformation function only returns one output feature then
         # then the transformed output feature would have the same name as the input feature. i.e the input feature will get overwritten.
         if (
-            len(self._hopsworks_udf.return_types) == 1
+            len(self.__hopsworks_udf.return_types) == 1
             and any(
                 [
-                    self.hopsworks_udf.function_name
+                    self.__hopsworks_udf.function_name
                     == transformation_feature.feature_name
-                    for transformation_feature in self.hopsworks_udf._transformation_features
+                    for transformation_feature in self.__hopsworks_udf._transformation_features
                 ]
             )
             and (
-                not self.hopsworks_udf.dropped_features
-                or self.hopsworks_udf.function_name
-                not in self.hopsworks_udf.dropped_features
+                not self.__hopsworks_udf.dropped_features
+                or self.__hopsworks_udf.function_name
+                not in self.__hopsworks_udf.dropped_features
             )
         ):
-            return [self.hopsworks_udf.function_name]
+            output_col_names = [self.__hopsworks_udf.function_name]
 
         if self.transformation_type == TransformationType.MODEL_DEPENDENT:
-            _BASE_COLUMN_NAME = f'{self._hopsworks_udf.function_name}_{"_".join(self._hopsworks_udf.transformation_features)}_'
-            if len(self._hopsworks_udf.return_types) > 1:
-                return [
+            _BASE_COLUMN_NAME = f'{self.__hopsworks_udf.function_name}_{"_".join(self.__hopsworks_udf.transformation_features)}_'
+            if len(self.__hopsworks_udf.return_types) > 1:
+                output_col_names = [
                     f"{_BASE_COLUMN_NAME}{i}"
-                    for i in range(len(self._hopsworks_udf.return_types))
+                    for i in range(len(self.__hopsworks_udf.return_types))
                 ]
             else:
-                return [f"{_BASE_COLUMN_NAME}"]
+                output_col_names = [f"{_BASE_COLUMN_NAME}"]
         elif self.transformation_type == TransformationType.ON_DEMAND:
-            return [self._hopsworks_udf.function_name]
+            output_col_names = [self.__hopsworks_udf.function_name]
+
+        if any(
+            len(output_col_name) > FEATURES.MAX_LENGTH_NAME
+            for output_col_name in output_col_names
+        ):
+            raise FeatureStoreException(
+                f"The default names for output features generated by the transformation function `{repr(self.__hopsworks_udf)}` exceeds the maximum length of {FEATURES.MAX_LENGTH_NAME} characters. Please use the `alias` function to assign shorter names to the output features."
+            )
+
+        return output_col_names
 
     @staticmethod
     def _validate_transformation_type(
@@ -311,7 +332,10 @@ class TransformationFunction:
     @property
     def hopsworks_udf(self) -> HopsworksUdf:
         """Meta data class for the user defined transformation function."""
-        return self._hopsworks_udf
+        # Make sure that the output column names for a model-dependent or on-demand transformation function, when accessed externally from the class.
+        if self.transformation_type and not self.__hopsworks_udf.output_column_names:
+            self.__hopsworks_udf.output_column_names = self._get_output_column_names()
+        return self.__hopsworks_udf
 
     @property
     def transformation_type(self) -> TransformationType:
@@ -321,41 +345,39 @@ class TransformationFunction:
     @transformation_type.setter
     def transformation_type(self, transformation_type) -> None:
         self._transformation_type = transformation_type
-        # Generate output column names when setting transformation type
-        self._hopsworks_udf.output_column_names = self._get_output_column_names()
 
     @property
     def transformation_statistics(
         self,
     ) -> Optional[TransformationStatistics]:
         """Feature statistics required for the defined UDF"""
-        return self.hopsworks_udf.transformation_statistics
+        return self.__hopsworks_udf.transformation_statistics
 
     @transformation_statistics.setter
     def transformation_statistics(
         self, statistics: List[FeatureDescriptiveStatistics]
     ) -> None:
-        self.hopsworks_udf.transformation_statistics = statistics
+        self.__hopsworks_udf.transformation_statistics = statistics
         # Generate output column names for one-hot encoder after transformation statistics is set.
         # This is done because the number of output columns for one-hot encoding dependents on number of unique values in training dataset statistics.
-        if self.hopsworks_udf.function_name == "one_hot_encoder":
-            self._hopsworks_udf.output_column_names = self._get_output_column_names()
+        if self.__hopsworks_udf.function_name == "one_hot_encoder":
+            self.__hopsworks_udf.output_column_names = self._get_output_column_names()
 
     @property
     def output_column_names(self) -> List[str]:
         """Names of the output columns generated by the transformation functions"""
-        if self._hopsworks_udf.function_name == "one_hot_encoder" and len(
-            self._hopsworks_udf.output_column_names
-        ) != len(self._hopsworks_udf.return_types):
-            self._hopsworks_udf.output_column_names = self._get_output_column_names()
-        return self._hopsworks_udf.output_column_names
+        if (
+            self.__hopsworks_udf.function_name == "one_hot_encoder"
+            and len(self.__hopsworks_udf.output_column_names)
+            != len(self.__hopsworks_udf.return_types)
+        ) or not self.__hopsworks_udf.output_column_names:
+            self.__hopsworks_udf.output_column_names = self._get_output_column_names()
+        return self.__hopsworks_udf.output_column_names
 
     def __repr__(self):
         if self.transformation_type == TransformationType.MODEL_DEPENDENT:
-            return (
-                f"Model-Dependent Transformation Function : {repr(self.hopsworks_udf)}"
-            )
+            return f"Model-Dependent Transformation Function : {repr(self.__hopsworks_udf)}"
         elif self.transformation_type == TransformationType.ON_DEMAND:
-            return f"On-Demand Transformation Function : {repr(self.hopsworks_udf)}"
+            return f"On-Demand Transformation Function : {repr(self.__hopsworks_udf)}"
         else:
-            return f"Transformation Function : {repr(self.hopsworks_udf)}"
+            return f"Transformation Function : {repr(self.__hopsworks_udf)}"

--- a/python/tests/test_transformation_function.py
+++ b/python/tests/test_transformation_function.py
@@ -237,7 +237,12 @@ class TestTransformationFunction:
             transformation_type=TransformationType.MODEL_DEPENDENT,
         )
 
-        assert tf.hopsworks_udf == test2
+        # Creating dict representation of udf.
+        udf_json = test2.to_dict()
+        # Adding output column names to dict for testing since it would be generated when UDF is accessed out the transformation function.
+        udf_json["outputColumnNames"] = ["test2_col1_"]
+
+        assert tf.hopsworks_udf.to_dict() == udf_json
 
     def test_generate_output_column_names_one_argument_one_output_type(self):
         @udf(int)
@@ -453,4 +458,301 @@ class TestTransformationFunction:
         assert (
             str(exe.value)
             == "On-Demand Transformation functions cannot use statistics, please remove statistics parameters from the functions"
+        )
+
+    def test_alias_one_output(self):
+        @udf(int)
+        def add_one(feature):
+            return feature + 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        mdt = mdt.alias("feature_plus_one_mdt")
+
+        assert mdt.output_column_names == ["feature_plus_one_mdt"]
+
+        odt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.ON_DEMAND,
+        )
+
+        odt = odt.alias("feature_plus_one_odt")
+
+        assert odt.output_column_names == ["feature_plus_one_odt"]
+
+    def test_alias_one_output_list(self):
+        @udf(int)
+        def add_one(feature):
+            return feature + 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        mdt = mdt.alias(["feature_plus_one_mdt"])
+
+        assert mdt.output_column_names == ["feature_plus_one_mdt"]
+
+        odt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.ON_DEMAND,
+        )
+
+        odt = odt.alias(["feature_plus_one_odt"])
+
+        assert odt.output_column_names == ["feature_plus_one_odt"]
+
+    def test_alias_multiple_output(self):
+        @udf([int, int])
+        def add_and_sub(feature):
+            return feature + 1, feature - 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_and_sub,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        mdt = mdt.alias("feature_plus_one_mdt", "feature_minus_one_mdt")
+
+        assert mdt.output_column_names == [
+            "feature_plus_one_mdt",
+            "feature_minus_one_mdt",
+        ]
+
+    def test_alias_multiple_output_list(self):
+        @udf([int, int])
+        def add_and_sub(feature):
+            return feature + 1, feature - 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_and_sub,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        mdt = mdt.alias(["feature_plus_one_mdt", "feature_minus_one_mdt"])
+
+        assert mdt.output_column_names == [
+            "feature_plus_one_mdt",
+            "feature_minus_one_mdt",
+        ]
+
+    def test_alias_invalid_number_column_names(self):
+        @udf([int, int])
+        def add_and_sub(feature):
+            return feature + 1, feature - 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_and_sub,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            mdt.alias(["feature_plus_one", "feature_minus_one", "invalid_col"])
+
+        assert (
+            str(exp.value)
+            == "The number of output feature names provided does not match the number of features returned by the transformation function 'add_and_sub(feature)'. Pease provide exactly 2 feature name(s) to match the output."
+        )
+
+        @udf(int)
+        def add_one(feature):
+            return feature + 1
+
+        odt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.ON_DEMAND,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            odt.alias(["feature_plus_one", "feature_minus_one", "invalid_col"])
+
+        assert (
+            str(exp.value)
+            == "The number of output feature names provided does not match the number of features returned by the transformation function 'add_one(feature)'. Pease provide exactly 1 feature name(s) to match the output."
+        )
+
+    def test_alias_invalid_type(self):
+        @udf([int])
+        def add_one(feature):
+            return feature + 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            mdt.alias({"name": "col1"})
+
+        assert (
+            str(exp.value)
+            == "Invalid output feature names provided for the transformation function 'add_one(feature)'. Please ensure all arguments are strings."
+        )
+
+        odt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.ON_DEMAND,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            odt.alias({"name": "col1"})
+
+        assert (
+            str(exp.value)
+            == "Invalid output feature names provided for the transformation function 'add_one(feature)'. Please ensure all arguments are strings."
+        )
+
+    def test_alias_duplicates(self):
+        @udf([int, int])
+        def add_and_sub(feature):
+            return feature + 1, feature - 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_and_sub,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            mdt.alias("feature_plus_one", "feature_plus_one")
+
+        assert (
+            str(exp.value)
+            == "Duplicate output feature names provided for the transformation function 'add_and_sub(feature)'. Please ensure all arguments names are unique."
+        )
+
+    def test_call_and_alias(self):
+        @udf(int)
+        def add_one(feature):
+            return feature + 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        mdt = mdt("feature2_mdt").alias(["feature_plus_one_mdt"])
+
+        assert mdt.output_column_names == ["feature_plus_one_mdt"]
+        assert mdt.hopsworks_udf.transformation_features == ["feature2_mdt"]
+
+        odt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.ON_DEMAND,
+        )
+
+        odt = odt("feature2_odt").alias(["feature_plus_one_odt"])
+
+        assert odt.output_column_names == ["feature_plus_one_odt"]
+        assert odt.hopsworks_udf.transformation_features == ["feature2_odt"]
+
+    def test_alias_invalid_length(self):
+        @udf(int)
+        def add_one(feature):
+            return feature + 1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            mdt.alias(["invalid" * 10])
+
+        assert (
+            str(exp.value)
+            == "Invalid output feature names specified for the transformation function 'add_one(feature)'. Please provide names shorter than 63 characters."
+        )
+
+        odt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=add_one,
+            transformation_type=TransformationType.ON_DEMAND,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            odt.alias(["invalid" * 10])
+
+        assert (
+            str(exp.value)
+            == "Invalid output feature names specified for the transformation function 'add_one(feature)'. Please provide names shorter than 63 characters."
+        )
+
+    def test_generated_output_col_name_invalid_mdt(self):
+        @udf(int)
+        def test(
+            long_feature_name1,
+            long_feature_name2,
+            long_feature_name3,
+            long_feature_name4,
+            long_feature_name5,
+            long_feature_name6,
+            long_feature_name7,
+        ):
+            return long_feature_name1
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=test,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            mdt._get_output_column_names()
+
+        assert (
+            str(exp.value)
+            == "The default names for output features generated by the transformation function `test(long_feature_name1, long_feature_name2, long_feature_name3, long_feature_name4, long_feature_name5, long_feature_name6, long_feature_name7)` exceeds the maximum length of 63 characters. Please use the `alias` function to assign shorter names to the output features."
+        )
+
+    def test_generate_output_col_name_invalid_odt(self):
+        @udf(int)
+        def really_long_function_name_that_exceed_63_characters_causing_invalid_name_for_on_demand_features(
+            features,
+        ):
+            return features
+
+        odt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=really_long_function_name_that_exceed_63_characters_causing_invalid_name_for_on_demand_features,
+            transformation_type=TransformationType.ON_DEMAND,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            odt._get_output_column_names()
+
+        assert (
+            str(exp.value)
+            == "The default names for output features generated by the transformation function `really_long_function_name_that_exceed_63_characters_causing_invalid_name_for_on_demand_features(features)` exceeds the maximum length of 63 characters. Please use the `alias` function to assign shorter names to the output features."
+        )
+
+        mdt = TransformationFunction(
+            featurestore_id=10,
+            hopsworks_udf=really_long_function_name_that_exceed_63_characters_causing_invalid_name_for_on_demand_features,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+
+        with pytest.raises(FeatureStoreException) as exp:
+            mdt._get_output_column_names()
+
+        assert (
+            str(exp.value)
+            == "The default names for output features generated by the transformation function `really_long_function_name_that_exceed_63_characters_causing_invalid_name_for_on_demand_features(features)` exceeds the maximum length of 63 characters. Please use the `alias` function to assign shorter names to the output features."
         )


### PR DESCRIPTION
…e names that are longer than 64 character causing logging feature group ingestion to failreverting fetching feature vector changes

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
