### PR TITLE
[HWORKS-1810] Add support for reading from Python from S3 compliant storages

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -389,6 +389,8 @@ class Engine:
         prefix = "/".join(path_parts)
 
         if storage_connector.session_token is not None:
+            # This is only for AWS IAM role passthrough.
+            # We don't need to set the endpoint_url and region here.
             s3 = boto3.client(
                 "s3",
                 aws_access_key_id=storage_connector.access_key,
@@ -400,6 +402,8 @@ class Engine:
                 "s3",
                 aws_access_key_id=storage_connector.access_key,
                 aws_secret_access_key=storage_connector.secret_key,
+                endpoint_url=storage_connector.arguments.get("fs.s3a.endpoint"),
+                region_name=storage_connector.region
             )
 
         df_list = []


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
