### PR TITLE
[HWORKS-2731][APPEND] Strip project segment from /mnt/hopsfs paths

### DIFF
--- a/python/hsml/engine/model_engine.py
+++ b/python/hsml/engine/model_engine.py
@@ -149,10 +149,15 @@ class ModelEngine:
             return model_path.replace(
                 constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX, "", 1
             )
-        if model_path.startswith(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE):
-            return model_path.replace(
-                constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE, "", 1
-            )
+        # /mnt/hopsfs/ is rooted at /Projects/, so the on-disk path is
+        # /mnt/hopsfs/<projectName>/<rest> — strip the project segment too
+        # so the result is project-relative, matching the /hopsfs/ branch.
+        base = constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE
+        if model_path.startswith(base + "/"):
+            rest = model_path[len(base) + 1 :]
+            first_slash = rest.find("/")
+            if first_slash != -1 and first_slash + 1 < len(rest):
+                return rest[first_slash + 1 :]
         return None
 
     def _download_model_from_hopsfs_recursive(

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -513,13 +513,22 @@ class TestModelEngine:
     @pytest.mark.parametrize(
         "model_path,expected_hdfs_path",
         [
+            # /hopsfs/ is the per-project mount: strip the prefix to get a
+            # project-relative dataset path.
             (
-                "/hopsfs/Projects/demo/Models/model.pkl",
-                "Projects/demo/Models/model.pkl",
+                "/hopsfs/Models/model.pkl",
+                "Models/model.pkl",
             ),
+            # /mnt/hopsfs/ is the cluster-wide mount rooted at /Projects/, so
+            # the path is /mnt/hopsfs/<projectName>/<rest>. Strip both segments.
             (
-                "/mnt/hopsfs/Projects/demo/Models/model.pkl",
-                "/Projects/demo/Models/model.pkl",
+                "/mnt/hopsfs/demo/Models/model.pkl",
+                "Models/model.pkl",
+            ),
+            # The actual failing case from the loadtest run on 2026-05-09.
+            (
+                "/mnt/hopsfs/demo/Resources/workflows/models/tensorflow",
+                "Resources/workflows/models/tensorflow",
             ),
         ],
     )
@@ -545,12 +554,12 @@ class TestModelEngine:
         "model_path,expected_hdfs_path",
         [
             (
-                "/hopsfs/Projects/demo/hopsfs/archive/model.pkl",
-                "Projects/demo/hopsfs/archive/model.pkl",
+                "/hopsfs/Models/hopsfs/archive/model.pkl",
+                "Models/hopsfs/archive/model.pkl",
             ),
             (
-                "/mnt/hopsfs/Projects/demo/mnt/hopsfs/archive/model.pkl",
-                "/Projects/demo/mnt/hopsfs/archive/model.pkl",
+                "/mnt/hopsfs/demo/Models/mnt/hopsfs/archive/model.pkl",
+                "Models/mnt/hopsfs/archive/model.pkl",
             ),
         ],
     )
@@ -569,12 +578,12 @@ class TestModelEngine:
         "model_path,expected_hdfs_path",
         [
             (
-                "/hopsfs/Projects/demo/Models/model.pkl",
-                "Projects/demo/Models/model.pkl",
+                "/hopsfs/Models/model.pkl",
+                "Models/model.pkl",
             ),
             (
-                "/mnt/hopsfs/Projects/demo/Models/model.pkl",
-                "/Projects/demo/Models/model.pkl",
+                "/mnt/hopsfs/demo/Models/model.pkl",
+                "Models/model.pkl",
             ),
         ],
     )

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -644,6 +644,82 @@ class TestModelEngine:
         copy_or_move.assert_not_called()
 
 
+class TestModelEngineExportFastSlowPath:
+    """Pin the slow/fast-path dispatch through to the leaf I/O calls.
+
+    The other TestModelEngine cases mock _copy_or_move_hopsfs_model away,
+    so they only assert on the *normalized* path passed to it. These tests
+    leave _copy_or_move_hopsfs_model intact and mock only _dataset_api and
+    _engine, so the path that actually reaches _dataset_api.get is asserted
+    directly. That's where the HWORKS-2731 regression manifested — the
+    normalizer produced a malformed path and the bug was only visible at
+    the dataset_api call site.
+    """
+
+    @pytest.mark.parametrize(
+        "model_path,expected_dataset_get_arg",
+        [
+            # /hopsfs/ — per-project mount.
+            ("/hopsfs/Resources/foo/bar.pkl", "Resources/foo/bar.pkl"),
+            # /mnt/hopsfs/ — cluster-wide mount, rooted at /Projects/.
+            ("/mnt/hopsfs/demo/Resources/foo/bar.pkl", "Resources/foo/bar.pkl"),
+            # The actual failing case from the 2026-05-09 loadtest run.
+            (
+                "/mnt/hopsfs/demo/Resources/workflows/models/tensorflow",
+                "Resources/workflows/models/tensorflow",
+            ),
+        ],
+    )
+    def test_fast_path_passes_project_relative_path_to_dataset_api(
+        self, mocker, model_path, expected_dataset_get_arg
+    ):
+        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
+        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
+        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
+        engine = model_engine.ModelEngine()
+        engine._dataset_api.get.return_value = {
+            "attributes": {
+                "dir": False,
+                "path": "/Projects/demo/" + expected_dataset_get_arg,
+            },
+        }
+
+        engine._save_model_from_local_or_hopsfs_mount(
+            model_instance=mocker.Mock(model_files_path="Models/test/1/Files"),
+            model_path=model_path,
+            keep_original_files=True,
+            update_upload_progress=mocker.Mock(),
+        )
+
+        # Regression guard: must be project-relative — NOT "/<projectName>/<rest>".
+        engine._dataset_api.get.assert_called_once_with(expected_dataset_get_arg)
+        # Fast path: HopsFS-internal copy, no chunked HTTP upload.
+        engine._engine.copy.assert_called_once()
+        engine._engine.upload.assert_not_called()
+
+    def test_slow_path_uses_engine_upload_for_non_mount_path(self, mocker):
+        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
+        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
+        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
+        mocker.patch("os.path.isdir", return_value=False)
+        engine = model_engine.ModelEngine()
+
+        engine._save_model_from_local_or_hopsfs_mount(
+            model_instance=mocker.Mock(model_files_path="Models/test/1/Files"),
+            model_path="/some/local/model.pkl",
+            keep_original_files=True,
+            update_upload_progress=mocker.Mock(),
+            upload_configuration={"chunk_size": 10},
+        )
+
+        # Slow path: chunked HTTP upload, no HopsFS-internal copy/move and no
+        # dataset_api lookup.
+        engine._engine.upload.assert_called_once()
+        engine._engine.copy.assert_not_called()
+        engine._engine.move.assert_not_called()
+        engine._dataset_api.get.assert_not_called()
+
+
 class TestModelNameValidation:
     """Tests for model name validation."""
 


### PR DESCRIPTION
## Summary

- Follow-up to #938 (HWORKS-2731). That PR introduced `HOPSFS_MOUNT_PREFIX_BASE = "/mnt/hopsfs"` so the fast model-export path (`_copy_or_move_hopsfs_model`) is taken when the model lives on the cluster-wide HopsFS mount, but the strip logic only removed the literal `/mnt/hopsfs` prefix. The cluster mount is rooted at `/Projects/`, so on-disk paths look like `/mnt/hopsfs/<projectName>/<rest>` — stripping just the prefix leaves `/<projectName>/<rest>`, which `dataset_api.get()` then sends to the backend with a leading slash and a project name in the dataset slot. The backend rejects this with HTTP 400 `errorCode 110011 "DataSet not found, path: /Projects/<projectName>/<projectName>"`. 16 model serving / model training loadtest jobs failed at `model.save()` as a result.
- Fix in `python/hsml/engine/model_engine.py::_normalize_hopsfs_mount_path`: strip the `<projectName>` segment too, so `/mnt/hopsfs/<projectName>/<rest>` normalizes to `<rest>`, matching what the per-project `/hopsfs/` mount already produces. Falls back to `None` (i.e. routes to the local-upload path) when there's no `<rest>` component.
- Update the `TestModelEngine` parametrize tables to use realistic cluster paths, including the actual failing case `/mnt/hopsfs/demo/Resources/workflows/models/tensorflow → Resources/workflows/models/tensorflow`. The previous tests used `/mnt/hopsfs/Projects/demo/...` which doesn't exist on the cluster — that's why this regression slipped past CI.

## Test plan

- [x] `pytest python/tests/test_model.py::TestModelEngine` — 9/9 pass with the new parametrize tables
- [x] `pytest python/tests/test_model.py` — 50/50 pass
- [x] `ruff check` + `ruff format --check` clean on changed files
- [ ] End-to-end: re-run the loadtest model-serving / model-training suites against a live cluster — the 16 `DataSet not found` failures should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)