### PR TITLE
[FSTORE-1807] get_feature_vector does not return a pandas dataframe with correct Data Types

### DIFF
--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1038,8 +1038,7 @@ class VectorServer:
             elif batch:
                 return pd.DataFrame(feature_vectorz, columns=column_names)
             else:
-                pandas_df = pd.DataFrame([feature_vectorz], columns=column_names)
-                return pandas_df
+                return pd.DataFrame([feature_vectorz], columns=column_names)
         elif return_type.lower() == "polars":
             if _logger.isEnabledFor(logging.DEBUG):
                 _logger.debug("Returning feature vector as polars dataframe")

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1038,8 +1038,7 @@ class VectorServer:
             elif batch:
                 return pd.DataFrame(feature_vectorz, columns=column_names)
             else:
-                pandas_df = pd.DataFrame(feature_vectorz).transpose()
-                pandas_df.columns = column_names
+                pandas_df = pd.DataFrame([feature_vectorz], columns=column_names)
                 return pandas_df
         elif return_type.lower() == "polars":
             if _logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
**Issue**:
When a feature group contains features with different data types, the get_feature_vector function returns a pandas DataFrame where all columns have the data type object.

**Root Cause**:
For single-row retrieval, the vector server was creating a DataFrame by treating the row as a column and then transposing it to form the final feature vector.
When pandas creates a DataFrame from a list, it automatically infers data types. However, since the vector server was constructing the DataFrame by considering feature vector as a single column, pandas could not correctly infer the data types. As a result, all columns defaulted to object.

**Fix**:
For single feature vector retrieval, the feature vector is now passed as a row when creating the DataFrame

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1807

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
