### PR TITLE
[HWORKS-2731] Support HOPSFS_MOUNT_PREFIX_BASE in model imports

### DIFF
--- a/python/hopsworks_common/constants.py
+++ b/python/hopsworks_common/constants.py
@@ -155,6 +155,7 @@ class MODEL:
 
 
 class MODEL_REGISTRY:
+    HOPSFS_MOUNT_PREFIX_BASE = "/mnt/hopsfs"
     HOPSFS_MOUNT_PREFIX = "/hopsfs/"
     MODELS_DATASET = "Models"
     MODEL_FILES_DIR_NAME = "Files"

--- a/python/hsml/engine/model_engine.py
+++ b/python/hsml/engine/model_engine.py
@@ -146,7 +146,9 @@ class ModelEngine:
 
     def _normalize_hopsfs_mount_path(self, model_path):
         if model_path.startswith(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX):
-            return model_path.replace(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX, "")
+            return model_path.replace(
+                constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX, "", 1
+            )
         if model_path.startswith(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE):
             return model_path.replace(
                 constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE, "", 1

--- a/python/hsml/engine/model_engine.py
+++ b/python/hsml/engine/model_engine.py
@@ -144,6 +144,15 @@ class ModelEngine:
             n_files += 1
             update_upload_progress(n_dirs=n_dirs, n_files=n_files)
 
+    def _normalize_hopsfs_mount_path(self, model_path):
+        if model_path.startswith(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX):
+            return model_path.replace(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX, "")
+        if model_path.startswith(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE):
+            return model_path.replace(
+                constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE, "", 1
+            )
+        return None
+
     def _download_model_from_hopsfs_recursive(
         self,
         from_hdfs_model_path: str,
@@ -249,11 +258,10 @@ class ModelEngine:
     ):
         """Save model files from a local path. The local path can be on hopsfs mount."""
         # check hopsfs mount
-        if model_path.startswith(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX):
+        from_hdfs_model_path = self._normalize_hopsfs_mount_path(model_path)
+        if from_hdfs_model_path is not None:
             self._copy_or_move_hopsfs_model(
-                from_hdfs_model_path=model_path.replace(
-                    constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX, ""
-                ),
+                from_hdfs_model_path=from_hdfs_model_path,
                 to_model_files_path=model_instance.model_files_path,
                 keep_original_files=keep_original_files,
                 update_upload_progress=update_upload_progress,

--- a/python/tests/test_constants.py
+++ b/python/tests/test_constants.py
@@ -54,6 +54,7 @@ class TestConstants:
     def test_model_registry_constants(self):
         # Arrange
         model_registry = {
+            "HOPSFS_MOUNT_PREFIX_BASE": "/mnt/hopsfs",
             "HOPSFS_MOUNT_PREFIX": "/hopsfs/",
             "MODELS_DATASET": "Models",
             "MODEL_FILES_DIR_NAME": "Files",

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -513,16 +513,17 @@ class TestModelEngine:
     @pytest.mark.parametrize(
         "model_path,expected_hdfs_path",
         [
-            ("/hopsfs/Projects/demo/Models/model.pkl", "Projects/demo/Models/model.pkl"),
+            (
+                "/hopsfs/Projects/demo/Models/model.pkl",
+                "Projects/demo/Models/model.pkl",
+            ),
             (
                 "/mnt/hopsfs/Projects/demo/Models/model.pkl",
                 "/Projects/demo/Models/model.pkl",
             ),
         ],
     )
-    def test_normalize_hopsfs_mount_path(
-        self, mocker, model_path, expected_hdfs_path
-    ):
+    def test_normalize_hopsfs_mount_path(self, mocker, model_path, expected_hdfs_path):
         mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
         mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
         mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
@@ -543,7 +544,10 @@ class TestModelEngine:
     @pytest.mark.parametrize(
         "model_path,expected_hdfs_path",
         [
-            ("/hopsfs/Projects/demo/Models/model.pkl", "Projects/demo/Models/model.pkl"),
+            (
+                "/hopsfs/Projects/demo/Models/model.pkl",
+                "Projects/demo/Models/model.pkl",
+            ),
             (
                 "/mnt/hopsfs/Projects/demo/Models/model.pkl",
                 "/Projects/demo/Models/model.pkl",
@@ -578,9 +582,7 @@ class TestModelEngine:
         )
         upload_local.assert_not_called()
 
-    def test_save_model_from_local_or_hopsfs_mount_uses_local_upload(
-        self, mocker
-    ):
+    def test_save_model_from_local_or_hopsfs_mount_uses_local_upload(self, mocker):
         mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
         mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
         mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -545,6 +545,30 @@ class TestModelEngine:
         "model_path,expected_hdfs_path",
         [
             (
+                "/hopsfs/Projects/demo/hopsfs/archive/model.pkl",
+                "Projects/demo/hopsfs/archive/model.pkl",
+            ),
+            (
+                "/mnt/hopsfs/Projects/demo/mnt/hopsfs/archive/model.pkl",
+                "/Projects/demo/mnt/hopsfs/archive/model.pkl",
+            ),
+        ],
+    )
+    def test_normalize_hopsfs_mount_path_strips_only_leading_prefix(
+        self, mocker, model_path, expected_hdfs_path
+    ):
+        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
+        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
+        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
+
+        engine = model_engine.ModelEngine()
+
+        assert engine._normalize_hopsfs_mount_path(model_path) == expected_hdfs_path
+
+    @pytest.mark.parametrize(
+        "model_path,expected_hdfs_path",
+        [
+            (
                 "/hopsfs/Projects/demo/Models/model.pkl",
                 "Projects/demo/Models/model.pkl",
             ),

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -24,6 +24,7 @@ from hopsworks_common.client.exceptions import ModelRegistryException
 from hsml import model
 from hsml.constants import MODEL
 from hsml.core import explicit_provenance
+from hsml.engine import model_engine
 
 
 class TestModel:
@@ -506,6 +507,106 @@ class TestModel:
         mock_td_provenance.assert_called_once()
         assert mock_fv.init_serving.called
         assert not mock_fv.init_batch_scoring.called
+
+
+class TestModelEngine:
+    @pytest.mark.parametrize(
+        "model_path,expected_hdfs_path",
+        [
+            ("/hopsfs/Projects/demo/Models/model.pkl", "Projects/demo/Models/model.pkl"),
+            (
+                "/mnt/hopsfs/Projects/demo/Models/model.pkl",
+                "/Projects/demo/Models/model.pkl",
+            ),
+        ],
+    )
+    def test_normalize_hopsfs_mount_path(
+        self, mocker, model_path, expected_hdfs_path
+    ):
+        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
+        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
+        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
+
+        engine = model_engine.ModelEngine()
+
+        assert engine._normalize_hopsfs_mount_path(model_path) == expected_hdfs_path
+
+    def test_normalize_hopsfs_mount_path_returns_none_for_local_path(self, mocker):
+        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
+        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
+        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
+
+        engine = model_engine.ModelEngine()
+
+        assert engine._normalize_hopsfs_mount_path("local/model.pkl") is None
+
+    @pytest.mark.parametrize(
+        "model_path,expected_hdfs_path",
+        [
+            ("/hopsfs/Projects/demo/Models/model.pkl", "Projects/demo/Models/model.pkl"),
+            (
+                "/mnt/hopsfs/Projects/demo/Models/model.pkl",
+                "/Projects/demo/Models/model.pkl",
+            ),
+        ],
+    )
+    def test_save_model_from_local_or_hopsfs_mount_uses_hopsfs_copy(
+        self, mocker, model_path, expected_hdfs_path
+    ):
+        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
+        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
+        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
+
+        engine = model_engine.ModelEngine()
+        copy_or_move = mocker.patch.object(engine, "_copy_or_move_hopsfs_model")
+        upload_local = mocker.patch.object(engine, "_upload_local_model")
+        model_instance = mocker.Mock(model_files_path="Models/test/1/Files")
+        progress = mocker.Mock()
+
+        engine._save_model_from_local_or_hopsfs_mount(
+            model_instance=model_instance,
+            model_path=model_path,
+            keep_original_files=True,
+            update_upload_progress=progress,
+        )
+
+        copy_or_move.assert_called_once_with(
+            from_hdfs_model_path=expected_hdfs_path,
+            to_model_files_path=model_instance.model_files_path,
+            keep_original_files=True,
+            update_upload_progress=progress,
+        )
+        upload_local.assert_not_called()
+
+    def test_save_model_from_local_or_hopsfs_mount_uses_local_upload(
+        self, mocker
+    ):
+        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
+        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
+        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
+
+        engine = model_engine.ModelEngine()
+        copy_or_move = mocker.patch.object(engine, "_copy_or_move_hopsfs_model")
+        upload_local = mocker.patch.object(engine, "_upload_local_model")
+        model_instance = mocker.Mock(model_files_path="Models/test/1/Files")
+        progress = mocker.Mock()
+        upload_configuration = {"config": "value"}
+
+        engine._save_model_from_local_or_hopsfs_mount(
+            model_instance=model_instance,
+            model_path="local/model.pkl",
+            keep_original_files=True,
+            update_upload_progress=progress,
+            upload_configuration=upload_configuration,
+        )
+
+        upload_local.assert_called_once_with(
+            from_local_model_path="local/model.pkl",
+            to_model_files_path=model_instance.model_files_path,
+            update_upload_progress=progress,
+            upload_configuration=upload_configuration,
+        )
+        copy_or_move.assert_not_called()
 
 
 class TestModelNameValidation:


### PR DESCRIPTION
Add MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE to the Python constants and cover it in the constant regression test. Refactor model path handling in ModelEngine so HopsFS mount paths are normalized through one helper before copy or move operations, allowing both /hopsfs/ and /mnt/hopsfs inputs to resolve to the expected HDFS path.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
