### PR TITLE
[FSTORE-1967] Add frontend UI for logical time scheduling

### DIFF
--- a/python/hopsworks_common/core/execution_api.py
+++ b/python/hopsworks_common/core/execution_api.py
@@ -14,18 +14,70 @@
 #   limitations under the License.
 #
 
+import json
+from datetime import datetime
+
 from hopsworks_apigen import also_available_as
 from hopsworks_common import client, execution
 
 
 @also_available_as("hopsworks.core.execution_api.ExecutionApi")
 class ExecutionApi:
-    def _start(self, job, args: str = None):
+    def _start(
+        self,
+        job,
+        args: str = None,
+        *,
+        start_time: datetime = None,
+        end_time: datetime = None,
+        logical_date: datetime = None,
+        env_vars: dict = None,
+    ):
+        """Start an execution.
+
+        If any of start_time/end_time/logical_date/env_vars is provided, POSTs a JSON body
+        (endpoint accepts `application/json`); otherwise falls back to the original plain-text
+        args body for backwards compatibility.
+        """
         _client = client.get_instance()
         path_params = ["project", _client._project_id, "jobs", job.name, "executions"]
 
+        use_json = (
+            start_time is not None
+            or end_time is not None
+            or logical_date is not None
+            or env_vars is not None
+        )
+        if not use_json:
+            return execution.Execution.from_response_json(
+                _client._send_request("POST", path_params, data=args), job
+            )
+
+        # Merge start/end_time into envVars if supplied separately; the backend treats the
+        # run envVars as the source of truth when set (overrides scheduler-provided HOPS_*).
+        merged_env = dict(env_vars) if env_vars else {}
+        if start_time is not None:
+            merged_env.setdefault("HOPS_START_TIME", _to_iso(start_time))
+        if end_time is not None:
+            merged_env.setdefault("HOPS_END_TIME", _to_iso(end_time))
+
+        body = {}
+        if args is not None:
+            body["args"] = args
+        if merged_env:
+            body["envVars"] = merged_env
+        if logical_date is not None:
+            body["logicalDate"] = _to_iso(logical_date)
+        if end_time is not None:
+            # data interval end mirrors HOPS_END_TIME for a one-shot backfill run.
+            body["dataIntervalEnd"] = _to_iso(end_time)
+
+        headers = {"content-type": "application/json"}
         return execution.Execution.from_response_json(
-            _client._send_request("POST", path_params, data=args), job
+            _client._send_request(
+                "POST", path_params, headers=headers, data=json.dumps(body)
+            ),
+            job,
         )
 
     def _get(self, job, id):
@@ -87,3 +139,13 @@ class ExecutionApi:
             data={"state": "stopped"},
             headers={"Content-Type": "application/json"},
         )
+
+
+def _to_iso(dt: datetime) -> str:
+    """ISO-8601 UTC string, matching what the backend parses into Instant."""
+    if dt.tzinfo is None:
+        # Treat naive as UTC rather than silently shift by the local offset.
+        from datetime import timezone as _tz
+
+        dt = dt.replace(tzinfo=_tz.utc)
+    return dt.isoformat()

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -420,8 +420,8 @@ class Job:
         *,
         catchup: bool = False,
         max_active_runs: int = 1,
-        start_time_offset_seconds: int = -3600,
-        end_time_offset_seconds: int = 0,
+        start_time_offset_seconds: int | None = None,
+        end_time_offset_seconds: int | None = None,
         skip_to_date: datetime = None,
         max_catchup_runs: int = None,
     ) -> JobSchedule:
@@ -430,20 +430,18 @@ class Job:
         If a schedule for this job already exists, the method updates it.
 
         ```python
-        # Hourly schedule. The scheduler injects HOPS_START_TIME / HOPS_END_TIME as env vars
-        # into each execution. Offsets are relative to the cron fire time.
-        # Defaults — start=-3600 (1h before fire), end=0 (at fire) — give the
-        # natural "last hour" window on an hourly schedule.
+        # Defaults (None, None): HOPS_START_TIME = last execution time (= previous cron fire),
+        # HOPS_END_TIME = current cron fire. Works on any cron — no per-schedule tuning needed.
         job.schedule(
             cron_expression="0 0 * ? * * *",
             start_time=datetime.datetime.now(tz=timezone.utc),
         )
 
-        # Process the previous 2 hours at every fire (e.g. 08:00 → 10:00 at 10:00 fire):
+        # Fixed 2-hour window ending at the cron fire (e.g. 08:00 → 10:00 at 10:00):
         job.schedule(
             cron_expression="0 0 * ? * * *",
-            start_time_offset_seconds=-2 * 3600,
-            end_time_offset_seconds=0,
+            start_time_offset_seconds=-2 * 3600,   # HOPS_START_TIME = fire - 2h
+            end_time_offset_seconds=0,             # HOPS_END_TIME   = fire
             catchup=True,              # replay all missed intervals on recovery
             max_active_runs=2,         # allow at most 2 concurrent runs
         )
@@ -462,12 +460,17 @@ class Job:
             max_active_runs:
                 Upper bound on concurrent executions for this job. Default 1.
             start_time_offset_seconds:
-                Offset (in seconds) applied to `HOPS_START_TIME` relative to the cron fire time.
-                Negative values look backwards from the fire; positive look forward.
-                Default -3600 (1 h before the fire).
+                Controls `HOPS_START_TIME`. Three modes:
+
+                - `None` (default) — use the previous cron fire (last execution time). Adapts
+                  to any cron naturally.
+                - `int` — `HOPS_START_TIME = cron_fire + seconds`. Negative values look
+                  backwards from the fire; positive look forward.
             end_time_offset_seconds:
-                Offset (in seconds) applied to `HOPS_END_TIME` relative to the cron fire time.
-                Default 0 (at the fire).
+                Controls `HOPS_END_TIME`. Three modes:
+
+                - `None` (default) — use the cron fire time (`HOPS_END_TIME = cron_fire`).
+                - `int` — `HOPS_END_TIME = cron_fire + seconds`.
             skip_to_date:
                 If set, reconciliation skips every missed interval strictly before this date.
             max_catchup_runs:

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -420,7 +420,7 @@ class Job:
         *,
         catchup: bool = False,
         max_active_runs: int = 1,
-        start_time_offset_seconds: int = 0,
+        start_time_offset_seconds: int = -3600,
         end_time_offset_seconds: int = 0,
         skip_to_date: datetime = None,
         max_catchup_runs: int = None,
@@ -430,20 +430,20 @@ class Job:
         If a schedule for this job already exists, the method updates it.
 
         ```python
-        # Hourly schedule with Airflow-style data intervals.
-        # The scheduler injects HOPS_LOGICAL_DATE, HOPS_START_TIME, HOPS_END_TIME as env vars
-        # into each execution. With zero offsets, HOPS_START_TIME is the previous cron fire
-        # and HOPS_END_TIME is the current fire.
+        # Hourly schedule. The scheduler injects HOPS_START_TIME / HOPS_END_TIME as env vars
+        # into each execution. Offsets are relative to the cron fire time.
+        # Defaults — start=-3600 (1h before fire), end=0 (at fire) — give the
+        # natural "last hour" window on an hourly schedule.
         job.schedule(
             cron_expression="0 0 * ? * * *",
             start_time=datetime.datetime.now(tz=timezone.utc),
         )
 
-        # Shift the window 1 hour earlier (e.g. "process data from two hours ago to one hour ago").
+        # Process the previous 2 hours at every fire (e.g. 08:00 → 10:00 at 10:00 fire):
         job.schedule(
             cron_expression="0 0 * ? * * *",
-            start_time_offset_seconds=-3600,
-            end_time_offset_seconds=-3600,
+            start_time_offset_seconds=-2 * 3600,
+            end_time_offset_seconds=0,
             catchup=True,              # replay all missed intervals on recovery
             max_active_runs=2,         # allow at most 2 concurrent runs
         )
@@ -462,11 +462,12 @@ class Job:
             max_active_runs:
                 Upper bound on concurrent executions for this job. Default 1.
             start_time_offset_seconds:
-                Offset (in seconds) applied to `HOPS_START_TIME` relative to the interval start.
-                Default 0.
+                Offset (in seconds) applied to `HOPS_START_TIME` relative to the cron fire time.
+                Negative values look backwards from the fire; positive look forward.
+                Default -3600 (1 h before the fire).
             end_time_offset_seconds:
-                Offset (in seconds) applied to `HOPS_END_TIME` relative to the interval end.
-                Default 0.
+                Offset (in seconds) applied to `HOPS_END_TIME` relative to the cron fire time.
+                Default 0 (at the fire).
             skip_to_date:
                 If set, reconciliation skips every missed interval strictly before this date.
             max_catchup_runs:

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -160,7 +160,16 @@ class Job:
 
     @public
     @usage.method_logger
-    def run(self, args: str | None = None, await_termination: bool = True) -> Execution:
+    def run(
+        self,
+        args: str | None = None,
+        await_termination: bool = True,
+        *,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        logical_date: datetime | None = None,
+        env_vars: dict | None = None,
+    ) -> Execution:
         """Run the job.
 
         Run the job, by default awaiting its completion, with the option of passing runtime arguments.
@@ -217,6 +226,19 @@ class Job:
             args: Optional runtime arguments for the job.
             await_termination: Identifies if the client should wait for the job to complete.
                 Ignored for Python App jobs which wait for RUNNING state instead.
+            start_time:
+                Optional. If set, injects `HOPS_START_TIME` (and `HOPS_END_TIME` if `end_time` is
+                also set) as env vars on this one-shot execution. Useful for manual backfills
+                without creating a schedule. Overrides any scheduler-computed value for this run.
+            end_time:
+                Optional. Paired with `start_time`; sets `HOPS_END_TIME` and also serves as the
+                run's `data_interval_end` for reconciliation purposes.
+            logical_date:
+                Optional. If set, overrides the run's logical date (data interval start). Usually
+                inferred from `start_time` / the schedule.
+            env_vars:
+                Optional dict of arbitrary env vars to inject into this execution. Values take
+                precedence over anything with the same name from the job config or the scheduler.
 
         Returns:
             The execution object for the submitted run.
@@ -227,7 +249,14 @@ class Job:
         if self._is_materialization_running(args):
             return None
         print(f"Launching job: {self.name}")
-        execution = self._execution_api._start(self, args=args)
+        execution = self._execution_api._start(
+            self,
+            args=args,
+            start_time=start_time,
+            end_time=end_time,
+            logical_date=logical_date,
+            env_vars=env_vars,
+        )
         if self._job_type == "PYTHON_APP":
             print("Python App started, waiting for it to become ready...")
             execution = self._execution_engine.wait_for_running(self, execution)
@@ -388,42 +417,76 @@ class Job:
         cron_expression: str,
         start_time: datetime = None,
         end_time: datetime = None,
+        *,
+        catchup: bool = False,
+        max_active_runs: int = 1,
+        start_time_offset_seconds: int = 0,
+        end_time_offset_seconds: int = 0,
+        skip_to_date: datetime = None,
+        max_catchup_runs: int = None,
     ) -> JobSchedule:
         """Schedule the execution of the job.
 
         If a schedule for this job already exists, the method updates it.
 
         ```python
-        # Schedule the job
+        # Hourly schedule with Airflow-style data intervals.
+        # The scheduler injects HOPS_LOGICAL_DATE, HOPS_START_TIME, HOPS_END_TIME as env vars
+        # into each execution. With zero offsets, HOPS_START_TIME is the previous cron fire
+        # and HOPS_END_TIME is the current fire.
         job.schedule(
-            cron_expression="0 */5 * ? * * *",
-            start_time=datetime.datetime.now(tz=timezone.utc)
+            cron_expression="0 0 * ? * * *",
+            start_time=datetime.datetime.now(tz=timezone.utc),
         )
 
-        # Retrieve the next execution time
-        print(job.job_schedule.next_execution_date_time)
+        # Shift the window 1 hour earlier (e.g. "process data from two hours ago to one hour ago").
+        job.schedule(
+            cron_expression="0 0 * ? * * *",
+            start_time_offset_seconds=-3600,
+            end_time_offset_seconds=-3600,
+            catchup=True,              # replay all missed intervals on recovery
+            max_active_runs=2,         # allow at most 2 concurrent runs
+        )
         ```
 
         Parameters:
             cron_expression: The quartz cron expression.
             start_time:
-                The schedule start time in UTC.
-                If `None`, the current time is used.
-                The `start_time` can be a value in the past.
+                The schedule start time in UTC. If `None`, the current time is used.
+                Can be in the past.
             end_time:
-                The schedule end time in UTC.
-                If `None`, the schedule will continue running indefinitely.
-                The `end_time` can be a value in the past.
+                The schedule end time in UTC. If `None`, runs indefinitely. Can be in the past.
+            catchup:
+                If True and the scheduler missed fires (outage, etc.), create one execution per
+                missed interval on recovery. If False (default), only create the most recent.
+            max_active_runs:
+                Upper bound on concurrent executions for this job. Default 1.
+            start_time_offset_seconds:
+                Offset (in seconds) applied to `HOPS_START_TIME` relative to the interval start.
+                Default 0.
+            end_time_offset_seconds:
+                Offset (in seconds) applied to `HOPS_END_TIME` relative to the interval end.
+                Default 0.
+            skip_to_date:
+                If set, reconciliation skips every missed interval strictly before this date.
+            max_catchup_runs:
+                Upper bound on missed intervals created during reconciliation (keeps most recent).
 
         Returns:
-            The schedule of the job
+            The schedule of the job.
         """
         job_schedule = JobSchedule(
             id=self._job_schedule.id if self._job_schedule else None,
             start_date_time=start_time if start_time else datetime.now(tz=timezone.utc),
             cron_expression=cron_expression,
-            end_time=end_time,
+            end_date_time=end_time,
             enabled=True,
+            catchup=catchup,
+            max_active_runs=max_active_runs,
+            start_time_offset_seconds=start_time_offset_seconds,
+            end_time_offset_seconds=end_time_offset_seconds,
+            skip_to_date=skip_to_date,
+            max_catchup_runs=max_catchup_runs,
         )
         self._job_schedule = self._job_api._schedule_job(
             self._name, job_schedule.to_dict()

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -168,7 +168,7 @@ class Job:
         start_time: datetime | None = None,
         end_time: datetime | None = None,
         logical_date: datetime | None = None,
-        env_vars: dict | None = None,
+        env_vars: dict[str, str] | None = None,
     ) -> Execution:
         """Run the job.
 
@@ -434,7 +434,7 @@ class Job:
         # HOPS_END_TIME = current cron fire. Works on any cron — no per-schedule tuning needed.
         job.schedule(
             cron_expression="0 0 * ? * * *",
-            start_time=datetime.datetime.now(tz=timezone.utc),
+            start_time=datetime.now(tz=timezone.utc),
         )
 
         # Fixed 2-hour window ending at the cron fire (e.g. 08:00 → 10:00 at 10:00):
@@ -515,7 +515,7 @@ class Job:
             id=self._job_schedule.id,
             start_date_time=self._job_schedule.start_date_time,
             cron_expression=self._job_schedule.cron_expression,
-            end_time=self._job_schedule.end_date_time,
+            end_date_time=self._job_schedule.end_date_time,
             enabled=False,
         )
         return self._update_schedule(job_schedule)
@@ -531,7 +531,7 @@ class Job:
             id=self._job_schedule.id,
             start_date_time=self._job_schedule.start_date_time,
             cron_expression=self._job_schedule.cron_expression,
-            end_time=self._job_schedule.end_date_time,
+            end_date_time=self._job_schedule.end_date_time,
             enabled=True,
         )
         return self._update_schedule(job_schedule)

--- a/python/hopsworks_common/job_schedule.py
+++ b/python/hopsworks_common/job_schedule.py
@@ -46,8 +46,8 @@ class JobSchedule:
         end_date_time=None,
         catchup=False,
         max_active_runs=1,
-        start_time_offset_seconds=0,
-        end_time_offset_seconds=0,
+        start_time_offset_seconds=None,
+        end_time_offset_seconds=None,
         skip_to_date=None,
         max_catchup_runs=None,
         **kwargs,
@@ -62,13 +62,16 @@ class JobSchedule:
         self._max_active_runs = (
             int(max_active_runs) if max_active_runs is not None else 1
         )
+        # None preserved: means "last execution time" for start, "cron fire time" for end.
         self._start_time_offset_seconds = (
             int(start_time_offset_seconds)
             if start_time_offset_seconds is not None
-            else 0
+            else None
         )
         self._end_time_offset_seconds = (
-            int(end_time_offset_seconds) if end_time_offset_seconds is not None else 0
+            int(end_time_offset_seconds)
+            if end_time_offset_seconds is not None
+            else None
         )
         self._skip_to_date = _ms_to_dt(skip_to_date)
         self._max_catchup_runs = (
@@ -149,13 +152,14 @@ class JobSchedule:
     @public
     @property
     def start_time_offset_seconds(self):
-        """Offset in seconds applied to HOPS_START_TIME relative to the data interval start."""
+        """Controls HOPS_START_TIME. `None` = previous cron fire (last execution time);
+        otherwise `cron_fire + seconds` (negative = before, positive = after)."""
         return self._start_time_offset_seconds
 
     @public
     @property
     def end_time_offset_seconds(self):
-        """Offset in seconds applied to HOPS_END_TIME relative to the data interval end."""
+        """Controls HOPS_END_TIME. `None` = cron fire time; otherwise `cron_fire + seconds`."""
         return self._end_time_offset_seconds
 
     @public

--- a/python/hopsworks_common/job_schedule.py
+++ b/python/hopsworks_common/job_schedule.py
@@ -29,8 +29,18 @@ def _ms_to_dt(v):
 
 
 def _dt_to_ms(v):
+    """Serialise a datetime to epoch milliseconds.
+
+    Naive datetimes are treated as UTC — the backend JobSchedule model stores instants
+    in UTC, and `datetime.timestamp()` on a naive value would otherwise interpret it
+    in the client machine's local timezone and silently shift scheduled times by the
+    local offset on any client outside UTC. Mirrors the `_to_iso` convention in
+    `execution_api.py`.
+    """
     if v is None:
         return None
+    if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
+        v = v.replace(tzinfo=timezone.utc)
     return int(v.timestamp() * 1000.0)
 
 
@@ -152,8 +162,11 @@ class JobSchedule:
     @public
     @property
     def start_time_offset_seconds(self):
-        """Controls HOPS_START_TIME. `None` = previous cron fire (last execution time);
-        otherwise `cron_fire + seconds` (negative = before, positive = after)."""
+        """Controls HOPS_START_TIME.
+
+        `None` = previous cron fire (last execution time); otherwise `cron_fire + seconds`
+        (negative = before, positive = after).
+        """
         return self._start_time_offset_seconds
 
     @public

--- a/python/hopsworks_common/job_schedule.py
+++ b/python/hopsworks_common/job_schedule.py
@@ -22,6 +22,18 @@ from hopsworks_apigen import public
 from hopsworks_common import util
 
 
+def _ms_to_dt(v):
+    if isinstance(v, int):
+        return datetime.fromtimestamp(v / 1000, tz=timezone.utc)
+    return v
+
+
+def _dt_to_ms(v):
+    if v is None:
+        return None
+    return int(v.timestamp() * 1000.0)
+
+
 @public("hopsworks.job_schedule.JobSchedule", "hsfs.core.job_schedule.JobSchedule")
 class JobSchedule:
     def __init__(
@@ -32,27 +44,35 @@ class JobSchedule:
         next_execution_date_time=None,
         id=None,
         end_date_time=None,
+        catchup=False,
+        max_active_runs=1,
+        start_time_offset_seconds=0,
+        end_time_offset_seconds=0,
+        skip_to_date=None,
+        max_catchup_runs=None,
         **kwargs,
     ):
         self._id = id
-        self._start_date_time = (
-            datetime.fromtimestamp(start_date_time / 1000, tz=timezone.utc)
-            if isinstance(start_date_time, int)
-            else start_date_time
-        )
-
-        self._end_date_time = (
-            datetime.fromtimestamp(end_date_time / 1000, tz=timezone.utc)
-            if isinstance(end_date_time, int)
-            else end_date_time
-        )
+        self._start_date_time = _ms_to_dt(start_date_time)
+        self._end_date_time = _ms_to_dt(end_date_time)
         self._enabled = enabled
         self._cron_expression = cron_expression
-
-        self._next_execution_date_time = (
-            datetime.fromtimestamp(next_execution_date_time / 1000, tz=timezone.utc)
-            if isinstance(next_execution_date_time, int)
-            else next_execution_date_time
+        self._next_execution_date_time = _ms_to_dt(next_execution_date_time)
+        self._catchup = bool(catchup) if catchup is not None else False
+        self._max_active_runs = (
+            int(max_active_runs) if max_active_runs is not None else 1
+        )
+        self._start_time_offset_seconds = (
+            int(start_time_offset_seconds)
+            if start_time_offset_seconds is not None
+            else 0
+        )
+        self._end_time_offset_seconds = (
+            int(end_time_offset_seconds) if end_time_offset_seconds is not None else 0
+        )
+        self._skip_to_date = _ms_to_dt(skip_to_date)
+        self._max_catchup_runs = (
+            int(max_catchup_runs) if max_catchup_runs is not None else None
         )
 
     @classmethod
@@ -63,14 +83,16 @@ class JobSchedule:
     def to_dict(self):
         return {
             "id": self._id,
-            "startDateTime": int(self._start_date_time.timestamp() * 1000.0)
-            if self._start_date_time
-            else None,
-            "endDateTime": int(self._end_date_time.timestamp() * 1000.0)
-            if self._end_date_time
-            else None,
+            "startDateTime": _dt_to_ms(self._start_date_time),
+            "endDateTime": _dt_to_ms(self._end_date_time),
             "cronExpression": self._cron_expression,
             "enabled": self._enabled,
+            "catchup": self._catchup,
+            "maxActiveRuns": self._max_active_runs,
+            "startTimeOffsetSeconds": self._start_time_offset_seconds,
+            "endTimeOffsetSeconds": self._end_time_offset_seconds,
+            "skipToDate": _dt_to_ms(self._skip_to_date),
+            "maxCatchupRuns": self._max_catchup_runs,
         }
 
     def json(self):
@@ -111,3 +133,39 @@ class JobSchedule:
     def next_execution_date_time(self):
         """Return the next execution time."""
         return self._next_execution_date_time
+
+    @public
+    @property
+    def catchup(self):
+        """If True, backfill all missed intervals on scheduler recovery; if False, only the most recent."""
+        return self._catchup
+
+    @public
+    @property
+    def max_active_runs(self):
+        """Maximum number of concurrent executions allowed for this job (default 1)."""
+        return self._max_active_runs
+
+    @public
+    @property
+    def start_time_offset_seconds(self):
+        """Offset in seconds applied to HOPS_START_TIME relative to the data interval start."""
+        return self._start_time_offset_seconds
+
+    @public
+    @property
+    def end_time_offset_seconds(self):
+        """Offset in seconds applied to HOPS_END_TIME relative to the data interval end."""
+        return self._end_time_offset_seconds
+
+    @public
+    @property
+    def skip_to_date(self):
+        """If set, reconciliation skips all missed intervals before this date."""
+        return self._skip_to_date
+
+    @public
+    @property
+    def max_catchup_runs(self):
+        """Upper bound on missed intervals created during reconciliation (keeps most recent)."""
+        return self._max_catchup_runs

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3260,7 +3260,9 @@ class FeatureGroup(FeatureGroupBase):
         # populate start/end behind their back and then raise the mutually-exclusive guard
         # below — even though they never set those args themselves.
         if wallclock_time is None:
-            start_time, end_time = util.apply_scheduler_time_defaults(start_time, end_time)
+            start_time, end_time = util.apply_scheduler_time_defaults(
+                start_time, end_time
+            )
 
         if wallclock_time and self._time_travel_format is None:
             raise FeatureStoreException(

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3202,6 +3202,10 @@ class FeatureGroup(FeatureGroupBase):
                 If specified, retrieves feature group as of specific point in time.
                 If not specified, returns as of most recent time.
                 Strings should be formatted in one of the following formats `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
+                Mutually exclusive with `start_time` / `end_time` (time-travel vs
+                event-time filter are different operations). An explicit `wallclock_time`
+                takes precedence over the scheduler-injected `HOPS_START_TIME` /
+                `HOPS_END_TIME` env vars: when it is set, those defaults are ignored.
             online: If `True`, read from online feature store.
             dataframe_type:
                 The type of the returned dataframe.
@@ -3217,18 +3221,30 @@ class FeatureGroup(FeatureGroupBase):
                 - key `"pandas_types"` and value `True` to retrieve columns as [Pandas nullable types](https://pandas.pydata.org/docs/user_guide/integer_na.html) rather than numpy/object(string) types (experimental).
             start_time:
                 Inclusive lower bound on the `event_time` column (`event_time >= start_time`).
-                If not provided, defaults to the `HOPS_START_TIME` environment variable when set
-                (scheduler-supplied data-interval start). An explicit value always takes precedence.
+                If not provided and `wallclock_time` is also not set, defaults to the
+                `HOPS_START_TIME` environment variable when set (scheduler-supplied
+                data-interval start). When `wallclock_time` is set the env-var fallback is
+                skipped — wallclock_time takes precedence. An explicit `start_time` always
+                wins over both. If neither `start_time` nor `HOPS_START_TIME` is set, no
+                lower bound is applied (the whole feature group is read).
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
-                `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
+                `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, `%Y-%m-%d %H:%M:%S.%f`,
+                or ISO-8601 UTC `%Y-%m-%dT%H:%M:%S.%fZ` (e.g. `2026-01-01T00:00:00.000000Z`).
+                Scheduler-injected `HOPS_START_TIME` / `HOPS_END_TIME` use the ISO-8601 form.
             end_time:
                 Exclusive upper bound on the `event_time` column (`event_time < end_time`). Combined
                 with the inclusive `start_time`, back-to-back scheduled windows partition the
                 timeline — events at the boundary are read exactly once and never dropped.
-                If not provided, defaults to the `HOPS_END_TIME` environment variable when set
-                (scheduler-supplied data-interval end). An explicit value always takes precedence.
+                If not provided and `wallclock_time` is also not set, defaults to the
+                `HOPS_END_TIME` environment variable when set (scheduler-supplied
+                data-interval end). When `wallclock_time` is set the env-var fallback is
+                skipped — wallclock_time takes precedence. An explicit `end_time` always
+                wins over both. If neither `end_time` nor `HOPS_END_TIME` is set, no upper
+                bound is applied (the whole feature group is read).
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
-                `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
+                `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, `%Y-%m-%d %H:%M:%S.%f`,
+                or ISO-8601 UTC `%Y-%m-%dT%H:%M:%S.%fZ` (e.g. `2026-01-01T00:00:00.000000Z`).
+                Scheduler-injected `HOPS_START_TIME` / `HOPS_END_TIME` use the ISO-8601 form.
 
         Returns:
             A dataframe in the requested format containing the feature group data.
@@ -3239,9 +3255,12 @@ class FeatureGroup(FeatureGroupBase):
             hopsworks.client.exceptions.FeatureStoreException: If start_time or end_time is specified but no event_time column is defined for the feature group.
             hopsworks.client.exceptions.FeatureStoreException: If wallclock_time is used together with start_time or end_time.
         """
-        # Fall back to scheduler-injected HOPS_START_TIME / HOPS_END_TIME env vars when
-        # the caller didn't supply explicit values. Explicit args always win.
-        start_time, end_time = util.apply_scheduler_time_defaults(start_time, end_time)
+        # Scheduler env-var defaults apply only on the start_time/end_time path. If the caller
+        # asked for time-travel via wallclock_time, leaving scheduler injection in place would
+        # populate start/end behind their back and then raise the mutually-exclusive guard
+        # below — even though they never set those args themselves.
+        if wallclock_time is None:
+            start_time, end_time = util.apply_scheduler_time_defaults(start_time, end_time)
 
         if wallclock_time and self._time_travel_format is None:
             raise FeatureStoreException(
@@ -3261,6 +3280,9 @@ class FeatureGroup(FeatureGroupBase):
                     "for this feature group. Set event_time when creating the feature group "
                     "to enable time-based filtering."
                 )
+            # Reaching this branch with wallclock_time set means the caller passed BOTH
+            # explicit start/end and wallclock_time (env-var defaults are skipped above
+            # when wallclock_time is not None). That combination is still user error.
             if wallclock_time is not None:
                 raise FeatureStoreException(
                     "Cannot use wallclock_time together with start_time/end_time. "
@@ -5140,7 +5162,9 @@ class ExternalFeatureGroup(FeatureGroupBase):
                 If not provided, defaults to the `HOPS_START_TIME` environment variable when set
                 (scheduler-supplied data-interval start). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
-                `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
+                `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, `%Y-%m-%d %H:%M:%S.%f`,
+                or ISO-8601 UTC `%Y-%m-%dT%H:%M:%S.%fZ` (e.g. `2026-01-01T00:00:00.000000Z`).
+                Scheduler-injected `HOPS_START_TIME` / `HOPS_END_TIME` use the ISO-8601 form.
             end_time:
                 Exclusive upper bound on the `event_time` column (`event_time < end_time`). Combined
                 with the inclusive `start_time`, back-to-back scheduled windows partition the
@@ -5148,7 +5172,9 @@ class ExternalFeatureGroup(FeatureGroupBase):
                 If not provided, defaults to the `HOPS_END_TIME` environment variable when set
                 (scheduler-supplied data-interval end). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
-                `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
+                `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, `%Y-%m-%d %H:%M:%S.%f`,
+                or ISO-8601 UTC `%Y-%m-%dT%H:%M:%S.%fZ` (e.g. `2026-01-01T00:00:00.000000Z`).
+                Scheduler-injected `HOPS_START_TIME` / `HOPS_END_TIME` use the ISO-8601 form.
 
         Returns:
             A dataframe in the requested format containing the feature group data.

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3172,6 +3172,20 @@ class FeatureGroup(FeatureGroupBase):
             fg.read(start_time=datetime.now() - timedelta(days=1), end_time=datetime.now())
             ```
 
+        Example: Incremental feature pipeline — let the scheduler supply the window.
+            When the Hopsworks scheduler fires a job, it injects `HOPS_START_TIME`
+            and `HOPS_END_TIME` env vars describing the data interval the run
+            should process. If `start_time` / `end_time` are not passed to `read`,
+            these env vars are used as defaults, so the same feature-pipeline
+            code works whether launched by the scheduler, by a backfill
+            (`Job.run(start_time=..., end_time=...)`), or manually:
+
+            ```python
+            # No explicit time args — falls back to HOPS_START_TIME / HOPS_END_TIME
+            # (scheduler-supplied) if set, otherwise reads the whole feature group.
+            fg.read()
+            ```
+
         Parameters:
             wallclock_time:
                 If specified, retrieves feature group as of specific point in time.
@@ -3192,10 +3206,14 @@ class FeatureGroup(FeatureGroupBase):
                 - key `"pandas_types"` and value `True` to retrieve columns as [Pandas nullable types](https://pandas.pydata.org/docs/user_guide/integer_na.html) rather than numpy/object(string) types (experimental).
             start_time:
                 Filter data to only include records where the event_time column is greater than start_time.
+                If not provided, defaults to the `HOPS_START_TIME` environment variable when set
+                (scheduler-supplied data-interval start). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
                 `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
             end_time:
                 Filter data to only include records where the event_time column is less than end_time.
+                If not provided, defaults to the `HOPS_END_TIME` environment variable when set
+                (scheduler-supplied data-interval end). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
                 `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
 
@@ -3208,6 +3226,10 @@ class FeatureGroup(FeatureGroupBase):
             hopsworks.client.exceptions.FeatureStoreException: If start_time or end_time is specified but no event_time column is defined for the feature group.
             hopsworks.client.exceptions.FeatureStoreException: If wallclock_time is used together with start_time or end_time.
         """
+        # Fall back to scheduler-injected HOPS_START_TIME / HOPS_END_TIME env vars when
+        # the caller didn't supply explicit values. Explicit args always win.
+        start_time, end_time = util.apply_scheduler_time_defaults(start_time, end_time)
+
         if wallclock_time and self._time_travel_format is None:
             raise FeatureStoreException(
                 "Time travel format is not set for the feature group, cannot read as of specific point in time."
@@ -5077,6 +5099,18 @@ class ExternalFeatureGroup(FeatureGroupBase):
             fg.read(start_time=datetime.now() - timedelta(days=1), end_time=datetime.now())
             ```
 
+        Example: Incremental feature pipeline — let the scheduler supply the window.
+            When the Hopsworks scheduler fires a job, it injects `HOPS_START_TIME`
+            and `HOPS_END_TIME` env vars describing the data interval the run
+            should process. If `start_time` / `end_time` are not passed to `read`,
+            these env vars are used as defaults.
+
+            ```python
+            # No explicit time args — falls back to HOPS_START_TIME / HOPS_END_TIME
+            # (scheduler-supplied) if set, otherwise reads the whole feature group.
+            fg.read()
+            ```
+
         Warning: Engine Support
             **Spark only**
 
@@ -5090,10 +5124,14 @@ class ExternalFeatureGroup(FeatureGroupBase):
             read_options: Additional options as key/value pairs to pass to the spark engine.
             start_time:
                 Filter data to only include records where the event_time column is greater than start_time.
+                If not provided, defaults to the `HOPS_START_TIME` environment variable when set
+                (scheduler-supplied data-interval start). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
                 `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
             end_time:
                 Filter data to only include records where the event_time column is less than end_time.
+                If not provided, defaults to the `HOPS_END_TIME` environment variable when set
+                (scheduler-supplied data-interval end). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
                 `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
 
@@ -5106,6 +5144,10 @@ class ExternalFeatureGroup(FeatureGroupBase):
             hopsworks.client.exceptions.FeatureStoreException: If trying to read an external feature group directly in.
             hopsworks.client.exceptions.FeatureStoreException: If start_time or end_time is specified but no event_time column is defined for the feature group.
         """
+        # Fall back to scheduler-injected HOPS_START_TIME / HOPS_END_TIME env vars when
+        # the caller didn't supply explicit values. Explicit args always win.
+        start_time, end_time = util.apply_scheduler_time_defaults(start_time, end_time)
+
         if (
             engine.get_type() == "python"
             and not online

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3205,13 +3205,15 @@ class FeatureGroup(FeatureGroupBase):
                   For example: `{"arrow_flight_config": {"timeout": 900}}`.
                 - key `"pandas_types"` and value `True` to retrieve columns as [Pandas nullable types](https://pandas.pydata.org/docs/user_guide/integer_na.html) rather than numpy/object(string) types (experimental).
             start_time:
-                Filter data to only include records where the event_time column is greater than start_time.
+                Inclusive lower bound on the `event_time` column (`event_time >= start_time`).
                 If not provided, defaults to the `HOPS_START_TIME` environment variable when set
                 (scheduler-supplied data-interval start). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
                 `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
             end_time:
-                Filter data to only include records where the event_time column is less than end_time.
+                Exclusive upper bound on the `event_time` column (`event_time < end_time`). Combined
+                with the inclusive `start_time`, back-to-back scheduled windows partition the
+                timeline — events at the boundary are read exactly once and never dropped.
                 If not provided, defaults to the `HOPS_END_TIME` environment variable when set
                 (scheduler-supplied data-interval end). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
@@ -5123,13 +5125,15 @@ class ExternalFeatureGroup(FeatureGroupBase):
             online: If `True` read from online feature store.
             read_options: Additional options as key/value pairs to pass to the spark engine.
             start_time:
-                Filter data to only include records where the event_time column is greater than start_time.
+                Inclusive lower bound on the `event_time` column (`event_time >= start_time`).
                 If not provided, defaults to the `HOPS_START_TIME` environment variable when set
                 (scheduler-supplied data-interval start). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as
                 `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`, `%Y-%m-%d %H:%M:%S`, or `%Y-%m-%d %H:%M:%S.%f`.
             end_time:
-                Filter data to only include records where the event_time column is less than end_time.
+                Exclusive upper bound on the `event_time` column (`event_time < end_time`). Combined
+                with the inclusive `start_time`, back-to-back scheduled windows partition the
+                timeline — events at the boundary are read exactly once and never dropped.
                 If not provided, defaults to the `HOPS_END_TIME` environment variable when set
                 (scheduler-supplied data-interval end). An explicit value always takes precedence.
                 Can be a `datetime`, `date`, Unix timestamp (int), pandas `Timestamp`, or a string formatted as

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -97,6 +97,46 @@ def parse_features(
     return []
 
 
+HOPS_START_TIME_ENV = "HOPS_START_TIME"
+HOPS_END_TIME_ENV = "HOPS_END_TIME"
+
+
+def apply_scheduler_time_defaults(
+    start_time: Any,
+    end_time: Any,
+) -> tuple[Any, Any]:
+    """Fall back to scheduler-injected `HOPS_START_TIME` / `HOPS_END_TIME` env vars.
+
+    When a Hopsworks job is triggered by the scheduler (or via a backfill `Job.run(
+    start_time=..., end_time=...)` call), the container receives `HOPS_START_TIME` and
+    `HOPS_END_TIME` as ISO-8601 UTC env vars describing the data interval the run should
+    process. This helper lets feature-store reads pick those up by default:
+
+      * If the caller passed an explicit value for `start_time` / `end_time`, that value
+        wins.
+      * Otherwise, the corresponding env var is read (if set) and returned.
+      * Env vars that fail to parse are ignored — the caller's `None` is preserved.
+
+    Returns the resolved `(start_time, end_time)` tuple.
+    """
+    import os
+
+    resolved_start = start_time
+    resolved_end = end_time
+
+    if start_time is None:
+        env_start = os.environ.get(HOPS_START_TIME_ENV)
+        if env_start:
+            resolved_start = env_start
+
+    if end_time is None:
+        env_end = os.environ.get(HOPS_END_TIME_ENV)
+        if env_end:
+            resolved_end = env_end
+
+    return resolved_start, resolved_end
+
+
 def build_time_filter(
     event_time_feature: feature.Feature,
     start_time: Any,

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -118,21 +118,34 @@ def apply_scheduler_time_defaults(
       * Env vars that fail to parse are ignored — the caller's `None` is preserved.
 
     Returns the resolved `(start_time, end_time)` tuple.
+
+    Prints a one-line notice to stdout when env-var defaults are applied so that the
+    scheduler-injected window is visible in the execution log. The notice is suppressed
+    when both args were explicit or when no env vars are set.
     """
     import os
 
     resolved_start = start_time
     resolved_end = end_time
+    applied: list[str] = []
 
     if start_time is None:
         env_start = os.environ.get(HOPS_START_TIME_ENV)
         if env_start:
             resolved_start = env_start
+            applied.append(f"start_time={env_start} (from ${HOPS_START_TIME_ENV})")
 
     if end_time is None:
         env_end = os.environ.get(HOPS_END_TIME_ENV)
         if env_end:
             resolved_end = env_end
+            applied.append(f"end_time={env_end} (from ${HOPS_END_TIME_ENV})")
+
+    if applied:
+        print(
+            "[hopsworks] Using scheduler-injected data interval: "
+            + ", ".join(applied)
+        )
 
     return resolved_start, resolved_end
 

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -157,17 +157,22 @@ def build_time_filter(
 ) -> filter.Filter | filter.Logic | None:
     """Build a time filter from start_time and end_time parameters.
 
+    The window is half-open `[start_time, end_time)`: `start_time` is inclusive (>=) and
+    `end_time` is exclusive (<). This guarantees that back-to-back scheduled windows
+    (`[t0, t1)` then `[t1, t2)`) partition the timeline — an event at exactly the boundary
+    `t1` is read by the second window only, never dropped by both and never duplicated.
+
     Parameters:
         event_time_feature: The feature to filter on.
-        start_time: The start time for the filter (exclusive).
-        end_time: The end time for the filter (exclusive).
+        start_time: The start time for the filter (inclusive, >=).
+        end_time: The end time for the filter (exclusive, <).
 
     Returns:
         The built time filter, or `None` if both `start_time` and `end_time` are `None`.
     """
     time_filter = None
     if start_time is not None:
-        time_filter = event_time_feature > start_time
+        time_filter = event_time_feature >= start_time
 
     if end_time is not None:
         end_filter = event_time_feature < end_time

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -114,8 +114,16 @@ def apply_scheduler_time_defaults(
 
       * If the caller passed an explicit value for `start_time` / `end_time`, that value
         wins.
-      * Otherwise, the corresponding env var is read (if set) and returned.
-      * Env vars that fail to parse are ignored — the caller's `None` is preserved.
+      * Otherwise, the corresponding env var is read and returned as-is when non-empty.
+      * Empty env vars (`""`) and unset env vars are treated as "not provided" — the
+        caller's `None` is preserved.
+
+    This function does not validate the env-var string format. Any non-empty value is
+    returned verbatim and is parsed downstream by `convert_event_time_to_timestamp` /
+    `get_timestamp_from_date_string` at the point the time filter is built. A malformed
+    env var therefore raises there, not here — with a message that names the offending
+    input, which is more useful for diagnosing scheduler misconfiguration than silently
+    falling back to "read whole feature group".
 
     Returns the resolved `(start_time, end_time)` tuple.
 

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -125,11 +125,20 @@ def apply_scheduler_time_defaults(
     input, which is more useful for diagnosing scheduler misconfiguration than silently
     falling back to "read whole feature group".
 
-    Returns the resolved `(start_time, end_time)` tuple.
-
     Prints a one-line notice to stdout when env-var defaults are applied so that the
     scheduler-injected window is visible in the execution log. The notice is suppressed
     when both args were explicit or when no env vars are set.
+
+    Parameters:
+        start_time: Caller-supplied start of the data window, or `None` to fall back to
+            `HOPS_START_TIME`.
+        end_time: Caller-supplied end of the data window, or `None` to fall back to
+            `HOPS_END_TIME`.
+
+    Returns:
+        The resolved `(start_time, end_time)` tuple. Each side is the caller's value
+        when it was not `None`, otherwise the corresponding env var (if set and
+        non-empty), otherwise `None`.
     """
     import os
 

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -151,8 +151,7 @@ def apply_scheduler_time_defaults(
 
     if applied:
         print(
-            "[hopsworks] Using scheduler-injected data interval: "
-            + ", ".join(applied)
+            "[hopsworks] Using scheduler-injected data interval: " + ", ".join(applied)
         )
 
     return resolved_start, resolved_end

--- a/python/tests/core/test_sink_job_configuration.py
+++ b/python/tests/core/test_sink_job_configuration.py
@@ -108,6 +108,12 @@ class TestSinkJobConfiguration:
                 "endDateTime": 2000,
                 "cronExpression": "0 0 * * *",
                 "enabled": True,
+                "catchup": False,
+                "maxActiveRuns": 1,
+                "startTimeOffsetSeconds": None,
+                "endTimeOffsetSeconds": None,
+                "skipToDate": None,
+                "maxCatchupRuns": None,
             },
         }
 
@@ -170,6 +176,12 @@ class TestSinkJobConfiguration:
             "endDateTime": 4000,
             "cronExpression": "0 * * * *",
             "enabled": False,
+            "catchup": False,
+            "maxActiveRuns": 1,
+            "startTimeOffsetSeconds": None,
+            "endTimeOffsetSeconds": None,
+            "skipToDate": None,
+            "maxCatchupRuns": None,
         }
 
     def test_column_mappings_are_sanitized_from_dicts(self):

--- a/python/tests/test_hsfs_util.py
+++ b/python/tests/test_hsfs_util.py
@@ -22,8 +22,8 @@ from hsfs import util
 class TestApplyDataIntervalDefaults:
     """hsfs.util.apply_scheduler_time_defaults falls back to HOPS_* env vars."""
 
-    def test_explicit_values_win(self):
-        # Even if the env vars are set, explicit args take precedence.
+    def test_explicit_values_win(self, capsys):
+        # Even if the env vars are set, explicit args take precedence — no notice printed.
         env = {
             "HOPS_START_TIME": "2026-01-01T00:00:00Z",
             "HOPS_END_TIME": "2026-02-01T00:00:00Z",
@@ -34,8 +34,9 @@ class TestApplyDataIntervalDefaults:
             )
         assert start == "2024-06-01"
         assert end == "2024-07-01"
+        assert capsys.readouterr().out == ""
 
-    def test_fills_both_from_env_when_unset(self):
+    def test_fills_both_from_env_when_unset(self, capsys):
         env = {
             "HOPS_START_TIME": "2026-01-01T00:00:00Z",
             "HOPS_END_TIME": "2026-02-01T00:00:00Z",
@@ -44,8 +45,12 @@ class TestApplyDataIntervalDefaults:
             start, end = util.apply_scheduler_time_defaults(None, None)
         assert start == "2026-01-01T00:00:00Z"
         assert end == "2026-02-01T00:00:00Z"
+        out = capsys.readouterr().out
+        assert "[hopsworks] Using scheduler-injected data interval:" in out
+        assert "start_time=2026-01-01T00:00:00Z" in out
+        assert "end_time=2026-02-01T00:00:00Z" in out
 
-    def test_fills_only_missing_side(self):
+    def test_fills_only_missing_side(self, capsys):
         # Only end_time is missing — start_time passes through, end_time is filled.
         env = {
             "HOPS_START_TIME": "2026-01-01T00:00:00Z",
@@ -55,24 +60,27 @@ class TestApplyDataIntervalDefaults:
             start, end = util.apply_scheduler_time_defaults("2024-06-01", None)
         assert start == "2024-06-01"
         assert end == "2026-02-01T00:00:00Z"
+        out = capsys.readouterr().out
+        assert "end_time=2026-02-01T00:00:00Z" in out
+        assert "start_time" not in out
 
-    def test_returns_none_when_no_env_and_no_args(self):
-        # Neither env vars nor explicit args: stay None so the read is unconstrained.
-        env = {"HOPS_START_TIME": "", "HOPS_END_TIME": ""}
-        with patch.dict("os.environ", env, clear=False):
-            # Remove the vars entirely too, in case the test environment has them set.
-            import os
+    def test_returns_none_when_no_env_and_no_args(self, capsys):
+        # Neither env vars nor explicit args: stay None and print nothing.
+        import os
 
+        with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("HOPS_START_TIME", None)
             os.environ.pop("HOPS_END_TIME", None)
             start, end = util.apply_scheduler_time_defaults(None, None)
         assert start is None
         assert end is None
+        assert capsys.readouterr().out == ""
 
-    def test_empty_env_string_is_ignored(self):
-        # Empty env var must not override None — treat it as unset.
+    def test_empty_env_string_is_ignored(self, capsys):
+        # Empty env var must not override None, and must not print a notice.
         env = {"HOPS_START_TIME": "", "HOPS_END_TIME": ""}
         with patch.dict("os.environ", env, clear=False):
             start, end = util.apply_scheduler_time_defaults(None, None)
         assert start is None
         assert end is None
+        assert capsys.readouterr().out == ""

--- a/python/tests/test_hsfs_util.py
+++ b/python/tests/test_hsfs_util.py
@@ -1,0 +1,78 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from unittest.mock import patch
+
+from hsfs import util
+
+
+class TestApplyDataIntervalDefaults:
+    """hsfs.util.apply_scheduler_time_defaults falls back to HOPS_* env vars."""
+
+    def test_explicit_values_win(self):
+        # Even if the env vars are set, explicit args take precedence.
+        env = {
+            "HOPS_START_TIME": "2026-01-01T00:00:00Z",
+            "HOPS_END_TIME": "2026-02-01T00:00:00Z",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            start, end = util.apply_scheduler_time_defaults(
+                "2024-06-01", "2024-07-01"
+            )
+        assert start == "2024-06-01"
+        assert end == "2024-07-01"
+
+    def test_fills_both_from_env_when_unset(self):
+        env = {
+            "HOPS_START_TIME": "2026-01-01T00:00:00Z",
+            "HOPS_END_TIME": "2026-02-01T00:00:00Z",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            start, end = util.apply_scheduler_time_defaults(None, None)
+        assert start == "2026-01-01T00:00:00Z"
+        assert end == "2026-02-01T00:00:00Z"
+
+    def test_fills_only_missing_side(self):
+        # Only end_time is missing — start_time passes through, end_time is filled.
+        env = {
+            "HOPS_START_TIME": "2026-01-01T00:00:00Z",
+            "HOPS_END_TIME": "2026-02-01T00:00:00Z",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            start, end = util.apply_scheduler_time_defaults("2024-06-01", None)
+        assert start == "2024-06-01"
+        assert end == "2026-02-01T00:00:00Z"
+
+    def test_returns_none_when_no_env_and_no_args(self):
+        # Neither env vars nor explicit args: stay None so the read is unconstrained.
+        env = {"HOPS_START_TIME": "", "HOPS_END_TIME": ""}
+        with patch.dict("os.environ", env, clear=False):
+            # Remove the vars entirely too, in case the test environment has them set.
+            import os
+
+            os.environ.pop("HOPS_START_TIME", None)
+            os.environ.pop("HOPS_END_TIME", None)
+            start, end = util.apply_scheduler_time_defaults(None, None)
+        assert start is None
+        assert end is None
+
+    def test_empty_env_string_is_ignored(self):
+        # Empty env var must not override None — treat it as unset.
+        env = {"HOPS_START_TIME": "", "HOPS_END_TIME": ""}
+        with patch.dict("os.environ", env, clear=False):
+            start, end = util.apply_scheduler_time_defaults(None, None)
+        assert start is None
+        assert end is None

--- a/python/tests/test_hsfs_util.py
+++ b/python/tests/test_hsfs_util.py
@@ -16,7 +16,8 @@
 
 from unittest.mock import patch
 
-from hsfs import util
+from hsfs import feature, util
+from hsfs.constructor import filter as filter_mod
 
 
 class TestApplyDataIntervalDefaults:
@@ -84,3 +85,78 @@ class TestApplyDataIntervalDefaults:
         assert start is None
         assert end is None
         assert capsys.readouterr().out == ""
+
+
+class TestBuildTimeFilter:
+    """hsfs.util.build_time_filter assembles the half-open `[start, end)` window.
+
+    The start-side boundary changed from `>` (exclusive) to `>=` (inclusive) so that
+    back-to-back scheduled windows `[t0, t1)` then `[t1, t2)` tile the timeline: an
+    event at exactly `t1` is read by the second window only, never by both (duplicate)
+    and never by neither (dropped). These tests pin that invariant at the filter level
+    — the engine translates `>=` and `<` into SQL predicates, and this is the layer we
+    control in the hsfs client.
+    """
+
+    @staticmethod
+    def _event_time():
+        # Use `bigint` so Feature._get_filter_value doesn't timestamp-encode the int
+        # value into a formatted string — the operator semantics we're asserting are
+        # independent of timestamp coercion, so a numeric column keeps the tests
+        # focused on `>=` vs `<` boundary behaviour.
+        return feature.Feature(name="event_time", type="bigint")
+
+    def test_start_time_uses_greater_than_or_equal(self):
+        # Inclusive lower bound: boundary events at exactly start_time are matched by
+        # the filter. Previously this was `GT` (exclusive), which silently dropped any
+        # event landing precisely on a scheduled-fire boundary.
+        f = util.build_time_filter(self._event_time(), 1000, None)
+        assert isinstance(f, filter_mod.Filter)
+        assert f.condition == filter_mod.Filter.GE
+        assert f.condition != filter_mod.Filter.GT
+        assert str(f.value) == "1000"
+
+    def test_end_time_uses_less_than(self):
+        # Exclusive upper bound: a boundary event at exactly end_time is NOT matched
+        # — it belongs to the next window's [end_time, ...) slice.
+        f = util.build_time_filter(self._event_time(), None, 2000)
+        assert isinstance(f, filter_mod.Filter)
+        assert f.condition == filter_mod.Filter.LT
+        assert str(f.value) == "2000"
+
+    def test_combined_half_open_interval(self):
+        # Both sides present → AND of `>= start` and `< end`. Verifies the operator
+        # composition as well as the two boundary semantics together.
+        logic = util.build_time_filter(self._event_time(), 1000, 2000)
+        assert isinstance(logic, filter_mod.Logic)
+        assert logic.type == filter_mod.Logic.AND
+        left = logic.get_left_filter_or_logic()
+        right = logic.get_right_filter_or_logic()
+        assert left.condition == filter_mod.Filter.GE
+        assert str(left.value) == "1000"
+        assert right.condition == filter_mod.Filter.LT
+        assert str(right.value) == "2000"
+
+    def test_no_bounds_returns_none(self):
+        # Neither side provided: no filter. Caller reads all rows.
+        assert util.build_time_filter(self._event_time(), None, None) is None
+
+    def test_consecutive_windows_boundary_belongs_to_second(self):
+        # The core tiling property: windows [t0, t1) and [t1, t2) share the boundary
+        # `t1`. With the new inclusive-start / exclusive-end semantics, an event whose
+        # event_time is exactly `t1`:
+        #   - is NOT matched by the first window  (condition < t1 is false at t1)
+        #   - IS matched by the second window     (condition >= t1 is true at t1)
+        # Assert this at the filter-condition level so we don't need a live backend.
+        w1 = util.build_time_filter(self._event_time(), 0, 1000)
+        w2 = util.build_time_filter(self._event_time(), 1000, 2000)
+
+        # Window 1 ends exclusive at 1000.
+        w1_right = w1.get_right_filter_or_logic()
+        assert w1_right.condition == filter_mod.Filter.LT
+        assert str(w1_right.value) == "1000"
+
+        # Window 2 starts inclusive at 1000 — same boundary value, different operator.
+        w2_left = w2.get_left_filter_or_logic()
+        assert w2_left.condition == filter_mod.Filter.GE
+        assert str(w2_left.value) == "1000"

--- a/python/tests/test_hsfs_util.py
+++ b/python/tests/test_hsfs_util.py
@@ -30,9 +30,7 @@ class TestApplyDataIntervalDefaults:
             "HOPS_END_TIME": "2026-02-01T00:00:00Z",
         }
         with patch.dict("os.environ", env, clear=False):
-            start, end = util.apply_scheduler_time_defaults(
-                "2024-06-01", "2024-07-01"
-            )
+            start, end = util.apply_scheduler_time_defaults("2024-06-01", "2024-07-01")
         assert start == "2024-06-01"
         assert end == "2024-07-01"
         assert capsys.readouterr().out == ""


### PR DESCRIPTION
Python SDK half of the logical-time scheduling work. Companion PRs:
- Backend: [logicalclocks/hopsworks-ee#2811](https://github.com/logicalclocks/hopsworks-ee/pull/2811)
- Frontend: [logicalclocks/hopsworks-front#1814](https://github.com/logicalclocks/hopsworks-front/pull/1814)
- Docs: (see docs PR on logicalclocks.github.io)

## Summary

- `JobSchedule`: adds `catchup`, `max_active_runs`, `start/end_time_offset_seconds`, `skip_to_date`, `max_catchup_runs` (kwargs, public properties, `to_dict`).
- `Job.schedule()`: exposes every new field as a typed kwarg with docstrings + examples. Also fixes a pre-existing bug where `end_time=` was silently swallowed by `**kwargs`.
- `Job.run()`: takes optional `start_time`, `end_time`, `logical_date`, `env_vars`. When any is set it POSTs the JSON execution body; otherwise the legacy text/plain path is unchanged. `start_time`/`end_time` auto-map to `HOPS_START_TIME`/`HOPS_END_TIME` env vars for one-shot backfill runs.
- `ExecutionApi._start`: dispatches between legacy text/plain launch and the new JSON launch endpoint.

## Test plan

- [ ] Existing `pytest` suite stays green.
- [ ] `job.schedule(cron_expression="0 0 * ? * * *", start_time_offset_seconds=-3600, end_time_offset_seconds=-3600)` — check that the resulting `JobSchedule` round-trips those fields.
- [ ] `job.run(start_time=datetime(...,tzinfo=utc), end_time=...)` — confirm the executions page shows `HOPS_START_TIME`/`HOPS_END_TIME` on the pod.
- [ ] `job.schedule(catchup=True, max_catchup_runs=24)` after a scheduler outage — confirm at most 24 missed intervals replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)