### PR TITLE
[HWORKS-2144][APPEND] Make host in set git provider optional (#547)

### DIFF
--- a/python/hopsworks_common/core/git_api.py
+++ b/python/hopsworks_common/core/git_api.py
@@ -152,7 +152,7 @@ class GitApi:
         return self._git_provider_api._get_provider(provider, host)
 
     @usage.method_logger
-    def set_provider(self, provider: str, username: str, token: str, host: str):
+    def set_provider(self, provider: str, username: str, token: str, host: str = None):
         """Configure a Git provider
 
         ```python
@@ -163,7 +163,7 @@ class GitApi:
 
         git_api = project.get_git_api()
 
-        git_api.set_provider("GitHub", "my_user", "my_token")
+        git_api.set_provider("GitHub", "my_user", "my_token", host="github.com")
 
         ```
         # Arguments
@@ -174,6 +174,9 @@ class GitApi:
         # Raises
             `hopsworks.client.exceptions.RestAPIError`: If the backend encounters an error when handling the request
         """
+        if host is None:
+            host = self._get_default_provider_host(provider)
+
         self._git_provider_api._set_provider(provider, username, token, host)
 
     @usage.method_logger
@@ -542,3 +545,16 @@ class GitApi:
         return git_commit.GitCommit.from_response_json(
             _client._send_request("GET", path_params, headers=headers)
         )
+
+    def _get_default_provider_host(self, provider: str) -> str:
+        """Get the default host name for the given provider"""
+        if provider == "GitHub":
+            return "github.com"
+        elif provider == "GitLab":
+            return "gitlab.com"
+        elif provider == "BitBucket":
+            return "bitbucket.org"
+        else:
+            raise GitException(
+                f"Unknown git provider {provider}. Supported providers are GitHub, GitLab and BitBucket."
+            )


### PR DESCRIPTION
* [HWORKS-2144][APPEND] Make host in set git povider optional

* Fix linting

* Add new line

* Update python/hopsworks_common/core/git_api.py



---------

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
