### PR TITLE
[FSTORE-2019] Allow specifying a Kubernetes namespace when creating a project

### DIFF
--- a/python/hopsworks/__init__.py
+++ b/python/hopsworks/__init__.py
@@ -430,7 +430,10 @@ def _initialize_module_apis():
 
 @public
 def create_project(
-    name: str, description: str | None = None, feature_store_topic: str | None = None
+    name: str,
+    description: str | None = None,
+    feature_store_topic: str | None = None,
+    namespace: str | None = None,
 ) -> project.Project | None:
     """Create a new project.
 
@@ -447,6 +450,8 @@ def create_project(
         name: The name of the project.
         description: Description of the project.
         feature_store_topic: Feature store topic name.
+        namespace: Kubernetes namespace to use for the project. If ``None`` the
+            backend derives one from the project name.
 
     Returns:
         The Project object to perform operations on.
@@ -458,7 +463,7 @@ def create_project(
         raise NoHopsworksConnectionError
 
     new_project = _hw_connection._project_api._create_project(
-        name, description, feature_store_topic
+        name, description, feature_store_topic, namespace
     )
     if _connected_project is None:
         _connected_project = new_project

--- a/python/hopsworks_common/connection.py
+++ b/python/hopsworks_common/connection.py
@@ -230,6 +230,7 @@ class Connection:
         name: str,
         description: str | None = None,
         feature_store_topic: str | None = None,
+        namespace: str | None = None,
     ) -> Project:
         """Create a new project.
 
@@ -246,11 +247,15 @@ class Connection:
             name: The name of the project.
             description: Description of the project, as it is shown in the UI.
             feature_store_topic: Feature store topic name.
+            namespace: Kubernetes namespace to use for the project. If ``None``
+                the backend derives one from the project name.
 
         Returns:
             A project handle object to perform operations on.
         """
-        return self._project_api._create_project(name, description, feature_store_topic)
+        return self._project_api._create_project(
+            name, description, feature_store_topic, namespace
+        )
 
     @usage.method_logger
     @connected

--- a/python/hopsworks_common/core/project_api.py
+++ b/python/hopsworks_common/core/project_api.py
@@ -115,7 +115,11 @@ class ProjectApi:
         return project.Project.from_response_json(project_json)
 
     def _create_project(
-        self, name: str, description: str = None, feature_store_topic: str = None
+        self,
+        name: str,
+        description: str = None,
+        feature_store_topic: str = None,
+        namespace: str = None,
     ) -> project.Project:
         """Create a new project.
 
@@ -123,6 +127,8 @@ class ProjectApi:
             name: Name of the project.
             description: Description of the project.
             feature_store_topic: Feature store topic name.
+            namespace: Kubernetes namespace to use for the project. If ``None``
+                the backend derives one from the project name.
 
         Returns:
             The Project object.
@@ -142,6 +148,8 @@ class ProjectApi:
             "description": description,
             "featureStoreTopic": feature_store_topic,
         }
+        if namespace is not None:
+            data["namespace"] = namespace
         _client._send_request(
             "POST",
             path_params,

--- a/python/tests/core/test_project_api.py
+++ b/python/tests/core/test_project_api.py
@@ -1,0 +1,61 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from hopsworks_common.core.project_api import ProjectApi
+
+
+class TestProjectApiCreate:
+    @pytest.fixture
+    def mock_client(self, mocker):
+        client_mock = Mock()
+        client_mock._send_request.return_value = {}
+        mocker.patch(
+            "hopsworks_common.core.project_api.client.get_instance",
+            return_value=client_mock,
+        )
+        return client_mock
+
+    @pytest.fixture
+    def api(self, mocker):
+        api = ProjectApi()
+        # Skip the follow-up GET that fetches the freshly created project; we
+        # only care about asserting the POST body here.
+        created = Mock()
+        created.get_url.return_value = "https://hopsworks.example/p/1"
+        mocker.patch.object(api, "_get_project", return_value=created)
+        return api
+
+    def test_create_project_omits_namespace_by_default(self, mock_client, api):
+        api._create_project("my_project", description="desc", feature_store_topic="t")
+
+        post_call = mock_client._send_request.call_args_list[0]
+        assert post_call.args[0] == "POST"
+        body = json.loads(post_call.kwargs["data"])
+        assert "namespace" not in body
+        assert body["projectName"] == "my_project"
+        assert body["description"] == "desc"
+        assert body["featureStoreTopic"] == "t"
+
+    def test_create_project_forwards_namespace_when_provided(self, mock_client, api):
+        api._create_project("my_project", namespace="custom-ns")
+
+        post_call = mock_client._send_request.call_args_list[0]
+        body = json.loads(post_call.kwargs["data"])
+        assert body["namespace"] == "custom-ns"


### PR DESCRIPTION
Adds an optional `namespace` parameter to `hopsworks.create_project()`, `Connection.create_project()`, and `ProjectApi._create_project()`. When provided it is forwarded as `namespace` in the create-project request body; when omitted, the backend continues to derive the namespace from the project name.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

https://hopsworks.atlassian.net/browse/FSTORE-2019

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
