### PR TITLE
[FSTORE-2070][APPEND] Revert SAP HANA data type handling

### DIFF
--- a/python/hopsworks_common/core/type_systems.py
+++ b/python/hopsworks_common/core/type_systems.py
@@ -40,13 +40,8 @@ if TYPE_CHECKING:
 if HAS_PYARROW:
     import pyarrow as pa
 
-    # Decimal types are handled structurally in
-    # convert_simple_pandas_dtype_to_offline_type because their precision
-    # and scale vary per column and cannot live in a static type-keyed
-    # map.
-    _TINYINT_TYPES = [pa.int8()]
-    _SMALLINT_TYPES = [pa.uint8(), pa.int16()]
-    _INT_TYPES = [pa.uint16(), pa.int32()]
+    # Decimal types are currently not supported
+    _INT_TYPES = [pa.uint8(), pa.uint16(), pa.int8(), pa.int16(), pa.int32()]
     _BIG_INT_TYPES = [pa.uint32(), pa.int64()]
     _FLOAT_TYPES = [pa.float16(), pa.float32()]
     _DOUBLE_TYPES = [pa.float64()]
@@ -57,8 +52,6 @@ if HAS_PYARROW:
     _BINARY_TYPES = [pa.binary(), pa.large_binary()]
 
     PYARROW_HOPSWORKS_DTYPE_MAPPING = {
-        **dict.fromkeys(_TINYINT_TYPES, "tinyint"),
-        **dict.fromkeys(_SMALLINT_TYPES, "smallint"),
         **dict.fromkeys(_INT_TYPES, "int"),
         **dict.fromkeys(_BIG_INT_TYPES, "bigint"),
         **dict.fromkeys(_FLOAT_TYPES, "float"),
@@ -84,10 +77,7 @@ if HAS_PYARROW:
                         value_type=value_type, index_type=index_type, ordered=ordered
                     )
                     for value_type in _STRING_TYPES
-                    for index_type in _TINYINT_TYPES
-                    + _SMALLINT_TYPES
-                    + _INT_TYPES
-                    + _BIG_INT_TYPES
+                    for index_type in _INT_TYPES + _BIG_INT_TYPES
                     for ordered in [True, False]
                 ],
             ],
@@ -434,17 +424,7 @@ def cast_column_to_online_type(
     return feature_column  # handle gracefully, just return the column as-is
 
 
-def convert_simple_pandas_dtype_to_offline_type(arrow_type: pa.DataType) -> str:
-    # Pyarrow decimal types carry per-column precision and scale, so they
-    # cannot live in a static type-keyed map. Match them structurally and
-    # render the Hive-style "decimal(p,s)" string the rest of the stack
-    # already accepts (offline writes, online ingestion, spark engine type
-    # mapping all check `offline_type.startswith("decimal")`).
-    # Guard the isinstance check: callers occasionally pass non-DataType
-    # values (legacy callsites + tests that exercise the "unsupported"
-    # path), and pa.types.is_decimal raises on those.
-    if isinstance(arrow_type, pa.DataType) and pa.types.is_decimal(arrow_type):
-        return f"decimal({arrow_type.precision},{arrow_type.scale})"
+def convert_simple_pandas_dtype_to_offline_type(arrow_type: str) -> str:
     try:
         return PYARROW_HOPSWORKS_DTYPE_MAPPING[arrow_type]
     except KeyError as err:

--- a/python/tests/core/test_type_systems.py
+++ b/python/tests/core/test_type_systems.py
@@ -45,9 +45,8 @@ class TestTypeSystems:
             arrow_type=pa.list_(pa.int8())
         )
 
-        # Assert: int8 maps to tinyint (granular int mapping was added so
-        # SAP HANA-style narrow integers preserve their offline type).
-        assert result == "array<tinyint>"
+        # Assert
+        assert result == "array<int>"
 
     def test_infer_type_pyarrow_large_list(self):
         # Act
@@ -56,7 +55,7 @@ class TestTypeSystems:
         )
 
         # Assert
-        assert result == "array<tinyint>"
+        assert result == "array<int>"
 
     def test_infer_type_pyarrow_struct(self):
         # Act
@@ -139,25 +138,6 @@ class TestTypeSystems:
 
         # Assert
         assert str(e_info.value) == "dtype 'time32[s]' not supported"
-
-    def test_infer_type_pyarrow_decimal128(self):
-        # Decimal columns must surface their declared precision and scale
-        # (rather than collapsing to a coarser type) so SAP HANA / Oracle
-        # DECIMAL(p,s) round-trips through hsfs without losing precision.
-        result = type_systems.convert_simple_pandas_dtype_to_offline_type(
-            arrow_type=pa.decimal128(12, 2)
-        )
-
-        # Assert
-        assert result == "decimal(12,2)"
-
-    def test_infer_type_pyarrow_decimal128_no_scale(self):
-        result = type_systems.convert_simple_pandas_dtype_to_offline_type(
-            arrow_type=pa.decimal128(38, 0)
-        )
-
-        # Assert
-        assert result == "decimal(38,0)"
 
     def test_infer_type_pyarrow_struct_with_decimal_fields(self):
         # Arrange
@@ -441,7 +421,7 @@ class TestTypeSystems:
         )
 
         # Assert
-        assert result == "smallint"
+        assert result == "int"
 
     def test_convert_simple_pandas_type_uint16(self):
         # Act
@@ -459,7 +439,7 @@ class TestTypeSystems:
         )
 
         # Assert
-        assert result == "tinyint"
+        assert result == "int"
 
     def test_convert_simple_pandas_type_int16(self):
         # Act
@@ -468,7 +448,7 @@ class TestTypeSystems:
         )
 
         # Assert
-        assert result == "smallint"
+        assert result == "int"
 
     def test_convert_simple_pandas_type_int32(self):
         # Act


### PR DESCRIPTION
Reverts the type-mapping changes introduced by FSTORE-2021 (commit f2a4b3c8a): narrow-int distinction (int8 -> tinyint, uint8/int16 -> smallint) and pyarrow decimal128 -> "decimal(p,s)" structural handling.

Restores `_INT_TYPES` to the original [uint8, uint16, int8, int16, int32] catch-all bucket and reverts `convert_simple_pandas_dtype_to_offline_type` to the pre-SAP-HANA KeyError-on-decimal behaviour. Test assertions for int8/uint8/int16 and array<int8>/large_list<int8> restored to "int" / "array<int>"; the two new pyarrow decimal128 tests removed.

The SAP HANA connector itself (storage connector class, ArrowFlightClient SUPPORTED_EXTERNAL_CONNECTORS entry, fixtures, tests) is untouched.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
