### PR TITLE
[FSTORE-1752] mysql connection pool is not handled properly when the server closes connection

### DIFF
--- a/python/hsfs/core/util_sql.py
+++ b/python/hsfs/core/util_sql.py
@@ -113,7 +113,7 @@ async def create_async_engine(
         loop=loop,
         minsize=options.get("minsize", default_min_size),
         maxsize=options.get("maxsize", default_min_size),
-        pool_recycle=options.get("pool_recycle", -1),
+        pool_recycle=options.get("pool_recycle", 14400),
         autocommit=options.get("autocommit", True),
     )
     return pool


### PR DESCRIPTION
The PR fixes an issue in which feature vector retrieval fails after a long period of inactivity.

**Root Cause:**
The [wait_timeout](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_wait_timeout) variable inside MySQL specifies the time a connection can be idle before it is closed. By default that time is 8hrs (28800 secs). This causes the connections inside the connection pool to get disconnected.

This problem can be handled by using the [`pool_recycle`](https://aiomysql.readthedocs.io/en/stable/pool.html) argument which [recycles a connection before it becomes state](https://docs.sqlalchemy.org/en/20/core/pooling.html#setting-pool-recycle)

**Fix Done:**
Set the `pool_recycle` variable to half the default `wait_timeout` value.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1752

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
