### PR TITLE
[FSTORE-1630][4.1] Model Dependent Transformation Functions creates feature names that are longer than 64 character causing logging feature group ingestion to fail

### DIFF
--- a/docs/templates/api/hopsworks_udf.md
+++ b/docs/templates/api/hopsworks_udf.md
@@ -6,6 +6,10 @@
 
 {{hopsworks_udf_properties}}
 
+## Methods
+
+{{hopsworks_udf_methods}}
+
 ## TransformationFeature
 
 {{transformation_feature}}

--- a/python/auto_doc.py
+++ b/python/auto_doc.py
@@ -451,6 +451,15 @@ PAGES = {
         "hopsworks_udf_properties": keras_autodoc.get_properties(
             "hsfs.hopsworks_udf.HopsworksUdf"
         ),
+        "hopsworks_udf_methods": keras_autodoc.get_methods(
+            "hsfs.hopsworks_udf.HopsworksUdf",
+            exclude=[
+                "update_return_type_one_hot",
+                "python_udf_wrapper",
+                "pandas_udf_wrapper",
+                "get_udf",
+            ],
+        ),
         "transformation_feature": ["hsfs.hopsworks_udf.TransformationFeature"],
     },
     "api/transformation_statistics.md": {

--- a/python/hopsworks_common/constants.py
+++ b/python/hopsworks_common/constants.py
@@ -70,6 +70,14 @@ class OPENSEARCH_CONFIG:
     CA_CERTS = "ca_certs"
 
 
+class FEATURES:
+    """
+    Class that stores constants about a feature.
+    """
+
+    MAX_LENGTH_NAME = 63
+
+
 class KAFKA_SSL_CONFIG:
     """
     Kafka SSL constant strings for configuration

--- a/python/hsfs/core/feature_monitoring_config.py
+++ b/python/hsfs/core/feature_monitoring_config.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import humps
 from hopsworks_common.client.exceptions import FeatureStoreException
+from hopsworks_common.constants import FEATURES
 from hsfs import util
 from hsfs.core import (
     feature_monitoring_config_engine,
@@ -34,7 +35,6 @@ from hsfs.core.feature_monitoring_result import FeatureMonitoringResult
 from hsfs.core.job_schedule import JobSchedule
 
 
-MAX_LENGTH_NAME = 63
 MAX_LENGTH_DESCRIPTION = 2000
 
 
@@ -686,8 +686,10 @@ class FeatureMonitoringConfig:
             raise AttributeError("The name of a registered config is read-only.")
         elif not isinstance(name, str):
             raise TypeError("name must be of type str")
-        if len(name) > MAX_LENGTH_NAME:
-            raise ValueError("name must be less than {MAX_LENGTH_NAME} characters.")
+        if len(name) > FEATURES.MAX_LENGTH_NAME:
+            raise ValueError(
+                "name must be less than {FEATURES.MAX_LENGTH_NAME} characters."
+            )
         self._name = name
 
     @property

--- a/python/hsfs/transformation_function.py
+++ b/python/hsfs/transformation_function.py
@@ -16,17 +16,22 @@ from __future__ import annotations
 
 import copy
 import json
+import logging
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 import humps
 from hopsworks_common.client.exceptions import FeatureStoreException
+from hopsworks_common.constants import FEATURES
 from hsfs import util
 from hsfs.core import transformation_function_engine
 from hsfs.core.feature_descriptive_statistics import FeatureDescriptiveStatistics
 from hsfs.decorators import typechecked
 from hsfs.hopsworks_udf import HopsworksUdf
 from hsfs.transformation_statistics import TransformationStatistics
+
+
+_logger = logging.getLogger(__name__)
 
 
 class TransformationType(Enum):
@@ -78,11 +83,16 @@ class TransformationFunction:
                 "Please use the hopsworks_udf decorator when defining transformation functions."
             )
 
-        self._hopsworks_udf: HopsworksUdf = hopsworks_udf
+        self.__hopsworks_udf: HopsworksUdf = hopsworks_udf
         TransformationFunction._validate_transformation_type(
             transformation_type=transformation_type, hopsworks_udf=hopsworks_udf
         )
         self.transformation_type = transformation_type
+
+        if self.__hopsworks_udf._generate_output_col_name:
+            # Reset output column names so that they would be regenerated.
+            # Handles the use case in which the same UDF is used to define both on-demand and model dependent transformations.
+            self.__hopsworks_udf._output_column_names = []
 
     def save(self) -> None:
         """Save a transformation function into the backend.
@@ -152,11 +162,8 @@ class TransformationFunction:
         """
         # Deep copy so that the same transformation function can be used to create multiple new transformation function with different features.
         transformation = copy.deepcopy(self)
-        transformation._hopsworks_udf = transformation._hopsworks_udf(*features)
-        # Regenerate output column names when setting new transformation features.
-        transformation._hopsworks_udf.output_column_names = (
-            transformation._get_output_column_names()
-        )
+        transformation.__hopsworks_udf = transformation.__hopsworks_udf(*features)
+
         return transformation
 
     @classmethod
@@ -227,8 +234,16 @@ class TransformationFunction:
             "id": self._id,
             "version": self._version,
             "featurestoreId": self._featurestore_id,
-            "hopsworksUdf": self._hopsworks_udf.to_dict(),
+            "hopsworksUdf": self.hopsworks_udf.to_dict(),
         }
+
+    def alias(self, *args: str):
+        """
+        Set the names of the transformed features output by the transformation function.
+        """
+        self.__hopsworks_udf.alias(*args)
+
+        return self
 
     def _get_output_column_names(self) -> str:
         """
@@ -240,33 +255,53 @@ class TransformationFunction:
         # If function name matches the name of an input feature and the transformation function only returns one output feature then
         # then the transformed output feature would have the same name as the input feature. i.e the input feature will get overwritten.
         if (
-            len(self._hopsworks_udf.return_types) == 1
+            len(self.__hopsworks_udf.return_types) == 1
             and any(
                 [
-                    self.hopsworks_udf.function_name
+                    self.__hopsworks_udf.function_name
                     == transformation_feature.feature_name
-                    for transformation_feature in self.hopsworks_udf._transformation_features
+                    for transformation_feature in self.__hopsworks_udf._transformation_features
                 ]
             )
             and (
-                not self.hopsworks_udf.dropped_features
-                or self.hopsworks_udf.function_name
-                not in self.hopsworks_udf.dropped_features
+                not self.__hopsworks_udf.dropped_features
+                or self.__hopsworks_udf.function_name
+                not in self.__hopsworks_udf.dropped_features
             )
         ):
-            return [self.hopsworks_udf.function_name]
+            output_col_names = [self.__hopsworks_udf.function_name]
 
         if self.transformation_type == TransformationType.MODEL_DEPENDENT:
-            _BASE_COLUMN_NAME = f'{self._hopsworks_udf.function_name}_{"_".join(self._hopsworks_udf.transformation_features)}_'
-            if len(self._hopsworks_udf.return_types) > 1:
-                return [
+            _BASE_COLUMN_NAME = f'{self.__hopsworks_udf.function_name}_{"_".join(self.__hopsworks_udf.transformation_features)}_'
+            if len(self.__hopsworks_udf.return_types) > 1:
+                output_col_names = [
                     f"{_BASE_COLUMN_NAME}{i}"
-                    for i in range(len(self._hopsworks_udf.return_types))
+                    for i in range(len(self.__hopsworks_udf.return_types))
                 ]
             else:
-                return [f"{_BASE_COLUMN_NAME}"]
+                output_col_names = [f"{_BASE_COLUMN_NAME}"]
         elif self.transformation_type == TransformationType.ON_DEMAND:
-            return [self._hopsworks_udf.function_name]
+            output_col_names = [self.__hopsworks_udf.function_name]
+
+        if any(
+            len(output_col_name) > FEATURES.MAX_LENGTH_NAME
+            for output_col_name in output_col_names
+        ):
+            _logger.warning(
+                f"The default output feature names generated by the transformation function {repr(self.__hopsworks_udf)} exceed the maximum allowed length of {FEATURES.MAX_LENGTH_NAME} characters. Default names have been truncated to fit within the size limit. To avoid this, consider using the alias function to explicitly specify output column names."
+            )
+            if len(output_col_names) > 1:
+                # Slicing the output column names
+                for index, output_col_name in enumerate(output_col_names):
+                    output_col_names[index] = (
+                        f"{output_col_name[:FEATURES.MAX_LENGTH_NAME-(len(output_col_names) + 1)]}_{str(index)}"
+                        if len(output_col_name) > FEATURES.MAX_LENGTH_NAME
+                        else output_col_name
+                    )
+            else:
+                output_col_names = [output_col_names[0][: FEATURES.MAX_LENGTH_NAME]]
+
+        return output_col_names
 
     @staticmethod
     def _validate_transformation_type(
@@ -311,7 +346,10 @@ class TransformationFunction:
     @property
     def hopsworks_udf(self) -> HopsworksUdf:
         """Meta data class for the user defined transformation function."""
-        return self._hopsworks_udf
+        # Make sure that the output column names for a model-dependent or on-demand transformation function, when accessed externally from the class.
+        if self.transformation_type and not self.__hopsworks_udf.output_column_names:
+            self.__hopsworks_udf.output_column_names = self._get_output_column_names()
+        return self.__hopsworks_udf
 
     @property
     def transformation_type(self) -> TransformationType:
@@ -321,41 +359,39 @@ class TransformationFunction:
     @transformation_type.setter
     def transformation_type(self, transformation_type) -> None:
         self._transformation_type = transformation_type
-        # Generate output column names when setting transformation type
-        self._hopsworks_udf.output_column_names = self._get_output_column_names()
 
     @property
     def transformation_statistics(
         self,
     ) -> Optional[TransformationStatistics]:
         """Feature statistics required for the defined UDF"""
-        return self.hopsworks_udf.transformation_statistics
+        return self.__hopsworks_udf.transformation_statistics
 
     @transformation_statistics.setter
     def transformation_statistics(
         self, statistics: List[FeatureDescriptiveStatistics]
     ) -> None:
-        self.hopsworks_udf.transformation_statistics = statistics
+        self.__hopsworks_udf.transformation_statistics = statistics
         # Generate output column names for one-hot encoder after transformation statistics is set.
         # This is done because the number of output columns for one-hot encoding dependents on number of unique values in training dataset statistics.
-        if self.hopsworks_udf.function_name == "one_hot_encoder":
-            self._hopsworks_udf.output_column_names = self._get_output_column_names()
+        if self.__hopsworks_udf.function_name == "one_hot_encoder":
+            self.__hopsworks_udf.output_column_names = self._get_output_column_names()
 
     @property
     def output_column_names(self) -> List[str]:
         """Names of the output columns generated by the transformation functions"""
-        if self._hopsworks_udf.function_name == "one_hot_encoder" and len(
-            self._hopsworks_udf.output_column_names
-        ) != len(self._hopsworks_udf.return_types):
-            self._hopsworks_udf.output_column_names = self._get_output_column_names()
-        return self._hopsworks_udf.output_column_names
+        if (
+            self.__hopsworks_udf.function_name == "one_hot_encoder"
+            and len(self.__hopsworks_udf.output_column_names)
+            != len(self.__hopsworks_udf.return_types)
+        ) or not self.__hopsworks_udf.output_column_names:
+            self.__hopsworks_udf.output_column_names = self._get_output_column_names()
+        return self.__hopsworks_udf.output_column_names
 
     def __repr__(self):
         if self.transformation_type == TransformationType.MODEL_DEPENDENT:
-            return (
-                f"Model-Dependent Transformation Function : {repr(self.hopsworks_udf)}"
-            )
+            return f"Model-Dependent Transformation Function : {repr(self.__hopsworks_udf)}"
         elif self.transformation_type == TransformationType.ON_DEMAND:
-            return f"On-Demand Transformation Function : {repr(self.hopsworks_udf)}"
+            return f"On-Demand Transformation Function : {repr(self.__hopsworks_udf)}"
         else:
-            return f"Transformation Function : {repr(self.hopsworks_udf)}"
+            return f"Transformation Function : {repr(self.__hopsworks_udf)}"


### PR DESCRIPTION
This PR cherry picks changes done in PR : https://github.com/logicalclocks/hopsworks-api/pull/428 to the 4.1 branch

JIRA Issue:  https://hopsworks.atlassian.net/browse/FSTORE-1630

Priority for Review: -

Related PRs: 
https://github.com/logicalclocks/hopsworks-ee/pull/2217
https://github.com/logicalclocks/loadtest/pull/509
https://github.com/logicalclocks/logicalclocks.github.io/pull/438
https://github.com/logicalclocks/hopsworks-front/pull/1436

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
