### PR TITLE
[FSTORE_1967] Append, fix for reading from FGs in jobs with no event-time

### DIFF
--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3258,8 +3258,10 @@ class FeatureGroup(FeatureGroupBase):
         # Scheduler env-var defaults apply only on the start_time/end_time path. If the caller
         # asked for time-travel via wallclock_time, leaving scheduler injection in place would
         # populate start/end behind their back and then raise the mutually-exclusive guard
-        # below — even though they never set those args themselves.
-        if wallclock_time is None:
+        # below — even though they never set those args themselves. Likewise, if the FG has
+        # no event_time column there is nothing to filter on, so the env vars must stay a
+        # no-op rather than be promoted into args that then trip the no-event_time guard.
+        if wallclock_time is None and self.event_time is not None:
             start_time, end_time = util.apply_scheduler_time_defaults(
                 start_time, end_time
             )
@@ -5188,8 +5190,14 @@ class ExternalFeatureGroup(FeatureGroupBase):
             hopsworks.client.exceptions.FeatureStoreException: If start_time or end_time is specified but no event_time column is defined for the feature group.
         """
         # Fall back to scheduler-injected HOPS_START_TIME / HOPS_END_TIME env vars when
-        # the caller didn't supply explicit values. Explicit args always win.
-        start_time, end_time = util.apply_scheduler_time_defaults(start_time, end_time)
+        # the caller didn't supply explicit values. Explicit args always win. If the FG
+        # has no event_time column there is nothing to filter on, so the env vars must
+        # stay a no-op rather than be promoted into args that then trip the no-event_time
+        # guard below.
+        if self.event_time is not None:
+            start_time, end_time = util.apply_scheduler_time_defaults(
+                start_time, end_time
+            )
 
         if (
             engine.get_type() == "python"

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -1767,6 +1767,61 @@ class TestFeatureGroupRead:
         ):
             fg.read(wallclock_time="2024-01-01", end_time="2024-01-31")
 
+    def test_read_no_event_time_ignores_scheduler_env_vars(self, mocker):
+        # The scheduler always injects HOPS_START_TIME / HOPS_END_TIME, including for jobs
+        # whose feature groups have no event_time column.
+        # Promoting those env vars into start/end args would then trip the no-event_time
+        # guard on a read() the caller invoked with no time args at all — which is what
+        # broke the fraud_online tutorial pipeline under the scheduler.
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=1,
+            featurestore_name="fs",
+            features=[feature.Feature("pk", primary=True)],
+            primary_key=["pk"],
+            partition_key=[],
+            event_time=None,
+        )
+        fake_query = mock.MagicMock()
+        mocker.patch.object(fg, "select_all", return_value=fake_query)
+        mocker.patch("hsfs.engine.get_instance")
+        env = {
+            "HOPS_START_TIME": "2026-01-01T00:00:00Z",
+            "HOPS_END_TIME": "2026-02-01T00:00:00Z",
+        }
+
+        with mock.patch.dict("os.environ", env, clear=False):
+            fg.read()
+
+        # No filter() should have been applied — the env-injected window must not bleed in.
+        fake_query.filter.assert_not_called()
+        fake_query.read.assert_called_once()
+
+    def test_read_explicit_start_time_no_event_time_still_raises_under_scheduler(self):
+        # Even when scheduler env vars are set, an *explicit* time arg from the caller on
+        # a no-event_time FG is genuine user error and must still raise. Only the env-var
+        # fallback is silenced for no-event_time FGs.
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=1,
+            featurestore_name="fs",
+            features=[feature.Feature("pk", primary=True)],
+            primary_key=["pk"],
+            partition_key=[],
+            event_time=None,
+        )
+        env = {
+            "HOPS_START_TIME": "2026-01-01T00:00:00Z",
+            "HOPS_END_TIME": "2026-02-01T00:00:00Z",
+        }
+        with (
+            mock.patch.dict("os.environ", env, clear=False),
+            pytest.raises(FeatureStoreException, match="no event_time column"),
+        ):
+            fg.read(start_time="2024-01-01")
+
 
 class TestExternalFeatureGroupRead:
     def test_read_with_start_time_no_event_time_raises(self, backend_fixtures):
@@ -1790,3 +1845,26 @@ class TestExternalFeatureGroupRead:
             # Act & Assert
             with pytest.raises(FeatureStoreException, match="no event_time column"):
                 fg.read(end_time="2024-01-31")
+
+    def test_read_no_event_time_ignores_scheduler_env_vars(
+        self, mocker, backend_fixtures
+    ):
+        # Same scheduler-injection issue as for FeatureGroup: env-injected HOPS_* vars
+        # must not be promoted into args on no-event_time FGs.
+        json = backend_fixtures["external_feature_group"]["get"]["response"]
+        fg = feature_group.ExternalFeatureGroup.from_response_json(json)
+        fg._event_time = None
+        fake_query = mock.MagicMock()
+        mocker.patch.object(fg, "select_all", return_value=fake_query)
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
+        mocker.patch("hsfs.engine.get_instance")
+        env = {
+            "HOPS_START_TIME": "2026-01-01T00:00:00Z",
+            "HOPS_END_TIME": "2026-02-01T00:00:00Z",
+        }
+
+        with mock.patch.dict("os.environ", env, clear=False):
+            fg.read()
+
+        fake_query.filter.assert_not_called()
+        fake_query.read.assert_called_once()


### PR DESCRIPTION
## Summary

- Follow-up to #917 (FSTORE-1967). The scheduler always injects `HOPS_START_TIME` / `HOPS_END_TIME` env vars, so on FeatureGroups without an `event_time` column even a bare `fg.read()` ended up with start/end populated from the env, then tripped the explicit-args guard: `Cannot filter by start_time/end_time: no event_time column is defined`. This broke the fraud_online tutorial's `profile_fg.read()` under the scheduler.
- Fix: gate `apply_scheduler_time_defaults` on `self.event_time is not None` in both `FeatureGroup.read()` and `ExternalFeatureGroup.read()`. Explicit `start_time`/`end_time` on a no-event_time FG still raise — only the silent env-var fallback is suppressed.
- Adds three regression tests (FG no-event_time + env vars → no-op; explicit start_time + no event_time + env vars → still raises; same for ExternalFG).

## Test plan

- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `TestFeatureGroupRead` (5 pre-existing + 2 new) and `TestExternalFeatureGroupRead` (2 pre-existing + 1 new) pass
- [x] `TestApplyDataIntervalDefaults` / `TestBuildTimeFilter` still pass (helper unchanged)
- [ ] End-to-end: re-run the failing scheduled job (`generate_random_data.py` → `profile_fraud_online_fg.read()`) on a cluster with this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)