### PR TITLE
[FSTORE-2011][Append] OracleConnector - another if-else bug

### DIFF
--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -393,7 +393,20 @@ class StorageConnector(ABC):
             elif self.type == StorageConnector.BIGQUERY:
                 database = self.query_project
             elif self.type == StorageConnector.SQL:
-                database = self.database
+                if self._database_type == StorageConnector.ORACLE:
+                    # For Oracle the `database` field holds the service name
+                    # (or TNS alias when using a wallet), not a schema, while
+                    # the backend filters tables by OWNER (schema).
+                    # Default to the connecting user's own schema.
+                    if not self.user:
+                        raise ValueError(
+                            "Database name is required for Oracle connectors "
+                            "without a configured user. Pass an explicit "
+                            "`database` to get_tables()."
+                        )
+                    database = self.user.upper()
+                else:
+                    database = self.database
             elif self.type == StorageConnector.UNITY_CATALOG:
                 if not self.default_catalog:
                     raise ValueError(

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -393,16 +393,16 @@ class StorageConnector(ABC):
             elif self.type == StorageConnector.BIGQUERY:
                 database = self.query_project
             elif self.type == StorageConnector.SQL:
-                if self._database_type == StorageConnector.ORACLE:
+                if self.database_type == StorageConnector.ORACLE:
                     # For Oracle the `database` field holds the service name
                     # (or TNS alias when using a wallet), not a schema, while
                     # the backend filters tables by OWNER (schema).
                     # Default to the connecting user's own schema.
                     if not self.user:
                         raise ValueError(
-                            "Database name is required for Oracle connectors "
-                            "without a configured user. Pass an explicit "
-                            "`database` to get_tables()."
+                            "A schema/owner is required for Oracle connectors "
+                            "without a configured user. Pass it as the "
+                            "`database` argument to get_tables()."
                         )
                     database = self.user.upper()
                 else:

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -1507,6 +1507,6 @@ class TestOracleConnector:
             wallet_path="/Projects/myproj/Resources/wallet.zip",
         )
         with pytest.raises(
-            ValueError, match="Database name is required for Oracle connectors"
+            ValueError, match="schema/owner is required for Oracle connectors"
         ):
             sc.get_tables()

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -1453,3 +1453,60 @@ class TestOracleConnector:
         )
         with pytest.raises(DataSourceException):
             sc.spark_options()
+
+    def test_get_tables_defaults_to_user_schema_for_oracle(self, mocker):
+        """For Oracle, get_tables(None) defaults to the user's schema, not service_name."""
+        sc = storage_connector.SqlConnector(
+            id=1,
+            name="test",
+            featurestore_id=1,
+            database_type="ORACLE",
+            host="myhost",
+            port=1521,
+            database="ORCL",
+            user="scott",
+            password="tiger",
+        )
+        mock_get_tables = mocker.patch.object(
+            sc._data_source_api, "get_tables", return_value=[]
+        )
+
+        sc.get_tables()
+
+        mock_get_tables.assert_called_once_with(sc, "SCOTT")
+
+    def test_get_tables_oracle_explicit_database_overrides_default(self, mocker):
+        """Explicit database to get_tables should not be replaced by the user."""
+        sc = storage_connector.SqlConnector(
+            id=1,
+            name="test",
+            featurestore_id=1,
+            database_type="ORACLE",
+            host="myhost",
+            port=1521,
+            database="ORCL",
+            user="scott",
+            password="tiger",
+        )
+        mock_get_tables = mocker.patch.object(
+            sc._data_source_api, "get_tables", return_value=[]
+        )
+
+        sc.get_tables("SH")
+
+        mock_get_tables.assert_called_once_with(sc, "SH")
+
+    def test_get_tables_oracle_without_user_raises(self):
+        """Oracle without a configured user has no sensible default schema."""
+        sc = storage_connector.SqlConnector(
+            id=1,
+            name="test",
+            featurestore_id=1,
+            database_type="ORACLE",
+            database="mydb_high",
+            wallet_path="/Projects/myproj/Resources/wallet.zip",
+        )
+        with pytest.raises(
+            ValueError, match="Database name is required for Oracle connectors"
+        ):
+            sc.get_tables()


### PR DESCRIPTION
## Summary

- For Oracle SQL connectors, `StorageConnector.get_tables(None)` defaulted `database` to `self.database` — but Oracle's `database` field holds the **service name** (or TNS alias when using a wallet), not a schema.
- The backend filters tables by `OWNER='<database>'`, so the query returned zero rows. The empty `DataSourceDTO` (no `items` key) then round-tripped through `DataSource.from_response_json` as a single empty `DataSource`, breaking `len(tables)` in the loadtest.
- Fix: when `database_type == "ORACLE"`, default to `self.user.upper()` (Oracle's default schema = the connecting user). Raise a clear `ValueError` when no user is configured (e.g. wallet-only setup) so the caller passes an explicit `database`.
- MySQL/PostgreSQL behavior unchanged.

## Test plan

- [x] `tests/test_storage_connector.py::TestOracleConnector` — added 3 unit tests covering the default, the explicit-override, and the no-user-raises paths
- [x] Full `TestSqlConnector` + `TestOracleConnector` + `TestJdbcConnector` + `test_storage_connector_get_data.py` (30 tests) all pass
- [x] `ruff check` and `ruff format --check` clean
- [ ] Re-run the loadtest `test_data_sources[SQL-SQL_ORACLE]` against a live Oracle Autonomous DB cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)