### PR TITLE
[FSTORE-1752][4.3] mysql connection pool is not handled properly when the server closes connection

### DIFF
--- a/python/hsfs/core/util_sql.py
+++ b/python/hsfs/core/util_sql.py
@@ -113,7 +113,7 @@ async def create_async_engine(
         loop=loop,
         minsize=options.get("minsize", default_min_size),
         maxsize=options.get("maxsize", default_min_size),
-        pool_recycle=options.get("pool_recycle", -1),
+        pool_recycle=options.get("pool_recycle", 14400),
         autocommit=options.get("autocommit", True),
     )
     return pool


### PR DESCRIPTION
This PR cherry picks changes done by PR : https://github.com/logicalclocks/hopsworks-api/pull/565 into the 4.3 branch

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1752

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
