### PR TITLE
[FSTORE-1755] Updating jobs fails

### DIFF
--- a/python/hopsworks_common/core/job_api.py
+++ b/python/hopsworks_common/core/job_api.py
@@ -183,7 +183,7 @@ class JobApi:
         """
         _client = client.get_instance()
 
-        config = util.validate_job_conf(config, self._project_name)
+        config = util.validate_job_conf(config, _client._project_name)
 
         path_params = ["project", _client._project_id, "jobs", name]
 


### PR DESCRIPTION
This PR fixes an issue in which updating jobs fails with an AttributeError: 'JobApi' object has no attribute '_project_name'

**Root Cause:**
'_project_name' has been moved into the client class and is not part of JobAPI anymore.

**Fix Done:**
Use '_project_name' from the client class

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1755

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
