### PR TITLE
[FSTORE-1794][4.2] Bump up fastavro to allow easy installation of hopsworks in Mac with apple silicon on Python 3.10

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,7 +63,7 @@ python = [
     "numpy<2",
     "pyarrow>=10.0",
     "confluent-kafka<=2.6.1",
-    "fastavro>=1.4.11,<=1.8.4",
+    "fastavro>=1.4.11,<=1.11.1",
     "tqdm",
 ]
 great-expectations = ["great_expectations==0.18.12"]


### PR DESCRIPTION
This PR cherry picks changes done in PR https://github.com/logicalclocks/hopsworks-api/pull/597 to the 4.2 branch

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1794

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
