### PR TITLE
[HWORKS-2672] HF Model Download Support

### DIFF
--- a/python/hopsworks_common/client/exceptions.py
+++ b/python/hopsworks_common/client/exceptions.py
@@ -250,6 +250,42 @@ class ModelRegistryException(Exception):
     """Generic model registry exception."""
 
 
+@also_available_as("hsml.client.exceptions.HuggingFaceImportException")
+class HuggingFaceImportException(ModelRegistryException):
+    """Raised when an asynchronous HuggingFace model import does not complete successfully.
+
+    Carries the stable error code emitted by the backend so callers can branch on it.
+    The backend codes are:
+
+    - ``auth_required`` — the supplied HuggingFace access token was rejected (invalid,
+      expired, or missing the gated-repo grant). Retry with a different token.
+    - ``not_found_or_auth_required`` — no token was supplied and HuggingFace returned
+      401 for the repo. Either the model id is wrong or the repo is private/gated;
+      HuggingFace deliberately hides which.
+    - ``model_not_found`` — HuggingFace returned 404 for the repo.
+    - ``no_disk_space`` — HopsFS storage quota was exhausted while downloading.
+    - ``download_failed: <file>`` — a specific file failed to download (network etc.).
+    - ``invalid_filename: <name>`` — a file in the repo had a name disallowed by the
+      path-safety check (``..`` segments, absolute paths, …).
+    - ``registration_failed: ...`` — files downloaded but the final registration step
+      failed.
+    - ``fetch_failed`` — generic upstream / metadata error talking to HuggingFace.
+    """
+
+    # Stable error keys returned by the backend. Match these against
+    # ``HuggingFaceImportException.error_code`` rather than substring-checking the message.
+    AUTH_REQUIRED = "auth_required"
+    NOT_FOUND_OR_AUTH_REQUIRED = "not_found_or_auth_required"
+    MODEL_NOT_FOUND = "model_not_found"
+    NO_DISK_SPACE = "no_disk_space"
+    FETCH_FAILED = "fetch_failed"
+
+    def __init__(self, error_code: str, message: str | None = None):
+        self.error_code = error_code
+        self.message = message or error_code
+        super().__init__(self.message)
+
+
 @also_available_as("hsml.client.exceptions.ModelServingException")
 class ModelServingException(Exception):
     """Generic model serving exception."""

--- a/python/hopsworks_common/client/exceptions.py
+++ b/python/hopsworks_common/client/exceptions.py
@@ -250,6 +250,7 @@ class ModelRegistryException(Exception):
     """Generic model registry exception."""
 
 
+@public("hopsworks.client.exceptions.HuggingFaceImportException")
 @also_available_as("hsml.client.exceptions.HuggingFaceImportException")
 class HuggingFaceImportException(ModelRegistryException):
     """Raised when an asynchronous HuggingFace model import does not complete successfully.

--- a/python/hopsworks_common/core/dataset_api.py
+++ b/python/hopsworks_common/core/dataset_api.py
@@ -210,6 +210,7 @@ class DatasetApi:
             The path to the uploaded file or directory.
 
         Raises:
+            hopsworks.client.exceptions.DatasetException: If the destination path already exists and overwrite is not set to `True`, or if the upload fails because the HopsFS storage quota is exhausted.
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         # local path could be absolute or relative,

--- a/python/hopsworks_common/core/dataset_api.py
+++ b/python/hopsworks_common/core/dataset_api.py
@@ -64,6 +64,9 @@ class DatasetApi:
     DEFAULT_DOWNLOAD_FLOW_CHUNK_SIZE = 1024 * 1024
     FLOW_PERMANENT_ERRORS = [404, 413, 415, 500, 501]
 
+    # Backend error code for DatasetErrorCode.UPLOAD_DISK_SPACE_ERROR (110000 + 55)
+    DATASET_ERROR_CODE_UPLOAD_DISK_SPACE = 110055
+
     # alias for backwards-compatibility:
     DEFAULT_FLOW_CHUNK_SIZE = DEFAULT_DOWNLOAD_FLOW_CHUNK_SIZE
 
@@ -389,6 +392,11 @@ class DatasetApi:
                     or chunk.retries > max_chunk_retries
                 ):
                     chunk.status = "failed"
+                    if re.error_code == DatasetApi.DATASET_ERROR_CODE_UPLOAD_DISK_SPACE:
+                        raise DatasetException(
+                            "Upload failed: HopsFS storage is full. "
+                            "Please contact your administrator to free up disk space."
+                        ) from re
                     raise re
                 time.sleep(chunk_retry_interval)
                 continue

--- a/python/hsml/core/huggingface_api.py
+++ b/python/hsml/core/huggingface_api.py
@@ -60,6 +60,17 @@ class HuggingFaceApi:
         arguments line up with the JSON request body the UI sends — when the
         backend sees a non-empty ``selectedFilenames`` it imports exactly those
         files and ignores the other selection args.
+
+        Parameters:
+            model_registry_id: id of the model registry to import into
+            hugging_face_model_id: HuggingFace model id (e.g. ``"meta-llama/Llama-3-8B"``)
+            hf_token: optional HuggingFace access token for gated or private models
+            selected_formats: optional list of model formats to import
+            selected_variants: optional list of variants to import
+            selected_filenames: optional list of explicit filenames to import; when set, the other ``selected_*`` args are ignored
+
+        Returns:
+            backend response with the ``jobId`` of the started import
         """
         body: dict = {"huggingFaceModelId": hugging_face_model_id}
         if hf_token:
@@ -80,7 +91,15 @@ class HuggingFaceApi:
         )
 
     def get_status(self, model_registry_id: int, job_id: str) -> dict:
-        """Poll the status of a running or finished HuggingFace import job."""
+        """Poll the status of a running or finished HuggingFace import job.
+
+        Parameters:
+            model_registry_id: id of the model registry the job is running in
+            job_id: id of the import job returned by :py:meth:`start_import`
+
+        Returns:
+            backend response describing the current job status
+        """
         _client = client.get_instance()
         return _client._send_request(
             "GET",
@@ -90,7 +109,13 @@ class HuggingFaceApi:
     def cancel(
         self, model_registry_id: int, job_id: str, cleanup: bool = False
     ) -> None:
-        """Cancel an import. If ``cleanup`` is true, the partial directory is removed."""
+        """Cancel an import. If ``cleanup`` is true, the partial directory is removed.
+
+        Parameters:
+            model_registry_id: id of the model registry the job is running in
+            job_id: id of the import job to cancel
+            cleanup: when true, the backend deletes the partially downloaded model directory
+        """
         _client = client.get_instance()
         query_params = {"cleanup": "true"} if cleanup else None
         _client._send_request(

--- a/python/hsml/core/huggingface_api.py
+++ b/python/hsml/core/huggingface_api.py
@@ -1,0 +1,100 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""HTTP client for the backend's HuggingFace import endpoints.
+
+Mirrors the three REST routes the model-registry resource exposes:
+
+- ``POST /modelregistries/{id}/models/huggingface``               start_import
+- ``GET  /modelregistries/{id}/models/huggingface/status/{job}``  get_status
+- ``DELETE /modelregistries/{id}/models/huggingface/status/{job}`` cancel
+"""
+
+from __future__ import annotations
+
+import json
+
+from hsml import client
+
+
+class HuggingFaceApi:
+    def __init__(self):
+        pass
+
+    def _base_path(self, model_registry_id: int) -> list:
+        _client = client.get_instance()
+        return [
+            "project",
+            _client._project_id,
+            "modelregistries",
+            str(model_registry_id),
+            "models",
+            "huggingface",
+        ]
+
+    def start_import(
+        self,
+        model_registry_id: int,
+        hugging_face_model_id: str,
+        hf_token: str | None = None,
+        selected_formats: list[str] | None = None,
+        selected_variants: list[str] | None = None,
+        selected_filenames: list[str] | None = None,
+    ) -> dict:
+        """Kick off an asynchronous HuggingFace import.
+
+        The backend returns 202 with ``{"jobId": "..."}``; the actual download runs
+        in the background and is polled via :py:meth:`get_status`. ``selected_*``
+        arguments line up with the JSON request body the UI sends — when the
+        backend sees a non-empty ``selectedFilenames`` it imports exactly those
+        files and ignores the other selection args.
+        """
+        body: dict = {"huggingFaceModelId": hugging_face_model_id}
+        if hf_token:
+            body["hfToken"] = hf_token
+        if selected_formats:
+            body["selectedFormats"] = list(selected_formats)
+        if selected_variants:
+            body["selectedVariants"] = list(selected_variants)
+        if selected_filenames:
+            body["selectedFilenames"] = list(selected_filenames)
+
+        _client = client.get_instance()
+        return _client._send_request(
+            "POST",
+            self._base_path(model_registry_id),
+            headers={"content-type": "application/json"},
+            data=json.dumps(body),
+        )
+
+    def get_status(self, model_registry_id: int, job_id: str) -> dict:
+        """Poll the status of a running or finished HuggingFace import job."""
+        _client = client.get_instance()
+        return _client._send_request(
+            "GET",
+            self._base_path(model_registry_id) + ["status", job_id],
+        )
+
+    def cancel(
+        self, model_registry_id: int, job_id: str, cleanup: bool = False
+    ) -> None:
+        """Cancel an import. If ``cleanup`` is true, the partial directory is removed."""
+        _client = client.get_instance()
+        query_params = {"cleanup": "true"} if cleanup else None
+        _client._send_request(
+            "DELETE",
+            self._base_path(model_registry_id) + ["status", job_id],
+            query_params=query_params,
+        )

--- a/python/hsml/model_registry.py
+++ b/python/hsml/model_registry.py
@@ -204,7 +204,7 @@ class ModelRegistry:
         selected_formats: list[str] | None = None,
         selected_variants: list[str] | None = None,
         selected_filenames: list[str] | None = None,
-        timeout: int = 3600,
+        timeout: int = 36000,
         poll_interval: int = 5,
     ) -> model.Model:
         """Import a model from HuggingFace into this Model Registry.

--- a/python/hsml/model_registry.py
+++ b/python/hsml/model_registry.py
@@ -34,6 +34,7 @@ from hsml.python import signature as python_signature  # noqa: F401
 from hsml.sklearn import signature as sklearn_signature  # noqa: F401
 from hsml.tensorflow import signature as tensorflow_signature  # noqa: F401
 from hsml.torch import signature as torch_signature  # noqa: F401
+from tqdm.auto import tqdm
 
 
 if TYPE_CHECKING:
@@ -282,19 +283,57 @@ class ModelRegistry:
                 "Backend did not return a jobId for the HuggingFace import.",
             )
 
+        print(
+            f"Importing '{hugging_face_model_id}' (job {job_id}). "
+            f"Polling every {poll_interval}s for up to {timeout}s."
+        )
+
         deadline = time.time() + timeout
         last_status: dict = {}
-        while time.time() < deadline:
-            last_status = self._huggingface_api.get_status(
-                self.model_registry_id, job_id
-            )
-            status = (last_status or {}).get("status")
-            if status == "COMPLETED":
-                return self._resolve_imported_model(hugging_face_model_id, last_status)
-            if status in ("FAILED", "CANCELLED"):
-                error = last_status.get("error") or "unknown_error"
-                raise self._build_hf_exception(error)
-            time.sleep(poll_interval)
+        pbar: tqdm | None = None
+        last_completed = 0
+        try:
+            while time.time() < deadline:
+                last_status = self._huggingface_api.get_status(
+                    self.model_registry_id, job_id
+                )
+                status = (last_status or {}).get("status")
+                total = int(last_status.get("totalFiles") or 0)
+                done = int(last_status.get("completedFiles") or 0)
+                current_file = last_status.get("currentFile")
+
+                # Lazy-init the progress bar once the backend reports a file count.
+                if pbar is None and total > 0:
+                    pbar = tqdm(total=total, unit="file", desc="HF import")
+                if pbar is not None:
+                    if done > last_completed:
+                        pbar.update(done - last_completed)
+                        last_completed = done
+                    if current_file:
+                        pbar.set_postfix_str(current_file, refresh=False)
+
+                if status == "COMPLETED":
+                    if pbar is not None:
+                        if total > last_completed:
+                            pbar.update(total - last_completed)
+                        pbar.close()
+                    print(
+                        f"✔ HuggingFace import succeeded: "
+                        f"'{hugging_face_model_id}' downloaded "
+                        f"({done}/{total} files)."
+                    )
+                    return self._resolve_imported_model(
+                        hugging_face_model_id, last_status
+                    )
+                if status in ("FAILED", "CANCELLED"):
+                    if pbar is not None:
+                        pbar.close()
+                    error = last_status.get("error") or "unknown_error"
+                    raise self._build_hf_exception(error)
+                time.sleep(poll_interval)
+        finally:
+            if pbar is not None:
+                pbar.close()
 
         # Timed out — best-effort cancel so the partial dir doesn't linger.
         with contextlib.suppress(Exception):

--- a/python/hsml/model_registry.py
+++ b/python/hsml/model_registry.py
@@ -15,13 +15,20 @@
 #
 from __future__ import annotations
 
+import contextlib
+import re
+import time
 import warnings
 from typing import TYPE_CHECKING
 
 import humps
 from hopsworks_apigen import public
 from hopsworks_common import usage, util
-from hsml.core import model_api
+from hopsworks_common.client.exceptions import (
+    HuggingFaceImportException,
+    RestAPIError,
+)
+from hsml.core import huggingface_api, model_api
 from hsml.llm import signature as llm_signature  # noqa: F401
 from hsml.python import signature as python_signature  # noqa: F401
 from hsml.sklearn import signature as sklearn_signature  # noqa: F401
@@ -52,6 +59,7 @@ class ModelRegistry:
         self._model_registry_id = model_registry_id
 
         self._model_api = model_api.ModelApi()
+        self._huggingface_api = huggingface_api.HuggingFaceApi()
 
         self._tensorflow = tensorflow_signature
         self._python = python_signature
@@ -185,6 +193,202 @@ class ModelRegistry:
     def model_registry_id(self):
         """Id of the model registry."""
         return self._model_registry_id
+
+    @public
+    @usage.method_logger
+    def hf_download(
+        self,
+        hugging_face_model_id: str,
+        hf_token: str | None = None,
+        selected_formats: list[str] | None = None,
+        selected_variants: list[str] | None = None,
+        selected_filenames: list[str] | None = None,
+        timeout: int = 3600,
+        poll_interval: int = 5,
+    ) -> model.Model:
+        """Import a model from HuggingFace into this Model Registry.
+
+        Kicks off the asynchronous server-side download, polls until the import
+        reaches a terminal status, and returns the registered model on success.
+
+        ```python
+        import hopsworks
+
+        project = hopsworks.login()
+        mr = project.get_model_registry()
+
+        # Public model — minimal call.
+        m = mr.hf_download("Qwen/Qwen2.5-0.5B")
+
+        # Gated / private — supply an HF access token.
+        m = mr.hf_download("meta-llama/Llama-3.2-1B", hf_token="hf_xxx")
+
+        # Multi-quant repo — pick exactly one variant.
+        m = mr.hf_download(
+            "unsloth/Kimi-K2.6-GGUF", selected_variants=["UD-Q4_K_XL"]
+        )
+        ```
+
+        Parameters:
+            hugging_face_model_id: HF repo id (``owner/repo``) or full HuggingFace URL.
+            hf_token: Optional HuggingFace access token; required for gated/private repos.
+            selected_formats: Weight-format keys to download (``safetensors``, ``pytorch``,
+                ``tensorflow``, ``flax``, ``gguf``, ``onnx``, ``openvino``, ``coreml``,
+                ``tflite``). When omitted, the backend picks one with the precedence
+                safetensors > pytorch > tensorflow > flax > … so multi-format repos don't
+                pull every copy of the same weights.
+            selected_variants: GGUF / unsloth quantisation tags to keep
+                (``Q4_K_M``, ``UD-Q4_K_XL``, ``BF16``, …). Acts as a sub-filter — files
+                with a quant tag are only downloaded if their tag is in the list. Files
+                without a tag (root README, config, …) are unaffected.
+            selected_filenames: Explicit per-file allowlist. When non-empty this
+                overrides ``selected_formats`` / ``selected_variants`` and the backend
+                downloads exactly these paths.
+            timeout: Maximum seconds to wait for the import to reach a terminal state.
+            poll_interval: Seconds between status polls.
+
+        Returns:
+            The newly registered model entity.
+
+        Raises:
+            hopsworks.client.exceptions.HuggingFaceImportException: If the backend
+                fails the import with a known terminal error. The exception's
+                ``error_code`` field carries the stable code (``auth_required``,
+                ``model_not_found``, ``not_found_or_auth_required``, ``no_disk_space``,
+                ``fetch_failed``, etc.).
+            hopsworks.client.exceptions.RestAPIError: For unexpected server errors
+                that are not part of the HF import error set.
+        """
+        # Map known synchronous backend errors (returned by POST /huggingface and
+        # /inspect on the resource) to the typed exception so the caller doesn't
+        # need to introspect a raw RestAPIError.
+        try:
+            start = self._huggingface_api.start_import(
+                self.model_registry_id,
+                hugging_face_model_id,
+                hf_token=hf_token,
+                selected_formats=selected_formats,
+                selected_variants=selected_variants,
+                selected_filenames=selected_filenames,
+            )
+        except RestAPIError as e:
+            self._raise_hf_exception_from_rest_error(e)
+            raise  # pragma: no cover
+
+        job_id = (start or {}).get("jobId") if isinstance(start, dict) else None
+        if not job_id:
+            raise HuggingFaceImportException(
+                HuggingFaceImportException.FETCH_FAILED,
+                "Backend did not return a jobId for the HuggingFace import.",
+            )
+
+        deadline = time.time() + timeout
+        last_status: dict = {}
+        while time.time() < deadline:
+            last_status = self._huggingface_api.get_status(
+                self.model_registry_id, job_id
+            )
+            status = (last_status or {}).get("status")
+            if status == "COMPLETED":
+                return self._resolve_imported_model(hugging_face_model_id, last_status)
+            if status in ("FAILED", "CANCELLED"):
+                error = last_status.get("error") or "unknown_error"
+                raise self._build_hf_exception(error)
+            time.sleep(poll_interval)
+
+        # Timed out — best-effort cancel so the partial dir doesn't linger.
+        with contextlib.suppress(Exception):
+            self._huggingface_api.cancel(self.model_registry_id, job_id, cleanup=True)
+        raise HuggingFaceImportException(
+            HuggingFaceImportException.FETCH_FAILED,
+            f"HuggingFace import {hugging_face_model_id} did not finish within "
+            f"{timeout}s. Last status: {last_status}",
+        )
+
+    @staticmethod
+    def _raise_hf_exception_from_rest_error(err: RestAPIError) -> None:
+        """If a RestAPIError carries one of the known HF backend codes, re-raise.
+
+        Promotes the error to :class:`HuggingFaceImportException`. Returns
+        without raising for unknown codes so the caller can re-raise the
+        original RestAPIError untouched.
+        """
+        body = err.response.json() if hasattr(err, "response") else {}
+        if not isinstance(body, dict):
+            body = {}
+        code = body.get("error") or body.get("errorCode")
+        message = body.get("message") or body.get("usrMsg")
+        known = {
+            HuggingFaceImportException.AUTH_REQUIRED,
+            HuggingFaceImportException.NOT_FOUND_OR_AUTH_REQUIRED,
+            HuggingFaceImportException.MODEL_NOT_FOUND,
+            HuggingFaceImportException.FETCH_FAILED,
+        }
+        if isinstance(code, str) and code in known:
+            raise HuggingFaceImportException(code, message)
+
+    @staticmethod
+    def _build_hf_exception(error: str) -> HuggingFaceImportException:
+        """Map a backend ``error`` field to a typed HuggingFaceImportException.
+
+        Some codes carry a payload separated by ``": "`` (``download_failed: foo.bin``,
+        ``invalid_filename: ../etc``, ``registration_failed: ...``). Strip that for
+        the ``error_code`` so callers can match on the prefix, but keep the full
+        message human-readable.
+        """
+        # download_failed: <file>, invalid_filename: <name>, registration_failed: <text>
+        m = re.match(r"^([a-z_]+)(?:\s*:\s*(.*))?$", error or "")
+        code = m.group(1) if m else (error or "unknown_error")
+        return HuggingFaceImportException(code, error)
+
+    def _resolve_imported_model(
+        self, hugging_face_model_id: str, status: dict
+    ) -> model.Model:
+        """Look up the registered Model after a successful import.
+
+        Mirrors the backend's name sanitiser (non-alphanumerics → ``_``) to
+        find the right model entry, then returns the highest-version match.
+        """
+        # Mirror the backend's parseModelId: drop scheme + host, drop query and
+        # fragment, then keep only the first two non-empty path segments
+        # ("owner/repo"). HF UI URLs like .../tree/main, .../blob/main/README.md,
+        # .../resolve/main/... need their trailing segments stripped before we
+        # take the repo name as the basis for the sanitised model name.
+        repo = hugging_face_model_id
+        for prefix in ("https://", "http://", "//"):
+            if repo.startswith(prefix):
+                repo = repo[len(prefix) :]
+                break
+        for host in ("huggingface.co/", "www.huggingface.co/", "hf.co/"):
+            if repo.startswith(host):
+                repo = repo[len(host) :]
+                break
+        repo = repo.split("?", 1)[0].split("#", 1)[0]
+        kept_segments: list[str] = []
+        for seg in repo.split("/"):
+            if not seg:
+                continue
+            kept_segments.append(seg)
+            if len(kept_segments) == 2:
+                break
+        last = kept_segments[-1] if kept_segments else ""
+        sanitised = re.sub(r"[^A-Za-z0-9]", "_", last)
+        # The status payload doesn't include the registered version directly,
+        # so look up the latest matching name. The HF importer always registers
+        # at MAX(version)+1, so the most recent get_models() entry is ours.
+        candidates = self._model_api.get_models(
+            sanitised,
+            self.model_registry_id,
+            shared_registry_project_name=self.shared_registry_project_name,
+        )
+        if not candidates:
+            raise HuggingFaceImportException(
+                "registration_failed",
+                f"Import for {hugging_face_model_id} reported COMPLETED but the "
+                f"model {sanitised!r} is not visible in the registry.",
+            )
+        # Sorted ascending by version typically; pick the highest just in case.
+        return max(candidates, key=lambda m: getattr(m, "version", 0))
 
     @public
     @property

--- a/python/tests/core/test_dataset_api.py
+++ b/python/tests/core/test_dataset_api.py
@@ -14,9 +14,9 @@
 #   limitations under the License.
 #
 
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
 from hopsworks_common.client.exceptions import DatasetException, RestAPIError
 from hopsworks_common.core.dataset_api import Chunk, DatasetApi
 

--- a/python/tests/core/test_dataset_api.py
+++ b/python/tests/core/test_dataset_api.py
@@ -1,0 +1,103 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+from unittest.mock import MagicMock
+
+from hopsworks_common.client.exceptions import DatasetException, RestAPIError
+from hopsworks_common.core.dataset_api import Chunk, DatasetApi
+
+
+def _make_rest_api_error(error_code: int, status_code: int = 500) -> RestAPIError:
+    """Build a RestAPIError with the given backend error code and HTTP status."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.reason = "Internal Server Error"
+    mock_response.content = b"{}"
+    mock_response.json.return_value = {
+        "errorCode": error_code,
+        "errorMsg": "some error",
+        "usrMsg": "some user message",
+    }
+    return RestAPIError("http://localhost/upload", mock_response)
+
+
+class TestDatasetApiUploadChunk:
+    def test_disk_space_error_raises_dataset_exception(self, mocker):
+        # Arrange
+        api = DatasetApi()
+        error = _make_rest_api_error(DatasetApi.DATASET_ERROR_CODE_UPLOAD_DISK_SPACE)
+        mocker.patch.object(api, "_upload_request", side_effect=error)
+        chunk = Chunk(b"data", 1, "pending")
+
+        # Act & Assert
+        with pytest.raises(DatasetException) as exc_info:
+            api._upload_chunk({}, "/test/path", "file.txt", chunk, None, 0, 1)
+
+        assert "storage is full" in str(exc_info.value).lower()
+        assert chunk.status == "failed"
+
+    def test_disk_space_error_is_not_retried(self, mocker):
+        # Disk-space is a permanent error (HTTP 500) — _upload_request should be
+        # called exactly once, with no retry attempts.
+        api = DatasetApi()
+        error = _make_rest_api_error(DatasetApi.DATASET_ERROR_CODE_UPLOAD_DISK_SPACE)
+        mock_upload = mocker.patch.object(api, "_upload_request", side_effect=error)
+        chunk = Chunk(b"data", 1, "pending")
+
+        with pytest.raises(DatasetException):
+            api._upload_chunk({}, "/test/path", "file.txt", chunk, None, 0, 1)
+
+        assert mock_upload.call_count == 1
+
+    def test_other_500_error_raises_rest_api_error(self, mocker):
+        # A different 500 error (e.g. generic UPLOAD_ERROR = 110043) must still
+        # propagate as RestAPIError so callers can inspect it.
+        api = DatasetApi()
+        error = _make_rest_api_error(110043)  # UPLOAD_ERROR
+        mocker.patch.object(api, "_upload_request", side_effect=error)
+        chunk = Chunk(b"data", 1, "pending")
+
+        with pytest.raises(RestAPIError):
+            api._upload_chunk({}, "/test/path", "file.txt", chunk, None, 0, 1)
+
+        assert chunk.status == "failed"
+
+    def test_transient_error_is_retried(self, mocker):
+        # A non-permanent status (e.g. 503) with retries > 0 should retry
+        # before eventually failing.
+        api = DatasetApi()
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.reason = "Service Unavailable"
+        mock_response.content = b"{}"
+        mock_response.json.return_value = {"errorCode": 0, "errorMsg": "unavailable"}
+        error = RestAPIError("http://localhost/upload", mock_response)
+
+        mock_upload = mocker.patch.object(api, "_upload_request", side_effect=error)
+        chunk = Chunk(b"data", 1, "pending")
+        max_retries = 2
+
+        with pytest.raises(RestAPIError):
+            api._upload_chunk({}, "/test/path", "file.txt", chunk, None, max_retries, 0)
+
+        # Initial attempt + max_retries retries
+        assert mock_upload.call_count == max_retries + 1
+
+    def test_dataset_error_code_upload_disk_space_constant(self):
+        # Sanity-check the constant value matches the backend enum:
+        # DatasetErrorCode range=110000, UPLOAD_DISK_SPACE_ERROR code=55
+        assert DatasetApi.DATASET_ERROR_CODE_UPLOAD_DISK_SPACE == 110055

--- a/python/tests/test_hf_download.py
+++ b/python/tests/test_hf_download.py
@@ -1,0 +1,278 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""Unit tests for ModelRegistry.hf_download.
+
+The HTTP layer (HuggingFaceApi / ModelApi) is mocked so we exercise the
+client-side state machine: kick off → poll → success/failure-mapping.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.client.exceptions import (
+    HuggingFaceImportException,
+    RestAPIError,
+)
+from hsml.model_registry import ModelRegistry
+
+
+def _make_registry():
+    """Construct a ModelRegistry with both downstream APIs mocked."""
+    mr = ModelRegistry(
+        project_name="proj",
+        project_id=119,
+        model_registry_id=119,
+    )
+    mr._huggingface_api = MagicMock()
+    mr._model_api = MagicMock()
+    return mr
+
+
+# ---- happy path ----
+
+
+def test_hf_download_completed_returns_model(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.return_value = {"jobId": "job-1"}
+    mr._huggingface_api.get_status.side_effect = [
+        {"status": "RUNNING", "completedFiles": 0, "totalFiles": 3},
+        {"status": "COMPLETED", "completedFiles": 3, "totalFiles": 3},
+    ]
+    mock_model = MagicMock()
+    mock_model.version = 1
+    mr._model_api.get_models.return_value = [mock_model]
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    result = mr.hf_download("Qwen/Qwen2.5-0.5B", poll_interval=0)
+
+    assert result is mock_model
+    mr._huggingface_api.start_import.assert_called_once()
+    args = mr._huggingface_api.start_import.call_args
+    # registry id should be the first positional argument
+    assert args.args[0] == 119
+    assert args.kwargs.get("hf_token") is None
+    # No selection args supplied → backend defaults are used.
+    assert args.kwargs.get("selected_formats") is None
+    assert args.kwargs.get("selected_variants") is None
+
+
+def test_hf_download_passes_selection_args_through(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.return_value = {"jobId": "job-2"}
+    mr._huggingface_api.get_status.return_value = {"status": "COMPLETED"}
+    mr._model_api.get_models.return_value = [MagicMock(version=1)]
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    mr.hf_download(
+        "unsloth/Kimi-K2.6-GGUF",
+        hf_token="hf_secret",
+        selected_formats=["gguf"],
+        selected_variants=["UD-Q4_K_XL"],
+        selected_filenames=None,
+        poll_interval=0,
+    )
+    kwargs = mr._huggingface_api.start_import.call_args.kwargs
+    assert kwargs["hf_token"] == "hf_secret"
+    assert kwargs["selected_formats"] == ["gguf"]
+    assert kwargs["selected_variants"] == ["UD-Q4_K_XL"]
+
+
+def test_hf_download_resolves_sanitised_model_name(monkeypatch):
+    """Sanitised model name lookup after a successful import.
+
+    The HF importer replaces non-alphanumerics in the repo name with '_';
+    the Python client mirrors that when looking up the registered model.
+    """
+    mr = _make_registry()
+    mr._huggingface_api.start_import.return_value = {"jobId": "job-3"}
+    mr._huggingface_api.get_status.return_value = {"status": "COMPLETED"}
+    mock_model = MagicMock(version=2)
+    mr._model_api.get_models.return_value = [MagicMock(version=1), mock_model]
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    result = mr.hf_download("Qwen/Qwen2.5-0.5B", poll_interval=0)
+
+    # Sanitiser: "Qwen2.5-0.5B" → "Qwen2_5_0_5B"
+    mr._model_api.get_models.assert_called_with(
+        "Qwen2_5_0_5B",
+        119,
+        shared_registry_project_name=None,
+    )
+    # Highest version wins.
+    assert result is mock_model
+
+
+def test_hf_download_strips_full_url_for_lookup(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.return_value = {"jobId": "job-4"}
+    mr._huggingface_api.get_status.return_value = {"status": "COMPLETED"}
+    mr._model_api.get_models.return_value = [MagicMock(version=1)]
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    mr.hf_download(
+        "https://huggingface.co/Qwen/Qwen2.5-0.5B/tree/main",
+        poll_interval=0,
+    )
+    # Looked up under the sanitised LAST path segment, not the URL.
+    name_arg = mr._model_api.get_models.call_args.args[0]
+    assert name_arg == "Qwen2_5_0_5B"
+
+
+# ---- failure mapping ----
+
+
+@pytest.mark.parametrize(
+    "error_field, expected_code",
+    [
+        ("auth_required", "auth_required"),
+        ("not_found_or_auth_required", "not_found_or_auth_required"),
+        ("model_not_found", "model_not_found"),
+        ("no_disk_space", "no_disk_space"),
+        # Suffix-style codes — the prefix becomes error_code, full message preserved.
+        ("download_failed: model.safetensors", "download_failed"),
+        ("invalid_filename: ../etc/passwd", "invalid_filename"),
+        ("registration_failed: db error", "registration_failed"),
+        ("fetch_failed", "fetch_failed"),
+    ],
+)
+def test_hf_download_failed_maps_error_code(monkeypatch, error_field, expected_code):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.return_value = {"jobId": "job-x"}
+    mr._huggingface_api.get_status.return_value = {
+        "status": "FAILED",
+        "error": error_field,
+    }
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    with pytest.raises(HuggingFaceImportException) as exc:
+        mr.hf_download("foo/bar", poll_interval=0)
+    assert exc.value.error_code == expected_code
+    # Full backend message preserved for the user.
+    assert error_field in str(exc.value)
+
+
+def test_hf_download_cancelled_raises(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.return_value = {"jobId": "job-c"}
+    mr._huggingface_api.get_status.return_value = {
+        "status": "CANCELLED",
+        "error": "auth_required",
+    }
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    with pytest.raises(HuggingFaceImportException) as exc:
+        mr.hf_download("foo/bar", poll_interval=0)
+    assert exc.value.error_code == "auth_required"
+
+
+# ---- synchronous start_import errors → typed exception ----
+
+
+def _rest_error(status: int, body: dict) -> RestAPIError:
+    """Build a RestAPIError with a controlled response body."""
+    response = MagicMock()
+    response.status_code = status
+    response.json.return_value = body
+    response.url = "http://test"
+    response.text = ""
+    err = RestAPIError.__new__(RestAPIError)
+    err.response = response
+    err.url = "http://test"
+    return err
+
+
+def test_hf_download_start_returns_401_auth_required(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.side_effect = _rest_error(
+        401, {"error": "auth_required"}
+    )
+
+    with pytest.raises(HuggingFaceImportException) as exc:
+        mr.hf_download("gated/repo", hf_token="bad", poll_interval=0)
+    assert exc.value.error_code == "auth_required"
+
+
+def test_hf_download_start_returns_404_not_found_or_auth(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.side_effect = _rest_error(
+        404, {"error": "not_found_or_auth_required"}
+    )
+
+    with pytest.raises(HuggingFaceImportException) as exc:
+        mr.hf_download("typo/repo", poll_interval=0)
+    assert exc.value.error_code == "not_found_or_auth_required"
+
+
+def test_hf_download_start_returns_404_model_not_found(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.side_effect = _rest_error(
+        404, {"error": "model_not_found"}
+    )
+
+    with pytest.raises(HuggingFaceImportException) as exc:
+        mr.hf_download("bad/repo", hf_token="hf_x", poll_interval=0)
+    assert exc.value.error_code == "model_not_found"
+
+
+def test_hf_download_unknown_rest_error_passes_through(monkeypatch):
+    """Unknown RestAPIError must pass through, not be re-wrapped.
+
+    A RestAPIError whose body doesn't match any known HF code should reach
+    the caller verbatim — re-wrapping it as HuggingFaceImportException would
+    surface a misleading code that users couldn't trust.
+    """
+    mr = _make_registry()
+    mr._huggingface_api.start_import.side_effect = _rest_error(
+        500, {"error": "internal_db_error"}
+    )
+
+    with pytest.raises(RestAPIError):
+        mr.hf_download("foo/bar", poll_interval=0)
+
+
+def test_hf_download_start_returns_no_jobid(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.return_value = {}
+
+    with pytest.raises(HuggingFaceImportException) as exc:
+        mr.hf_download("foo/bar", poll_interval=0)
+    assert exc.value.error_code == "fetch_failed"
+
+
+def test_hf_download_timeout_attempts_cleanup(monkeypatch):
+    mr = _make_registry()
+    mr._huggingface_api.start_import.return_value = {"jobId": "job-t"}
+    mr._huggingface_api.get_status.return_value = {"status": "RUNNING"}
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    monkeypatch.setattr("time.time", _ticking_clock(start=0.0, step=10.0))
+
+    with pytest.raises(HuggingFaceImportException) as exc:
+        mr.hf_download("foo/bar", timeout=5, poll_interval=0)
+    assert exc.value.error_code == "fetch_failed"
+    # Best-effort cleanup must have been invoked with cleanup=True.
+    mr._huggingface_api.cancel.assert_called_once_with(119, "job-t", cleanup=True)
+
+
+def _ticking_clock(start: float, step: float):
+    """A deterministic time.time() that advances by `step` on every call."""
+    state = {"now": start}
+
+    def _now():
+        v = state["now"]
+        state["now"] += step
+        return v
+
+    return _now


### PR DESCRIPTION
## Summary
- Catch backend error code `110055` (`UPLOAD_DISK_SPACE_ERROR`) during chunked file uploads and raise a `DatasetException` with a clear, actionable message instead of a generic `RestAPIError`.
- Add unit tests covering the disk-space error path, retry behavior for transient errors, and propagation of other permanent errors.

## Test plan
- [x] `uv run pytest python/tests/core/test_dataset_api.py` — all 5 new tests pass
- [ ] Manual upload test against a cluster with low disk space to confirm the user-facing message

🤖 Generated with [Claude Code](https://claude.com/claude-code)