### PR TITLE
[HWORKS-2037] Always default to python engine in the Python kernel

### DIFF
--- a/python/hopsworks/__init__.py
+++ b/python/hopsworks/__init__.py
@@ -118,7 +118,7 @@ def login(
         ```
 
     In addition to setting function arguments directly, `hopsworks.login()` also reads the environment variables:
-    HOPSWORKS_HOST, HOPSWORKS_PORT, HOPSWORKS_PROJECT, HOPSWORKS_API_KEY, HOPSWORKS_HOSTNAME_VERIFICATION and HOPSWORKS_TRUST_STORE_PATH.
+    HOPSWORKS_HOST, HOPSWORKS_PORT, HOPSWORKS_PROJECT, HOPSWORKS_API_KEY, HOPSWORKS_HOSTNAME_VERIFICATION, HOPSWORKS_TRUST_STORE_PATH and HOPSWORKS_ENGINE.
 
     The function arguments do however take precedence over the environment variables in case both are set.
 
@@ -178,6 +178,10 @@ def login(
     # If project argument not defined, get HOPSWORKS_PROJECT environment variable
     if project is None and "HOPSWORKS_PROJECT" in os.environ:
         project = os.environ["HOPSWORKS_PROJECT"]
+
+    # If project argument not defined, get HOPSWORKS_ENGINE environment variable
+    if engine is None and "HOPSWORKS_ENGINE" in os.environ:
+        engine = os.environ["HOPSWORKS_ENGINE"]
 
     # If host argument not defined, get HOPSWORKS_HOST environment variable
     if host is None and "HOPSWORKS_HOST" in os.environ:

--- a/python/hopsworks/__init__.py
+++ b/python/hopsworks/__init__.py
@@ -151,6 +151,10 @@ def login(
 
     global _hw_connection
 
+    # If project argument not defined, get HOPSWORKS_ENGINE environment variable
+    if engine is None and "HOPSWORKS_ENGINE" in os.environ:
+        engine = os.environ["HOPSWORKS_ENGINE"]
+
     # If inside hopsworks, just return the current project for now
     if "REST_ENDPOINT" in os.environ:
         _hw_connection = _hw_connection(
@@ -178,10 +182,6 @@ def login(
     # If project argument not defined, get HOPSWORKS_PROJECT environment variable
     if project is None and "HOPSWORKS_PROJECT" in os.environ:
         project = os.environ["HOPSWORKS_PROJECT"]
-
-    # If project argument not defined, get HOPSWORKS_ENGINE environment variable
-    if engine is None and "HOPSWORKS_ENGINE" in os.environ:
-        engine = os.environ["HOPSWORKS_ENGINE"]
 
     # If host argument not defined, get HOPSWORKS_HOST environment variable
     if host is None and "HOPSWORKS_HOST" in os.environ:


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
