### PR TITLE
[FSTORE-1721] Creating training data with time series split fails when setting `event_time =True` when event_time is not explicitly selected in the query

### DIFF
--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -180,7 +180,9 @@ class Query:
             join_prefix = query_join.prefix
 
             join_features = {
-                feature.name if not join_prefix else join_prefix + feature.name
+                feature._get_fully_qualified_feature_name(
+                    feature_group=query._left_feature_group, prefix=join_prefix
+                )
                 for feature in query._left_features
             }
 
@@ -215,7 +217,9 @@ class Query:
         query_feature_feature_group_mapping: Dict[str, set[str]] = {}
 
         query_feature_feature_group_mapping = {
-            feature.name: set(
+            feature._get_fully_qualified_feature_name(
+                feature_group=self._left_feature_group
+            ): set(
                 [
                     f"{self._left_feature_group.name} version {self._left_feature_group.version}"
                 ]

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -974,7 +974,14 @@ class Engine:
             == TrainingDatasetSplit.TIME_SERIES_SPLIT
         ):
             event_time = query_obj._left_feature_group.event_time
-            if event_time not in [_feature.name for _feature in query_obj.features]:
+
+            event_time_feature = [
+                _feature
+                for _feature in query_obj.features
+                if _feature.name == event_time
+            ]
+
+            if not event_time_feature:
                 query_obj.append_feature(
                     query_obj._left_feature_group.__getattr__(event_time)
                 )
@@ -987,6 +994,11 @@ class Engine:
                     drop_event_time=True,
                 )
             else:
+                # Use the fully qualified name of the event time feature if required
+                event_time = event_time_feature[0]._get_fully_qualified_feature_name(
+                    feature_group=query_obj._left_feature_group
+                )
+
                 result_dfs = self._time_series_split(
                     query_obj.read(
                         read_options=read_option, dataframe_type=dataframe_type

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -825,7 +825,13 @@ class Engine:
             == TrainingDatasetSplit.TIME_SERIES_SPLIT
         ):
             event_time = query_obj._left_feature_group.event_time
-            if event_time not in [_feature.name for _feature in query_obj.features]:
+            event_time_feature = [
+                _feature
+                for _feature in query_obj.features
+                if _feature.name == event_time
+            ]
+
+            if not event_time_feature:
                 query_obj.append_feature(
                     query_obj._left_feature_group.__getattr__(event_time)
                 )
@@ -836,6 +842,11 @@ class Engine:
                     drop_event_time=True,
                 )
             else:
+                # Use the fully qualified name of the event time feature if required
+                event_time = event_time_feature[0]._get_fully_qualified_feature_name(
+                    feature_group=query_obj._left_feature_group
+                )
+
                 return self._time_series_split(
                     training_dataset,
                     query_obj.read(read_options=read_options),

--- a/python/hsfs/feature.py
+++ b/python/hsfs/feature.py
@@ -17,13 +17,17 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import hsfs
 import humps
 from hsfs import util
 from hsfs.constructor import filter
 from hsfs.decorators import typechecked
+
+
+if TYPE_CHECKING:
+    from hsfs.feature_group import FeatureGroup
 
 
 @typechecked
@@ -104,6 +108,31 @@ class Feature:
             "onDemand": self.on_demand,
             "useFullyQualifiedName": self._use_fully_qualified_name,
         }
+
+    def _get_fully_qualified_feature_name(
+        self, feature_group: FeatureGroup = None, prefix: str = None
+    ) -> str:
+        """
+        Returns the name of the feature when used to generated dataframes for training/batch data.
+        - If the feature is configured to use a fully qualified name, it returns that name.
+        - Otherwise, if a prefix is provided, it returns the feature name prefixed accordingly.
+        - If neither condition applies, it returns the feature’s original name.
+
+        # Args:
+            feature_group (FeatureGroup, optional): The feature group context in which the name is being used.
+            prefix (str, optional): A prefix to prepend to the feature name if applicable.
+
+        # Returns:
+            str: The fully qualified feature name.
+        """
+        if self._use_fully_qualified_name:
+            return util.generate_fully_qualified_feature_name(
+                feature_group=feature_group, feature_name=self._name
+            )
+        elif prefix:
+            return prefix + self._name
+        else:
+            return self._name
 
     def json(self) -> str:
         return json.dumps(self, cls=util.Encoder)

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -2425,6 +2425,61 @@ class TestSpark:
         assert mock_spark_engine_time_series_split.call_count == 1
         assert mock_spark_engine_random_split.call_count == 0
 
+    def test_split_df_time_split_query_features_fully_qualified_name(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hopsworks_common.client.get_instance")
+        mocker.patch("hsfs.constructor.query.Query.read")
+        mock_spark_engine_time_series_split = mocker.patch(
+            "hsfs.engine.spark.Engine._time_series_split"
+        )
+        mock_spark_engine_random_split = mocker.patch(
+            "hsfs.engine.spark.Engine._random_split"
+        )
+
+        spark_engine = spark.Engine()
+
+        td = training_dataset.TrainingDataset(
+            name="test",
+            version=1,
+            data_format="CSV",
+            featurestore_id=99,
+            splits={"col1": 1},
+            train_start=1000000000,
+            train_end=2000000000,
+            test_end=3000000000,
+        )
+
+        f = feature.Feature(name="col1", type="str")
+        f1 = feature.Feature(name="col2", type="str")
+        f2 = feature.Feature(
+            name="test_fs_test_1_event_time", type="str", use_fully_qualified_name=True
+        )
+
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            id=10,
+            event_time="event_time",
+            featurestore_name="test_fs",
+        )
+
+        q = query.Query(left_feature_group=fg, left_features=[f, f1, f2])
+
+        # Act
+        spark_engine._split_df(
+            query_obj=q,
+            training_dataset=td,
+            read_options={},
+        )
+
+        # Assert
+        assert mock_spark_engine_time_series_split.call_count == 1
+        assert mock_spark_engine_random_split.call_count == 0
+
     def test_random_split(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client.get_instance")

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -2453,7 +2453,7 @@ class TestSpark:
         f = feature.Feature(name="col1", type="str")
         f1 = feature.Feature(name="col2", type="str")
         f2 = feature.Feature(
-            name="test_fs_test_1_event_time", type="str", use_fully_qualified_name=True
+            name="event_time", type="str", use_fully_qualified_name=True
         )
 
         fg = feature_group.FeatureGroup(

--- a/python/tests/test_feature.py
+++ b/python/tests/test_feature.py
@@ -15,7 +15,7 @@
 #
 
 
-from hsfs import feature
+from hsfs import feature, feature_group
 
 
 class TestFeature:
@@ -102,3 +102,83 @@ class TestFeature:
         assert spaced_feature.name == "col_1"
         assert upper_feature.name == "col1"
         assert both_feature.name == "bravo_col"
+
+    def test_get_fully_qualified_feature_name_without_prefix_and_without_use_fqn(self):
+        # Arrange
+        f = feature.Feature("feature_name")
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            id=10,
+            event_time="event_time",
+            featurestore_name="test_fs",
+        )
+
+        # Act
+        result = f._get_fully_qualified_feature_name(fg)
+
+        # Assert
+        assert result == "feature_name"
+
+    def test_get_fully_qualified_feature_name_with_prefix_and_without_use_fqn(self):
+        # Arrange
+        f = feature.Feature("feature_name")
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            id=10,
+            event_time="event_time",
+            featurestore_name="test_fs",
+        )
+
+        # Act
+        result = f._get_fully_qualified_feature_name(fg, prefix="prefix_")
+
+        # Assert
+        assert result == "prefix_feature_name"
+
+    def test_get_fully_qualified_feature_name_without_prefix_and_with_use_fqn(self):
+        # Arrange
+        f = feature.Feature("feature_name", use_fully_qualified_name=True)
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            id=10,
+            event_time="event_time",
+            featurestore_name="test_fs",
+        )
+
+        # Act
+        result = f._get_fully_qualified_feature_name(fg)
+
+        # Assert
+        assert result == "test_fs_test_1_feature_name"
+
+    def test_get_fully_qualified_feature_name_with_prefix_and_with_use_fqn(self):
+        # Arrange
+        f = feature.Feature("feature_name", use_fully_qualified_name=True)
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            id=10,
+            event_time="event_time",
+            featurestore_name="test_fs",
+        )
+
+        # Act
+        result = f._get_fully_qualified_feature_name(fg, prefix="prefix_")
+
+        # Assert
+        assert result == "test_fs_test_1_feature_name"


### PR DESCRIPTION
This PR fixes an issue introduced by PR : https://github.com/logicalclocks/hopsworks-api/pull/512

**Issue:**
Creation of time series split fails when the argument `event_time=True` and the event_time is not explicitly selected in the query used to create the feature view.

**Root Cause:** 
When event time is not explicitly selected in the query used to create the feature view and training dataset is created with `event_time=True`, then a fully qualified name is used to refer to the event time. This usecase was not handled for time series split.

**Fix Done:**
Handled using fully qualified names to refer to features in time series splits.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1721

Priority for Review: -

Related PRs: 
https://github.com/logicalclocks/loadtest/pull/554

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
