### PR TITLE
[FSTORE-1796] Cannot Retrieve Feature Vectors from Feature View with Only On-Demand Features and a Normal Label Feature

### DIFF
--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1877,7 +1877,9 @@ class VectorServer:
         """True if all features in the feature view are on-demand."""
         if self.__all_features_on_demand is None:
             self.__all_features_on_demand = all(
-                feature.on_demand_transformation_function for feature in self._features
+                feature.on_demand_transformation_function
+                for feature in self._features
+                if not feature.label
             )
         return self.__all_features_on_demand
 


### PR DESCRIPTION
This PR fixes an issue introduced in the [PR](https://github.com/logicalclocks/hopsworks-api/pull/558)

**Issue:**
[PR](https://github.com/logicalclocks/hopsworks-api/pull/558) added the support for allowing fetching feature vectors from feature views created from offline feature group but contain only on-demand features. However when a feature view contains a normal feature as the label then `init_serving` fails. This is bug since label feature are ignored during feature vector retrieval and should not affect `init_serving`.

**Root Cause:**
Label feature were considered while performing validation for initializing serving.

**Fix Done:**
Filter our label feature before performing validations for initializing serving.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1796

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
