### PR TITLE
[FSTORE-2017] Add support for Unity Catalog Data Source

### DIFF
--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -180,6 +180,7 @@ class ArrowFlightClient:
         StorageConnector.REDSHIFT,
         StorageConnector.SQL,
         StorageConnector.GCS,
+        StorageConnector.UNITY_CATALOG,
     ]
     # Oracle rides on StorageConnector.SQL above — it's distinguished on the
     # backend by sqlConnector.databaseType == "ORACLE". Keep that routing in

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -2851,6 +2851,7 @@ class UnityCatalogConnector(StorageConnector):
         workspace_url: str | None = None,
         access_token: str | None = None,
         default_catalog: str | None = None,
+        aws_region: str | None = None,
         arguments: list[dict[str, Any]] | dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -2858,6 +2859,7 @@ class UnityCatalogConnector(StorageConnector):
         self._workspace_url = workspace_url
         self._access_token = access_token
         self._default_catalog = default_catalog
+        self._aws_region = aws_region
         if isinstance(arguments, list):
             self._arguments = {a["name"]: a["value"] for a in arguments}
         else:
@@ -2883,6 +2885,16 @@ class UnityCatalogConnector(StorageConnector):
 
     @public
     @property
+    def aws_region(self) -> str | None:
+        """Optional explicit AWS region for the managed storage backing this Unity Catalog.
+
+        When unset, the Arrow Flight read path guesses the region from the STS
+        session-token Databricks returns with temporary table credentials.
+        """
+        return self._aws_region
+
+    @public
+    @property
     def arguments(self) -> dict[str, Any]:
         """Additional Unity Catalog connection arguments passed through to the Arrow Flight server."""
         return self._arguments
@@ -2893,6 +2905,7 @@ class UnityCatalogConnector(StorageConnector):
         return {
             "workspace_url": self._workspace_url,
             "default_catalog": self._default_catalog,
+            "aws_region": self._aws_region,
         }
 
     def spark_options(self) -> dict[str, Any]:

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -395,6 +395,12 @@ class StorageConnector(ABC):
             elif self.type == StorageConnector.SQL:
                 database = self.database
             elif self.type == StorageConnector.UNITY_CATALOG:
+                if not self.default_catalog:
+                    raise ValueError(
+                        "Database name is required for Unity Catalog connectors. "
+                        "Set a default catalog on the connector or pass an "
+                        "explicit `database` to get_tables()."
+                    )
                 database = self.default_catalog
             else:
                 raise ValueError(
@@ -2861,7 +2867,14 @@ class UnityCatalogConnector(StorageConnector):
         self._default_catalog = default_catalog
         self._aws_region = aws_region
         if isinstance(arguments, list):
-            self._arguments = {a["name"]: a["value"] for a in arguments}
+            # Match the other connectors in this file: tolerate name-only entries
+            # and skip entries without a name. Backend serialises these as a list
+            # of {name, value} dicts but `value` is permitted to be missing.
+            self._arguments = {
+                a["name"]: a.get("value")
+                for a in arguments
+                if a.get("name") is not None
+            }
         else:
             self._arguments = arguments or {}
 

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -73,6 +73,7 @@ class StorageConnector(ABC):
     CRM = "CRM"
     REST = "REST"
     ORACLE = "ORACLE"
+    UNITY_CATALOG = "UNITY_CATALOG"
 
     NOT_FOUND_ERROR_CODE = 270042
 
@@ -107,6 +108,7 @@ class StorageConnector(ABC):
         | OpenSearchConnector
         | CRMAndAnalyticsConnector
         | RestConnector
+        | UnityCatalogConnector
     ):
         json_decamelized = humps.decamelize(json_dict)
         _ = json_decamelized.pop("type", None)
@@ -130,6 +132,7 @@ class StorageConnector(ABC):
         | OpenSearchConnector
         | CRMAndAnalyticsConnector
         | RestConnector
+        | UnityCatalogConnector
     ):
         json_decamelized = humps.decamelize(json_dict)
         _ = json_decamelized.pop("type", None)
@@ -391,6 +394,8 @@ class StorageConnector(ABC):
                 database = self.query_project
             elif self.type == StorageConnector.SQL:
                 database = self.database
+            elif self.type == StorageConnector.UNITY_CATALOG:
+                database = self.default_catalog
             else:
                 raise ValueError(
                     "Database name is required for this connector type. "
@@ -2825,6 +2830,77 @@ class CRMAndAnalyticsConnector(StorageConnector):
 
     def spark_options(self) -> dict[str, Any]:
         return {}
+
+
+@public
+class UnityCatalogConnector(StorageConnector):
+    """Databricks Unity Catalog storage connector.
+
+    Reads Delta-formatted tables governed by Unity Catalog via the Arrow Flight query service.
+    Direct Spark reads are not supported in this release; use the Arrow Flight path instead.
+    """
+
+    type = StorageConnector.UNITY_CATALOG
+
+    def __init__(
+        self,
+        id: int | None,
+        name: str,
+        featurestore_id: int,
+        description: str | None = None,
+        workspace_url: str | None = None,
+        access_token: str | None = None,
+        default_catalog: str | None = None,
+        arguments: list[dict[str, Any]] | dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(id, name, description, featurestore_id)
+        self._workspace_url = workspace_url
+        self._access_token = access_token
+        self._default_catalog = default_catalog
+        if isinstance(arguments, list):
+            self._arguments = {a["name"]: a["value"] for a in arguments}
+        else:
+            self._arguments = arguments or {}
+
+    @public
+    @property
+    def workspace_url(self) -> str | None:
+        """Databricks workspace URL used for API calls."""
+        return self._workspace_url
+
+    @public
+    @property
+    def access_token(self) -> str | None:
+        """Databricks personal access token, decrypted from the Hopsworks secret store on retrieval."""
+        return self._access_token
+
+    @public
+    @property
+    def default_catalog(self) -> str | None:
+        """Optional default Unity Catalog catalog to use when no catalog is explicitly specified."""
+        return self._default_catalog
+
+    @public
+    @property
+    def arguments(self) -> dict[str, Any]:
+        """Additional Unity Catalog connection arguments passed through to the Arrow Flight server."""
+        return self._arguments
+
+    @public
+    def connector_options(self) -> dict[str, Any]:
+        """Return UC connector options shaped for external library use."""
+        return {
+            "workspace_url": self._workspace_url,
+            "default_catalog": self._default_catalog,
+        }
+
+    def spark_options(self) -> dict[str, Any]:
+        # v1 has no Spark read path — all UC reads go through Arrow Flight.
+        raise NotImplementedError(
+            "Direct Spark reads are not supported for Unity Catalog connectors in this release. "
+            "Reads flow through the Arrow Flight query service."
+        )
 
 
 class RestConnectorHeader:

--- a/python/tests/fixtures/storage_connector_fixtures.json
+++ b/python/tests/fixtures/storage_connector_fixtures.json
@@ -135,6 +135,55 @@
         },
         "headers": null
     },
+    "get_unity_catalog": {
+        "response": {
+            "type": "featurestoreUnityCatalogConnectorDTO",
+            "description": "Unity Catalog connector description",
+            "featurestoreId": 67,
+            "id": 1,
+            "name": "test_unity_catalog",
+            "storageConnectorType": "UNITY_CATALOG",
+            "workspace_url": "https://test.cloud.databricks.com",
+            "access_token": "dapi-test-token",
+            "default_catalog": "test_catalog",
+            "arguments": [{"name": "arg1", "value": "val1"}]
+        },
+        "method": "GET",
+        "path_params": [
+            "project",
+            "119",
+            "featurestores",
+            67,
+            "storageconnectors",
+            "test_unity_catalog"
+        ],
+        "query_params": {
+            "temporaryCredentials": true
+        },
+        "headers": null
+    },
+    "get_unity_catalog_basic_info": {
+        "response": {
+            "type": "featurestoreUnityCatalogConnectorDTO",
+            "featurestoreId": 67,
+            "id": 1,
+            "name": "test_unity_catalog",
+            "storageConnectorType": "UNITY_CATALOG"
+        },
+        "method": "GET",
+        "path_params": [
+            "project",
+            "119",
+            "featurestores",
+            67,
+            "storageconnectors",
+            "test_unity_catalog"
+        ],
+        "query_params": {
+            "temporaryCredentials": true
+        },
+        "headers": null
+    },
     "get_redshift_basic_info": {
         "response": {
             "type": "featurestoreRedshiftConnectorDTO",

--- a/python/tests/fixtures/storage_connector_fixtures.json
+++ b/python/tests/fixtures/storage_connector_fixtures.json
@@ -146,6 +146,7 @@
             "workspace_url": "https://test.cloud.databricks.com",
             "access_token": "dapi-test-token",
             "default_catalog": "test_catalog",
+            "aws_region": "us-west-2",
             "arguments": [{"name": "arg1", "value": "val1"}]
         },
         "method": "GET",

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -145,6 +145,67 @@ class TestS3Connector:
         assert result == "s3://test-bucket/abc/def/some/location"
 
 
+class TestUnityCatalogConnector:
+    def test_from_response_json(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["storage_connector"]["get_unity_catalog"]["response"]
+
+        # Act
+        sc = storage_connector.StorageConnector.from_response_json(json)
+
+        # Assert
+        assert sc.id == 1
+        assert sc.name == "test_unity_catalog"
+        assert sc._featurestore_id == 67
+        assert sc.description == "Unity Catalog connector description"
+        assert sc.type == storage_connector.StorageConnector.UNITY_CATALOG
+        assert sc.workspace_url == "https://test.cloud.databricks.com"
+        assert sc.access_token == "dapi-test-token"
+        assert sc.default_catalog == "test_catalog"
+        assert sc.arguments == {"arg1": "val1"}
+
+    def test_from_response_json_basic_info(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["storage_connector"]["get_unity_catalog_basic_info"][
+            "response"
+        ]
+
+        # Act
+        sc = storage_connector.StorageConnector.from_response_json(json)
+
+        # Assert
+        assert sc.id == 1
+        assert sc.name == "test_unity_catalog"
+        assert sc._featurestore_id == 67
+        assert sc.description is None
+        assert sc.workspace_url is None
+        assert sc.access_token is None
+        assert sc.default_catalog is None
+        assert sc.arguments == {}
+
+    def test_connector_options(self):
+        sc = storage_connector.UnityCatalogConnector(
+            id=1,
+            name="uc",
+            featurestore_id=1,
+            workspace_url="https://ws.cloud.databricks.com",
+            access_token="dapi-xyz",
+            default_catalog="sales",
+        )
+        opts = sc.connector_options()
+        assert opts["workspace_url"] == "https://ws.cloud.databricks.com"
+        assert opts["default_catalog"] == "sales"
+
+    def test_spark_options_not_supported(self):
+        sc = storage_connector.UnityCatalogConnector(
+            id=1, name="uc", featurestore_id=1, workspace_url="https://x.com"
+        )
+        import pytest
+
+        with pytest.raises(NotImplementedError):
+            sc.spark_options()
+
+
 class TestRedshiftConnector:
     def test_from_response_json(self, backend_fixtures):
         # Arrange

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -162,6 +162,7 @@ class TestUnityCatalogConnector:
         assert sc.workspace_url == "https://test.cloud.databricks.com"
         assert sc.access_token == "dapi-test-token"
         assert sc.default_catalog == "test_catalog"
+        assert sc.aws_region == "us-west-2"
         assert sc.arguments == {"arg1": "val1"}
 
     def test_from_response_json_basic_info(self, backend_fixtures):
@@ -181,6 +182,7 @@ class TestUnityCatalogConnector:
         assert sc.workspace_url is None
         assert sc.access_token is None
         assert sc.default_catalog is None
+        assert sc.aws_region is None
         assert sc.arguments == {}
 
     def test_connector_options(self):

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -202,8 +202,6 @@ class TestUnityCatalogConnector:
         sc = storage_connector.UnityCatalogConnector(
             id=1, name="uc", featurestore_id=1, workspace_url="https://x.com"
         )
-        import pytest
-
         with pytest.raises(NotImplementedError):
             sc.spark_options()
 


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2017

## Summary

- New `UnityCatalogConnector` subclass in `hsfs.storage_connector` exposing `workspace_url`, `access_token`, `default_catalog`, `arguments`; registered in `from_response_json` dispatch and in the `get_tables` default-database inference.
- `arrow_flight_client.SUPPORTED_EXTERNAL_CONNECTORS` includes UC so external feature groups pointing at UC tables route through the Arrow Flight query service.
- `spark_options()` raises `NotImplementedError` — v1 is Arrow-Flight-only, no direct Spark read path.
- New fixtures + `TestUnityCatalogConnector` cover from_response_json, basic-info, connector_options, and the spark-options guardrail.

## Test plan
- [ ] `pytest python/tests/test_storage_connector.py::TestUnityCatalogConnector` passes
- [ ] `ruff check` and `docsig` clean
- [ ] End-to-end: `fs.create_external_feature_group(storage_connector=uc_conn, ...)` followed by `.read()` against a real Databricks workspace

Companion PRs:
- hopsworks-ee (backend)
- flyingduck (query engine)
- hopsworks-front (UI)
- loadtest, logicalclocks.github.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)