### PR TITLE
[HWORKS-2759] Add support for SPAs to Hopsworks Dashboards

### DIFF
--- a/python/hsfs/core/dashboard.py
+++ b/python/hsfs/core/dashboard.py
@@ -34,11 +34,15 @@ class Dashboard:
         id: int | None = None,
         name: str | None = None,
         charts: list[Chart] | None = None,
+        type: str | None = None,
+        bundle_path: str | None = None,
         **kwargs,
     ):
         self._id = id
         self._name = name
         self._charts = charts
+        self._type = type
+        self._bundle_path = bundle_path
 
     @classmethod
     def from_response_json(cls, json_dict: dict[str, Any]) -> list[Dashboard]:
@@ -52,11 +56,18 @@ class Dashboard:
         return cls(**json_decamelized)
 
     def to_dict(self):
-        return {
+        # Order matters for snapshot-style assertions, but the backend ignores it.
+        # `bundlePath` is camelCase because the JAX-RS DTO uses Jackson's default.
+        out: dict[str, Any] = {
             "id": self._id,
             "name": self._name,
             "charts": self._charts,
         }
+        if self._type is not None:
+            out["type"] = self._type
+        if self._bundle_path is not None:
+            out["bundlePath"] = self._bundle_path
+        return out
 
     def json(self):
         return json.dumps(self, cls=util.Encoder)
@@ -84,6 +95,24 @@ class Dashboard:
     @charts.setter
     def charts(self, charts: list[Chart]) -> None:
         self._charts = charts
+
+    @property
+    def type(self) -> str | None:
+        """Dashboard kind, either ``"GRID"`` or ``"BUNDLE"``."""
+        return self._type
+
+    @type.setter
+    def type(self, type: str) -> None:
+        self._type = type
+
+    @property
+    def bundle_path(self) -> str | None:
+        """Absolute HopsFS path to the bundle directory, only set for BUNDLE dashboards."""
+        return self._bundle_path
+
+    @bundle_path.setter
+    def bundle_path(self, bundle_path: str) -> None:
+        self._bundle_path = bundle_path
 
     def delete(self) -> None:
         """Delete the dashboard from the feature store.

--- a/python/hsfs/core/dashboard_api.py
+++ b/python/hsfs/core/dashboard_api.py
@@ -20,7 +20,7 @@ from hsfs.core.dashboard import Dashboard
 
 
 class DashboardApi:
-    def create_dashboard(self, dashboard: Dashboard) -> None:
+    def create_dashboard(self, dashboard: Dashboard) -> Dashboard:
         _client = client.get_instance()
         path_params = [
             "project",
@@ -28,12 +28,13 @@ class DashboardApi:
             "dashboards",
         ]
 
-        _client._send_request(
+        response = _client._send_request(
             "POST",
             path_params,
             headers={"content-type": "application/json"},
             data=dashboard.json(),
         )
+        return Dashboard.from_response_json(response)
 
     def get_dashboards(self) -> list[Dashboard]:
         _client = client.get_instance()

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -2239,6 +2239,105 @@ class FeatureStore:
         )
         return DashboardApi().create_dashboard(dashboard)
 
+    def create_bundle(self, name: str, path: str) -> Dashboard:
+        """Upload a built SPA directory and register it as a BUNDLE dashboard.
+
+        The directory at ``path`` must contain an ``index.html`` produced by a
+        front-end build (e.g. ``vite build``).
+        Files are uploaded to ``Resources/dashboards/{name}`` in the project's
+        HopsFS, then a ``BUNDLE`` dashboard is registered pointing at that path.
+        The backend derives the bundle path from ``name``, so name validation is
+        strict: alphanumerics, underscore, and hyphen only.
+        Calling ``create_bundle`` again with the same name uploads new files over
+        the existing bundle and returns the existing dashboard — no duplicate row
+        is created, and the existing bundle is never deleted by the cleanup path.
+        On registration failure for a *first-time* create, the SDK attempts to
+        remove the orphaned upload directory before re-raising the exception.
+
+        Example:
+            ```python
+            fs.create_bundle(name="sales-overview", path="./dist")
+            ```
+
+        Parameters:
+            name: Name of the dashboard; also used as the destination directory.
+            path: Local directory containing the built SPA.
+
+        Returns:
+            The created or existing dashboard metadata.
+
+        Raises:
+            ValueError: If ``name`` is invalid, ``path`` does not exist, or ``path`` does not contain ``index.html``.
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        import re
+        from os.path import isdir, isfile, join
+
+        from hopsworks_common.core.dataset_api import DatasetApi
+
+        # Mirror the backend's name regex so we fail before uploading. The name
+        # becomes a HopsFS path segment, so we forbid slashes, dots, and any
+        # punctuation that could let a name escape the dashboards directory.
+        if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$", name):
+            raise ValueError(
+                f"invalid dashboard name {name!r}: must match "
+                r"[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}"
+            )
+        if not isdir(path):
+            raise ValueError(f"{path}: bundle directory not found")
+        if not isfile(join(path, "index.html")):
+            raise ValueError(
+                f"{path}/index.html not found — run your front-end build first"
+            )
+
+        upload_dir = f"Resources/dashboards/{name}"
+        dataset_api = DatasetApi()
+        dashboard_api = DashboardApi()
+
+        # Idempotency: a BUNDLE dashboard with this name in this project means
+        # we're refreshing its content. Resolve existence BEFORE uploading so
+        # the cleanup branch below is only reachable when this call is the
+        # one that just produced the upload — otherwise we'd risk deleting a
+        # pre-existing bundle on a transient registration failure.
+        existing = self._find_bundle_dashboard(dashboard_api, name)
+
+        dataset_api.upload(path, upload_dir, overwrite=True)
+
+        if existing is not None:
+            return existing
+
+        import contextlib
+
+        try:
+            # bundle_path is server-derived; the field on the DTO is informational.
+            dashboard = Dashboard(name=name, type="BUNDLE")
+            return dashboard_api.create_dashboard(dashboard)
+        except Exception:
+            # Safe to clean up: `existing` was None at the start of this call,
+            # so the upload we just did is the only thing in upload_dir.
+            with contextlib.suppress(Exception):
+                dataset_api.remove(upload_dir)
+            raise
+
+    @staticmethod
+    def _find_bundle_dashboard(
+        dashboard_api: DashboardApi, name: str
+    ) -> Dashboard | None:
+        """Return the BUNDLE dashboard with this name in this project, or None.
+
+        Falls back to None if listing fails — we'd rather risk a duplicate
+        registration than silently lose user data by deleting an existing
+        bundle on cleanup.
+        """
+        try:
+            dashboards = dashboard_api.get_dashboards() or []
+        except Exception:
+            return None
+        for d in dashboards:
+            if d.name == name and d.type == "BUNDLE":
+                return d
+        return None
+
     def get_dashboards(self) -> list[Dashboard]:
         """Get all dashboards in the feature store.
 

--- a/python/tests/test_dashboard.py
+++ b/python/tests/test_dashboard.py
@@ -1,0 +1,320 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from hsfs.core.dashboard import Dashboard
+
+
+class TestDashboard:
+    def test_from_response_json_includes_type_and_bundle_path(self):
+        """BUNDLE dashboards round-trip type and bundlePath through the JSON model."""
+        payload = {
+            "id": 7,
+            "name": "sales-overview",
+            "type": "BUNDLE",
+            "bundlePath": "/Projects/demo/Resources/dashboards/sales-overview",
+            "charts": [],
+        }
+
+        result = Dashboard.from_response_json(payload)
+
+        assert result.id == 7
+        assert result.name == "sales-overview"
+        assert result.type == "BUNDLE"
+        assert result.bundle_path == (
+            "/Projects/demo/Resources/dashboards/sales-overview"
+        )
+
+    def test_from_response_json_grid_default(self):
+        """GRID dashboards do not require type/bundle_path in the payload."""
+        payload = {"id": 1, "name": "grid-demo", "charts": []}
+
+        result = Dashboard.from_response_json(payload)
+
+        assert result.type is None
+        assert result.bundle_path is None
+
+    def test_to_dict_omits_unset_bundle_fields(self):
+        """A GRID dashboard's serialized payload must not carry empty bundle fields."""
+        d = Dashboard(name="grid-demo", charts=[])
+
+        out = d.to_dict()
+
+        assert "type" not in out
+        assert "bundlePath" not in out
+
+    def test_to_dict_includes_type_when_set(self):
+        """A BUNDLE dashboard serializes type; bundlePath is server-derived and may be unset."""
+        d = Dashboard(name="b", type="BUNDLE")
+
+        out = d.to_dict()
+
+        assert out["type"] == "BUNDLE"
+
+
+class TestCreateBundle:
+    def test_rejects_invalid_name_with_slash(self, tmp_path):
+        """Names that could escape the dashboards directory must fail before any upload."""
+        from hsfs.feature_store import FeatureStore
+
+        fs = FeatureStore.__new__(FeatureStore)
+        bundle = tmp_path / "dist"
+        bundle.mkdir()
+        (bundle / "index.html").write_text("ok")
+
+        with pytest.raises(ValueError, match="invalid dashboard name"):
+            fs.create_bundle(name="../etc/passwd", path=str(bundle))
+
+    def test_rejects_invalid_name_with_dot(self, tmp_path):
+        """Leading dots and dotted segments are rejected."""
+        from hsfs.feature_store import FeatureStore
+
+        fs = FeatureStore.__new__(FeatureStore)
+        bundle = tmp_path / "dist"
+        bundle.mkdir()
+        (bundle / "index.html").write_text("ok")
+
+        with pytest.raises(ValueError, match="invalid dashboard name"):
+            fs.create_bundle(name=".hidden", path=str(bundle))
+
+    def test_rejects_missing_index_html(self, tmp_path):
+        """A bundle directory without index.html fails before any upload."""
+        from hsfs.feature_store import FeatureStore
+
+        fs = FeatureStore.__new__(FeatureStore)
+        bundle = tmp_path / "no_index"
+        bundle.mkdir()
+        (bundle / "main.js").write_text("// no index")
+
+        with pytest.raises(ValueError, match="index.html not found"):
+            fs.create_bundle(name="x", path=str(bundle))
+
+    def test_rejects_missing_directory(self, tmp_path):
+        """A non-existent path fails fast with a clear message."""
+        from hsfs.feature_store import FeatureStore
+
+        fs = FeatureStore.__new__(FeatureStore)
+
+        with pytest.raises(ValueError, match="bundle directory not found"):
+            fs.create_bundle(name="x", path=str(tmp_path / "missing"))
+
+    def test_uploads_then_creates_bundle_dashboard(self, tmp_path):
+        """Happy path: upload to Resources/dashboards/{name}, then POST a BUNDLE dashboard.
+
+        The DTO does NOT carry bundlePath — the backend derives it from name.
+        """
+        from hsfs.feature_store import FeatureStore
+
+        fs = FeatureStore.__new__(FeatureStore)
+
+        bundle = tmp_path / "dist"
+        bundle.mkdir()
+        (bundle / "index.html").write_text("<!doctype html><title>x</title>")
+
+        captured: dict[str, object] = {}
+
+        def fake_upload(self, local_path, upload_path, overwrite=False, **kwargs):
+            captured["upload_path"] = upload_path
+            captured["overwrite"] = overwrite
+            captured["local_path"] = local_path
+
+        def fake_create(self, dashboard):
+            captured["sent"] = json.loads(dashboard.json())
+            return Dashboard(
+                id=99,
+                name=dashboard.name,
+                type=dashboard.type,
+                bundle_path=f"/Projects/demo/Resources/dashboards/{dashboard.name}",
+            )
+
+        with (
+            patch(
+                "hopsworks_common.core.dataset_api.DatasetApi.upload",
+                fake_upload,
+            ),
+            patch(
+                "hsfs.core.dashboard_api.DashboardApi.create_dashboard",
+                fake_create,
+            ),
+        ):
+            result = fs.create_bundle(name="sales", path=str(bundle))
+
+        assert captured["upload_path"] == "Resources/dashboards/sales"
+        assert captured["overwrite"] is True
+        assert captured["sent"]["type"] == "BUNDLE"
+        # Client must not send bundlePath — the backend derives it.
+        assert "bundlePath" not in captured["sent"]
+        assert result.id == 99
+
+    def test_cleans_up_upload_only_on_first_create_failure(self, tmp_path):
+        """If create_dashboard fails on first registration, the SDK removes the bundle."""
+        from hsfs.feature_store import FeatureStore
+
+        fs = FeatureStore.__new__(FeatureStore)
+
+        bundle = tmp_path / "dist"
+        bundle.mkdir()
+        (bundle / "index.html").write_text("ok")
+
+        removed: list[str] = []
+
+        def fake_upload(self, local_path, upload_path, overwrite=False, **kwargs):
+            pass
+
+        def boom(self, dashboard):
+            raise RuntimeError("backend rejected")
+
+        def fake_remove(self, path):
+            removed.append(path)
+
+        def no_existing(self):
+            return []
+
+        with (
+            patch(
+                "hopsworks_common.core.dataset_api.DatasetApi.upload",
+                fake_upload,
+            ),
+            patch(
+                "hopsworks_common.core.dataset_api.DatasetApi.remove",
+                fake_remove,
+            ),
+            patch(
+                "hsfs.core.dashboard_api.DashboardApi.get_dashboards",
+                no_existing,
+            ),
+            patch(
+                "hsfs.core.dashboard_api.DashboardApi.create_dashboard",
+                boom,
+            ),
+            pytest.raises(RuntimeError, match="backend rejected"),
+        ):
+            fs.create_bundle(name="will_fail", path=str(bundle))
+
+        assert removed == ["Resources/dashboards/will_fail"]
+
+    def test_returns_existing_dashboard_without_creating_duplicate(self, tmp_path):
+        """If a BUNDLE dashboard with this name exists, return it; no second row, no remove."""
+        from hsfs.feature_store import FeatureStore
+
+        fs = FeatureStore.__new__(FeatureStore)
+
+        bundle = tmp_path / "dist"
+        bundle.mkdir()
+        (bundle / "index.html").write_text("v2 content")
+
+        uploads: list[str] = []
+        creates: list[Dashboard] = []
+        removed: list[str] = []
+
+        existing = Dashboard(
+            id=42,
+            name="rebuilt",
+            type="BUNDLE",
+            bundle_path="/Projects/demo/Resources/dashboards/rebuilt",
+        )
+
+        def fake_get_dashboards(self):
+            return [existing]
+
+        def fake_upload(self, local_path, upload_path, overwrite=False, **kwargs):
+            uploads.append(upload_path)
+
+        def fake_create(self, dashboard):
+            creates.append(dashboard)
+            return dashboard
+
+        def fake_remove(self, path):
+            removed.append(path)
+
+        with (
+            patch(
+                "hsfs.core.dashboard_api.DashboardApi.get_dashboards",
+                fake_get_dashboards,
+            ),
+            patch(
+                "hopsworks_common.core.dataset_api.DatasetApi.upload",
+                fake_upload,
+            ),
+            patch(
+                "hopsworks_common.core.dataset_api.DatasetApi.remove",
+                fake_remove,
+            ),
+            patch(
+                "hsfs.core.dashboard_api.DashboardApi.create_dashboard",
+                fake_create,
+            ),
+        ):
+            result = fs.create_bundle(name="rebuilt", path=str(bundle))
+
+        assert result is existing
+        assert uploads == ["Resources/dashboards/rebuilt"]
+        # Critical: we must not create a duplicate row, and we must not delete
+        # the pre-existing bundle if we somehow hit the cleanup path.
+        assert creates == []
+        assert removed == []
+
+    def test_existing_grid_dashboard_with_same_name_does_not_block_bundle(
+        self, tmp_path
+    ):
+        """A GRID dashboard with the same name is not the same record — create the BUNDLE."""
+        from hsfs.feature_store import FeatureStore
+
+        fs = FeatureStore.__new__(FeatureStore)
+
+        bundle = tmp_path / "dist"
+        bundle.mkdir()
+        (bundle / "index.html").write_text("ok")
+
+        creates: list[Dashboard] = []
+
+        # A GRID with the same name (a quirk of the existing dashboard model)
+        # is NOT the same record. Only an existing BUNDLE should short-circuit.
+        grid_with_same_name = Dashboard(id=1, name="dual", type="GRID", charts=[])
+
+        def fake_get_dashboards(self):
+            return [grid_with_same_name]
+
+        def fake_upload(self, local_path, upload_path, overwrite=False, **kwargs):
+            pass
+
+        def fake_create(self, dashboard):
+            creates.append(dashboard)
+            return Dashboard(id=2, name=dashboard.name, type="BUNDLE")
+
+        with (
+            patch(
+                "hsfs.core.dashboard_api.DashboardApi.get_dashboards",
+                fake_get_dashboards,
+            ),
+            patch(
+                "hopsworks_common.core.dataset_api.DatasetApi.upload",
+                fake_upload,
+            ),
+            patch(
+                "hsfs.core.dashboard_api.DashboardApi.create_dashboard",
+                fake_create,
+            ),
+        ):
+            result = fs.create_bundle(name="dual", path=str(bundle))
+
+        assert result.id == 2
+        assert len(creates) == 1
+        assert creates[0].type == "BUNDLE"


### PR DESCRIPTION
## Summary

- Adds `fs.create_bundle(name, path)` to upload a built SPA `dist/` and register it as a BUNDLE-typed dashboard.
- Mirrors the backend name regex (`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`) client-side and checks `index.html` exists before any upload, so invalid input fails fast.
- Idempotent on `(project, name, type=BUNDLE)`: a re-run uploads new files over the existing bundle and returns the existing dashboard row. Cleanup branch only fires when *this* call produced the upload, so a transient registration failure can never delete a pre-existing bundle.
- `Dashboard` model gains optional `type` and `bundle_path`; `to_dict` omits them when unset to keep GRID dashboards on the same wire shape.

## Companion PRs

- `hopsworks-ee`: BUNDLE type, REST endpoints, JPA migration, IIFE bundle.
- `hopsworks-front`: `BundleDashboard` host + parent-window proxy.

## Test plan

- [ ] `fs.create_bundle("foo", "./dist")` uploads to `Resources/dashboards/foo` and registers a BUNDLE dashboard.
- [ ] Re-running with the same name uploads new files and does NOT create a duplicate row.
- [ ] Invalid name raises `ValueError` before any upload (slash, dot, leading hyphen, > 64 chars).
- [ ] Missing `index.html` raises `ValueError` before any upload.
- [ ] On registration failure for a first-time create, the orphaned upload directory is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)