### PR TITLE
[FSTORE-1721][4.2][APPEND] Creating training data with time series split fails when setting event_time =True when event_time is not explicitly selected in the query

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -978,13 +978,26 @@ class Engine:
             event_time_feature = [
                 _feature
                 for _feature in query_obj.features
-                if _feature.name == event_time
+                if (
+                    _feature.name == event_time
+                    and _feature._feature_group_id == query_obj._left_feature_group.id
+                )
             ]
 
             if not event_time_feature:
-                query_obj.append_feature(
-                    query_obj._left_feature_group.__getattr__(event_time)
+                # Event time feature not in query manually adding event_time of root feature group.
+                # Using fully qualified name of the event time feature to avoid ambiguity.
+
+                event_time_feature = query_obj._left_feature_group.__getattr__(
+                    event_time
                 )
+                event_time_feature.use_fully_qualified_name = True
+
+                query_obj.append_feature(event_time_feature)
+                event_time = event_time_feature._get_fully_qualified_feature_name(
+                    feature_group=query_obj._left_feature_group
+                )
+
                 result_dfs = self._time_series_split(
                     query_obj.read(
                         read_options=read_option, dataframe_type=dataframe_type

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -831,13 +831,23 @@ class Engine:
             event_time_feature = [
                 _feature
                 for _feature in query_obj.features
-                if _feature.name == event_time
+                if (
+                    _feature.name == event_time
+                    and _feature._feature_group_id == query_obj._left_feature_group.id
+                )
             ]
 
             if not event_time_feature:
-                query_obj.append_feature(
-                    query_obj._left_feature_group.__getattr__(event_time)
+                event_time_feature = query_obj._left_feature_group.__getattr__(
+                    event_time
                 )
+                event_time_feature.use_fully_qualified_name = True
+
+                query_obj.append_feature(event_time_feature)
+                event_time = event_time_feature._get_fully_qualified_feature_name(
+                    feature_group=query_obj._left_feature_group
+                )
+
                 return self._time_series_split(
                     training_dataset,
                     query_obj.read(read_options=read_options),

--- a/python/hsfs/feature.py
+++ b/python/hsfs/feature.py
@@ -125,7 +125,7 @@ class Feature:
         # Returns:
             str: The fully qualified feature name.
         """
-        if self._use_fully_qualified_name:
+        if self.use_fully_qualified_name:
             return util.generate_fully_qualified_feature_name(
                 feature_group=feature_group, feature_name=self._name
             )
@@ -133,6 +133,15 @@ class Feature:
             return prefix + self._name
         else:
             return self._name
+
+    @property
+    def use_fully_qualified_name(self) -> bool:
+        """Use fully qualified name for the feature when generating dataframes for training/batch data."""
+        return self._use_fully_qualified_name
+
+    @use_fully_qualified_name.setter
+    def use_fully_qualified_name(self, use_fully_qualified_name: bool) -> None:
+        self._use_fully_qualified_name = use_fully_qualified_name
 
     def json(self) -> str:
         return json.dumps(self, cls=util.Encoder)

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -1888,6 +1888,7 @@ class TestPython:
             id=10,
             event_time="event_time",
             features=[f, f1, f2],
+            featurestore_name="test_fs",
         )
 
         q = query.Query(left_feature_group=fg, left_features=[])
@@ -1947,19 +1948,21 @@ class TestPython:
             test_end=3000000000,
         )
 
+        f = feature.Feature(name="col1", type="str")
+        f1 = feature.Feature(name="col2", type="str")
+        f2 = feature.Feature(name="event_time", type="str")
+
         fg = feature_group.FeatureGroup(
             name="test",
             version=1,
             featurestore_id=99,
             primary_key=[],
             partition_key=[],
+            features=[f, f1, f2],
             id=10,
             event_time="event_time",
+            featurestore_name="test_fs",
         )
-
-        f = feature.Feature(name="col1", type="str")
-        f1 = feature.Feature(name="col2", type="str")
-        f2 = feature.Feature(name="event_time", type="str")
 
         q = query.Query(left_feature_group=fg, left_features=[f, f1, f2])
 
@@ -2019,21 +2022,22 @@ class TestPython:
             test_end=3000000000,
         )
 
+        f = feature.Feature(name="col1", type="str")
+        f1 = feature.Feature(name="col2", type="str")
+        f2 = feature.Feature(
+            name="event_time", type="str", use_fully_qualified_name=True
+        )
+
         fg = feature_group.FeatureGroup(
             name="test",
             version=1,
             featurestore_id=99,
             primary_key=[],
+            features=[f, f1, f2],
             partition_key=[],
             id=10,
             event_time="event_time",
             featurestore_name="test_fs",
-        )
-
-        f = feature.Feature(name="col1", type="str")
-        f1 = feature.Feature(name="col2", type="str")
-        f2 = feature.Feature(
-            name="event_time", type="str", use_fully_qualified_name=True
         )
 
         q = query.Query(left_feature_group=fg, left_features=[f, f1, f2])

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -2353,6 +2353,7 @@ class TestSpark:
             id=10,
             event_time="event_time",
             features=[f, f1, f2],
+            featurestore_name="test_fs",
         )
 
         q = query.Query(left_feature_group=fg, left_features=None)
@@ -2403,8 +2404,10 @@ class TestSpark:
             featurestore_id=99,
             primary_key=[],
             partition_key=[],
+            features=[f, f1, f2],
             id=10,
             event_time="event_time",
+            featurestore_name="test_fs",
         )
 
         q = query.Query(left_feature_group=fg, left_features=[f, f1, f2])
@@ -2457,6 +2460,7 @@ class TestSpark:
             featurestore_id=99,
             primary_key=[],
             partition_key=[],
+            features=[f, f1, f2],
             id=10,
             event_time="event_time",
             featurestore_name="test_fs",


### PR DESCRIPTION
Cherry picking changes done in PR - #538

JIRA Issue: : https://hopsworks.atlassian.net/browse/FSTORE-1721

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
