### PR TITLE
[HWORKS-2744][APPEND] Fix hopsworks.hsfs[.*] / hopsworks.hsml[.*] dotted-import regression

### DIFF
--- a/python/hopsworks/__init__.py
+++ b/python/hopsworks/__init__.py
@@ -127,6 +127,53 @@ def __getattr__(name):  # type: ignore[no-untyped-def]
     return value
 
 
+# PEP 562 ``__getattr__`` only fires on attribute access, not when the import
+# machinery resolves a dotted module path. Without this finder,
+# ``from hopsworks.hsfs.builtin_transformations import X`` raises
+# ``ModuleNotFoundError: No module named 'hopsworks.hsfs'`` — the public
+# ``hopsworks.hsfs[.*]`` / ``hopsworks.hsml[.*]`` aliases have been supported
+# since #292 (Aug 2024) and downstream code (e.g. loadtest, customer notebooks)
+# depends on them. A meta-path finder restores the alias contract while keeping
+# the lazy goal: ``hsfs`` / ``hsml`` are only imported when something actually
+# references them, not on ``import hopsworks``.
+import importlib.util  # noqa: E402
+
+
+_ALIAS_TO_REAL = {"hopsworks.hsfs": "hsfs", "hopsworks.hsml": "hsml"}
+
+
+class _AliasLoader:
+    """No-op loader that hands back an already-executed module."""
+
+    def __init__(self, real_module):  # type: ignore[no-untyped-def]
+        self._real = real_module
+
+    def create_module(self, spec):  # type: ignore[no-untyped-def]
+        return self._real
+
+    def exec_module(self, module):  # type: ignore[no-untyped-def]
+        pass  # real module was already executed by importlib.import_module
+
+
+class _HsfsHsmlAliasFinder:
+    """Route ``hopsworks.hsfs[.*]`` and ``hopsworks.hsml[.*]`` to the real packages."""
+
+    def find_spec(self, fullname, path=None, target=None):  # type: ignore[no-untyped-def]
+        for alias, real in _ALIAS_TO_REAL.items():
+            if fullname == alias or fullname.startswith(alias + "."):
+                real_name = real + fullname[len(alias) :]
+                real_mod = importlib.import_module(real_name)
+                return importlib.util.spec_from_loader(fullname, _AliasLoader(real_mod))
+        return None
+
+
+# Append (not prepend) so the standard ``PathFinder`` and pytest's assertion
+# rewriter still run first for ordinary modules; our finder only fires for the
+# two alias namespaces, which no real on-disk subpackage shadows.
+if not any(isinstance(f, _HsfsHsmlAliasFinder) for f in sys.meta_path):
+    sys.meta_path.append(_HsfsHsmlAliasFinder())
+
+
 def _make_connection(*args, **kwargs):  # type: ignore[no-untyped-def]
     """Factory: create a new Connection via the lazy-loaded Connection class."""
     return _load_connection_class().connection(*args, **kwargs)

--- a/python/tests/test_hopsworks_lazy_alias.py
+++ b/python/tests/test_hopsworks_lazy_alias.py
@@ -1,0 +1,123 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for the ``hopsworks.hsfs`` / ``hopsworks.hsml`` alias contract.
+
+These aliases have been part of the public surface since #292 (Aug 2024).
+The PEP 562 lazy refactor in #920 (May 2026) inadvertently regressed the
+dotted-import form because attribute hooks aren't consulted by Python's
+import machinery — only by attribute access. The meta-path finder in
+``hopsworks/__init__.py`` restores the contract.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_isolated(snippet: str) -> tuple[int, str]:
+    """Execute ``snippet`` in a fresh interpreter for clean ``sys.modules``."""
+    proc = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, (proc.stdout + proc.stderr).strip()
+
+
+def test_import_hopsworks_does_not_load_hsfs():
+    """``import hopsworks`` must not eagerly load ``hsfs`` or ``hsml``."""
+    rc, out = _run_isolated(
+        """
+        import sys
+        import hopsworks  # noqa: F401
+        assert 'hsfs' not in sys.modules, sys.modules.keys()
+        assert 'hsml' not in sys.modules
+        assert 'hopsworks.hsfs' not in sys.modules
+        assert 'hopsworks.hsml' not in sys.modules
+        print('OK')
+        """
+    )
+    assert rc == 0 and out.endswith("OK"), out
+
+
+def test_dotted_submodule_import_works():
+    """``from hopsworks.hsfs.X import Y`` resolves via the meta-path finder."""
+    rc, out = _run_isolated(
+        """
+        from hopsworks.hsfs.builtin_transformations import one_hot_encoder
+        assert one_hot_encoder is not None
+        print('OK')
+        """
+    )
+    assert rc == 0 and out.endswith("OK"), out
+
+
+def test_dotted_submodule_import_lazily_loads_hsfs():
+    """The dotted import is what triggers the real ``hsfs`` load, not ``import hopsworks``."""
+    rc, out = _run_isolated(
+        """
+        import sys
+        import hopsworks  # noqa: F401
+        assert 'hsfs' not in sys.modules
+        from hopsworks.hsfs.builtin_transformations import one_hot_encoder  # noqa: F401
+        assert 'hsfs' in sys.modules
+        assert sys.modules['hopsworks.hsfs'] is sys.modules['hsfs']
+        print('OK')
+        """
+    )
+    assert rc == 0 and out.endswith("OK"), out
+
+
+def test_attribute_access_still_works():
+    """The PEP 562 ``__getattr__`` path is unaffected by the finder."""
+    rc, out = _run_isolated(
+        """
+        import hopsworks
+        _ = hopsworks.hsfs
+        _ = hopsworks.hsml
+        _ = hopsworks.udf
+        print('OK')
+        """
+    )
+    assert rc == 0 and out.endswith("OK"), out
+
+
+def test_alias_and_real_module_are_identical():
+    """``hopsworks.hsfs`` and ``hsfs`` must be the same module object."""
+    rc, out = _run_isolated(
+        """
+        import hopsworks.hsfs
+        import hsfs
+        assert hopsworks.hsfs is hsfs
+        import hopsworks.hsml
+        import hsml
+        assert hopsworks.hsml is hsml
+        print('OK')
+        """
+    )
+    assert rc == 0 and out.endswith("OK"), out
+
+
+def test_repeated_dotted_imports_are_idempotent():
+    """Re-importing a dotted submodule must hand back the same object."""
+    rc, out = _run_isolated(
+        """
+        from hopsworks.hsfs.builtin_transformations import one_hot_encoder as a
+        from hopsworks.hsfs.builtin_transformations import one_hot_encoder as b
+        assert a is b
+        print('OK')
+        """
+    )
+    assert rc == 0 and out.endswith("OK"), out


### PR DESCRIPTION
#920 refactored hopsworks/__init__.py to lazy-load hsfs/hsml via PEP 562 __getattr__. That works for attribute access (`hopsworks.hsfs`) but breaks the dotted-import path:

  from hopsworks.hsfs.builtin_transformations import one_hot_encoder
  ModuleNotFoundError: No module named 'hopsworks.hsfs'

Python's import machinery does not consult PEP 562 hooks when resolving dotted module paths — it walks meta_path and the filesystem. The hopsworks.hsfs / hopsworks.hsml aliases have been part of the public surface since #292 (Aug 2024) and downstream code (loadtest, customer notebooks) depends on them.

A meta-path finder is the right hook: it's invoked during import resolution, lazily loads the real hsfs / hsml module on first reference, and routes hopsworks.hsfs.* to hsfs.*. Laziness is preserved — neither hsfs nor hsml is imported on `import hopsworks`; they load only when a consumer actually references them via either path.

Adds 6 isolated-subprocess tests covering: laziness, dotted import, attribute access, alias-real identity, lazy-trigger-on-dotted-import, and idempotence.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
