### PR TITLE
[FSTORE-1749][UNDO] get_feature_vectors fails with 'DatumReader' object has no attribute 'writers_schema'

### DIFF
--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1384,7 +1384,7 @@ class VectorServer:
                                 if isinstance(feature_value, bytes)
                                 else b64decode(feature_value)
                             ),
-                            avro_schema.writer_schema.to_json(),
+                            avro_schema.writers_schema.to_json(),
                         )
                         # embedded features are deserialized already but not complex features stored in Opensearch
                         if (


### PR DESCRIPTION
…ject has no attribute 'writers_schema' (#553)"

This reverts commit 246da6611c9fd9a8870ab0f00dbe5c7e8b99c4ea.

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
