### PR TITLE
[HWORKS-2762][Append] Fixing env_vars and start_time/end_time loadtest failures

### DIFF
--- a/python/hopsworks_common/app.py
+++ b/python/hopsworks_common/app.py
@@ -200,7 +200,10 @@ class App:
             hopsworks.client.exceptions.JobExecutionException: If the app fails to start or the serving timeout is exceeded.
         """
         _logger.info("Starting app: %s", self._name)
-        self._app_api._start(self._name, env_vars=self._env_vars)
+        if self._env_vars:
+            self._app_api._start(self._name, env_vars=self._env_vars)
+        else:
+            self._app_api._start(self._name)
 
         if await_serving:
             _logger.info("Waiting for app to become ready...")

--- a/python/hopsworks_common/app.py
+++ b/python/hopsworks_common/app.py
@@ -89,6 +89,9 @@ class App:
         self._memory_usage = memory_usage
         self._cpu_requested = cpu_requested
         self._memory_requested = memory_requested
+        # Runtime env-var override; set by AppApi.create_app() and applied on run().
+        # Not part of the persisted app config — the backend has no field for it.
+        self._env_vars: dict[str, str] | None = None
 
         self._app_api = app_api.AppApi()
 
@@ -197,7 +200,7 @@ class App:
             hopsworks.client.exceptions.JobExecutionException: If the app fails to start or the serving timeout is exceeded.
         """
         _logger.info("Starting app: %s", self._name)
-        self._app_api._start(self._name)
+        self._app_api._start(self._name, env_vars=self._env_vars)
 
         if await_serving:
             _logger.info("Waiting for app to become ready...")

--- a/python/hopsworks_common/core/app_api.py
+++ b/python/hopsworks_common/core/app_api.py
@@ -80,6 +80,7 @@ class AppApi:
         environment: str = "python-app-pipeline",
         memory: int = 2048,
         cores: float = 1.0,
+        env_vars: dict[str, str] | None = None,
     ) -> app.App:
         """Create a new Streamlit app.
 
@@ -105,6 +106,8 @@ class AppApi:
             environment: Python environment name (default: "python-app-pipeline").
             memory: Memory in MB (default: 2048).
             cores: CPU cores (default: 1.0).
+            env_vars: Per-runtime env vars applied when the app is started.
+                These override account-level env vars for this app's executions.
 
         Returns:
             The created App object.
@@ -133,11 +136,19 @@ class AppApi:
             "PUT", path_params, headers=headers, data=json.dumps(config)
         )
 
-        # Return the app from the apps endpoint
-        return self.get_app(name)
+        created = self.get_app(name)
+        # env_vars is a runtime-only override applied at start time; the backend
+        # has no app-config field for it, so attach it to the returned object.
+        created._env_vars = dict(env_vars) if env_vars else None
+        return created
 
-    def _start(self, app_name: str):
-        """Start an app execution."""
+    def _start(self, app_name: str, env_vars: dict[str, str] | None = None):
+        """Start an app execution.
+
+        When ``env_vars`` is provided, POSTs a JSON body with ``envVars`` so the
+        backend applies the runtime override; otherwise falls back to the legacy
+        text/plain POST that Jersey dispatches to the no-body start handler.
+        """
         _client = client.get_instance()
         path_params = [
             "project",
@@ -146,6 +157,12 @@ class AppApi:
             app_name,
             "executions",
         ]
+        if env_vars:
+            headers = {"content-type": "application/json"}
+            body = {"envVars": dict(env_vars)}
+            return _client._send_request(
+                "POST", path_params, headers=headers, data=json.dumps(body)
+            )
         headers = {"content-type": "text/plain"}
         return _client._send_request("POST", path_params, headers=headers)
 

--- a/python/tests/core/test_app.py
+++ b/python/tests/core/test_app.py
@@ -279,6 +279,23 @@ class TestApp:
         mock_api.return_value._start.assert_called_once_with("my_app")
         assert result._state == "RUNNING"
 
+    def test_run_passes_env_vars(self, mocker):
+        mocker.patch("hopsworks_common.client.get_instance")
+        mock_api = mocker.patch("hopsworks_common.core.app_api.AppApi")
+
+        refreshed = App(name="my_app", state="RUNNING", serving=False)
+        mock_api.return_value.get_app.return_value = refreshed
+
+        app = App(name="my_app", state="STOPPED")
+        app._app_api = mock_api.return_value
+        app._env_vars = {"FOO": "bar"}
+
+        app.run(await_serving=False)
+
+        mock_api.return_value._start.assert_called_once_with(
+            "my_app", env_vars={"FOO": "bar"}
+        )
+
     def test_stop_when_not_running(self, mocker):
         mocker.patch("hopsworks_common.client.get_instance")
         mock_api = mocker.patch("hopsworks_common.core.app_api.AppApi")


### PR DESCRIPTION
## Summary
- Add `env_vars` parameter to `AppApi.create_app()` and apply it at `run()` time by POSTing a JSON `envVars` body to the start-execution endpoint. Restores the per-runtime override path used by the `test_streamlit_app_lifecycle` loadtest, which was failing with `AppApi.create_app() got an unexpected keyword argument 'env_vars'`.
- Backend treats per-runtime env vars as the source of truth (overriding account-level values), matching the precedence already used for jobs. The legacy text/plain start path is preserved for the no-env-vars case.
- Pairs with the loadtest fix in logicalclocks/loadtest that normalizes tz-aware event times in `feature_group_read_start_end_time` so the start/end-time assertions pass under the Python engine.

## Test plan
- [ ] `test_streamlit_app_lifecycle` passes end-to-end (account-level + runtime override env vars both visible in the served page).
- [ ] Existing `app.run()` flows without `env_vars` continue to start via the legacy text/plain POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)