### PR TITLE
[HWORKS-2762] User account level environment variables

### DIFF
--- a/python/hopsworks/__init__.py
+++ b/python/hopsworks/__init__.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Literal
 
 from hopsworks.connection import Connection
-from hopsworks.core import project_api, secret_api
+from hopsworks.core import env_var_api, project_api, secret_api
 from hopsworks.decorators import NoHopsworksConnectionError
 from hopsworks_apigen import public
 from hopsworks_common import client, constants, project, usage, version
@@ -57,6 +57,7 @@ _hw_connection = Connection.connection
 
 _connected_project = None
 _secrets_api = None
+_env_vars_api = None
 _project_api = None
 
 udf = hsfs.hopsworks_udf.udf
@@ -384,6 +385,7 @@ def logout():
     global _hw_connection
     global _project_api
     global _secrets_api
+    global _env_vars_api
 
     if _is_connection_active():
         _hw_connection.close()
@@ -391,6 +393,7 @@ def logout():
     client.stop()
     _project_api = None
     _secrets_api = None
+    _env_vars_api = None
     _hw_connection = Connection.connection
 
 
@@ -424,8 +427,10 @@ def get_current_project() -> project.Project:
 def _initialize_module_apis():
     global _project_api
     global _secrets_api
+    global _env_vars_api
     _project_api = project_api.ProjectApi()
     _secrets_api = secret_api.SecretsApi()
+    _env_vars_api = env_var_api.EnvVarsApi()
 
 
 @public
@@ -485,6 +490,19 @@ def get_secrets_api() -> secret_api.SecretsApi:
     if not _is_connection_active():
         raise NoHopsworksConnectionError
     return _secrets_api
+
+
+@public
+def get_env_vars_api() -> env_var_api.EnvVarsApi:
+    """Get the environment variables api.
+
+    Returns:
+        The environment variables API handle.
+    """
+    global _env_vars_api
+    if not _is_connection_active():
+        raise NoHopsworksConnectionError
+    return _env_vars_api
 
 
 def _set_active_project(project):

--- a/python/hopsworks_common/core/env_var_api.py
+++ b/python/hopsworks_common/core/env_var_api.py
@@ -23,11 +23,35 @@ from hopsworks_common import client, decorators, env_var
 
 @public("hopsworks.core.env_var_api.EnvVarsApi")
 class EnvVarsApi:
-    """API for managing user account environment variables in Hopsworks."""
+    """Manage user account environment variables in Hopsworks.
+
+    Account env vars are encrypted at rest and automatically injected into
+    every runtime the user starts (jobs, deployments, apps, Jupyter, terminal).
+    Per-runtime env vars override account-level on collision.
+
+    Example:
+        ```python
+        import hopsworks
+        hopsworks.login()
+        api = hopsworks.get_env_vars_api()
+
+        api.create_env_var("OPENAI_API_KEY", "sk-...")
+        api.create_env_var("HF_TOKEN", "hf_...")
+
+        for v in api.get_env_vars():
+            print(v.name, v.value)
+
+        api.delete_env_var("OPENAI_API_KEY")
+        ```
+    """
 
     @public
     def get_env_vars(self) -> list[env_var.EnvVar]:
-        """Get all account environment variables."""
+        """Return all account-level env vars for the authenticated user.
+
+        Returns:
+            List of [`EnvVar`][hopsworks.env_var.EnvVar] objects, possibly empty.
+        """
         _client = client.get_instance()
         return env_var.EnvVar.from_response_json(
             _client._send_request("GET", ["users", "envvars"])
@@ -36,7 +60,14 @@ class EnvVarsApi:
     @public
     @decorators.catch_not_found("hopsworks_common.env_var.EnvVar", fallback_return=None)
     def get_env_var(self, name: str) -> env_var.EnvVar | None:
-        """Get an account environment variable."""
+        """Look up a single env var by name.
+
+        Returns ``None`` when no env var with that name exists, instead of
+        raising — convenient for "set if missing" patterns.
+
+        Parameters:
+            name: Variable name (e.g. ``"OPENAI_API_KEY"``).
+        """
         _client = client.get_instance()
         env_vars = env_var.EnvVar.from_response_json(
             _client._send_request("GET", ["users", "envvars", name])
@@ -45,27 +76,60 @@ class EnvVarsApi:
 
     @public
     def get(self, name: str) -> str | None:
-        """Get an account environment variable value."""
+        """Return just the value of an env var, or ``None`` if missing.
+
+        Convenience wrapper around [`get_env_var`][hopsworks.core.env_var_api.EnvVarsApi.get_env_var].
+
+        Example:
+            ```python
+            api.get("OPENAI_API_KEY")  # -> "sk-..." or None
+            ```
+        """
         env_var_obj = self.get_env_var(name)
         return env_var_obj.value if env_var_obj else None
 
     @public
     def create_env_var(self, name: str, value: str) -> env_var.EnvVar:
-        """Create an account environment variable.
+        """Add a new account-level env var.
 
-        Raises a ``RestAPIError`` with code ``ENV_VAR_RESERVED_NAME`` when the
-        name is reserved and ``ENV_VAR_INVALID_NAME`` when the name is invalid.
+        Parameters:
+            name: Variable name. Must match ``^[A-Za-z_][A-Za-z0-9_]*$`` and
+                not be reserved by the platform (``API_KEY``, ``HOPS_*``,
+                ``HOPSWORKS_*``, etc — see ``ReservedEnvVars`` in the backend).
+            value: Variable value. Up to 8192 characters.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: ``ENV_VAR_RESERVED_NAME``,
+                ``ENV_VAR_INVALID_NAME``, ``ENV_VAR_VALUE_TOO_LARGE``, or
+                ``ENV_VAR_LIMIT_EXCEEDED`` (default cap is 64 vars per user).
+
+        Example:
+            ```python
+            api.create_env_var("OPENAI_API_KEY", "sk-...")
+            ```
         """
         return self._upsert("POST", ["users", "envvars"], name, value)
 
     @public
     def update_env_var(self, name: str, value: str) -> env_var.EnvVar:
-        """Update the value of an existing account environment variable."""
+        """Replace the value of an existing env var.
+
+        Raises ``RestAPIError`` with ``ENV_VAR_NOT_FOUND`` if the name doesn't
+        exist. Use [`set_env_var`][hopsworks.core.env_var_api.EnvVarsApi.set_env_var]
+        to upsert instead.
+        """
         return self._upsert("PUT", ["users", "envvars", name], name, value)
 
     @public
     def set_env_var(self, name: str, value: str) -> env_var.EnvVar:
-        """Create the env var if missing, otherwise update its value."""
+        """Upsert: create the env var if missing, else update its value.
+
+        Example:
+            ```python
+            # Idempotent — safe to call from setup scripts
+            api.set_env_var("HF_TOKEN", os.environ["HF_TOKEN"])
+            ```
+        """
         existing = self.get_env_var(name)
         if existing is None:
             return self.create_env_var(name, value)
@@ -88,13 +152,40 @@ class EnvVarsApi:
         return env_vars[0]
 
     @public
-    def delete(self, name: str):
-        """Delete an account environment variable."""
+    def delete_env_var(self, name: str) -> None:
+        """Remove a single env var from the account.
+
+        Raises ``RestAPIError`` with ``ENV_VAR_NOT_FOUND`` if the name doesn't
+        exist.
+
+        Example:
+            ```python
+            api.delete_env_var("OPENAI_API_KEY")
+            ```
+        """
         _client = client.get_instance()
         _client._send_request("DELETE", ["users", "envvars", name])
 
     @public
-    def delete_all(self):
-        """Delete all account environment variables."""
+    def delete(self, name: str) -> None:
+        """Alias for [`delete_env_var`][hopsworks.core.env_var_api.EnvVarsApi.delete_env_var].
+
+        Kept for parity with [`SecretsApi.delete`][hopsworks.core.secret_api.SecretsApi].
+        New code should prefer ``delete_env_var``.
+        """
+        self.delete_env_var(name)
+
+    @public
+    def delete_all(self) -> None:
+        """Remove all account-level env vars for the authenticated user.
+
+        Returns silently if there are none.
+
+        Example:
+            ```python
+            api.delete_all()
+            assert api.get_env_vars() == []
+            ```
+        """
         _client = client.get_instance()
         _client._send_request("DELETE", ["users", "envvars"])

--- a/python/hopsworks_common/core/env_var_api.py
+++ b/python/hopsworks_common/core/env_var_api.py
@@ -38,23 +38,37 @@ class EnvVarsApi:
         api.create_env_var("OPENAI_API_KEY", "sk-...")
         api.create_env_var("HF_TOKEN", "hf_...")
 
+        # Print only names — values are typically credentials, don't log them.
         for v in api.get_env_vars():
-            print(v.name, v.value)
+            print(v.name)
 
         api.delete_env_var("OPENAI_API_KEY")
         ```
     """
 
     @public
-    def get_env_vars(self) -> list[env_var.EnvVar]:
+    def get_env_vars(self, include_value: bool = True) -> list[env_var.EnvVar]:
         """Return all account-level env vars for the authenticated user.
+
+        The backend omits values from the list response by default to reduce
+        accidental exposure (UI, logs, proxies). The SDK opts back in here so
+        existing callers see ``EnvVar.value`` populated; pass
+        ``include_value=False`` if you only need names (e.g. building a UI
+        list before drilling into a single var).
+
+        Parameters:
+            include_value: When ``False``, the returned EnvVars have no value
+                set. Default ``True`` preserves the existing behavior.
 
         Returns:
             List of [`EnvVar`][hopsworks.env_var.EnvVar] objects, possibly empty.
         """
         _client = client.get_instance()
+        params = {"includeValue": "true" if include_value else "false"}
         return env_var.EnvVar.from_response_json(
-            _client._send_request("GET", ["users", "envvars"])
+            _client._send_request(
+                "GET", ["users", "envvars"], query_params=params
+            )
         )
 
     @public

--- a/python/hopsworks_common/core/env_var_api.py
+++ b/python/hopsworks_common/core/env_var_api.py
@@ -1,0 +1,100 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from __future__ import annotations
+
+import json
+
+from hopsworks_apigen import public
+from hopsworks_common import client, decorators, env_var
+
+
+@public("hopsworks.core.env_var_api.EnvVarsApi")
+class EnvVarsApi:
+    """API for managing user account environment variables in Hopsworks."""
+
+    @public
+    def get_env_vars(self) -> list[env_var.EnvVar]:
+        """Get all account environment variables."""
+        _client = client.get_instance()
+        return env_var.EnvVar.from_response_json(
+            _client._send_request("GET", ["users", "envvars"])
+        )
+
+    @public
+    @decorators.catch_not_found("hopsworks_common.env_var.EnvVar", fallback_return=None)
+    def get_env_var(self, name: str) -> env_var.EnvVar | None:
+        """Get an account environment variable."""
+        _client = client.get_instance()
+        env_vars = env_var.EnvVar.from_response_json(
+            _client._send_request("GET", ["users", "envvars", name])
+        )
+        return env_vars[0] if env_vars else None
+
+    @public
+    def get(self, name: str) -> str | None:
+        """Get an account environment variable value."""
+        env_var_obj = self.get_env_var(name)
+        return env_var_obj.value if env_var_obj else None
+
+    @public
+    def create_env_var(self, name: str, value: str) -> env_var.EnvVar:
+        """Create an account environment variable.
+
+        Raises a ``RestAPIError`` with code ``ENV_VAR_RESERVED_NAME`` when the
+        name is reserved and ``ENV_VAR_INVALID_NAME`` when the name is invalid.
+        """
+        return self._upsert("POST", ["users", "envvars"], name, value)
+
+    @public
+    def update_env_var(self, name: str, value: str) -> env_var.EnvVar:
+        """Update the value of an existing account environment variable."""
+        return self._upsert("PUT", ["users", "envvars", name], name, value)
+
+    @public
+    def set_env_var(self, name: str, value: str) -> env_var.EnvVar:
+        """Create the env var if missing, otherwise update its value."""
+        existing = self.get_env_var(name)
+        if existing is None:
+            return self.create_env_var(name, value)
+        return self.update_env_var(name, value)
+
+    def _upsert(
+        self, method: str, path: list[str], name: str, value: str
+    ) -> env_var.EnvVar:
+        _client = client.get_instance()
+        headers = {"content-type": "application/json"}
+        payload = {"name": name, "value": value}
+        env_vars = env_var.EnvVar.from_response_json(
+            _client._send_request(
+                method,
+                path,
+                headers=headers,
+                data=json.dumps(payload),
+            )
+        )
+        return env_vars[0]
+
+    @public
+    def delete(self, name: str):
+        """Delete an account environment variable."""
+        _client = client.get_instance()
+        _client._send_request("DELETE", ["users", "envvars", name])
+
+    @public
+    def delete_all(self):
+        """Delete all account environment variables."""
+        _client = client.get_instance()
+        _client._send_request("DELETE", ["users", "envvars"])

--- a/python/hopsworks_common/core/env_var_api.py
+++ b/python/hopsworks_common/core/env_var_api.py
@@ -67,6 +67,9 @@ class EnvVarsApi:
 
         Parameters:
             name: Variable name (e.g. ``"OPENAI_API_KEY"``).
+
+        Returns:
+            The matching [`EnvVar`][hopsworks.env_var.EnvVar], or ``None``.
         """
         _client = client.get_instance()
         env_vars = env_var.EnvVar.from_response_json(
@@ -84,6 +87,12 @@ class EnvVarsApi:
             ```python
             api.get("OPENAI_API_KEY")  # -> "sk-..." or None
             ```
+
+        Parameters:
+            name: Variable name.
+
+        Returns:
+            The env var's value, or ``None`` when no var with that name exists.
         """
         env_var_obj = self.get_env_var(name)
         return env_var_obj.value if env_var_obj else None
@@ -92,21 +101,24 @@ class EnvVarsApi:
     def create_env_var(self, name: str, value: str) -> env_var.EnvVar:
         """Add a new account-level env var.
 
+        Example:
+            ```python
+            api.create_env_var("OPENAI_API_KEY", "sk-...")
+            ```
+
         Parameters:
             name: Variable name. Must match ``^[A-Za-z_][A-Za-z0-9_]*$`` and
                 not be reserved by the platform (``API_KEY``, ``HOPS_*``,
                 ``HOPSWORKS_*``, etc — see ``ReservedEnvVars`` in the backend).
             value: Variable value. Up to 8192 characters.
 
+        Returns:
+            The created [`EnvVar`][hopsworks.env_var.EnvVar].
+
         Raises:
             hopsworks.client.exceptions.RestAPIError: ``ENV_VAR_RESERVED_NAME``,
                 ``ENV_VAR_INVALID_NAME``, ``ENV_VAR_VALUE_TOO_LARGE``, or
                 ``ENV_VAR_LIMIT_EXCEEDED`` (default cap is 64 vars per user).
-
-        Example:
-            ```python
-            api.create_env_var("OPENAI_API_KEY", "sk-...")
-            ```
         """
         return self._upsert("POST", ["users", "envvars"], name, value)
 
@@ -114,9 +126,19 @@ class EnvVarsApi:
     def update_env_var(self, name: str, value: str) -> env_var.EnvVar:
         """Replace the value of an existing env var.
 
-        Raises ``RestAPIError`` with ``ENV_VAR_NOT_FOUND`` if the name doesn't
-        exist. Use [`set_env_var`][hopsworks.core.env_var_api.EnvVarsApi.set_env_var]
-        to upsert instead.
+        Use [`set_env_var`][hopsworks.core.env_var_api.EnvVarsApi.set_env_var]
+        to upsert (create-if-missing) instead.
+
+        Parameters:
+            name: Variable name. Must already exist.
+            value: New value. Up to 8192 characters.
+
+        Returns:
+            The updated [`EnvVar`][hopsworks.env_var.EnvVar].
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: ``ENV_VAR_NOT_FOUND``
+                if no env var with that name exists.
         """
         return self._upsert("PUT", ["users", "envvars", name], name, value)
 
@@ -129,6 +151,13 @@ class EnvVarsApi:
             # Idempotent — safe to call from setup scripts
             api.set_env_var("HF_TOKEN", os.environ["HF_TOKEN"])
             ```
+
+        Parameters:
+            name: Variable name.
+            value: Variable value.
+
+        Returns:
+            The created or updated [`EnvVar`][hopsworks.env_var.EnvVar].
         """
         existing = self.get_env_var(name)
         if existing is None:
@@ -155,13 +184,17 @@ class EnvVarsApi:
     def delete_env_var(self, name: str) -> None:
         """Remove a single env var from the account.
 
-        Raises ``RestAPIError`` with ``ENV_VAR_NOT_FOUND`` if the name doesn't
-        exist.
-
         Example:
             ```python
             api.delete_env_var("OPENAI_API_KEY")
             ```
+
+        Parameters:
+            name: Variable name to remove.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: ``ENV_VAR_NOT_FOUND``
+                if no env var with that name exists.
         """
         _client = client.get_instance()
         _client._send_request("DELETE", ["users", "envvars", name])
@@ -172,6 +205,9 @@ class EnvVarsApi:
 
         Kept for parity with [`SecretsApi.delete`][hopsworks.core.secret_api.SecretsApi].
         New code should prefer ``delete_env_var``.
+
+        Parameters:
+            name: Variable name to remove.
         """
         self.delete_env_var(name)
 

--- a/python/hopsworks_common/core/env_var_api.py
+++ b/python/hopsworks_common/core/env_var_api.py
@@ -66,9 +66,7 @@ class EnvVarsApi:
         _client = client.get_instance()
         params = {"includeValue": "true" if include_value else "false"}
         return env_var.EnvVar.from_response_json(
-            _client._send_request(
-                "GET", ["users", "envvars"], query_params=params
-            )
+            _client._send_request("GET", ["users", "envvars"], query_params=params)
         )
 
     @public

--- a/python/hopsworks_common/env_var.py
+++ b/python/hopsworks_common/env_var.py
@@ -86,6 +86,22 @@ class EnvVar:
         """
         return self._env_var_api.delete_env_var(self.name)
 
+    def to_dict(self):
+        """Serialise to a JSON-friendly dict, redacting the value.
+
+        Used by ``util.Encoder`` when ``json()`` / ``str(env_var)`` /
+        logging serialises an EnvVar. The value is intentionally redacted
+        because env vars typically hold credentials/tokens and we don't
+        want them landing in logs / notebook outputs / error reports.
+        Use ``env_var.value`` directly if you need the plaintext.
+        """
+        return {
+            "name": self._name,
+            "value": "***" if self._value is not None else None,
+            "added_on": self._added_on,
+            "updated_on": self._updated_on,
+        }
+
     def json(self):
         return json.dumps(self, cls=util.Encoder)
 

--- a/python/hopsworks_common/env_var.py
+++ b/python/hopsworks_common/env_var.py
@@ -1,0 +1,98 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+
+import humps
+from hopsworks_apigen import public
+from hopsworks_common import util
+from hopsworks_common.core import env_var_api
+
+
+@public("hopsworks.env_var.EnvVar")
+class EnvVar:
+    """Represents a user account environment variable in Hopsworks."""
+
+    NOT_FOUND_ERROR_CODE = 160070
+
+    def __init__(
+        self,
+        name=None,
+        value=None,
+        added_on=None,
+        updated_on=None,
+        type=None,
+        href=None,
+        expand=None,
+        items=None,
+        count=None,
+        **kwargs,
+    ):
+        self._name = name
+        self._value = value
+        self._added_on = added_on
+        self._updated_on = updated_on
+        self._env_var_api = env_var_api.EnvVarsApi()
+
+    @classmethod
+    def from_response_json(cls, json_dict):
+        json_decamelized = humps.decamelize(json_dict)
+        if "items" not in json_decamelized or len(json_decamelized["items"]) == 0:
+            return []
+        return [cls(**env_var) for env_var in json_decamelized["items"]]
+
+    @public
+    @property
+    def name(self):
+        """Name of the environment variable."""
+        return self._name
+
+    @public
+    @property
+    def value(self):
+        """Value of the environment variable."""
+        return self._value
+
+    @public
+    @property
+    def created(self):
+        """Date when the environment variable was created."""
+        return self._added_on
+
+    @public
+    @property
+    def updated(self):
+        """Date when the environment variable was last updated."""
+        return self._updated_on
+
+    @public
+    def delete(self):
+        """Delete the environment variable."""
+        return self._env_var_api.delete(self.name)
+
+    def json(self):
+        return json.dumps(self, cls=util.Encoder)
+
+    def __str__(self):
+        return self.json()
+
+    def __repr__(self):
+        return f"EnvVar({self._name!r})"
+
+    @public
+    def get_url(self):
+        """Get url to the environment variables page in Hopsworks."""
+        return util.get_hostname_replaced_url("/account/env-variables")

--- a/python/hopsworks_common/env_var.py
+++ b/python/hopsworks_common/env_var.py
@@ -80,8 +80,11 @@ class EnvVar:
 
     @public
     def delete(self):
-        """Delete the environment variable."""
-        return self._env_var_api.delete(self.name)
+        """Remove this env var from the user's account.
+
+        Equivalent to ``api.delete_env_var(self.name)``.
+        """
+        return self._env_var_api.delete_env_var(self.name)
 
     def json(self):
         return json.dumps(self, cls=util.Encoder)

--- a/python/tests/core/test_env_var_api.py
+++ b/python/tests/core/test_env_var_api.py
@@ -154,7 +154,17 @@ class TestEnvVarsApi:
         assert result.value == "new"
         assert client._send_request.call_args_list[1].args[0] == "PUT"
 
-    def test_delete_calls_delete(self, mocker):
+    def test_delete_env_var_calls_delete(self, mocker):
+        api = EnvVarsApi()
+        c = _patch_client(mocker, None)
+        api.delete_env_var("OPENAI_API_KEY")
+        method, path = c._send_request.call_args.args[:2]
+        assert method == "DELETE"
+        assert path == ["users", "envvars", "OPENAI_API_KEY"]
+
+    def test_delete_alias(self, mocker):
+        # The plain `delete(name)` alias must still work — it's there for
+        # parity with SecretsApi.delete and existing user code.
         api = EnvVarsApi()
         c = _patch_client(mocker, None)
         api.delete("OPENAI_API_KEY")

--- a/python/tests/core/test_env_var_api.py
+++ b/python/tests/core/test_env_var_api.py
@@ -1,0 +1,198 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.client.exceptions import RestAPIError
+from hopsworks_common.core.env_var_api import EnvVarsApi
+from hopsworks_common.env_var import EnvVar
+
+
+def _list_response(items: list[dict]) -> dict:
+    return {"items": items, "type": "envVarDTO"}
+
+
+def _single_response(name: str, value: str) -> dict:
+    return _list_response([{"name": name, "value": value}])
+
+
+def _make_rest_api_error(error_code: int, status_code: int = 404) -> RestAPIError:
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.reason = "Not Found"
+    mock_response.content = b"{}"
+    mock_response.json.return_value = {
+        "errorCode": error_code,
+        "errorMsg": "not found",
+        "usrMsg": "not found",
+    }
+    return RestAPIError("http://localhost/users/envvars/X", mock_response)
+
+
+def _patch_client(mocker, send_request_return):
+    client_instance = MagicMock()
+    if isinstance(send_request_return, Exception):
+        client_instance._send_request.side_effect = send_request_return
+    else:
+        client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hopsworks_common.core.env_var_api.client.get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+class TestEnvVarsApi:
+    def test_get_env_vars_returns_list(self, mocker):
+        api = EnvVarsApi()
+        _patch_client(
+            mocker,
+            _list_response(
+                [
+                    {"name": "OPENAI_API_KEY", "value": "sk-1"},
+                    {"name": "HF_TOKEN", "value": "hf-1"},
+                ]
+            ),
+        )
+        result = api.get_env_vars()
+        assert len(result) == 2
+        assert result[0].name == "OPENAI_API_KEY"
+        assert result[0].value == "sk-1"
+        assert result[1].name == "HF_TOKEN"
+
+    def test_get_env_vars_empty(self, mocker):
+        api = EnvVarsApi()
+        _patch_client(mocker, _list_response([]))
+        assert api.get_env_vars() == []
+
+    def test_get_env_var_returns_single(self, mocker):
+        api = EnvVarsApi()
+        _patch_client(mocker, _single_response("OPENAI_API_KEY", "sk-1"))
+        result = api.get_env_var("OPENAI_API_KEY")
+        assert isinstance(result, EnvVar)
+        assert result.name == "OPENAI_API_KEY"
+        assert result.value == "sk-1"
+
+    def test_get_env_var_not_found_returns_none(self, mocker):
+        api = EnvVarsApi()
+        _patch_client(mocker, _make_rest_api_error(EnvVar.NOT_FOUND_ERROR_CODE))
+        assert api.get_env_var("MISSING") is None
+
+    def test_get_returns_value(self, mocker):
+        api = EnvVarsApi()
+        _patch_client(mocker, _single_response("OPENAI_API_KEY", "sk-1"))
+        assert api.get("OPENAI_API_KEY") == "sk-1"
+
+    def test_get_returns_none_when_missing(self, mocker):
+        api = EnvVarsApi()
+        _patch_client(mocker, _make_rest_api_error(EnvVar.NOT_FOUND_ERROR_CODE))
+        assert api.get("MISSING") is None
+
+    def test_create_env_var_posts(self, mocker):
+        api = EnvVarsApi()
+        c = _patch_client(mocker, _single_response("OPENAI_API_KEY", "sk-1"))
+        result = api.create_env_var("OPENAI_API_KEY", "sk-1")
+        assert result.name == "OPENAI_API_KEY"
+        c._send_request.assert_called_once()
+        method, path = c._send_request.call_args.args[:2]
+        assert method == "POST"
+        assert path == ["users", "envvars"]
+        sent = json.loads(c._send_request.call_args.kwargs["data"])
+        assert sent == {"name": "OPENAI_API_KEY", "value": "sk-1"}
+
+    def test_update_env_var_puts(self, mocker):
+        api = EnvVarsApi()
+        c = _patch_client(mocker, _single_response("OPENAI_API_KEY", "sk-2"))
+        result = api.update_env_var("OPENAI_API_KEY", "sk-2")
+        assert result.value == "sk-2"
+        method, path = c._send_request.call_args.args[:2]
+        assert method == "PUT"
+        assert path == ["users", "envvars", "OPENAI_API_KEY"]
+
+    def test_set_env_var_creates_when_absent(self, mocker):
+        api = EnvVarsApi()
+        client = MagicMock()
+        client._send_request.side_effect = [
+            _make_rest_api_error(EnvVar.NOT_FOUND_ERROR_CODE),  # get_env_var
+            _single_response("NEW_VAR", "v"),  # POST
+        ]
+        mocker.patch(
+            "hopsworks_common.core.env_var_api.client.get_instance",
+            return_value=client,
+        )
+        result = api.set_env_var("NEW_VAR", "v")
+        assert result.name == "NEW_VAR"
+        assert client._send_request.call_args_list[1].args[0] == "POST"
+
+    def test_set_env_var_updates_when_present(self, mocker):
+        api = EnvVarsApi()
+        client = MagicMock()
+        client._send_request.side_effect = [
+            _single_response("EXISTING", "old"),  # get_env_var returns hit
+            _single_response("EXISTING", "new"),  # PUT
+        ]
+        mocker.patch(
+            "hopsworks_common.core.env_var_api.client.get_instance",
+            return_value=client,
+        )
+        result = api.set_env_var("EXISTING", "new")
+        assert result.value == "new"
+        assert client._send_request.call_args_list[1].args[0] == "PUT"
+
+    def test_delete_calls_delete(self, mocker):
+        api = EnvVarsApi()
+        c = _patch_client(mocker, None)
+        api.delete("OPENAI_API_KEY")
+        method, path = c._send_request.call_args.args[:2]
+        assert method == "DELETE"
+        assert path == ["users", "envvars", "OPENAI_API_KEY"]
+
+    def test_delete_all_calls_delete(self, mocker):
+        api = EnvVarsApi()
+        c = _patch_client(mocker, None)
+        api.delete_all()
+        method, path = c._send_request.call_args.args[:2]
+        assert method == "DELETE"
+        assert path == ["users", "envvars"]
+
+    def test_other_error_propagates(self, mocker):
+        api = EnvVarsApi()
+        # Not a NOT_FOUND code — should propagate as RestAPIError.
+        _patch_client(mocker, _make_rest_api_error(160068, status_code=400))
+        with pytest.raises(RestAPIError):
+            api.get_env_var("ANY")
+
+
+class TestEnvVar:
+    def test_from_response_json_empty(self):
+        assert EnvVar.from_response_json({"items": []}) == []
+
+    def test_from_response_json_no_items_key(self):
+        assert EnvVar.from_response_json({}) == []
+
+    def test_from_response_json_single(self):
+        result = EnvVar.from_response_json(
+            {"items": [{"name": "X", "value": "y", "addedOn": None, "updatedOn": None}]}
+        )
+        assert len(result) == 1
+        assert result[0].name == "X"
+        assert result[0].value == "y"
+
+    def test_repr(self):
+        env_var = EnvVar(name="X", value="y")
+        assert repr(env_var) == "EnvVar('X')"


### PR DESCRIPTION
## Summary

Add a new user-account-scoped \`EnvVarsApi\` mirroring \`SecretsApi\`. Lets users manage account-level env vars that the backend injects into every runtime they start.

- \`hopsworks_common.env_var.EnvVar\` with \`name\`/\`value\`/\`added\`/\`updated\` and \`delete()\`
- \`hopsworks_common.core.env_var_api.EnvVarsApi\`: \`get_env_vars\`, \`get_env_var\`, \`get\`, \`create_env_var\`, \`update_env_var\`, \`set_env_var\` (upsert), \`delete\`, \`delete_all\`
- \`hopsworks.get_env_vars_api()\` top-level handle (\`Connection.get_env_vars_api\` intentionally not exposed — env vars are user-scoped, not project-scoped)
- \`@catch_not_found\` on \`get_env_var\` so missing names return \`None\` instead of raising
- pytest mock-based coverage of CRUD, NOT_FOUND→None, \`set_env_var\` upsert paths

## Test plan
- [ ] \`hopsworks.get_env_vars_api().create_env_var('OPENAI_API_KEY', '…')\`
- [ ] \`api.get_env_vars()\` lists all
- [ ] \`api.get_env_var('MISSING')\` returns \`None\`
- [ ] \`api.set_env_var\` upserts (create if missing, update if present)
- [ ] \`api.delete_all()\` clears
- [ ] Reserved-name / invalid-name errors propagate as \`RestAPIError\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)