### PR TITLE
HOPSFS-273: pass all fs.s3a.* params to spark hadoop

### DIFF
--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -1380,12 +1380,19 @@ class Engine:
                 storage_connector.session_token,
             )
 
-        # This is the name of the property as expected from the user, without the bucket name.
-        FS_S3_ENDPOINT = "fs.s3a.endpoint"
-        if FS_S3_ENDPOINT in storage_connector.arguments:
+        # Forward all user-specified fs.s3a.* options to Hadoop conf
+        for key, value in storage_connector.spark_options().items():
+            if not isinstance(key, str):
+                continue
+            if not key.startswith("fs.s3a."):
+                continue
+            if value is None:
+                continue
+            # Strip the leading 'fs.s3a.' so we can prefix with the connector specific prefix
+            suffix = key.split("fs.s3a.", 1)[1]
             self._spark_context._jsc.hadoopConfiguration().set(
-                f"{prefix}.endpoint",
-                storage_connector.spark_options().get(FS_S3_ENDPOINT),
+                f"{prefix}.{suffix}",
+                str(value),
             )
 
     def _setup_adls_hadoop_conf(self, storage_connector, path):


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
