### PR TITLE
[FSTORE-1682] Change default behaviour of get_feature_vector to return on-demand features by default

### DIFF
--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -371,7 +371,7 @@ class VectorServer:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: bool = False,
+        transform: bool = True,
         on_demand_features: Optional[bool] = True,
         request_parameters: Optional[Dict[str, Any]] = None,
         transformation_context: Dict[str, Any] = None,
@@ -443,7 +443,7 @@ class VectorServer:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: bool = False,
+        transform: bool = True,
         on_demand_features: Optional[bool] = True,
         transformation_context: Dict[str, Any] = None,
     ) -> Union[pd.DataFrame, pl.DataFrame, np.ndarray, List[Any], List[Dict[str, Any]]]:

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -328,7 +328,7 @@ class VectorServer:
                 for feature_name in unprefixed_features - available_parameters
             }
 
-            # Prefixed feature names for features that are not available in the in their unprefixed form as request-parameters.
+            # Prefixed feature names for features that are not available in the in their prefixed form as request-parameters.
             prefixed_missing_features = transformation_features - available_parameters
 
             # Get Missing request parameters: These are will include request parameters that are not provided in their unprefixed or prefixed form.
@@ -371,7 +371,7 @@ class VectorServer:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: bool = True,
+        transform: bool = False,
         on_demand_features: Optional[bool] = True,
         request_parameters: Optional[Dict[str, Any]] = None,
         transformation_context: Dict[str, Any] = None,
@@ -439,7 +439,7 @@ class VectorServer:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: bool = True,
+        transform: bool = False,
         on_demand_features: Optional[bool] = True,
         transformation_context: Dict[str, Any] = None,
     ) -> Union[pd.DataFrame, pl.DataFrame, np.ndarray, List[Any], List[Dict[str, Any]]]:
@@ -1273,6 +1273,10 @@ class VectorServer:
         if transform and not on_demand_features:
             _logger.warning(
                 "On-demand features are always returned when `transform=True`, regardless of the value set to `on_demand_features`. To fetch untransformed feature vector without on-demand features, set both `transform=False` and `on_demand_features=False`."
+            )
+        elif not transform:
+            _logger.info(
+                "Returning feature vector without applying Model Dependent transformations. Set `transform=True` to apply model-dependent transformations to the feature vector or use the `transform` function in the Feature View."
             )
 
         if transform or on_demand_features:

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -406,6 +406,10 @@ class VectorServer:
             _logger.debug("get_feature_vector Online SQL client")
             serving_vector = self.sql_client.get_single_feature_vector(rondb_entry)
 
+        self._raise_transformation_warnings(
+            transform=transform, on_demand_features=on_demand_features
+        )
+
         vector = self.assemble_feature_vector(
             result_dict=serving_vector,
             passed_values=passed_features or {},
@@ -489,6 +493,10 @@ class VectorServer:
                 if isinstance(request_parameters, list)
                 else [[]]
             )
+
+        self._raise_transformation_warnings(
+            transform=transform, on_demand_features=on_demand_features
+        )
 
         for (idx, entry), passed, vector_features in itertools.zip_longest(
             enumerate(entries),
@@ -1257,6 +1265,39 @@ class VectorServer:
                 )
         return rows
 
+    def _raise_transformation_warnings(self, transform: bool, on_demand_features: bool):
+        """
+        Function that raises warnings based on the values of `transform` and `on_demand_features` parameters to let users know about the behavior of the function.
+
+        # Arguments
+            transform : `bool`. Specify if model-dependent transformations should be applied.
+            on_demand_features : `bool`. Specify if on-demand features should be computed.
+        """
+        warn_on_demand_features = (
+            not on_demand_features and self.on_demand_transformation_functions
+        )
+        warn_model_dependent_features = (
+            not transform and self.model_dependent_transformation_functions
+        )
+
+        if transform and not on_demand_features:
+            _logger.warning(
+                "On-demand features are always returned when `transform=True`, regardless of `on_demand_features`. "
+                "To fetch an untransformed feature vector without on-demand features, set both `transform=False` and `on_demand_features=False`."
+            )
+        elif warn_on_demand_features and warn_model_dependent_features:
+            _logger.info(
+                "Both `transform` and `on_demand_features` are set to False. Returning feature vector without on-demand features or model-dependent transformations."
+            )
+        elif warn_on_demand_features:
+            _logger.info(
+                "On-demand features are not computed when `on_demand_features=False`. Returning feature vector without on-demand features."
+            )
+        elif warn_model_dependent_features:
+            _logger.info(
+                "Model-dependent transformation functions are not applied when `transform=False`. Returning feature vector without model-dependent transformations."
+            )
+
     def apply_transformation(
         self,
         row_dict: Union[dict, pd.DataFrame],
@@ -1269,15 +1310,6 @@ class VectorServer:
         Function that applies both on-demand and model dependent transformation to the input dictonary
         """
         encoded_feature_dict = row_dict
-
-        if transform and not on_demand_features:
-            _logger.warning(
-                "On-demand features are always returned when `transform=True`, regardless of the value set to `on_demand_features`. To fetch untransformed feature vector without on-demand features, set both `transform=False` and `on_demand_features=False`."
-            )
-        elif not transform:
-            _logger.info(
-                "Returning feature vector without applying Model Dependent transformations. Set `transform=True` to apply model-dependent transformations to the feature vector or use the `transform` function in the Feature View."
-            )
 
         if transform or on_demand_features:
             # Check for any missing request parameters

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -531,7 +531,7 @@ class FeatureView:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: Optional[bool] = False,
+        transform: Optional[bool] = True,
         on_demand_features: Optional[bool] = True,
         request_parameters: Optional[Dict[str, Any]] = None,
         transformation_context: Dict[str, Any] = None,
@@ -608,8 +608,9 @@ class FeatureView:
             force_sql_client: boolean, defaults to False. If set to True, reads from online feature store
                 using the SQL client if initialised.
             allow_missing: Setting to `True` returns feature vectors with missing values.
-            transform: `bool`, defaults to `True`. Setting this to `False` returns a feature vector that includes both precomputed and on-demand features without applying model-dependent transformations. When set to `True`, it automatically sets `on_demand_features` to `True` and applies model-dependent transformations.
-            on_demand_features: `bool`, defaults to `False`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
+            transform: `bool`, default=`True`. If set to `True`, model-dependent transformations are applied to the feature vector, and `on_demand_feature` is automatically set to `True`, ensuring the inclusion of on-demand features.
+                If set to `False`, the function returns the feature vector without applying any model-dependent transformations.
+            on_demand_features: `bool`, defaults to `True`. Setting this to `False` returns untransformed featuretransform: `bool`, default=`True`. vectors without any on-demand features.
             request_parameters: Request parameters required by on-demand transformation functions to compute on-demand features present in the feature view.
             transformation_context: `Dict[str, Any]` A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 These variables must be explicitly defined as parameters in the transformation function to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
@@ -653,7 +654,7 @@ class FeatureView:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: Optional[bool] = False,
+        transform: Optional[bool] = True,
         on_demand_features: Optional[bool] = True,
         request_parameters: Optional[List[Dict[str, Any]]] = None,
         transformation_context: Dict[str, Any] = None,
@@ -728,8 +729,9 @@ class FeatureView:
             force_rest_client: boolean, defaults to False. If set to True, reads from online feature store
                 using the REST client if initialised.
             allow_missing: Setting to `True` returns feature vectors with missing values.
-            transformed: `bool`, defaults to `True`. Setting this to `False` returns a feature vector that includes both precomputed and on-demand features without applying model-dependent transformations. When set to `True`, it automatically sets `on_demand_features` to `True` and applies model-dependent transformations.
-            on_demand_features: `bool`, defaults to `False`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
+            transform: `bool`, default=`True`. If set to `True`, model-dependent transformations are applied to the feature vector, and `on_demand_feature` is automatically set to `True`, ensuring the inclusion of on-demand features.
+                If set to `False`, the function returns the feature vector without applying any model-dependent transformations.
+            on_demand_features: `bool`, defaults to `True`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
             request_parameters: Request parameters required by on-demand transformation functions to compute on-demand features present in the feature view.
             transformation_context: `Dict[str, Any]` A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 These variables must be explicitly defined as parameters in the transformation function to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -532,6 +532,7 @@ class FeatureView:
         force_rest_client: bool = False,
         force_sql_client: bool = False,
         transform: Optional[bool] = True,
+        on_demand_features: Optional[bool] = True,
         request_parameters: Optional[Dict[str, Any]] = None,
         transformation_context: Dict[str, Any] = None,
     ) -> Union[List[Any], pd.DataFrame, np.ndarray, pl.DataFrame]:
@@ -607,7 +608,8 @@ class FeatureView:
             force_sql_client: boolean, defaults to False. If set to True, reads from online feature store
                 using the SQL client if initialised.
             allow_missing: Setting to `True` returns feature vectors with missing values.
-            transformed: Setting to `False` returns the untransformed feature vectors.
+            transform: `bool`, defaults to `True`. Setting this to `False` returns a feature vector that includes both precomputed and on-demand features without applying model-dependent transformations. When set to `True`, it automatically sets `on_demand_features` to `True` and applies model-dependent transformations.
+            on_demand_features: `bool`, defaults to `True`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
             request_parameters: Request parameters required by on-demand transformation functions to compute on-demand features present in the feature view.
             transformation_context: `Dict[str, Any]` A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 These variables must be explicitly defined as parameters in the transformation function to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
@@ -637,6 +639,7 @@ class FeatureView:
             force_rest_client=force_rest_client,
             force_sql_client=force_sql_client,
             transform=transform,
+            on_demand_features=on_demand_features,
             request_parameters=request_parameters,
             transformation_context=transformation_context,
         )
@@ -651,6 +654,7 @@ class FeatureView:
         force_rest_client: bool = False,
         force_sql_client: bool = False,
         transform: Optional[bool] = True,
+        on_demand_features: Optional[bool] = True,
         request_parameters: Optional[List[Dict[str, Any]]] = None,
         transformation_context: Dict[str, Any] = None,
     ) -> Union[List[List[Any]], pd.DataFrame, np.ndarray, pl.DataFrame]:
@@ -724,7 +728,8 @@ class FeatureView:
             force_rest_client: boolean, defaults to False. If set to True, reads from online feature store
                 using the REST client if initialised.
             allow_missing: Setting to `True` returns feature vectors with missing values.
-            transformed: Setting to `False` returns the untransformed feature vectors.
+            transformed: `bool`, defaults to `True`. Setting this to `False` returns a feature vector that includes both precomputed and on-demand features without applying model-dependent transformations. When set to `True`, it automatically sets `on_demand_features` to `True` and applies model-dependent transformations.
+            on_demand_features: `bool`, defaults to `True`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
             request_parameters: Request parameters required by on-demand transformation functions to compute on-demand features present in the feature view.
             transformation_context: `Dict[str, Any]` A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 These variables must be explicitly defined as parameters in the transformation function to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
@@ -757,6 +762,7 @@ class FeatureView:
             force_rest_client=force_rest_client,
             force_sql_client=force_sql_client,
             transform=transform,
+            on_demand_features=on_demand_features,
             request_parameters=request_parameters,
             transformation_context=transformation_context,
         )

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -531,7 +531,7 @@ class FeatureView:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: Optional[bool] = True,
+        transform: Optional[bool] = False,
         on_demand_features: Optional[bool] = True,
         request_parameters: Optional[Dict[str, Any]] = None,
         transformation_context: Dict[str, Any] = None,
@@ -609,7 +609,7 @@ class FeatureView:
                 using the SQL client if initialised.
             allow_missing: Setting to `True` returns feature vectors with missing values.
             transform: `bool`, defaults to `True`. Setting this to `False` returns a feature vector that includes both precomputed and on-demand features without applying model-dependent transformations. When set to `True`, it automatically sets `on_demand_features` to `True` and applies model-dependent transformations.
-            on_demand_features: `bool`, defaults to `True`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
+            on_demand_features: `bool`, defaults to `False`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
             request_parameters: Request parameters required by on-demand transformation functions to compute on-demand features present in the feature view.
             transformation_context: `Dict[str, Any]` A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 These variables must be explicitly defined as parameters in the transformation function to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
@@ -653,7 +653,7 @@ class FeatureView:
         allow_missing: bool = False,
         force_rest_client: bool = False,
         force_sql_client: bool = False,
-        transform: Optional[bool] = True,
+        transform: Optional[bool] = False,
         on_demand_features: Optional[bool] = True,
         request_parameters: Optional[List[Dict[str, Any]]] = None,
         transformation_context: Dict[str, Any] = None,
@@ -729,7 +729,7 @@ class FeatureView:
                 using the REST client if initialised.
             allow_missing: Setting to `True` returns feature vectors with missing values.
             transformed: `bool`, defaults to `True`. Setting this to `False` returns a feature vector that includes both precomputed and on-demand features without applying model-dependent transformations. When set to `True`, it automatically sets `on_demand_features` to `True` and applies model-dependent transformations.
-            on_demand_features: `bool`, defaults to `True`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
+            on_demand_features: `bool`, defaults to `False`. Setting this to `False` returns untransformed feature vectors without any on-demand features.
             request_parameters: Request parameters required by on-demand transformation functions to compute on-demand features present in the feature view.
             transformation_context: `Dict[str, Any]` A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 These variables must be explicitly defined as parameters in the transformation function to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.


### PR DESCRIPTION
This PR introduces a **breaking change**.

It changes the behaviour of `get_feature_vector` so as a disconnect, on-demand features from the `transform` argument. 

In the updated behaviour when:
- `transform=True` and `on_demand_feature=True/False` -  Return the complete transfomed feature vector with on-demand features and model-dependent features.
- `transform=False` and `on_demand_feature=True` - Return feature vector with on-demand features but no model-dependent transformations applied.
- `transform=False` and `on_demand_feature=False` - Return untransformed feature vector without on-demand features or model-dependent transformations applied.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1682

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
