### PR TITLE
[FSTORE-1672][APPEND] Allow multiple on-demand features to be returned from an on-demand transformation function and allow passing of local variables to a transformation function

### DIFF
--- a/python/hopsworks_common/connection.py
+++ b/python/hopsworks_common/connection.py
@@ -147,6 +147,7 @@ class Connection:
         self._api_key_file = api_key_file
         self._api_key_value = api_key_value
         self._connected = False
+        self._backend_version = None
 
         self.connect()
 
@@ -304,16 +305,16 @@ class Connection:
         regexMatcher = re.compile(versionPattern)
 
         client_version = version.__version__
-        backend_version = self._variable_api.get_version("hopsworks")
+        self.backend_version = self._variable_api.get_version("hopsworks")
 
         major_minor_client = regexMatcher.search(client_version).group(0)
-        major_minor_backend = regexMatcher.search(backend_version).group(0)
+        major_minor_backend = regexMatcher.search(self._backend_version).group(0)
 
         if major_minor_backend != major_minor_client:
             print("\n", file=sys.stderr)
             warnings.warn(
                 "The installed hopsworks client version {0} may not be compatible with the connected Hopsworks backend version {1}. \nTo ensure compatibility please install the latest bug fix release matching the minor version of your backend ({2}) by running 'pip install hopsworks=={2}.*'".format(
-                    client_version, backend_version, major_minor_backend
+                    client_version, self._backend_version, major_minor_backend
                 ),
                 stacklevel=1,
             )
@@ -628,6 +629,23 @@ class Connection:
     @property
     def api_key_value(self) -> Optional[str]:
         return self._api_key_value
+
+    @property
+    def backend_version(self) -> Optional[str]:
+        """
+        The version of the backend currently connected to hopsworks.
+        """
+        return self._backend_version
+
+    @backend_version.setter
+    def backend_version(self, backend_version: str) -> None:
+        """
+        The version of the backend currently connected to hopsworks.
+        """
+        self._backend_version = backend_version.split("-SNAPSHOT")[
+            0
+        ].strip()  # Strip off the -SNAPSHOT part of the version if it is present.
+        return self._backend_version
 
     @api_key_file.setter
     @not_connected

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2400,7 +2400,11 @@ class FeatureGroup(FeatureGroupBase):
                         )
                     )
                 else:
-                    if not transformation_function.transformation_type:
+                    if (
+                        not transformation_function.transformation_type
+                        or transformation_function.transformation_type
+                        == TransformationType.UNDEFINED
+                    ):
                         transformation_function.transformation_type = (
                             TransformationType.ON_DEMAND
                         )
@@ -2754,11 +2758,11 @@ class FeatureGroup(FeatureGroupBase):
         if (
             (features is None and len(self._features) > 0)
             or (
-                isinstance(features, List)
+                isinstance(features, list)
                 and len(features) > 0
                 and all([isinstance(f, feature.Feature) for f in features])
             )
-            or (not features and len(self.transformation_functions) > 0)
+            or (features is None and len(self.transformation_functions) > 0)
         ):
             # This is done for compatibility. Users can specify the feature list in the
             # (get_or_)create_feature_group. Users can also provide the feature list in the save().

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -164,7 +164,11 @@ class FeatureView:
                         )
                     )
                 else:
-                    if not transformation_function.transformation_type:
+                    if (
+                        not transformation_function.transformation_type
+                        or transformation_function.transformation_type
+                        == TransformationType.UNDEFINED
+                    ):
                         transformation_function.transformation_type = (
                             TransformationType.MODEL_DEPENDENT
                         )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "tqdm",
     "grpcio>=1.49.1,<2.0.0",         # ^1.49.1
     "protobuf>=4.25.4,<5.0.0",       # ^4.25.4
-    "packaging>=22",         # ^21.0
+    "packaging",         # ^21.0
 ]
 
 [project.optional-dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "tqdm",
     "grpcio>=1.49.1,<2.0.0",         # ^1.49.1
     "protobuf>=4.25.4,<5.0.0",       # ^4.25.4
+    "packaging>=22",         # ^21.0
 ]
 
 [project.optional-dependencies]

--- a/python/tests/test_feature_view.py
+++ b/python/tests/test_feature_view.py
@@ -15,6 +15,7 @@
 #
 import warnings
 
+from hopsworks_common import version
 from hsfs import feature_view, training_dataset_feature
 from hsfs.constructor import fs_query, query
 from hsfs.feature_store import FeatureStore
@@ -148,6 +149,11 @@ class TestFeatureView:
     def test_transformation_function_instances(self, mocker, backend_fixtures):
         # Arrange
         feature_store_id = 99
+        mocked_connection = mocker.MagicMock()
+        mocked_connection.backend_version = version.__version__
+        mocked_connection = mocker.patch(
+            "hopsworks_common.client.get_connection", return_value=mocked_connection
+        )
         mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine")
         json = backend_fixtures["fs_query"]["get"]["response"]
 

--- a/python/tests/test_transformation_function.py
+++ b/python/tests/test_transformation_function.py
@@ -19,9 +19,11 @@ import logging
 
 import pandas as pd
 import pytest
+from hopsworks_common import version
 from hsfs.client.exceptions import FeatureStoreException
 from hsfs.hopsworks_udf import udf
 from hsfs.transformation_function import TransformationFunction, TransformationType
+from packaging.version import Version
 
 
 class TestTransformationFunction:
@@ -228,7 +230,15 @@ class TestTransformationFunction:
             == "Please use the hopsworks_udf decorator when defining transformation functions."
         )
 
-    def test_transformation_function_definition_with_hopworks_udf(self):
+    def test_transformation_function_definition_with_hopworks_udf(self, mocker):
+        mocked_connection = mocker.MagicMock()
+        mocked_connection.backend_version = (
+            version.__version__
+        )  # Mocking backend version to be the same as the current version
+        mocked_connection = mocker.patch(
+            "hopsworks_common.client.get_connection", return_value=mocked_connection
+        )
+
         @udf(int)
         def test2(col1):
             return col1 + 1
@@ -956,7 +966,19 @@ class TestTransformationFunction:
             "really_long_function_name_that_exceed_63_characters_causing_inv"
         ]
 
-    def test_equality_mdt(self):
+    @pytest.mark.skipif(
+        Version("4.1.6") >= Version(version.__version__),
+        reason="Requires Hopsworks 4.1.7 or higher to be working.",
+    )
+    def test_equality_mdt(self, mocker):
+        mocked_connection = mocker.MagicMock()
+        mocked_connection.backend_version = (
+            version.__version__
+        )  # Mocking backend version to be the same as the current version
+        mocked_connection = mocker.patch(
+            "hopsworks_common.client.get_connection", return_value=mocked_connection
+        )
+
         @udf([int])
         def add_one(feature):
             return feature + 1
@@ -975,7 +997,19 @@ class TestTransformationFunction:
 
         assert mdt1 == mdt2
 
-    def test_equality_odt(self):
+    @pytest.mark.skipif(
+        Version("4.1.6") >= Version(version.__version__),
+        reason="Requires Hopsworks 4.1.7 or higher to be working.",
+    )
+    def test_equality_odt(self, mocker):
+        mocked_connection = mocker.MagicMock()
+        mocked_connection.backend_version = (
+            version.__version__
+        )  # Mocking backend version to be the same as the current version
+        mocked_connection = mocker.patch(
+            "hopsworks_common.client.get_connection", return_value=mocked_connection
+        )
+
         @udf([int])
         def add_one(feature):
             return feature + 1
@@ -994,7 +1028,19 @@ class TestTransformationFunction:
 
         assert odt1 == odt2
 
-    def test_inequality(self):
+    @pytest.mark.skipif(
+        Version("4.1.6") >= Version(version.__version__),
+        reason="Requires Hopsworks 4.1.7 or higher to be working.",
+    )
+    def test_inequality(self, mocker):
+        mocked_connection = mocker.MagicMock()
+        mocked_connection.backend_version = (
+            version.__version__
+        )  # Mocking backend version to be the same as the current version
+        mocked_connection = mocker.patch(
+            "hopsworks_common.client.get_connection", return_value=mocked_connection
+        )
+
         @udf([int])
         def add_one(feature):
             return feature + 1


### PR DESCRIPTION
This PR adds support for backwards compatibility with 4.1.x clusters and fixes a few workflow test

- Adding new undefined transformation type that will be used for a transformation function object no attached a feature view object. This fixes the usecase were a `to_dict` called on a transformation function object not attached to a feature view/group. 
- Explicitly checking for None value in feature group ´save´ function. To support passing dataframes to it.

This PR cherry picks the changes for https://github.com/logicalclocks/hopsworks-api/pull/473

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1672

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
