### PR TITLE
[HWORKS-2780] Add Python Agent Image

### DIFF
--- a/python/hopsworks/cli/commands/agent.py
+++ b/python/hopsworks/cli/commands/agent.py
@@ -1,0 +1,408 @@
+"""``hops agent`` — Python agent deployment lifecycle.
+
+Agents are server-only deployments (no model attached) created from a local
+``.py`` script or a directory with ``pyproject.toml``.
+``create`` calls ``ms.deploy_agent`` which builds/uploads the code, provisions
+a Python environment from the ``python-agent-pipeline`` base image, and
+creates or updates a regular Hopsworks deployment.
+The remaining verbs (``info``, ``start``, ``stop``, ``query``, ``logs``,
+``delete``) mirror ``hops deployment`` but resolve names through an
+agent-only lookup that excludes model-backed deployments.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+from hopsworks.cli import output, session
+
+
+@click.group("agent")
+def agent_group() -> None:
+    """Python agent deployment commands."""
+
+
+@agent_group.command("list")
+@click.pass_context
+def agent_list(ctx: click.Context) -> None:
+    """List every agent deployment in the active project.
+
+    Args:
+        ctx: Click context.
+    """
+    ms = _get_model_serving(ctx)
+    try:
+        deployments = ms.get_deployments()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not list agents: {exc}") from exc
+
+    rows = []
+    for d in deployments or []:
+        if not _is_agent(d):
+            continue
+        rows.append(
+            [
+                getattr(d, "id", "?"),
+                getattr(d, "name", "?"),
+                _predictor_attr(d, "environment", "-"),
+                _predictor_attr(d, "script_file", "-"),
+                _deployment_status(d),
+            ]
+        )
+    output.print_table(["ID", "NAME", "ENVIRONMENT", "SCRIPT", "STATUS"], rows)
+
+
+@agent_group.command("info")
+@click.argument("name")
+@click.pass_context
+def agent_info(ctx: click.Context, name: str) -> None:
+    """Show details for a single agent.
+
+    Args:
+        ctx: Click context.
+        name: Agent name.
+    """
+    agent = _get_agent(ctx, name)
+
+    if output.JSON_MODE:
+        output.print_json(_agent_to_dict(agent))
+        return
+
+    rows = [
+        ["ID", getattr(agent, "id", "?")],
+        ["Name", getattr(agent, "name", "?")],
+        ["Environment", _predictor_attr(agent, "environment", "-")],
+        ["Script", _predictor_attr(agent, "script_file", "-")],
+        ["Serving tool", getattr(agent, "serving_tool", "-")],
+        ["Model server", getattr(agent, "model_server", "-")],
+        ["API protocol", getattr(agent, "api_protocol", "-")],
+        ["Description", getattr(agent, "description", "-") or "-"],
+        ["Status", _deployment_status(agent)],
+    ]
+    output.print_table(["FIELD", "VALUE"], rows)
+
+
+@agent_group.command("create")
+@click.argument("entry", type=click.Path(exists=True))
+@click.option("--name", help="Agent name; defaults to the basename of ENTRY.")
+@click.option(
+    "--requirements",
+    type=click.Path(exists=True),
+    help="Local requirements.txt to install into the agent environment.",
+)
+@click.option(
+    "--environment",
+    help="Python environment name; defaults to the agent name.",
+)
+@click.option(
+    "--upload-dir",
+    default="Resources/agents",
+    show_default=True,
+    help="HopsFS directory under which agent files are placed.",
+)
+@click.option("--description", default=None, help="Agent description.")
+@click.pass_context
+def agent_create(
+    ctx: click.Context,
+    entry: str,
+    name: str | None,
+    requirements: str | None,
+    environment: str | None,
+    upload_dir: str,
+    description: str | None,
+) -> None:
+    """Create (or update) an agent from a local script or package.
+
+    ``ENTRY`` is a ``.py`` file or a directory containing ``pyproject.toml``.
+    On re-runs, the latest code is uploaded and the deployment's predictor is
+    rewritten; the running state is left untouched (use ``start`` or invoke
+    ``restart`` via the SDK to roll a running agent onto new code).
+
+    Args:
+        ctx: Click context.
+        entry: Local path to script or package.
+        name: Agent name; defaults to the basename of ``entry``.
+        requirements: Optional ``requirements.txt`` path.
+        environment: Python environment name.
+        upload_dir: HopsFS upload directory.
+        description: Description string.
+    """
+    ms = _get_model_serving(ctx)
+    try:
+        agent = ms.deploy_agent(
+            entry=entry,
+            name=name,
+            requirements=requirements,
+            environment=environment,
+            upload_dir=upload_dir,
+            description=description,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Agent create failed: {exc}") from exc
+
+    output.success("✓ Created agent %s", getattr(agent, "name", name or entry))
+
+
+@agent_group.command("start")
+@click.argument("name")
+@click.option(
+    "--wait",
+    type=int,
+    default=600,
+    show_default=True,
+    help="Seconds to wait for RUNNING.",
+)
+@click.pass_context
+def agent_start(ctx: click.Context, name: str, wait: int) -> None:
+    """Start an agent and optionally wait for the RUNNING state.
+
+    Args:
+        ctx: Click context.
+        name: Agent name.
+        wait: Seconds to wait for the agent to become RUNNING.
+    """
+    agent = _get_agent(ctx, name)
+    try:
+        agent.start(await_running=wait)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Start failed: {exc}") from exc
+    output.success("✓ Started agent %s", name)
+
+
+@agent_group.command("stop")
+@click.argument("name")
+@click.option(
+    "--wait",
+    type=int,
+    default=600,
+    show_default=True,
+    help="Seconds to wait for STOPPED.",
+)
+@click.pass_context
+def agent_stop(ctx: click.Context, name: str, wait: int) -> None:
+    """Stop a running agent.
+
+    Args:
+        ctx: Click context.
+        name: Agent name.
+        wait: Seconds to wait for the agent to stop.
+    """
+    agent = _get_agent(ctx, name)
+    try:
+        agent.stop(await_stopped=wait)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Stop failed: {exc}") from exc
+    output.success("✓ Stopped agent %s", name)
+
+
+@agent_group.command("query")
+@click.argument("name")
+@click.option(
+    "--data",
+    help='JSON body to POST, e.g. \'{"prompt": "hello"}\'.',
+)
+@click.option(
+    "--file",
+    "file_path",
+    type=click.Path(exists=True),
+    help="JSON file with the request body.",
+)
+@click.pass_context
+def agent_query(
+    ctx: click.Context, name: str, data: str | None, file_path: str | None
+) -> None:
+    """Send a request to a running agent.
+
+    Args:
+        ctx: Click context.
+        name: Agent name.
+        data: Inline JSON body.
+        file_path: Alternative JSON file source.
+    """
+    if not data and not file_path:
+        raise click.UsageError("Provide --data or --file.")
+    payload_str = Path(file_path).read_text() if file_path else (data or "")
+    try:
+        payload = json.loads(payload_str)
+    except json.JSONDecodeError as exc:
+        raise click.BadParameter(f"Invalid JSON: {exc}") from exc
+
+    agent = _get_agent(ctx, name)
+    try:
+        response = agent.predict(data=payload)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Query failed: {exc}") from exc
+
+    if output.JSON_MODE:
+        output.print_json(response)
+        return
+    click.echo(json.dumps(response, indent=2, default=str))
+
+
+@agent_group.command("logs")
+@click.argument("name")
+@click.option(
+    "--component",
+    default="predictor",
+    show_default=True,
+    help="Component to fetch logs for (predictor, transformer, ...).",
+)
+@click.option(
+    "--tail", type=int, default=100, show_default=True, help="Number of lines."
+)
+@click.option(
+    "--source",
+    type=click.Choice(["opensearch", "kubernetes"]),
+    default="opensearch",
+    show_default=True,
+    help=(
+        "opensearch: historical logs from the project serving index "
+        "(works for stopped agents). kubernetes: live pod-tailing."
+    ),
+)
+@click.option("--since", help="ISO-8601 lower bound on log timestamp.")
+@click.option("--until", help="ISO-8601 upper bound on log timestamp.")
+@click.option(
+    "-f",
+    "--follow",
+    is_flag=True,
+    help="Stream new log lines as they are written (Ctrl-C to stop).",
+)
+@click.option(
+    "--interval",
+    type=float,
+    default=2.0,
+    show_default=True,
+    help="Seconds between polls when --follow is set.",
+)
+@click.pass_context
+def agent_logs(
+    ctx: click.Context,
+    name: str,
+    component: str,
+    tail: int,
+    source: str,
+    since: str | None,
+    until: str | None,
+    follow: bool,
+    interval: float,
+) -> None:
+    """Read or follow logs from an agent component.
+
+    Args:
+        ctx: Click context.
+        name: Agent name.
+        component: Component to query (e.g. ``predictor``, ``transformer``).
+        tail: Number of lines.
+        source: ``opensearch`` or ``kubernetes``.
+        since: ISO-8601 lower bound on log timestamp.
+        until: ISO-8601 upper bound on log timestamp.
+        follow: Stream new lines instead of returning a one-shot tail.
+        interval: Seconds between polls when following.
+    """
+    agent = _get_agent(ctx, name)
+
+    if follow:
+        try:
+            for chunk in agent.tail_logs(
+                component=component,
+                interval=interval,
+                source=source,
+                since=since or "now",
+            ):
+                click.echo(chunk, nl=False)
+        except KeyboardInterrupt:
+            return
+        except Exception as exc:  # noqa: BLE001
+            raise click.ClickException(f"Log follow failed: {exc}") from exc
+        return
+
+    try:
+        text = agent.read_logs(
+            component=component,
+            tail=tail,
+            source=source,
+            since=since,
+            until=until,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Log fetch failed: {exc}") from exc
+    if output.JSON_MODE:
+        output.print_json({"component": component, "logs": text})
+        return
+    click.echo(text or "<no logs>")
+
+
+@agent_group.command("delete")
+@click.argument("name")
+@click.option("--yes", is_flag=True, help="Skip confirmation prompt.")
+@click.option("--force", is_flag=True, help="Force-delete even when running.")
+@click.pass_context
+def agent_delete(ctx: click.Context, name: str, yes: bool, force: bool) -> None:
+    """Delete an agent deployment.
+
+    Args:
+        ctx: Click context.
+        name: Agent name.
+        yes: Skip confirmation when True.
+        force: Pass ``force=True`` to the SDK (stops the agent first if running).
+    """
+    agent = _get_agent(ctx, name)
+    if not yes and not output.JSON_MODE:
+        click.confirm(f"Delete agent '{name}'?", abort=True)
+    try:
+        agent.delete(force=force)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Delete failed: {exc}") from exc
+    output.success("✓ Deleted agent %s", name)
+
+
+def _get_model_serving(ctx: click.Context) -> Any:
+    project = session.get_project(ctx)
+    return project.get_model_serving()
+
+
+def _get_agent(ctx: click.Context, name: str) -> Any:
+    ms = _get_model_serving(ctx)
+    try:
+        d = ms.get_deployment(name)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Agent '{name}' not found: {exc}") from exc
+    if d is None or not _is_agent(d):
+        raise click.ClickException(f"Agent '{name}' not found.")
+    return d
+
+
+def _is_agent(d: Any) -> bool:
+    """Identify server-only (agent) deployments: no model attached."""
+    return getattr(d, "model_name", None) in (None, "")
+
+
+def _predictor_attr(d: Any, attr: str, default: Any) -> Any:
+    predictor = getattr(d, "predictor", None)
+    return getattr(predictor, attr, default) if predictor is not None else default
+
+
+def _deployment_status(d: Any) -> str:
+    for attr in ("status", "deployment_state", "_state"):
+        value = getattr(d, attr, None)
+        if value:
+            return str(value)
+    return "-"
+
+
+def _agent_to_dict(d: Any) -> dict[str, Any]:
+    return {
+        "id": getattr(d, "id", None),
+        "name": getattr(d, "name", None),
+        "environment": _predictor_attr(d, "environment", None),
+        "script_file": _predictor_attr(d, "script_file", None),
+        "serving_tool": getattr(d, "serving_tool", None),
+        "model_server": getattr(d, "model_server", None),
+        "api_protocol": getattr(d, "api_protocol", None),
+        "description": getattr(d, "description", None),
+        "status": _deployment_status(d),
+    }

--- a/python/hopsworks/cli/commands/agent.py
+++ b/python/hopsworks/cli/commands/agent.py
@@ -377,7 +377,15 @@ def _get_agent(ctx: click.Context, name: str) -> Any:
 
 
 def _is_agent(d: Any) -> bool:
-    """Identify server-only (agent) deployments: no model attached."""
+    """Identify server-only (agent) deployments with no attached model.
+
+    Prefer the SDK-provided ``has_model`` attribute when available because it
+    accounts for the full deployment model attachment state.
+    Fall back to the legacy ``model_name`` heuristic for non-SDK objects.
+    """
+    has_model = getattr(d, "has_model", None)
+    if has_model is not None:
+        return not bool(has_model)
     return getattr(d, "model_name", None) in (None, "")
 
 

--- a/python/hopsworks/cli/main.py
+++ b/python/hopsworks/cli/main.py
@@ -39,6 +39,7 @@ _LAZY_SUBCOMMANDS: dict[str, str] = {
     "env": "hopsworks.cli.commands.env:env_group",
     "job": "hopsworks.cli.commands.job:job_group",
     "app": "hopsworks.cli.commands.app:app_group",
+    "agent": "hopsworks.cli.commands.agent:agent_group",
     "transformation": "hopsworks.cli.commands.transformation:transformation_group",
     "superset": "hopsworks.cli.commands.superset:superset_group",
     "search": "hopsworks.cli.commands.search:search_group",

--- a/python/hopsworks_common/core/library_api.py
+++ b/python/hopsworks_common/core/library_api.py
@@ -57,3 +57,28 @@ class LibraryApi:
             ),
             environment=self,
         )
+
+    def _uninstall(self, library_name: str, name: str) -> None:
+        """Uninstall a library from the environment.
+
+        Parameters:
+            library_name: Name of the library.
+            name: Name of the environment.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client.get_instance()
+
+        path_params = [
+            "project",
+            _client._project_id,
+            "python",
+            "environments",
+            name,
+            "libraries",
+            library_name,
+        ]
+
+        headers = {"content-type": "application/json"}
+        _client._send_request("DELETE", path_params, headers=headers)

--- a/python/hopsworks_common/environment.py
+++ b/python/hopsworks_common/environment.py
@@ -176,6 +176,37 @@ class Environment:
 
     @public
     @usage.method_logger
+    def uninstall(self, library_name: str, await_uninstallation: bool | None = True):
+        """Uninstall a library from the environment.
+
+        ```python
+        import hopsworks
+
+        project = hopsworks.login()
+
+        env_api = project.get_environment_api()
+        env = env_api.get_environment("my_custom_environment")
+
+        env.uninstall("matplotlib")
+        ```
+
+        Parameters:
+            library_name: Name of the installed library to remove.
+            await_uninstallation: If `True` the method returns only when the uninstallation finishes.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        # Wait for any ongoing environment operations
+        self._environment_engine.await_environment_command(self.name)
+
+        self._library_api._uninstall(library_name, self.name)
+
+        if await_uninstallation:
+            self._environment_engine.await_library_command(self.name, library_name)
+
+    @public
+    @usage.method_logger
     def delete(self):
         """Delete the environment.
 

--- a/python/hopsworks_common/environment.py
+++ b/python/hopsworks_common/environment.py
@@ -176,7 +176,9 @@ class Environment:
 
     @public
     @usage.method_logger
-    def uninstall(self, library_name: str, await_uninstallation: bool | None = True):
+    def uninstall(
+        self, library_name: str, await_uninstallation: bool | None = True
+    ) -> None:
         """Uninstall a library from the environment.
 
         ```python

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -120,6 +120,37 @@ class Deployment:
 
     @public
     @usage.method_logger
+    def restart(
+        self,
+        await_stopped: int | None = 600,
+        await_running: int | None = 600,
+        fail_if_stopped: bool = False,
+    ):
+        """Restart the deployment so it picks up the latest code and environment state.
+
+        If the deployment is already stopped, it is started in place by default.
+        Pass `fail_if_stopped=True` to require that the deployment is currently running.
+
+        Parameters:
+            await_stopped: Awaiting time (seconds) for the deployment to stop.
+            await_running: Awaiting time (seconds) for the deployment to start again.
+            fail_if_stopped: Raise instead of starting in place when the deployment is not running.
+
+        Raises:
+            hopsworks.client.exceptions.ModelServingException: If `fail_if_stopped` is `True` and the deployment is not running.
+            hopsworks.client.exceptions.RestAPIError: In case the backend encounters an issue.
+        """
+        if self.is_stopped():
+            if fail_if_stopped:
+                raise ModelServingException(
+                    "Cannot restart a deployment that is not running"
+                )
+        else:
+            self.stop(await_stopped=await_stopped)
+        self.start(await_running=await_running)
+
+    @public
+    @usage.method_logger
     def delete(self, force: bool = False):
         """Delete the deployment.
 

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -125,7 +125,7 @@ class Deployment:
         await_stopped: int | None = 600,
         await_running: int | None = 600,
         fail_if_stopped: bool = False,
-    ):
+    ) -> None:
         """Restart the deployment so it picks up the latest code and environment state.
 
         If the deployment is already stopped, it is started in place by default.

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -124,28 +124,19 @@ class Deployment:
         self,
         await_stopped: int | None = 600,
         await_running: int | None = 600,
-        fail_if_stopped: bool = False,
     ) -> None:
         """Restart the deployment so it picks up the latest code and environment state.
 
-        If the deployment is already stopped, it is started in place by default.
-        Pass `fail_if_stopped=True` to require that the deployment is currently running.
+        If the deployment is already stopped, it is started in place.
 
         Parameters:
             await_stopped: Awaiting time (seconds) for the deployment to stop.
             await_running: Awaiting time (seconds) for the deployment to start again.
-            fail_if_stopped: Raise instead of starting in place when the deployment is not running.
 
         Raises:
-            hopsworks.client.exceptions.ModelServingException: If `fail_if_stopped` is `True` and the deployment is not running.
             hopsworks.client.exceptions.RestAPIError: In case the backend encounters an issue.
         """
-        if self.is_stopped():
-            if fail_if_stopped:
-                raise ModelServingException(
-                    "Cannot restart a deployment that is not running"
-                )
-        else:
+        if not self.is_stopped():
             self.stop(await_stopped=await_stopped)
         self.start(await_running=await_running)
 

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -477,7 +477,9 @@ class ModelServing:
 
         _ensure_dataset_dir(ds_api, agent_dir)
 
-        env = env_api.get_environment(env_name) or env_api.create_environment(env_name)
+        env = env_api.get_environment(env_name) or env_api.create_environment(
+            env_name, base_environment_name="minimal-inference-pipeline"
+        )
 
         if is_script:
             script_file = ds_api.upload(entry_abs, agent_dir, overwrite=True)

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -426,9 +426,15 @@ class ModelServing:
 
         Parameters:
             entry: Local path to a `.py` script or to a directory containing `pyproject.toml`.
-            name: Name of the deployment, also used as the default Python environment name. Defaults to the basename of `entry` (without the `.py` extension for scripts). Must match `[A-Za-z0-9_-]+`.
+            name:
+                Name of the deployment, also used as the default Python environment name.
+                Defaults to the basename of `entry` (without the `.py` extension for scripts).
+                Must match `[A-Za-z0-9_-]+`.
             requirements: Local path to a `requirements.txt` to install into the environment.
-            environment: Name of the Python environment to use; defaults to `name`. Created if it does not exist. Must match `[A-Za-z0-9_-]+`.
+            environment:
+                Name of the Python environment to use; defaults to `name`.
+                Created if it does not exist.
+                Must match `[A-Za-z0-9_-]+`.
             upload_dir: Directory in the Hopsworks Filesystem under which agent files are placed; the agent gets its own subdirectory `<upload_dir>/<name>`.
             description: Description of the deployment.
             resources: Resources to be allocated for the predictor.

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -20,8 +20,11 @@ from typing import TYPE_CHECKING
 
 from hopsworks_apigen import public
 from hopsworks_common import usage, util
+from hopsworks_common.client.exceptions import RestAPIError
 from hopsworks_common.constants import INFERENCE_ENDPOINTS as IE
 from hopsworks_common.constants import PREDICTOR_STATE
+from hopsworks_common.core import dataset_api as _dataset_api
+from hopsworks_common.core import environment_api as _environment_api
 from hsml.core import serving_api
 from hsml.deployment import Deployment
 from hsml.predictor import Predictor
@@ -384,6 +387,110 @@ class ModelServing:
 
     @public
     @usage.method_logger
+    def deploy_agent(
+        self,
+        entry: str,
+        name: str,
+        requirements: str | None = None,
+        environment: str | None = None,
+        description: str | None = None,
+        resources: PredictorResources | dict | None = None,
+        inference_logger: InferenceLogger | dict | str | None = None,
+        inference_batcher: InferenceBatcher | dict | None = None,
+        api_protocol: str | None = IE.API_PROTOCOL_REST,
+        scaling_configuration: PredictorScalingConfig | dict | None = None,
+    ) -> Deployment:
+        """Deploy a Python script or package as an agent.
+
+        The agent is created on first call and updated on subsequent calls.
+        Each call uploads the latest local code and refreshes the Python environment.
+        The deployment's running state is left untouched; call `start()` after the first deploy and `restart()` to roll a running agent onto the new code.
+        Works the same whether invoked from outside or inside a Hopsworks cluster.
+
+        Pass either a `.py` script or a directory containing a `pyproject.toml`.
+        For a script, the file is uploaded and run directly.
+        For a package, a wheel is built locally with the project's PEP 517 backend, uploaded, and installed; a small runner module invokes the package via `runpy.run_module`.
+
+        ```python
+        ms = project.get_model_serving()
+
+        agent = ms.deploy_agent(entry="my_agent.py", name="my_agent")
+        agent.start() # or agent.restart()
+
+        # iterate: edit code locally, push, then roll the running agent onto it
+        agent = ms.deploy_agent(entry="my_agent.py", name="my_agent")
+        agent.restart()
+        ```
+
+        Parameters:
+            entry: Local path to a `.py` script or to a directory containing `pyproject.toml`.
+            name: Name of the deployment, also used as the default Python environment name.
+            requirements: Local path to a `requirements.txt` to install into the environment.
+            environment: Name of the Python environment to use; defaults to `name`. Created if it does not exist.
+            description: Description of the deployment.
+            resources: Resources to be allocated for the predictor.
+            inference_logger: Inference logger configuration.
+            inference_batcher: Inference batcher configuration.
+            api_protocol: API protocol to be enabled in the deployment (i.e., 'REST' or 'GRPC').
+            scaling_configuration: Scaling configuration for the predictor.
+
+        Returns:
+            The deployment metadata object.
+
+        Raises:
+            ValueError: If `entry` is neither a `.py` file nor a directory with `pyproject.toml`.
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        entry_abs = os.path.abspath(entry)
+        is_script = os.path.isfile(entry_abs) and entry_abs.endswith(".py")
+        is_package = os.path.isdir(entry_abs) and os.path.isfile(
+            os.path.join(entry_abs, "pyproject.toml")
+        )
+        if not (is_script or is_package):
+            raise ValueError(
+                f"entry must be a .py file or a directory containing pyproject.toml: {entry}"
+            )
+
+        env_name = environment or name
+        agent_dir = f"Resources/agents/{name}"
+
+        ds_api = _dataset_api.DatasetApi()
+        env_api = _environment_api.EnvironmentApi()
+
+        _ensure_dataset_dir(ds_api, agent_dir)
+
+        env = env_api.get_environment(env_name) or env_api.create_environment(env_name)
+
+        if is_script:
+            script_file = ds_api.upload(entry_abs, agent_dir, overwrite=True)
+        else:
+            script_file = _build_and_install_package(ds_api, env, entry_abs, agent_dir)
+
+        if requirements is not None:
+            req_remote = ds_api.upload(
+                os.path.abspath(requirements), agent_dir, overwrite=True
+            )
+            env.install_requirements(req_remote)
+
+        existing = self.get_deployment(name)
+        if existing is not None:
+            return existing
+
+        predictor = Predictor.for_server(
+            name=name,
+            script_file=script_file,
+            description=description,
+            resources=resources,
+            inference_logger=inference_logger,
+            inference_batcher=inference_batcher,
+            api_protocol=api_protocol,
+            environment=env_name,
+            scaling_configuration=scaling_configuration,
+        )
+        return predictor.deploy()
+
+    @public
+    @usage.method_logger
     def create_deployment(
         self,
         predictor: Predictor,
@@ -479,3 +586,64 @@ class ModelServing:
 
     def __repr__(self):
         return f"ModelServing(project: {self._project_name!r})"
+
+
+def _ensure_dataset_dir(ds_api, path: str) -> None:
+    """Create `path` in the Hopsworks Filesystem if missing, creating parents as needed."""
+    if ds_api.exists(path):
+        return
+    parent, _, _ = path.rpartition("/")
+    if parent:
+        _ensure_dataset_dir(ds_api, parent)
+    ds_api.mkdir(path)
+
+
+def _build_and_install_package(ds_api, env, package_dir: str, agent_dir: str) -> str:
+    """Build a wheel from `package_dir`, upload it, install it into `env`, and upload a runner script.
+
+    Returns the remote path of the runner script to use as `script_file`.
+    """
+    import tempfile
+
+    from build import ProjectBuilder
+
+    pkg_name = _read_package_name(package_dir)
+
+    with tempfile.TemporaryDirectory() as build_dir:
+        wheel_local = ProjectBuilder(package_dir).build("wheel", build_dir)
+        wheel_remote = ds_api.upload(wheel_local, agent_dir, overwrite=True)
+
+        # Force a reinstall: pip skips a same-version wheel, so we uninstall first.
+        # On first deploy the package is not installed yet — that 404 is expected.
+        try:
+            env.uninstall(pkg_name)
+        except RestAPIError as e:
+            if e.response.status_code != 404:
+                raise
+
+        env.install_wheel(wheel_remote)
+
+        runner_local = os.path.join(build_dir, "runner.py")
+        with open(runner_local, "w") as f:
+            f.write(
+                f"import runpy\nrunpy.run_module({pkg_name!r}, run_name='__main__')\n"
+            )
+        return ds_api.upload(runner_local, agent_dir, overwrite=True)
+
+
+def _read_package_name(package_dir: str) -> str:
+    """Read `[project].name` from the package's `pyproject.toml`."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+
+    with open(os.path.join(package_dir, "pyproject.toml"), "rb") as f:
+        pyproject = tomllib.load(f)
+    project = pyproject.get("project") or {}
+    pkg_name = project.get("name")
+    if not isinstance(pkg_name, str):
+        raise ValueError(
+            f"Cannot read [project].name as a static string from {package_dir}/pyproject.toml"
+        )
+    return pkg_name

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import TYPE_CHECKING
 
 from hopsworks_apigen import public
@@ -390,9 +391,10 @@ class ModelServing:
     def deploy_agent(
         self,
         entry: str,
-        name: str,
+        name: str | None = None,
         requirements: str | None = None,
         environment: str | None = None,
+        upload_dir: str = "Resources/agents",
         description: str | None = None,
         resources: PredictorResources | dict | None = None,
         inference_logger: InferenceLogger | dict | str | None = None,
@@ -403,7 +405,7 @@ class ModelServing:
         """Deploy a Python script or package as an agent.
 
         The agent is created on first call and updated on subsequent calls.
-        Each call uploads the latest local code and refreshes the Python environment.
+        Each call uploads the latest local code, refreshes the Python environment, and rewrites the deployment's predictor metadata to reflect the arguments passed in — including any unspecified arguments, which fall back to their defaults.
         The deployment's running state is left untouched; call `start()` after the first deploy and `restart()` to roll a running agent onto the new code.
         Works the same whether invoked from outside or inside a Hopsworks cluster.
 
@@ -414,19 +416,20 @@ class ModelServing:
         ```python
         ms = project.get_model_serving()
 
-        agent = ms.deploy_agent(entry="my_agent.py", name="my_agent")
+        agent = ms.deploy_agent(entry="my_agent.py")
         agent.start() # or agent.restart()
 
         # iterate: edit code locally, push, then roll the running agent onto it
-        agent = ms.deploy_agent(entry="my_agent.py", name="my_agent")
+        agent = ms.deploy_agent(entry="my_agent.py")
         agent.restart()
         ```
 
         Parameters:
             entry: Local path to a `.py` script or to a directory containing `pyproject.toml`.
-            name: Name of the deployment, also used as the default Python environment name.
+            name: Name of the deployment, also used as the default Python environment name. Defaults to the basename of `entry` (without the `.py` extension for scripts). Must match `[A-Za-z0-9_-]+`.
             requirements: Local path to a `requirements.txt` to install into the environment.
-            environment: Name of the Python environment to use; defaults to `name`. Created if it does not exist.
+            environment: Name of the Python environment to use; defaults to `name`. Created if it does not exist. Must match `[A-Za-z0-9_-]+`.
+            upload_dir: Directory in the Hopsworks Filesystem under which agent files are placed; the agent gets its own subdirectory `<upload_dir>/<name>`.
             description: Description of the deployment.
             resources: Resources to be allocated for the predictor.
             inference_logger: Inference logger configuration.
@@ -438,7 +441,7 @@ class ModelServing:
             The deployment metadata object.
 
         Raises:
-            ValueError: If `entry` is neither a `.py` file nor a directory with `pyproject.toml`.
+            ValueError: If `entry` is neither a `.py` file nor a directory with `pyproject.toml`, or if `name`/`environment` contain characters outside `[A-Za-z0-9_-]`.
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         entry_abs = os.path.abspath(entry)
@@ -451,8 +454,17 @@ class ModelServing:
                 f"entry must be a .py file or a directory containing pyproject.toml: {entry}"
             )
 
+        if name is None:
+            name = os.path.basename(entry_abs)
+            if is_script:
+                name = os.path.splitext(name)[0]
+        _validate_agent_identifier(name, "name")
+
         env_name = environment or name
-        agent_dir = f"Resources/agents/{name}"
+        if environment is not None:
+            _validate_agent_identifier(environment, "environment")
+
+        agent_dir = f"{upload_dir}/{name}"
 
         ds_api = _dataset_api.DatasetApi()
         env_api = _environment_api.EnvironmentApi()
@@ -472,10 +484,6 @@ class ModelServing:
             )
             env.install_requirements(req_remote)
 
-        existing = self.get_deployment(name)
-        if existing is not None:
-            return existing
-
         predictor = Predictor.for_server(
             name=name,
             script_file=script_file,
@@ -487,6 +495,16 @@ class ModelServing:
             environment=env_name,
             scaling_configuration=scaling_configuration,
         )
+
+        existing = self.get_deployment(name)
+        if existing is not None:
+            # Preserve identity so save() updates the existing record instead of creating a new one.
+            predictor._id = existing.predictor.id
+            existing.predictor = predictor
+            existing.description = description
+            existing.save()
+            return existing
+
         return predictor.deploy()
 
     @public
@@ -588,6 +606,22 @@ class ModelServing:
         return f"ModelServing(project: {self._project_name!r})"
 
 
+_AGENT_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _validate_agent_identifier(value: str, field: str) -> None:
+    """Reject identifiers that would be unsafe to interpolate into a dataset path.
+
+    `name` and `environment` flow into both the upload subdirectory and predictor metadata,
+    so disallowing path separators and traversal segments protects against accidental writes
+    outside `<upload_dir>/<name>`.
+    """
+    if not _AGENT_IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(
+            f"{field} must match {_AGENT_IDENTIFIER_RE.pattern!r}, got {value!r}"
+        )
+
+
 def _ensure_dataset_dir(ds_api, path: str) -> None:
     """Create `path` in the Hopsworks Filesystem if missing, creating parents as needed."""
     if ds_api.exists(path):
@@ -610,7 +644,11 @@ def _build_and_install_package(ds_api, env, package_dir: str, agent_dir: str) ->
     pkg_name = _read_package_name(package_dir)
 
     with tempfile.TemporaryDirectory() as build_dir:
-        wheel_local = ProjectBuilder(package_dir).build("wheel", build_dir)
+        # `build` returns the wheel filename relative to build_dir on some versions and
+        # an absolute path on others; os.path.join leaves an absolute result untouched.
+        wheel_local = os.path.join(
+            build_dir, ProjectBuilder(package_dir).build("wheel", build_dir)
+        )
         wheel_remote = ds_api.upload(wheel_local, agent_dir, overwrite=True)
 
         # Force a reinstall: pip skips a same-version wheel, so we uninstall first.

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -489,7 +489,7 @@ class ModelServing:
         _ensure_dataset_dir(ds_api, agent_dir)
 
         env = env_api.get_environment(env_name) or env_api.create_environment(
-            env_name, base_environment_name="minimal-inference-pipeline"
+            env_name, base_environment_name="python-agent-pipeline"
         )
 
         if is_script:

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -16,9 +16,14 @@
 from __future__ import annotations
 
 import os
+import posixpath
 import re
+import tempfile
+import zipfile
 from typing import TYPE_CHECKING
 
+from build import ProjectBuilder
+from build.env import DefaultIsolatedEnv
 from hopsworks_apigen import public
 from hopsworks_common import usage, util
 from hopsworks_common.client.exceptions import RestAPIError
@@ -30,6 +35,12 @@ from hsml.core import serving_api
 from hsml.deployment import Deployment
 from hsml.predictor import Predictor
 from hsml.transformer import Transformer
+
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 
 if TYPE_CHECKING:
@@ -639,8 +650,6 @@ def _normalize_upload_dir(value: str) -> str:
     the project root (e.g. `Resources/../..`).
     Returns the normalized form for use in path interpolation.
     """
-    import posixpath
-
     if not value:
         raise ValueError("upload_dir must not be empty")
     normalized = posixpath.normpath(value)
@@ -666,11 +675,6 @@ def _build_and_install_package(ds_api, env, package_dir: str, agent_dir: str) ->
 
     Returns the remote path of the runner script to use as `script_file`.
     """
-    import tempfile
-
-    from build import ProjectBuilder
-    from build.env import DefaultIsolatedEnv
-
     pkg_name = _read_package_name(package_dir)
 
     with tempfile.TemporaryDirectory() as build_dir:
@@ -683,6 +687,12 @@ def _build_and_install_package(ds_api, env, package_dir: str, agent_dir: str) ->
             # `build` returns the wheel filename relative to build_dir on some versions and
             # an absolute path on others; os.path.join leaves an absolute result untouched.
             wheel_local = os.path.join(build_dir, builder.build("wheel", build_dir))
+
+        # The distribution name (`pkg_name`) is what pip uses to install/uninstall, but it
+        # may not be a valid Python identifier (e.g. "my-agent"). The runner needs the
+        # importable module name, which we read from the built wheel's contents.
+        module_name = _find_runnable_module(wheel_local)
+
         wheel_remote = ds_api.upload(wheel_local, agent_dir, overwrite=True)
 
         # Force a reinstall: pip skips a same-version wheel, so we uninstall first.
@@ -698,18 +708,44 @@ def _build_and_install_package(ds_api, env, package_dir: str, agent_dir: str) ->
         runner_local = os.path.join(build_dir, "runner.py")
         with open(runner_local, "w") as f:
             f.write(
-                f"import runpy\nrunpy.run_module({pkg_name!r}, run_name='__main__')\n"
+                f"import runpy\nrunpy.run_module({module_name!r}, run_name='__main__')\n"
             )
         return ds_api.upload(runner_local, agent_dir, overwrite=True)
 
 
+def _find_runnable_module(wheel_path: str) -> str:
+    """Return the top-level package in the wheel that exposes a `__main__.py`.
+
+    Used to generate the runner's `runpy.run_module(<name>, ...)` call.
+    The wheel's contents are authoritative (they reflect what's actually installable and
+    importable), so this works even when the distribution name differs from the importable
+    name (e.g. `my-agent` distribution containing a `my_agent` package).
+    """
+    with zipfile.ZipFile(wheel_path) as wheel:
+        candidates = sorted(
+            {
+                parts[0]
+                for name in wheel.namelist()
+                for parts in [name.split("/")]
+                if len(parts) == 2 and parts[1] == "__main__.py"
+            }
+        )
+    if len(candidates) == 1:
+        return candidates[0]
+    wheel_basename = os.path.basename(wheel_path)
+    if not candidates:
+        raise ValueError(
+            f"{wheel_basename} has no top-level package with `__main__.py`; "
+            "agents deployed as packages must be runnable via `python -m`."
+        )
+    raise ValueError(
+        f"{wheel_basename} has multiple top-level packages with `__main__.py` "
+        f"({', '.join(candidates)}); cannot determine the agent entry point."
+    )
+
+
 def _read_package_name(package_dir: str) -> str:
     """Read `[project].name` from the package's `pyproject.toml`."""
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib
-
     with open(os.path.join(package_dir, "pyproject.toml"), "rb") as f:
         pyproject = tomllib.load(f)
     project = pyproject.get("project") or {}

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -470,7 +470,7 @@ class ModelServing:
         if environment is not None:
             _validate_agent_identifier(environment, "environment")
 
-        agent_dir = f"{upload_dir}/{name}"
+        agent_dir = f"{_normalize_upload_dir(upload_dir)}/{name}"
 
         ds_api = _dataset_api.DatasetApi()
         env_api = _environment_api.EnvironmentApi()
@@ -485,6 +485,8 @@ class ModelServing:
             script_file = ds_api.upload(entry_abs, agent_dir, overwrite=True)
         else:
             script_file = _build_and_install_package(ds_api, env, entry_abs, agent_dir)
+        # The serving backend expects the script path under /Projects/<proj>/...
+        script_file = util.convert_to_abs(script_file, self._project_name)
 
         if requirements is not None:
             req_remote = ds_api.upload(
@@ -630,6 +632,25 @@ def _validate_agent_identifier(value: str, field: str) -> None:
         )
 
 
+def _normalize_upload_dir(value: str) -> str:
+    """Normalize `upload_dir` and ensure it stays within the project's dataset root.
+
+    Rejects empty input, absolute paths, and any traversal that resolves to the parent of
+    the project root (e.g. `Resources/../..`).
+    Returns the normalized form for use in path interpolation.
+    """
+    import posixpath
+
+    if not value:
+        raise ValueError("upload_dir must not be empty")
+    normalized = posixpath.normpath(value)
+    if normalized == ".." or normalized.startswith(("/", "../")):
+        raise ValueError(
+            f"upload_dir must be a relative path that stays within the project, got {value!r}"
+        )
+    return normalized
+
+
 def _ensure_dataset_dir(ds_api, path: str) -> None:
     """Create `path` in the Hopsworks Filesystem if missing, creating parents as needed."""
     if ds_api.exists(path):
@@ -648,15 +669,20 @@ def _build_and_install_package(ds_api, env, package_dir: str, agent_dir: str) ->
     import tempfile
 
     from build import ProjectBuilder
+    from build.env import DefaultIsolatedEnv
 
     pkg_name = _read_package_name(package_dir)
 
     with tempfile.TemporaryDirectory() as build_dir:
-        # `build` returns the wheel filename relative to build_dir on some versions and
-        # an absolute path on others; os.path.join leaves an absolute result untouched.
-        wheel_local = os.path.join(
-            build_dir, ProjectBuilder(package_dir).build("wheel", build_dir)
-        )
+        # Use an isolated env so the project's PEP 517 backend (hatchling, setuptools, …)
+        # is installed on the fly rather than required up-front in the caller's env.
+        with DefaultIsolatedEnv() as build_env:
+            builder = ProjectBuilder.from_isolated_env(build_env, package_dir)
+            build_env.install(builder.build_system_requires)
+            build_env.install(builder.get_requires_for_build("wheel"))
+            # `build` returns the wheel filename relative to build_dir on some versions and
+            # an absolute path on others; os.path.join leaves an absolute result untouched.
+            wheel_local = os.path.join(build_dir, builder.build("wheel", build_dir))
         wheel_remote = ds_api.upload(wheel_local, agent_dir, overwrite=True)
 
         # Force a reinstall: pip skips a same-version wheel, so we uninstall first.

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -519,8 +519,10 @@ class ModelServing:
 
         existing = self.get_deployment(name)
         if existing is not None:
-            # Preserve identity so save() updates the existing record instead of creating a new one.
+            # Preserve identity and server-assigned version so save() updates the
+            # existing record instead of creating a new one.
             predictor._id = existing.predictor.id
+            predictor._version = existing.predictor.version
             existing.predictor = predictor
             existing.description = description
             existing.save()

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -41,6 +41,9 @@ except ImportError:
     import tomli as tomllib
 
 
+_AGENT_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
 if TYPE_CHECKING:
     from hsml.inference_batcher import InferenceBatcher
     from hsml.inference_endpoint import InferenceEndpoint
@@ -644,9 +647,6 @@ class ModelServing:
 
     def __repr__(self):
         return f"ModelServing(project: {self._project_name!r})"
-
-
-_AGENT_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _validate_agent_identifier(value: str, field: str) -> None:

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -22,8 +22,6 @@ import tempfile
 import zipfile
 from typing import TYPE_CHECKING
 
-from build import ProjectBuilder
-from build.env import DefaultIsolatedEnv
 from hopsworks_apigen import public
 from hopsworks_common import usage, util
 from hopsworks_common.client.exceptions import RestAPIError
@@ -515,9 +513,13 @@ class ModelServing:
         script_file = util.convert_to_abs(script_file, self._project_name)
 
         if requirements is not None:
-            req_remote = ds_api.upload(
-                os.path.abspath(requirements), agent_dir, overwrite=True
-            )
+            requirements_abs = os.path.abspath(requirements)
+            if not os.path.isfile(requirements_abs):
+                raise ValueError(
+                    "requirements must be a path to an existing file: "
+                    + requirements_abs
+                )
+            req_remote = ds_api.upload(requirements_abs, agent_dir, overwrite=True)
             env.install_requirements(req_remote)
 
         predictor = Predictor.for_server(
@@ -692,6 +694,10 @@ def _build_and_install_package(ds_api, env, package_dir: str, agent_dir: str) ->
 
     Returns the remote path of the runner script to use as `script_file`.
     """
+    from build.env import DefaultIsolatedEnv
+
+    from build import ProjectBuilder
+
     pkg_name = _read_package_name(package_dir)
 
     with tempfile.TemporaryDirectory() as build_dir:

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -694,9 +694,8 @@ def _build_and_install_package(ds_api, env, package_dir: str, agent_dir: str) ->
 
     Returns the remote path of the runner script to use as `script_file`.
     """
-    from build.env import DefaultIsolatedEnv
-
     from build import ProjectBuilder
+    from build.env import DefaultIsolatedEnv
 
     pkg_name = _read_package_name(package_dir)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "protobuf>=4.25.4,<5.0.0",       # ^4.25.4
     "packaging",                     # ^21.0
     "hopsworks-apigen>=1.0.4,<2.0.0",
+    "build",
 ]
 
 [project.scripts]

--- a/python/tests/cli/test_agent.py
+++ b/python/tests/cli/test_agent.py
@@ -1,0 +1,207 @@
+"""CliRunner tests for ``hops agent`` commands.
+
+Drive every verb through the shared ``mock_project`` fixture so no test hits
+real Hopsworks. The fake ``ModelServing`` returns ``Deployment``-shaped mocks
+that mimic the ``has_model`` / ``model_name`` shape ``_is_agent`` relies on.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from click.testing import CliRunner
+from hopsworks.cli.main import cli
+
+
+def _agent_mock(name: str = "my-agent", deployment_id: int = 7) -> mock.MagicMock:
+    """Build a Deployment-shaped mock that ``_is_agent`` classifies as agent."""
+    d = mock.MagicMock()
+    d.id = deployment_id
+    d.name = name
+    d.has_model = False
+    d.model_name = None
+    d.serving_tool = "DEFAULT"
+    d.model_server = "PYTHON"
+    d.api_protocol = "REST"
+    d.description = ""
+    predictor = mock.MagicMock()
+    predictor.environment = "agent-env"
+    predictor.script_file = "/Projects/demo/Resources/agents/my-agent/agent.py"
+    d.predictor = predictor
+    return d
+
+
+def _model_mock(name: str = "fraud") -> mock.MagicMock:
+    d = mock.MagicMock()
+    d.id = 99
+    d.name = name
+    d.has_model = True
+    d.model_name = name
+    return d
+
+
+def test_agent_help_lists_subcommands():
+    result = CliRunner().invoke(cli, ["agent", "--help"])
+    assert result.exit_code == 0, result.output
+    for verb in ("list", "info", "create", "start", "stop", "query", "logs", "delete"):
+        assert verb in result.output
+
+
+def test_agent_list_filters_out_model_deployments(mock_project):
+    ms = mock.MagicMock()
+    ms.get_deployments.return_value = [_agent_mock("my-agent"), _model_mock("fraud")]
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "list"])
+    assert result.exit_code == 0, result.output
+    assert "my-agent" in result.output
+    assert "fraud" not in result.output
+
+
+def test_agent_info_unknown_name_errors(mock_project):
+    ms = mock.MagicMock()
+    ms.get_deployment.return_value = None
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "info", "missing"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_agent_info_rejects_model_deployment(mock_project):
+    ms = mock.MagicMock()
+    ms.get_deployment.return_value = _model_mock("fraud")
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "info", "fraud"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_agent_start_calls_sdk(mock_project):
+    ms = mock.MagicMock()
+    agent = _agent_mock("my-agent")
+    ms.get_deployment.return_value = agent
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "start", "my-agent", "--wait", "30"])
+    assert result.exit_code == 0, result.output
+    agent.start.assert_called_with(await_running=30)
+
+
+def test_agent_stop_calls_sdk(mock_project):
+    ms = mock.MagicMock()
+    agent = _agent_mock("my-agent")
+    ms.get_deployment.return_value = agent
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "stop", "my-agent", "--wait", "45"])
+    assert result.exit_code == 0, result.output
+    agent.stop.assert_called_with(await_stopped=45)
+
+
+def test_agent_query_parses_json_data(mock_project):
+    ms = mock.MagicMock()
+    agent = _agent_mock("my-agent")
+    agent.predict.return_value = {"answer": 42}
+    ms.get_deployment.return_value = agent
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(
+        cli,
+        ["agent", "query", "my-agent", "--data", '{"prompt": "hello"}'],
+    )
+    assert result.exit_code == 0, result.output
+    agent.predict.assert_called_with(data={"prompt": "hello"})
+    assert "42" in result.output
+
+
+def test_agent_query_requires_data_or_file(mock_project):
+    ms = mock.MagicMock()
+    ms.get_deployment.return_value = _agent_mock("my-agent")
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "query", "my-agent"])
+    assert result.exit_code != 0
+    assert "Provide --data or --file" in result.output
+
+
+def test_agent_logs_one_shot(mock_project):
+    ms = mock.MagicMock()
+    agent = _agent_mock("my-agent")
+    agent.read_logs.return_value = "line1\nline2"
+    ms.get_deployment.return_value = agent
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "logs", "my-agent", "--tail", "5"])
+    assert result.exit_code == 0, result.output
+    agent.read_logs.assert_called_with(
+        component="predictor", tail=5, source="opensearch", since=None, until=None
+    )
+    assert "line1" in result.output
+
+
+def test_agent_delete(mock_project):
+    ms = mock.MagicMock()
+    agent = _agent_mock("my-agent")
+    ms.get_deployment.return_value = agent
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "delete", "my-agent", "--yes"])
+    assert result.exit_code == 0, result.output
+    agent.delete.assert_called_with(force=False)
+
+
+def test_agent_create_invokes_deploy_agent(mock_project, tmp_path):
+    ms = mock.MagicMock()
+    created = _agent_mock("entry")
+    ms.deploy_agent.return_value = created
+    mock_project.get_model_serving.return_value = ms
+
+    entry = tmp_path / "entry.py"
+    entry.write_text("def predict(x):\n    return x\n")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "agent",
+            "create",
+            str(entry),
+            "--name",
+            "my-agent",
+            "--description",
+            "demo",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    ms.deploy_agent.assert_called_once()
+    kwargs = ms.deploy_agent.call_args.kwargs
+    assert kwargs["entry"] == str(entry)
+    assert kwargs["name"] == "my-agent"
+    assert kwargs["description"] == "demo"
+
+
+def test_agent_list_falls_back_to_model_name_heuristic(mock_project):
+    """Non-SDK deployment objects without ``has_model`` still classify correctly."""
+    legacy_agent = mock.MagicMock(spec=["id", "name", "model_name", "predictor"])
+    legacy_agent.id = 1
+    legacy_agent.name = "legacy-agent"
+    legacy_agent.model_name = None
+    legacy_agent.predictor = mock.MagicMock(
+        environment="agent-env", script_file="/x/y.py"
+    )
+
+    legacy_model = mock.MagicMock(spec=["id", "name", "model_name", "predictor"])
+    legacy_model.id = 2
+    legacy_model.name = "legacy-model"
+    legacy_model.model_name = "fraud"
+    legacy_model.predictor = mock.MagicMock(environment="env", script_file="-")
+
+    ms = mock.MagicMock()
+    ms.get_deployments.return_value = [legacy_agent, legacy_model]
+    mock_project.get_model_serving.return_value = ms
+
+    result = CliRunner().invoke(cli, ["agent", "list"])
+    assert result.exit_code == 0, result.output
+    assert "legacy-agent" in result.output
+    assert "legacy-model" not in result.output

--- a/python/tests/core/test_library_api.py
+++ b/python/tests/core/test_library_api.py
@@ -23,9 +23,7 @@ class TestLibraryApi:
         api = library_api.LibraryApi()
         mock_client = mocker.MagicMock()
         mock_client._project_id = 99
-        mocker.patch(
-            "hopsworks_common.client.get_instance", return_value=mock_client
-        )
+        mocker.patch("hopsworks_common.client.get_instance", return_value=mock_client)
 
         # Act
         api._uninstall("matplotlib", "myenv")

--- a/python/tests/core/test_library_api.py
+++ b/python/tests/core/test_library_api.py
@@ -1,0 +1,46 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hopsworks_common.core import library_api
+
+
+class TestLibraryApi:
+    def test_uninstall_sends_delete_to_library_path(self, mocker):
+        # Arrange
+        api = library_api.LibraryApi()
+        mock_client = mocker.MagicMock()
+        mock_client._project_id = 99
+        mocker.patch(
+            "hopsworks_common.client.get_instance", return_value=mock_client
+        )
+
+        # Act
+        api._uninstall("matplotlib", "myenv")
+
+        # Assert
+        mock_client._send_request.assert_called_once_with(
+            "DELETE",
+            [
+                "project",
+                99,
+                "python",
+                "environments",
+                "myenv",
+                "libraries",
+                "matplotlib",
+            ],
+            headers={"content-type": "application/json"},
+        )

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -224,6 +224,67 @@ class TestDeployment:
         # Assert
         mock_serving_engine_start.assert_called_once_with(d, await_status=await_stopped)
 
+    # restart
+
+    def test_restart_when_running(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mocker.patch("hsml.deployment.Deployment.is_stopped", return_value=False)
+        mock_stop = mocker.patch("hsml.deployment.Deployment.stop")
+        mock_start = mocker.patch("hsml.deployment.Deployment.start")
+
+        # Act
+        d.restart()
+
+        # Assert
+        mock_stop.assert_called_once_with(await_stopped=600)
+        mock_start.assert_called_once_with(await_running=600)
+
+    def test_restart_when_stopped_starts_in_place(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mocker.patch("hsml.deployment.Deployment.is_stopped", return_value=True)
+        mock_stop = mocker.patch("hsml.deployment.Deployment.stop")
+        mock_start = mocker.patch("hsml.deployment.Deployment.start")
+
+        # Act
+        d.restart()
+
+        # Assert
+        mock_stop.assert_not_called()
+        mock_start.assert_called_once_with(await_running=600)
+
+    def test_restart_fail_if_stopped_raises(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mocker.patch("hsml.deployment.Deployment.is_stopped", return_value=True)
+        mock_stop = mocker.patch("hsml.deployment.Deployment.stop")
+        mock_start = mocker.patch("hsml.deployment.Deployment.start")
+
+        # Act & Assert
+        with pytest.raises(ModelServingException):
+            d.restart(fail_if_stopped=True)
+        mock_stop.assert_not_called()
+        mock_start.assert_not_called()
+
+    def test_restart_passes_custom_awaits(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mocker.patch("hsml.deployment.Deployment.is_stopped", return_value=False)
+        mock_stop = mocker.patch("hsml.deployment.Deployment.stop")
+        mock_start = mocker.patch("hsml.deployment.Deployment.start")
+
+        # Act
+        d.restart(await_stopped=42, await_running=137)
+
+        # Assert
+        mock_stop.assert_called_once_with(await_stopped=42)
+        mock_start.assert_called_once_with(await_running=137)
+
     # delete
 
     def test_delete_default(self, mocker, backend_fixtures):

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -256,20 +256,6 @@ class TestDeployment:
         mock_stop.assert_not_called()
         mock_start.assert_called_once_with(await_running=600)
 
-    def test_restart_fail_if_stopped_raises(self, mocker, backend_fixtures):
-        # Arrange
-        p = self._get_dummy_predictor(mocker, backend_fixtures)
-        d = deployment.Deployment(predictor=p)
-        mocker.patch("hsml.deployment.Deployment.is_stopped", return_value=True)
-        mock_stop = mocker.patch("hsml.deployment.Deployment.stop")
-        mock_start = mocker.patch("hsml.deployment.Deployment.start")
-
-        # Act & Assert
-        with pytest.raises(ModelServingException):
-            d.restart(fail_if_stopped=True)
-        mock_stop.assert_not_called()
-        mock_start.assert_not_called()
-
     def test_restart_passes_custom_awaits(self, mocker, backend_fixtures):
         # Arrange
         p = self._get_dummy_predictor(mocker, backend_fixtures)

--- a/python/tests/test_environment.py
+++ b/python/tests/test_environment.py
@@ -1,0 +1,53 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hopsworks_common import environment
+
+
+class TestEnvironment:
+    def test_uninstall_default_awaits_before_and_after(self, mocker):
+        # Arrange
+        env = environment.Environment(name="myenv")
+        mock_await_env = mocker.patch.object(
+            env._environment_engine, "await_environment_command"
+        )
+        mock_uninstall = mocker.patch.object(env._library_api, "_uninstall")
+        mock_await_lib = mocker.patch.object(
+            env._environment_engine, "await_library_command"
+        )
+
+        # Act
+        env.uninstall("matplotlib")
+
+        # Assert: in-flight env operations are awaited first, then DELETE, then await uninstall.
+        mock_await_env.assert_called_once_with("myenv")
+        mock_uninstall.assert_called_once_with("matplotlib", "myenv")
+        mock_await_lib.assert_called_once_with("myenv", "matplotlib")
+
+    def test_uninstall_no_await(self, mocker):
+        # Arrange
+        env = environment.Environment(name="myenv")
+        mocker.patch.object(env._environment_engine, "await_environment_command")
+        mocker.patch.object(env._library_api, "_uninstall")
+        mock_await_lib = mocker.patch.object(
+            env._environment_engine, "await_library_command"
+        )
+
+        # Act
+        env.uninstall("matplotlib", await_uninstallation=False)
+
+        # Assert
+        mock_await_lib.assert_not_called()

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -1,0 +1,330 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import os
+
+import pytest
+from hopsworks_common.client.exceptions import RestAPIError
+from hsml import model_serving
+
+
+@pytest.fixture
+def ms():
+    return model_serving.ModelServing(project_name="proj", project_id=99)
+
+
+@pytest.fixture
+def stub_apis(mocker):
+    """Patch the DatasetApi and EnvironmentApi factories used by deploy_agent.
+
+    Returns the (ds_api, env_api, env) MagicMocks so tests can assert call patterns.
+    """
+    ds_api = mocker.MagicMock(name="ds_api")
+    # Default: dest dir already exists, uploads return their target path.
+    ds_api.exists.return_value = True
+    ds_api.upload.side_effect = lambda local, dest, overwrite=False: (
+        f"{dest}/{os.path.basename(local)}"
+    )
+
+    env = mocker.MagicMock(name="env")
+    env_api = mocker.MagicMock(name="env_api")
+    env_api.get_environment.return_value = env
+
+    mocker.patch(
+        "hsml.model_serving._dataset_api.DatasetApi", return_value=ds_api
+    )
+    mocker.patch(
+        "hsml.model_serving._environment_api.EnvironmentApi", return_value=env_api
+    )
+    return ds_api, env_api, env
+
+
+class TestDeployAgentEntryValidation:
+    def test_rejects_nonexistent_path(self, ms):
+        with pytest.raises(ValueError, match="must be a .py file"):
+            ms.deploy_agent(entry="/nope/does/not/exist.py", name="agent")
+
+    def test_rejects_dir_without_pyproject(self, ms, tmp_path):
+        with pytest.raises(ValueError, match="must be a .py file"):
+            ms.deploy_agent(entry=str(tmp_path), name="agent")
+
+    def test_rejects_non_py_file(self, ms, tmp_path):
+        bad = tmp_path / "agent.txt"
+        bad.write_text("not python")
+        with pytest.raises(ValueError, match="must be a .py file"):
+            ms.deploy_agent(entry=str(bad), name="agent")
+
+
+class TestDeployAgentScript:
+    def test_uploads_script_creates_env_and_predictor(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Arrange
+        ds_api, env_api, env = stub_apis
+        script = tmp_path / "my_agent.py"
+        script.write_text("print('hi')")
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+        deployed = mocker.MagicMock(name="deployment")
+        mock_for_server.return_value.deploy.return_value = deployed
+
+        # Act
+        result = ms.deploy_agent(entry=str(script), name="my_agent")
+
+        # Assert
+        assert result is deployed
+        ds_api.upload.assert_called_once_with(
+            str(script.resolve()), "Resources/agents/my_agent", overwrite=True
+        )
+        env_api.get_environment.assert_called_once_with("my_agent")
+        env_api.create_environment.assert_not_called()
+        env.install_wheel.assert_not_called()
+        env.install_requirements.assert_not_called()
+        kwargs = mock_for_server.call_args.kwargs
+        assert kwargs["name"] == "my_agent"
+        assert kwargs["script_file"] == "Resources/agents/my_agent/my_agent.py"
+        assert kwargs["environment"] == "my_agent"
+
+    def test_creates_env_when_missing(self, ms, mocker, tmp_path, stub_apis):
+        # Arrange
+        ds_api, env_api, env = stub_apis
+        env_api.get_environment.return_value = None
+        env_api.create_environment.return_value = env
+        script = tmp_path / "my_agent.py"
+        script.write_text("")
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(script), name="my_agent")
+
+        # Assert
+        env_api.create_environment.assert_called_once_with("my_agent")
+
+    def test_custom_environment_name_overrides_default(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Arrange
+        ds_api, env_api, _ = stub_apis
+        script = tmp_path / "agent.py"
+        script.write_text("")
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(script), name="my_agent", environment="shared_env")
+
+        # Assert
+        env_api.get_environment.assert_called_once_with("shared_env")
+        assert mock_for_server.call_args.kwargs["environment"] == "shared_env"
+
+    def test_existing_deployment_short_circuits(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Arrange
+        ds_api, _, _ = stub_apis
+        script = tmp_path / "agent.py"
+        script.write_text("")
+        existing = mocker.MagicMock(name="existing_deployment")
+        mocker.patch.object(ms, "get_deployment", return_value=existing)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        result = ms.deploy_agent(entry=str(script), name="my_agent")
+
+        # Assert: code is still uploaded, but no new predictor is created
+        # and the existing deployment is returned untouched.
+        assert result is existing
+        ds_api.upload.assert_called_once()
+        mock_for_server.assert_not_called()
+        existing.start.assert_not_called()
+        existing.stop.assert_not_called()
+        existing.restart.assert_not_called()
+
+    def test_uploads_requirements_and_installs(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Arrange
+        ds_api, _, env = stub_apis
+        script = tmp_path / "agent.py"
+        script.write_text("")
+        reqs = tmp_path / "requirements.txt"
+        reqs.write_text("requests\n")
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(
+            entry=str(script), name="my_agent", requirements=str(reqs)
+        )
+
+        # Assert
+        upload_calls = [c.args for c in ds_api.upload.call_args_list]
+        assert (str(reqs.resolve()), "Resources/agents/my_agent") in upload_calls
+        env.install_requirements.assert_called_once_with(
+            "Resources/agents/my_agent/requirements.txt"
+        )
+
+
+class TestDeployAgentPackage:
+    def _make_package(self, tmp_path, pkg_name="my_agent"):
+        pkg = tmp_path / pkg_name
+        pkg.mkdir()
+        (pkg / "pyproject.toml").write_text(
+            f'[project]\nname = "{pkg_name}"\nversion = "0.1.0"\n'
+        )
+        return pkg
+
+    def _patch_builder(self, mocker, wheel_path):
+        mock_builder = mocker.patch("build.ProjectBuilder")
+        mock_builder.return_value.build.return_value = str(wheel_path)
+        return mock_builder
+
+    def _capture_runner(self, ds_api):
+        """Override the default upload stub to snapshot runner.py before its tempdir is gone."""
+        captured = {}
+
+        def fake_upload(local, dest, overwrite=False):
+            if local.endswith("runner.py"):
+                with open(local) as f:
+                    captured["content"] = f.read()
+            return f"{dest}/{os.path.basename(local)}"
+
+        ds_api.upload.side_effect = fake_upload
+        return captured
+
+    def test_builds_uninstalls_and_installs_wheel_and_writes_runner(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Arrange
+        ds_api, _, env = stub_apis
+        pkg = self._make_package(tmp_path)
+        wheel_local = tmp_path / "my_agent-0.1.0-py3-none-any.whl"
+        wheel_local.write_bytes(b"")
+        mock_builder = self._patch_builder(mocker, wheel_local)
+        captured = self._capture_runner(ds_api)
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(pkg), name="my_agent")
+
+        # Assert: wheel was built, uninstalled, then installed.
+        mock_builder.assert_called_once_with(str(pkg.resolve()))
+        env.uninstall.assert_called_once_with("my_agent")
+        env.install_wheel.assert_called_once_with(
+            f"Resources/agents/my_agent/{wheel_local.name}"
+        )
+
+        # The runner script was uploaded as the predictor's script_file.
+        assert (
+            mock_for_server.call_args.kwargs["script_file"]
+            == "Resources/agents/my_agent/runner.py"
+        )
+        # The runner contains the runpy invocation for the package.
+        assert "runpy.run_module('my_agent'" in captured["content"]
+        assert "run_name='__main__'" in captured["content"]
+
+    def test_uninstall_404_swallowed_on_first_deploy(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Arrange
+        _, _, env = stub_apis
+        pkg = self._make_package(tmp_path)
+        wheel_local = tmp_path / "my_agent-0.1.0-py3-none-any.whl"
+        wheel_local.write_bytes(b"")
+        self._patch_builder(mocker, wheel_local)
+
+        not_found = mocker.MagicMock()
+        not_found.status_code = 404
+        not_found.json.return_value = {}
+        env.uninstall.side_effect = RestAPIError("", not_found)
+
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act: must not raise on the 404 from the first-time uninstall.
+        ms.deploy_agent(entry=str(pkg), name="my_agent")
+
+        # Assert: install still happened.
+        env.install_wheel.assert_called_once()
+
+    def test_uninstall_non_404_propagates(self, ms, mocker, tmp_path, stub_apis):
+        # Arrange
+        _, _, env = stub_apis
+        pkg = self._make_package(tmp_path)
+        wheel_local = tmp_path / "my_agent-0.1.0-py3-none-any.whl"
+        wheel_local.write_bytes(b"")
+        self._patch_builder(mocker, wheel_local)
+
+        server_error = mocker.MagicMock()
+        server_error.status_code = 500
+        server_error.json.return_value = {}
+        env.uninstall.side_effect = RestAPIError("", server_error)
+
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act & Assert
+        with pytest.raises(RestAPIError):
+            ms.deploy_agent(entry=str(pkg), name="my_agent")
+        env.install_wheel.assert_not_called()
+
+
+class TestEnsureDatasetDir:
+    def test_noop_when_path_exists(self, mocker):
+        ds_api = mocker.MagicMock()
+        ds_api.exists.return_value = True
+
+        model_serving._ensure_dataset_dir(ds_api, "Resources/agents/x")
+
+        ds_api.mkdir.assert_not_called()
+
+    def test_creates_missing_path_walking_up(self, mocker):
+        ds_api = mocker.MagicMock()
+        # "Resources" exists; everything below it does not.
+        ds_api.exists.side_effect = lambda p: p == "Resources"
+
+        model_serving._ensure_dataset_dir(ds_api, "Resources/agents/my_agent")
+
+        # Parents are created before children.
+        assert [c.args[0] for c in ds_api.mkdir.call_args_list] == [
+            "Resources/agents",
+            "Resources/agents/my_agent",
+        ]
+
+
+class TestReadPackageName:
+    def test_reads_static_name(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "my_agent"\nversion = "0.1.0"\n'
+        )
+
+        assert model_serving._read_package_name(str(tmp_path)) == "my_agent"
+
+    def test_raises_when_name_missing(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nversion = "0.1.0"\n'
+        )
+
+        with pytest.raises(ValueError, match="\\[project\\].name"):
+            model_serving._read_package_name(str(tmp_path))
+
+    def test_raises_when_no_project_table(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[build-system]\nrequires = []\n")
+
+        with pytest.raises(ValueError, match="\\[project\\].name"):
+            model_serving._read_package_name(str(tmp_path))

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -366,11 +366,8 @@ class TestDeployAgentPackage:
         mocker.patch.object(ms, "get_deployment", return_value=None)
         mocker.patch("hsml.model_serving.Predictor.for_server")
 
-        # Act
         ms.deploy_agent(entry=str(pkg), name="my_agent")
 
-        # Assert: the wheel local path passed to upload is absolute and lives
-        # under the build directory `_build_and_install_package` created.
         wheel_uploads = [p for p in captured_uploads if p.endswith(wheel_filename)]
         assert len(wheel_uploads) == 1
         wheel_local_path = wheel_uploads[0]
@@ -473,10 +470,7 @@ class TestDeployAgentPackage:
 
         mocker.patch("hsml.model_serving.DefaultIsolatedEnv")
         mock_builder = mocker.patch("hsml.model_serving.ProjectBuilder")
-        mock_builder.from_isolated_env.return_value.build.return_value = str(
-            wheel_local
-        )
-
+        mock_builder.from_isolated_env.return_value.build.return_value = str(wheel_local)
         mocker.patch.object(ms, "get_deployment", return_value=None)
 
         with pytest.raises(ValueError, match="no top-level package with `__main__.py`"):

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -195,7 +195,7 @@ class TestDeployAgentScript:
 
         # Assert
         env_api.create_environment.assert_called_once_with(
-            "my_agent", base_environment_name="minimal-inference-pipeline"
+            "my_agent", base_environment_name="python-agent-pipeline"
         )
 
     def test_custom_environment_name_overrides_default(

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -470,7 +470,9 @@ class TestDeployAgentPackage:
 
         mocker.patch("hsml.model_serving.DefaultIsolatedEnv")
         mock_builder = mocker.patch("hsml.model_serving.ProjectBuilder")
-        mock_builder.from_isolated_env.return_value.build.return_value = str(wheel_local)
+        mock_builder.from_isolated_env.return_value.build.return_value = str(
+            wheel_local
+        )
         mocker.patch.object(ms, "get_deployment", return_value=None)
 
         with pytest.raises(ValueError, match="no top-level package with `__main__.py`"):

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -43,9 +43,7 @@ def stub_apis(mocker):
     env_api = mocker.MagicMock(name="env_api")
     env_api.get_environment.return_value = env
 
-    mocker.patch(
-        "hsml.model_serving._dataset_api.DatasetApi", return_value=ds_api
-    )
+    mocker.patch("hsml.model_serving._dataset_api.DatasetApi", return_value=ds_api)
     mocker.patch(
         "hsml.model_serving._environment_api.EnvironmentApi", return_value=env_api
     )
@@ -66,6 +64,26 @@ class TestDeployAgentEntryValidation:
         bad.write_text("not python")
         with pytest.raises(ValueError, match="must be a .py file"):
             ms.deploy_agent(entry=str(bad), name="agent")
+
+
+class TestDeployAgentIdentifierValidation:
+    @pytest.fixture
+    def script(self, tmp_path):
+        s = tmp_path / "agent.py"
+        s.write_text("")
+        return s
+
+    @pytest.mark.parametrize(
+        "bad", ["../escape", "a/b", "..", ".", "name with space", ""]
+    )
+    def test_rejects_unsafe_name(self, ms, script, bad):
+        with pytest.raises(ValueError, match="name must match"):
+            ms.deploy_agent(entry=str(script), name=bad)
+
+    @pytest.mark.parametrize("bad", ["../escape", "a/b", ".."])
+    def test_rejects_unsafe_environment(self, ms, script, bad):
+        with pytest.raises(ValueError, match="environment must match"):
+            ms.deploy_agent(entry=str(script), name="ok", environment=bad)
 
 
 class TestDeployAgentScript:
@@ -97,6 +115,44 @@ class TestDeployAgentScript:
         assert kwargs["name"] == "my_agent"
         assert kwargs["script_file"] == "Resources/agents/my_agent/my_agent.py"
         assert kwargs["environment"] == "my_agent"
+
+    def test_default_name_from_script_basename(self, ms, mocker, tmp_path, stub_apis):
+        # Arrange: omit `name` — should be derived from the .py basename without extension.
+        ds_api, env_api, _ = stub_apis
+        script = tmp_path / "my_agent.py"
+        script.write_text("")
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(script))
+
+        # Assert
+        env_api.get_environment.assert_called_once_with("my_agent")
+        ds_api.upload.assert_called_once_with(
+            str(script.resolve()), "Resources/agents/my_agent", overwrite=True
+        )
+        assert mock_for_server.call_args.kwargs["name"] == "my_agent"
+
+    def test_custom_upload_dir(self, ms, mocker, tmp_path, stub_apis):
+        # Arrange
+        ds_api, _, _ = stub_apis
+        script = tmp_path / "agent.py"
+        script.write_text("")
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(script), name="agent", upload_dir="Jupyter/agents")
+
+        # Assert: the file lands under the custom base directory.
+        ds_api.upload.assert_called_once_with(
+            str(script.resolve()), "Jupyter/agents/agent", overwrite=True
+        )
+        assert (
+            mock_for_server.call_args.kwargs["script_file"]
+            == "Jupyter/agents/agent/agent.py"
+        )
 
     def test_creates_env_when_missing(self, ms, mocker, tmp_path, stub_apis):
         # Arrange
@@ -131,7 +187,7 @@ class TestDeployAgentScript:
         env_api.get_environment.assert_called_once_with("shared_env")
         assert mock_for_server.call_args.kwargs["environment"] == "shared_env"
 
-    def test_existing_deployment_short_circuits(
+    def test_existing_deployment_metadata_is_rewritten_and_saved(
         self, ms, mocker, tmp_path, stub_apis
     ):
         # Arrange
@@ -139,24 +195,34 @@ class TestDeployAgentScript:
         script = tmp_path / "agent.py"
         script.write_text("")
         existing = mocker.MagicMock(name="existing_deployment")
+        existing.predictor.id = 42
         mocker.patch.object(ms, "get_deployment", return_value=existing)
-        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+        new_predictor = mocker.MagicMock(name="new_predictor")
+        mock_for_server = mocker.patch(
+            "hsml.model_serving.Predictor.for_server", return_value=new_predictor
+        )
 
         # Act
-        result = ms.deploy_agent(entry=str(script), name="my_agent")
+        result = ms.deploy_agent(
+            entry=str(script), name="my_agent", description="updated"
+        )
 
-        # Assert: code is still uploaded, but no new predictor is created
-        # and the existing deployment is returned untouched.
+        # Assert: the existing deployment is returned, its predictor is replaced
+        # with one carrying the same id, and save() is called instead of deploy().
         assert result is existing
         ds_api.upload.assert_called_once()
-        mock_for_server.assert_not_called()
+        mock_for_server.assert_called_once()
+        assert mock_for_server.call_args.kwargs["description"] == "updated"
+        assert new_predictor._id == 42
+        assert existing.predictor is new_predictor
+        assert existing.description == "updated"
+        existing.save.assert_called_once_with()
+        new_predictor.deploy.assert_not_called()
         existing.start.assert_not_called()
         existing.stop.assert_not_called()
         existing.restart.assert_not_called()
 
-    def test_uploads_requirements_and_installs(
-        self, ms, mocker, tmp_path, stub_apis
-    ):
+    def test_uploads_requirements_and_installs(self, ms, mocker, tmp_path, stub_apis):
         # Arrange
         ds_api, _, env = stub_apis
         script = tmp_path / "agent.py"
@@ -167,9 +233,7 @@ class TestDeployAgentScript:
         mocker.patch("hsml.model_serving.Predictor.for_server")
 
         # Act
-        ms.deploy_agent(
-            entry=str(script), name="my_agent", requirements=str(reqs)
-        )
+        ms.deploy_agent(entry=str(script), name="my_agent", requirements=str(reqs))
 
         # Assert
         upload_calls = [c.args for c in ds_api.upload.call_args_list]
@@ -237,6 +301,65 @@ class TestDeployAgentPackage:
         # The runner contains the runpy invocation for the package.
         assert "runpy.run_module('my_agent'" in captured["content"]
         assert "run_name='__main__'" in captured["content"]
+
+    def test_wheel_basename_return_is_resolved_against_build_dir(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Some versions of `build` return just the wheel filename, not an absolute path.
+        # We must still hand a real path to the uploader, so deploy_agent should resolve
+        # the result against the build directory it passed in.
+        ds_api, _, _ = stub_apis
+        pkg = self._make_package(tmp_path)
+        wheel_filename = "my_agent-0.1.0-py3-none-any.whl"
+        captured_build_dir = {}
+
+        def fake_build(distribution, output_directory):
+            captured_build_dir["dir"] = output_directory
+            return wheel_filename  # basename only, as on older `build` versions
+
+        mock_builder = mocker.patch("build.ProjectBuilder")
+        mock_builder.return_value.build.side_effect = fake_build
+
+        captured_uploads = []
+        ds_api.upload.side_effect = lambda local, dest, overwrite=False: (
+            captured_uploads.append(local) or f"{dest}/{os.path.basename(local)}"
+        )
+
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(pkg), name="my_agent")
+
+        # Assert: the wheel local path passed to upload is absolute and lives
+        # under the build directory `_build_and_install_package` created.
+        wheel_uploads = [p for p in captured_uploads if p.endswith(wheel_filename)]
+        assert len(wheel_uploads) == 1
+        wheel_local_path = wheel_uploads[0]
+        assert os.path.isabs(wheel_local_path)
+        assert wheel_local_path == os.path.join(
+            captured_build_dir["dir"], wheel_filename
+        )
+
+    def test_default_name_from_package_dir_basename(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Arrange: omit `name` — should be the package directory's basename.
+        _, env_api, env = stub_apis
+        pkg = self._make_package(tmp_path, pkg_name="my_pkg")
+        wheel_local = tmp_path / "my_pkg-0.1.0-py3-none-any.whl"
+        wheel_local.write_bytes(b"")
+        self._patch_builder(mocker, wheel_local)
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(pkg))
+
+        # Assert
+        env_api.get_environment.assert_called_once_with("my_pkg")
+        env.uninstall.assert_called_once_with("my_pkg")
+        assert mock_for_server.call_args.kwargs["name"] == "my_pkg"
 
     def test_uninstall_404_swallowed_on_first_deploy(
         self, ms, mocker, tmp_path, stub_apis
@@ -316,9 +439,7 @@ class TestReadPackageName:
         assert model_serving._read_package_name(str(tmp_path)) == "my_agent"
 
     def test_raises_when_name_missing(self, tmp_path):
-        (tmp_path / "pyproject.toml").write_text(
-            '[project]\nversion = "0.1.0"\n'
-        )
+        (tmp_path / "pyproject.toml").write_text('[project]\nversion = "0.1.0"\n')
 
         with pytest.raises(ValueError, match="\\[project\\].name"):
             model_serving._read_package_name(str(tmp_path))

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -85,6 +85,26 @@ class TestDeployAgentIdentifierValidation:
         with pytest.raises(ValueError, match="environment must match"):
             ms.deploy_agent(entry=str(script), name="ok", environment=bad)
 
+    @pytest.mark.parametrize("bad", ["", "/abs/path", "..", "../escape", "Resources/../.."])
+    def test_rejects_unsafe_upload_dir(self, ms, script, bad):
+        with pytest.raises(ValueError, match="upload_dir"):
+            ms.deploy_agent(entry=str(script), name="ok", upload_dir=bad)
+
+    def test_normalizes_upload_dir(self, ms, mocker, script, stub_apis):
+        # Trailing slash and intermediate '.'/'..' segments that resolve safely should be allowed
+        # and the result reused as the upload base.
+        ds_api, _, _ = stub_apis
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        ms.deploy_agent(
+            entry=str(script), name="ok", upload_dir="Resources/foo/../agents/"
+        )
+
+        ds_api.upload.assert_called_once_with(
+            str(script.resolve()), "Resources/agents/ok", overwrite=True
+        )
+
 
 class TestDeployAgentScript:
     def test_uploads_script_creates_env_and_predictor(
@@ -113,7 +133,9 @@ class TestDeployAgentScript:
         env.install_requirements.assert_not_called()
         kwargs = mock_for_server.call_args.kwargs
         assert kwargs["name"] == "my_agent"
-        assert kwargs["script_file"] == "Resources/agents/my_agent/my_agent.py"
+        assert (
+            kwargs["script_file"] == "/Projects/proj/Resources/agents/my_agent/my_agent.py"
+        )
         assert kwargs["environment"] == "my_agent"
 
     def test_default_name_from_script_basename(self, ms, mocker, tmp_path, stub_apis):
@@ -151,7 +173,7 @@ class TestDeployAgentScript:
         )
         assert (
             mock_for_server.call_args.kwargs["script_file"]
-            == "Jupyter/agents/agent/agent.py"
+            == "/Projects/proj/Jupyter/agents/agent/agent.py"
         )
 
     def test_creates_env_when_missing(self, ms, mocker, tmp_path, stub_apis):
@@ -255,8 +277,9 @@ class TestDeployAgentPackage:
         return pkg
 
     def _patch_builder(self, mocker, wheel_path):
+        mocker.patch("build.env.DefaultIsolatedEnv")
         mock_builder = mocker.patch("build.ProjectBuilder")
-        mock_builder.return_value.build.return_value = str(wheel_path)
+        mock_builder.from_isolated_env.return_value.build.return_value = str(wheel_path)
         return mock_builder
 
     def _capture_runner(self, ds_api):
@@ -288,8 +311,9 @@ class TestDeployAgentPackage:
         # Act
         ms.deploy_agent(entry=str(pkg), name="my_agent")
 
-        # Assert: wheel was built, uninstalled, then installed.
-        mock_builder.assert_called_once_with(str(pkg.resolve()))
+        # Assert: wheel was built (in an isolated env), uninstalled, then installed.
+        mock_builder.from_isolated_env.assert_called_once()
+        assert mock_builder.from_isolated_env.call_args.args[1] == str(pkg.resolve())
         env.uninstall.assert_called_once_with("my_agent")
         env.install_wheel.assert_called_once_with(
             f"Resources/agents/my_agent/{wheel_local.name}"
@@ -298,7 +322,7 @@ class TestDeployAgentPackage:
         # The runner script was uploaded as the predictor's script_file.
         assert (
             mock_for_server.call_args.kwargs["script_file"]
-            == "Resources/agents/my_agent/runner.py"
+            == "/Projects/proj/Resources/agents/my_agent/runner.py"
         )
         # The runner contains the runpy invocation for the package.
         assert "runpy.run_module('my_agent'" in captured["content"]
@@ -319,8 +343,9 @@ class TestDeployAgentPackage:
             captured_build_dir["dir"] = output_directory
             return wheel_filename  # basename only, as on older `build` versions
 
+        mocker.patch("build.env.DefaultIsolatedEnv")
         mock_builder = mocker.patch("build.ProjectBuilder")
-        mock_builder.return_value.build.side_effect = fake_build
+        mock_builder.from_isolated_env.return_value.build.side_effect = fake_build
 
         captured_uploads = []
         ds_api.upload.side_effect = lambda local, dest, overwrite=False: (

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -168,7 +168,9 @@ class TestDeployAgentScript:
         ms.deploy_agent(entry=str(script), name="my_agent")
 
         # Assert
-        env_api.create_environment.assert_called_once_with("my_agent")
+        env_api.create_environment.assert_called_once_with(
+            "my_agent", base_environment_name="minimal-inference-pipeline"
+        )
 
     def test_custom_environment_name_overrides_default(
         self, ms, mocker, tmp_path, stub_apis

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -15,6 +15,7 @@
 #
 
 import os
+import zipfile
 
 import pytest
 from hopsworks_common.client.exceptions import RestAPIError
@@ -85,7 +86,9 @@ class TestDeployAgentIdentifierValidation:
         with pytest.raises(ValueError, match="environment must match"):
             ms.deploy_agent(entry=str(script), name="ok", environment=bad)
 
-    @pytest.mark.parametrize("bad", ["", "/abs/path", "..", "../escape", "Resources/../.."])
+    @pytest.mark.parametrize(
+        "bad", ["", "/abs/path", "..", "../escape", "Resources/../.."]
+    )
     def test_rejects_unsafe_upload_dir(self, ms, script, bad):
         with pytest.raises(ValueError, match="upload_dir"):
             ms.deploy_agent(entry=str(script), name="ok", upload_dir=bad)
@@ -134,7 +137,8 @@ class TestDeployAgentScript:
         kwargs = mock_for_server.call_args.kwargs
         assert kwargs["name"] == "my_agent"
         assert (
-            kwargs["script_file"] == "/Projects/proj/Resources/agents/my_agent/my_agent.py"
+            kwargs["script_file"]
+            == "/Projects/proj/Resources/agents/my_agent/my_agent.py"
         )
         assert kwargs["environment"] == "my_agent"
 
@@ -276,9 +280,16 @@ class TestDeployAgentPackage:
         )
         return pkg
 
-    def _patch_builder(self, mocker, wheel_path):
-        mocker.patch("build.env.DefaultIsolatedEnv")
-        mock_builder = mocker.patch("build.ProjectBuilder")
+    def _write_wheel(self, wheel_path, top_level="my_agent"):
+        """Write a minimal valid zip to `wheel_path` exposing `<top_level>/__main__.py`."""
+        with zipfile.ZipFile(wheel_path, "w") as z:
+            z.writestr(f"{top_level}/__init__.py", "")
+            z.writestr(f"{top_level}/__main__.py", "")
+
+    def _patch_builder(self, mocker, wheel_path, top_level="my_agent"):
+        self._write_wheel(wheel_path, top_level=top_level)
+        mocker.patch("hsml.model_serving.DefaultIsolatedEnv")
+        mock_builder = mocker.patch("hsml.model_serving.ProjectBuilder")
         mock_builder.from_isolated_env.return_value.build.return_value = str(wheel_path)
         return mock_builder
 
@@ -302,7 +313,6 @@ class TestDeployAgentPackage:
         ds_api, _, env = stub_apis
         pkg = self._make_package(tmp_path)
         wheel_local = tmp_path / "my_agent-0.1.0-py3-none-any.whl"
-        wheel_local.write_bytes(b"")
         mock_builder = self._patch_builder(mocker, wheel_local)
         captured = self._capture_runner(ds_api)
         mocker.patch.object(ms, "get_deployment", return_value=None)
@@ -341,10 +351,11 @@ class TestDeployAgentPackage:
 
         def fake_build(distribution, output_directory):
             captured_build_dir["dir"] = output_directory
+            self._write_wheel(os.path.join(output_directory, wheel_filename))
             return wheel_filename  # basename only, as on older `build` versions
 
-        mocker.patch("build.env.DefaultIsolatedEnv")
-        mock_builder = mocker.patch("build.ProjectBuilder")
+        mocker.patch("hsml.model_serving.DefaultIsolatedEnv")
+        mock_builder = mocker.patch("hsml.model_serving.ProjectBuilder")
         mock_builder.from_isolated_env.return_value.build.side_effect = fake_build
 
         captured_uploads = []
@@ -375,8 +386,7 @@ class TestDeployAgentPackage:
         _, env_api, env = stub_apis
         pkg = self._make_package(tmp_path, pkg_name="my_pkg")
         wheel_local = tmp_path / "my_pkg-0.1.0-py3-none-any.whl"
-        wheel_local.write_bytes(b"")
-        self._patch_builder(mocker, wheel_local)
+        self._patch_builder(mocker, wheel_local, top_level="my_pkg")
         mocker.patch.object(ms, "get_deployment", return_value=None)
         mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
 
@@ -395,7 +405,6 @@ class TestDeployAgentPackage:
         _, _, env = stub_apis
         pkg = self._make_package(tmp_path)
         wheel_local = tmp_path / "my_agent-0.1.0-py3-none-any.whl"
-        wheel_local.write_bytes(b"")
         self._patch_builder(mocker, wheel_local)
 
         not_found = mocker.MagicMock()
@@ -417,7 +426,6 @@ class TestDeployAgentPackage:
         _, _, env = stub_apis
         pkg = self._make_package(tmp_path)
         wheel_local = tmp_path / "my_agent-0.1.0-py3-none-any.whl"
-        wheel_local.write_bytes(b"")
         self._patch_builder(mocker, wheel_local)
 
         server_error = mocker.MagicMock()
@@ -432,6 +440,47 @@ class TestDeployAgentPackage:
         with pytest.raises(RestAPIError):
             ms.deploy_agent(entry=str(pkg), name="my_agent")
         env.install_wheel.assert_not_called()
+
+    def test_runner_uses_importable_module_not_distribution_name(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        # Distribution name "my-agent" is not a valid Python identifier; the importable
+        # package is "my_agent". The runner must use the importable name.
+        ds_api, _, env = stub_apis
+        pkg = self._make_package(tmp_path, pkg_name="my-agent")
+        wheel_local = tmp_path / "my_agent-0.1.0-py3-none-any.whl"
+        self._patch_builder(mocker, wheel_local, top_level="my_agent")
+        captured = self._capture_runner(ds_api)
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(pkg), name="myagent")
+
+        # Assert: pip-side uninstall uses the dist name; runpy uses the importable name.
+        env.uninstall.assert_called_once_with("my-agent")
+        assert "runpy.run_module('my_agent'" in captured["content"]
+
+    def test_raises_when_wheel_has_no_runnable_module(
+        self, ms, mocker, tmp_path, stub_apis
+    ):
+        ds_api, _, _ = stub_apis
+        pkg = self._make_package(tmp_path)
+        wheel_local = tmp_path / "my_agent-0.1.0-py3-none-any.whl"
+        # Wheel exists but has no top-level package with __main__.py.
+        with zipfile.ZipFile(wheel_local, "w") as z:
+            z.writestr("my_agent/__init__.py", "")
+
+        mocker.patch("hsml.model_serving.DefaultIsolatedEnv")
+        mock_builder = mocker.patch("hsml.model_serving.ProjectBuilder")
+        mock_builder.from_isolated_env.return_value.build.return_value = str(
+            wheel_local
+        )
+
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+
+        with pytest.raises(ValueError, match="no top-level package with `__main__.py`"):
+            ms.deploy_agent(entry=str(pkg), name="my_agent")
 
 
 class TestEnsureDatasetDir:

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -17,6 +17,8 @@
 import os
 import zipfile
 
+import build  # noqa: F401  # eagerly load so test patches resolve build.ProjectBuilder
+import build.env  # noqa: F401  # eagerly load so test patches resolve build.env.DefaultIsolatedEnv
 import pytest
 from hopsworks_common.client.exceptions import RestAPIError
 from hsml import model_serving
@@ -288,8 +290,8 @@ class TestDeployAgentPackage:
 
     def _patch_builder(self, mocker, wheel_path, top_level="my_agent"):
         self._write_wheel(wheel_path, top_level=top_level)
-        mocker.patch("hsml.model_serving.DefaultIsolatedEnv")
-        mock_builder = mocker.patch("hsml.model_serving.ProjectBuilder")
+        mocker.patch("build.env.DefaultIsolatedEnv")
+        mock_builder = mocker.patch("build.ProjectBuilder")
         mock_builder.from_isolated_env.return_value.build.return_value = str(wheel_path)
         return mock_builder
 
@@ -354,8 +356,8 @@ class TestDeployAgentPackage:
             self._write_wheel(os.path.join(output_directory, wheel_filename))
             return wheel_filename  # basename only, as on older `build` versions
 
-        mocker.patch("hsml.model_serving.DefaultIsolatedEnv")
-        mock_builder = mocker.patch("hsml.model_serving.ProjectBuilder")
+        mocker.patch("build.env.DefaultIsolatedEnv")
+        mock_builder = mocker.patch("build.ProjectBuilder")
         mock_builder.from_isolated_env.return_value.build.side_effect = fake_build
 
         captured_uploads = []
@@ -468,8 +470,8 @@ class TestDeployAgentPackage:
         with zipfile.ZipFile(wheel_local, "w") as z:
             z.writestr("my_agent/__init__.py", "")
 
-        mocker.patch("hsml.model_serving.DefaultIsolatedEnv")
-        mock_builder = mocker.patch("hsml.model_serving.ProjectBuilder")
+        mocker.patch("build.env.DefaultIsolatedEnv")
+        mock_builder = mocker.patch("build.ProjectBuilder")
         mock_builder.from_isolated_env.return_value.build.return_value = str(
             wheel_local
         )


### PR DESCRIPTION
## Summary

- Pulls in @aversey's `agent-deployments` work (`ms.deploy_agent(...)`), which lets a user deploy a local `.py` script or `pyproject.toml`-rooted package as a server-only Hopsworks deployment backed by the new `python-agent-pipeline` base image.
- Adds a `hops agent` CLI command group mirroring `hops deployment`: `list | info | create | start | stop | query | logs | delete`. Registered lazily in `cli/main.py` so cold paths (`hops --help`, `hops setup`) don't pay the SDK import cost.

## Test plan

- [x] `ruff check --config python/pyproject.toml` on every changed `.py` — passes
- [x] `ruff format --check` on every changed `.py` — passes (121 files already formatted)
- [x] `docsig hopsworks_common hopsworks hsfs hsml` — `agent.py` clean; only pre-existing SIG306 *warnings* elsewhere
- [x] `hops agent --help`, `hops agent create --help`, `hops agent query --help`, `hops agent logs --help` render correctly (verified with Click's `CliRunner`)
- [ ] CI matrix `pytest python/tests` (left to CI — local `uv sync` is blocked by a separate `hopsworks_apigen` griffe alias-resolution issue when building the editable wheel; unrelated to this CLI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)