### PR TITLE
[FSTORE-1796][4.2] Cannot Retrieve Feature Vectors from Feature View with Only On-Demand Features and a Normal Label Feature 

### DIFF
--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1877,7 +1877,9 @@ class VectorServer:
         """True if all features in the feature view are on-demand."""
         if self.__all_features_on_demand is None:
             self.__all_features_on_demand = all(
-                feature.on_demand_transformation_function for feature in self._features
+                feature.on_demand_transformation_function
+                for feature in self._features
+                if not feature.label
             )
         return self.__all_features_on_demand
 


### PR DESCRIPTION
This PR cherry picks changes done by the PR https://github.com/logicalclocks/hopsworks-api/pull/593 to the 4.2 branch.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1796

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
