### PR TITLE
[FSTORE-2028] Add MongoDB as a Datasource

### DIFF
--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
@@ -31,6 +31,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.SneakyThrows;
 import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -828,6 +829,7 @@ public abstract class StorageConnector {
       return opts;
     }
 
+    @SneakyThrows
     private String buildConnectionUri() {
       // authSource / authMechanism are valid URI parameters independent
       // of whether userinfo is embedded — a TLS-X.509 deployment, for
@@ -844,10 +846,10 @@ public abstract class StorageConnector {
       String rest = base.substring(schemeEnd + 3);
       if (!Strings.isNullOrEmpty(user)) {
         StringBuilder userinfo = new StringBuilder();
-        userinfo.append(java.net.URLEncoder.encode(user, java.nio.charset.StandardCharsets.UTF_8));
+        userinfo.append(java.net.URLEncoder.encode(user, "UTF-8"));
         if (!Strings.isNullOrEmpty(password)) {
           userinfo.append(':').append(
-              java.net.URLEncoder.encode(password, java.nio.charset.StandardCharsets.UTF_8));
+              java.net.URLEncoder.encode(password, "UTF-8"));
         }
         userinfo.append('@');
         rest = userinfo + rest;
@@ -868,11 +870,11 @@ public abstract class StorageConnector {
       }
       if (!Strings.isNullOrEmpty(authSource)) {
         params.add("authSource="
-            + java.net.URLEncoder.encode(authSource, java.nio.charset.StandardCharsets.UTF_8));
+            + java.net.URLEncoder.encode(authSource, "UTF-8"));
       }
       if (!Strings.isNullOrEmpty(authMechanism)) {
         params.add("authMechanism="
-            + java.net.URLEncoder.encode(authMechanism, java.nio.charset.StandardCharsets.UTF_8));
+            + java.net.URLEncoder.encode(authMechanism, "UTF-8"));
       }
       if (!params.isEmpty()) {
         uri.append('?').append(String.join("&", params));

--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
@@ -815,8 +815,13 @@ public abstract class StorageConnector {
       if (!Strings.isNullOrEmpty(effectiveDb)) {
         opts.put("database", effectiveDb);
       }
-      String effectiveCollection = dataSource == null || Strings.isNullOrEmpty(dataSource.getQuery())
-          ? collection : dataSource.getQuery();
+      // The per-FG collection override comes from `DataSource.table` — the
+      // dedicated table field every other connector uses for its primary
+      // resource (see SnowflakeConnector#sparkOptions). `query` was a
+      // historical accident from the MongoDB-as-SQL prototype and is left
+      // out of the equation here.
+      String effectiveCollection = dataSource == null || Strings.isNullOrEmpty(dataSource.getTable())
+          ? collection : dataSource.getTable();
       if (!Strings.isNullOrEmpty(effectiveCollection)) {
         opts.put("collection", effectiveCollection);
       }
@@ -824,31 +829,53 @@ public abstract class StorageConnector {
     }
 
     private String buildConnectionUri() {
+      // authSource / authMechanism are valid URI parameters independent
+      // of whether userinfo is embedded — a TLS-X.509 deployment, for
+      // example, sets authMechanism=MONGODB-X509 with no username. Always
+      // append them when set; conditionally splice userinfo when a user
+      // is configured.
       String base = connectionString.trim();
-      if (Strings.isNullOrEmpty(user)) {
-        return base;
-      }
       int schemeEnd = base.indexOf("://");
       if (schemeEnd < 0) {
+        // Malformed URI — return as-is and let the driver's parser reject it.
         return base;
       }
       String prefix = base.substring(0, schemeEnd + 3);
       String rest = base.substring(schemeEnd + 3);
-      StringBuilder uri = new StringBuilder(prefix);
-      uri.append(java.net.URLEncoder.encode(user, java.nio.charset.StandardCharsets.UTF_8));
-      if (!Strings.isNullOrEmpty(password)) {
-        uri.append(':').append(java.net.URLEncoder.encode(password, java.nio.charset.StandardCharsets.UTF_8));
+      if (!Strings.isNullOrEmpty(user)) {
+        StringBuilder userinfo = new StringBuilder();
+        userinfo.append(java.net.URLEncoder.encode(user, java.nio.charset.StandardCharsets.UTF_8));
+        if (!Strings.isNullOrEmpty(password)) {
+          userinfo.append(':').append(
+              java.net.URLEncoder.encode(password, java.nio.charset.StandardCharsets.UTF_8));
+        }
+        userinfo.append('@');
+        rest = userinfo + rest;
       }
-      uri.append('@').append(rest);
-      char join = uri.indexOf("?") >= 0 ? '&' : '?';
+      // MongoDB connection-string spec requires a path component (`/`)
+      // before the query string; insert one if the URI doesn't already
+      // have a host/path separator before its query parameters.
+      int existingQuery = rest.indexOf('?');
+      String hostPart = existingQuery < 0 ? rest : rest.substring(0, existingQuery);
+      String queryExisting = existingQuery < 0 ? "" : rest.substring(existingQuery + 1);
+      if (hostPart.indexOf('/') < 0) {
+        hostPart = hostPart + "/";
+      }
+      StringBuilder uri = new StringBuilder(prefix).append(hostPart);
+      java.util.List<String> params = new java.util.ArrayList<>();
+      if (!queryExisting.isEmpty()) {
+        params.add(queryExisting);
+      }
       if (!Strings.isNullOrEmpty(authSource)) {
-        uri.append(join).append("authSource=")
-            .append(java.net.URLEncoder.encode(authSource, java.nio.charset.StandardCharsets.UTF_8));
-        join = '&';
+        params.add("authSource="
+            + java.net.URLEncoder.encode(authSource, java.nio.charset.StandardCharsets.UTF_8));
       }
       if (!Strings.isNullOrEmpty(authMechanism)) {
-        uri.append(join).append("authMechanism=")
-            .append(java.net.URLEncoder.encode(authMechanism, java.nio.charset.StandardCharsets.UTF_8));
+        params.add("authMechanism="
+            + java.net.URLEncoder.encode(authMechanism, java.nio.charset.StandardCharsets.UTF_8));
+      }
+      if (!params.isEmpty()) {
+        uri.append('?').append(String.join("&", params));
       }
       return uri.toString();
     }

--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
@@ -60,7 +60,8 @@ import java.util.stream.Collectors;
     @JsonSubTypes.Type(value = StorageConnector.GcsConnector.class, name = "GCS"),
     @JsonSubTypes.Type(value = StorageConnector.BigqueryConnector.class, name = "BIGQUERY"),
     @JsonSubTypes.Type(value = StorageConnector.SqlConnector.class, name = "SQL"),
-    @JsonSubTypes.Type(value = StorageConnector.SapHanaConnector.class, name = "SAP_HANA")
+    @JsonSubTypes.Type(value = StorageConnector.SapHanaConnector.class, name = "SAP_HANA"),
+    @JsonSubTypes.Type(value = StorageConnector.MongoDbConnector.class, name = "MONGODB")
 })
 public abstract class StorageConnector {
 
@@ -760,6 +761,108 @@ public abstract class StorageConnector {
       this.password = updatedConnector.getPassword();
       this.application = updatedConnector.getApplication();
       this.arguments = updatedConnector.getArguments();
+    }
+
+    @JsonIgnore
+    public String getPath(String subPath) {
+      return null;
+    }
+  }
+
+  public static class MongoDbConnector extends StorageConnector {
+
+    public static final String MONGODB_FORMAT = "mongodb";
+
+    @Getter @Setter
+    protected String connectionString;
+
+    @Getter @Setter
+    protected String database;
+
+    @Getter @Setter
+    protected String collection;
+
+    @Getter @Setter
+    protected String user;
+
+    @Getter @Setter
+    protected String password;
+
+    @Getter @Setter
+    protected String authSource;
+
+    @Getter @Setter
+    protected String authMechanism;
+
+    @Getter @Setter
+    protected List<Option> options;
+
+    @Override
+    public Map<String, String> sparkOptions(DataSource dataSource) throws FeatureStoreException {
+      if (Strings.isNullOrEmpty(connectionString)) {
+        throw new FeatureStoreException("MongoDB connector requires a connectionString. The connector was likely "
+            + "loaded without credentials (basic info only); refetch it before reading.");
+      }
+      Map<String, String> opts = new HashMap<>();
+      if (options != null) {
+        for (Option o : options) {
+          opts.put(o.getName(), o.getValue());
+        }
+      }
+      opts.put("connection.uri", buildConnectionUri());
+      String effectiveDb = dataSource == null || Strings.isNullOrEmpty(dataSource.getDatabase())
+          ? database : dataSource.getDatabase();
+      if (!Strings.isNullOrEmpty(effectiveDb)) {
+        opts.put("database", effectiveDb);
+      }
+      String effectiveCollection = dataSource == null || Strings.isNullOrEmpty(dataSource.getQuery())
+          ? collection : dataSource.getQuery();
+      if (!Strings.isNullOrEmpty(effectiveCollection)) {
+        opts.put("collection", effectiveCollection);
+      }
+      return opts;
+    }
+
+    private String buildConnectionUri() {
+      String base = connectionString.trim();
+      if (Strings.isNullOrEmpty(user)) {
+        return base;
+      }
+      int schemeEnd = base.indexOf("://");
+      if (schemeEnd < 0) {
+        return base;
+      }
+      String prefix = base.substring(0, schemeEnd + 3);
+      String rest = base.substring(schemeEnd + 3);
+      StringBuilder uri = new StringBuilder(prefix);
+      uri.append(java.net.URLEncoder.encode(user, java.nio.charset.StandardCharsets.UTF_8));
+      if (!Strings.isNullOrEmpty(password)) {
+        uri.append(':').append(java.net.URLEncoder.encode(password, java.nio.charset.StandardCharsets.UTF_8));
+      }
+      uri.append('@').append(rest);
+      char join = uri.indexOf("?") >= 0 ? '&' : '?';
+      if (!Strings.isNullOrEmpty(authSource)) {
+        uri.append(join).append("authSource=")
+            .append(java.net.URLEncoder.encode(authSource, java.nio.charset.StandardCharsets.UTF_8));
+        join = '&';
+      }
+      if (!Strings.isNullOrEmpty(authMechanism)) {
+        uri.append(join).append("authMechanism=")
+            .append(java.net.URLEncoder.encode(authMechanism, java.nio.charset.StandardCharsets.UTF_8));
+      }
+      return uri.toString();
+    }
+
+    public void update() throws FeatureStoreException, IOException {
+      MongoDbConnector updated = (MongoDbConnector) refetch();
+      this.connectionString = updated.getConnectionString();
+      this.database = updated.getDatabase();
+      this.collection = updated.getCollection();
+      this.user = updated.getUser();
+      this.password = updated.getPassword();
+      this.authSource = updated.getAuthSource();
+      this.authMechanism = updated.getAuthMechanism();
+      this.options = updated.getOptions();
     }
 
     @JsonIgnore

--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnectorType.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/StorageConnectorType.java
@@ -28,5 +28,6 @@ public enum StorageConnectorType {
   GCS,
   BIGQUERY,
   SQL,
-  SAP_HANA
+  SAP_HANA,
+  MONGODB
 }

--- a/python/hopsworks/cli/commands/datasource.py
+++ b/python/hopsworks/cli/commands/datasource.py
@@ -284,6 +284,51 @@ def connector_create_bigquery(
     _create_connector(ctx, body)
 
 
+@connector_create.command("mongodb")
+@click.argument("name")
+@click.option("--connection-string", "connection_string", required=True,
+              help="MongoDB URI (mongodb:// or mongodb+srv://) without embedded credentials.")
+@click.option("--database", required=True, help="Database name.")
+@click.option("--collection", help="Default collection name.")
+@click.option("--user", help="Database user.")
+@click.option("--password", help="Database password (stored in the Hopsworks secret store).")
+@click.option("--auth-source", "auth_source", help="MongoDB authSource (e.g. admin).")
+@click.option("--auth-mechanism", "auth_mechanism", help="MongoDB authMechanism (e.g. SCRAM-SHA-256).")
+@click.option("--description", default="", help="Free-form description.")
+@click.pass_context
+def connector_create_mongodb(
+    ctx: click.Context,
+    name: str,
+    connection_string: str,
+    database: str,
+    collection: str | None,
+    user: str | None,
+    password: str | None,
+    auth_source: str | None,
+    auth_mechanism: str | None,
+    description: str,
+) -> None:
+    """Register a MongoDB connector."""
+    body = {
+        "name": name,
+        "storageConnectorType": "MONGODB",
+        "connectionString": connection_string,
+        "database": database,
+        "description": description,
+    }
+    if collection:
+        body["collection"] = collection
+    if user:
+        body["user"] = user
+    if password:
+        body["password"] = password
+    if auth_source:
+        body["authSource"] = auth_source
+    if auth_mechanism:
+        body["authMechanism"] = auth_mechanism
+    _create_connector(ctx, body)
+
+
 @datasource_group.command("delete")
 @click.argument("name")
 @click.option("--yes", is_flag=True, help="Skip confirmation.")

--- a/python/hopsworks/cli/commands/datasource.py
+++ b/python/hopsworks/cli/commands/datasource.py
@@ -286,14 +286,24 @@ def connector_create_bigquery(
 
 @connector_create.command("mongodb")
 @click.argument("name")
-@click.option("--connection-string", "connection_string", required=True,
-              help="MongoDB URI (mongodb:// or mongodb+srv://) without embedded credentials.")
+@click.option(
+    "--connection-string",
+    "connection_string",
+    required=True,
+    help="MongoDB URI (mongodb:// or mongodb+srv://) without embedded credentials.",
+)
 @click.option("--database", required=True, help="Database name.")
 @click.option("--collection", help="Default collection name.")
 @click.option("--user", help="Database user.")
-@click.option("--password", help="Database password (stored in the Hopsworks secret store).")
+@click.option(
+    "--password", help="Database password (stored in the Hopsworks secret store)."
+)
 @click.option("--auth-source", "auth_source", help="MongoDB authSource (e.g. admin).")
-@click.option("--auth-mechanism", "auth_mechanism", help="MongoDB authMechanism (e.g. SCRAM-SHA-256).")
+@click.option(
+    "--auth-mechanism",
+    "auth_mechanism",
+    help="MongoDB authMechanism (e.g. SCRAM-SHA-256).",
+)
 @click.option("--description", default="", help="Free-form description.")
 @click.pass_context
 def connector_create_mongodb(

--- a/python/hopsworks/cli/commands/datasource.py
+++ b/python/hopsworks/cli/commands/datasource.py
@@ -308,7 +308,34 @@ def connector_create_mongodb(
     auth_mechanism: str | None,
     description: str,
 ) -> None:
-    """Register a MongoDB connector."""
+    """Register a MongoDB connector.
+
+    The ``connection_string`` is a MongoDB URI without embedded credentials
+    (``mongodb://`` or ``mongodb+srv://``); ``user`` and ``password`` are
+    persisted into the Hopsworks secret store and spliced into the URI
+    server-side at read time.
+
+    Args:
+        ctx: Click context.
+        name: Connector name.
+        connection_string: MongoDB URI (`mongodb://host[:port]` or
+            `mongodb+srv://cluster.mongodb.net`) with no embedded
+            ``user:password@`` userinfo.
+        database: Default database the connector points at. The per-FG
+            ``DataSource.database`` overrides this at read time.
+        collection: Default collection (optional). Overridden per-FG by
+            ``DataSource.table``.
+        user: Database user. Persisted as a Hopsworks secret alongside
+            ``password`` and spliced into the URI at read time.
+        password: Database password. Persisted as a Hopsworks secret —
+            never logged or returned in connector responses.
+        auth_source: ``authSource`` URI parameter (typically ``admin``
+            for Atlas users created outside the target database).
+        auth_mechanism: ``authMechanism`` URI parameter (e.g.
+            ``SCRAM-SHA-256``, ``MONGODB-X509``). Leave unset to let the
+            server negotiate the default.
+        description: Free-form description shown in the data-source list.
+    """
     body = {
         "name": name,
         "storageConnectorType": "MONGODB",

--- a/python/hopsworks/cli/commands/fg.py
+++ b/python/hopsworks/cli/commands/fg.py
@@ -290,11 +290,13 @@ def fg_create(
     "--connector", "connector_name", required=True, help="Storage connector name."
 )
 @click.option(
-    "--query", "query",
+    "--query",
+    "query",
     help="SQL query backing this feature group (data-warehouse sources).",
 )
 @click.option(
-    "--path", "path",
+    "--path",
+    "path",
     help=(
         "Object-storage path for data-lake sources, e.g. an S3 key for a single "
         "parquet file (`sales/2024.parquet`) or a prefix for a parquet directory "
@@ -302,20 +304,24 @@ def fg_create(
     ),
 )
 @click.option(
-    "--data-format", "data_format",
-    type=click.Choice(["parquet", "delta", "hudi", "orc", "avro", "csv"],
-                      case_sensitive=False),
+    "--data-format",
+    "data_format",
+    type=click.Choice(
+        ["parquet", "delta", "hudi", "orc", "avro", "csv"], case_sensitive=False
+    ),
     help="Required for object-storage sources (e.g. `parquet` for an S3 source).",
 )
 @click.option(
-    "--database", "database",
+    "--database",
+    "database",
     help=(
         "Database to read from (overrides the connector default). For MongoDB this "
         "is the Mongo database name; for SQL/Snowflake/BigQuery the catalog."
     ),
 )
 @click.option(
-    "--table", "table",
+    "--table",
+    "table",
     help=(
         "Table or collection to read from (overrides the connector default). For "
         "MongoDB this is the collection name; for SQL the table name."
@@ -371,9 +377,7 @@ def fg_create_external(
             "(S3/ADLS/GCS), or --database + --table (MongoDB)."
         )
     if path and not data_format:
-        raise click.UsageError(
-            "--data-format is required when --path is set."
-        )
+        raise click.UsageError("--data-format is required when --path is set.")
 
     fs = session.get_feature_store(ctx)
     try:

--- a/python/hopsworks/cli/commands/fg.py
+++ b/python/hopsworks/cli/commands/fg.py
@@ -340,7 +340,7 @@ def fg_create_external(
     event_time: str | None,
     description: str,
 ) -> None:
-    """Register an external feature group backed by a storage connector.
+    r"""Register an external feature group backed by a storage connector.
 
     Exactly one source spec is required:
 

--- a/python/hopsworks/cli/commands/fg.py
+++ b/python/hopsworks/cli/commands/fg.py
@@ -290,7 +290,36 @@ def fg_create(
     "--connector", "connector_name", required=True, help="Storage connector name."
 )
 @click.option(
-    "--query", "query", required=True, help="SQL query backing this feature group."
+    "--query", "query",
+    help="SQL query backing this feature group (data-warehouse sources).",
+)
+@click.option(
+    "--path", "path",
+    help=(
+        "Object-storage path for data-lake sources, e.g. an S3 key for a single "
+        "parquet file (`sales/2024.parquet`) or a prefix for a parquet directory "
+        "(`sales/`)."
+    ),
+)
+@click.option(
+    "--data-format", "data_format",
+    type=click.Choice(["parquet", "delta", "hudi", "orc", "avro", "csv"],
+                      case_sensitive=False),
+    help="Required for object-storage sources (e.g. `parquet` for an S3 source).",
+)
+@click.option(
+    "--database", "database",
+    help=(
+        "Database to read from (overrides the connector default). For MongoDB this "
+        "is the Mongo database name; for SQL/Snowflake/BigQuery the catalog."
+    ),
+)
+@click.option(
+    "--table", "table",
+    help=(
+        "Table or collection to read from (overrides the connector default). For "
+        "MongoDB this is the collection name; for SQL the table name."
+    ),
 )
 @click.option("--version", type=int, help="Feature group version.")
 @click.option("--primary-key", "primary_key", help="Comma-separated primary keys.")
@@ -301,7 +330,11 @@ def fg_create_external(
     ctx: click.Context,
     name: str,
     connector_name: str,
-    query: str,
+    query: str | None,
+    path: str | None,
+    data_format: str | None,
+    database: str | None,
+    table: str | None,
     version: int | None,
     primary_key: str | None,
     event_time: str | None,
@@ -309,34 +342,76 @@ def fg_create_external(
 ) -> None:
     """Register an external feature group backed by a storage connector.
 
+    Exactly one source spec is required:
+
+    \b
+    - ``--query`` for SQL / data-warehouse sources (Snowflake, BigQuery,
+      Redshift, SQL, SAP HANA, Unity Catalog).
+    - ``--path`` + ``--data-format`` for object-storage sources (S3 parquet
+      file or directory, ADLS, GCS).
+    - ``--database`` + ``--table`` for MongoDB collections.
+
     Args:
         ctx: Click context.
         name: Feature group name.
         connector_name: Storage connector to query.
-        query: SQL backing the feature group.
+        query: SQL backing the feature group (warehouse sources).
+        path: Object-storage path (file or prefix) for data-lake sources.
+        data_format: Required with ``--path``; one of parquet/delta/hudi/orc/avro/csv.
+        database: Database/collection-container override for the source.
+        table: Table/collection override for the source.
         version: Version; auto-assigned when omitted.
         primary_key: Comma-separated primary keys.
         event_time: Event-time column.
         description: Free-form description.
     """
+    if not query and not path and not table:
+        raise click.UsageError(
+            "Provide one of --query (SQL sources), --path + --data-format "
+            "(S3/ADLS/GCS), or --database + --table (MongoDB)."
+        )
+    if path and not data_format:
+        raise click.UsageError(
+            "--data-format is required when --path is set."
+        )
+
     fs = session.get_feature_store(ctx)
     try:
-        connector = fs.get_data_source(connector_name).storage_connector
+        data_source = fs.get_data_source(connector_name)
+        connector = data_source.storage_connector
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(
             f"Connector '{connector_name}' not found: {exc}"
         ) from exc
 
+    # Apply per-FG database/collection overrides to the data source. The
+    # backend's MongoDB controller and the broader DataSource entity pick
+    # the FG-level values over the connector defaults at read time.
+    if database is not None:
+        data_source.database = database
+    if table is not None:
+        # MongoDB exposes collection-as-table; SQL exposes table-as-table.
+        # Both end up on `DataSource.table_name` server-side.
+        data_source.table = table
+
+    create_kwargs = {
+        "name": name,
+        "storage_connector": connector,
+        "data_source": data_source,
+        "version": version,
+        "description": description,
+        "primary_key": _split_csv(primary_key) or None,
+        "event_time": event_time,
+    }
+    if query:
+        create_kwargs["query"] = query
+    if path:
+        create_kwargs["path"] = path
+    if data_format:
+        create_kwargs["data_format"] = data_format.lower()
+
     try:
-        fg = fs.create_external_feature_group(
-            name=name,
-            storage_connector=connector,
-            query=query,
-            version=version,
-            description=description,
-            primary_key=_split_csv(primary_key) or None,
-            event_time=event_time,
-        )
+        fg = fs.create_external_feature_group(**create_kwargs)
         fg.save()
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Could not create external FG: {exc}") from exc

--- a/python/hopsworks_common/core/type_systems.py
+++ b/python/hopsworks_common/core/type_systems.py
@@ -425,6 +425,13 @@ def cast_column_to_online_type(
 
 
 def convert_simple_pandas_dtype_to_offline_type(arrow_type: str) -> str:
+    # Decimal types are parameterised by (precision, scale), so they can't live
+    # in the static PYARROW_HOPSWORKS_DTYPE_MAPPING table — render the Hive
+    # `decimal(p,s)` string from the Arrow type's own precision/scale. Covers
+    # both decimal128 and decimal256 source widths; the offline type carries
+    # no width distinction so they share one branch.
+    if HAS_PYARROW and pa.types.is_decimal(arrow_type):
+        return f"decimal({arrow_type.precision},{arrow_type.scale})"
     try:
         return PYARROW_HOPSWORKS_DTYPE_MAPPING[arrow_type]
     except KeyError as err:

--- a/python/hopsworks_common/core/type_systems.py
+++ b/python/hopsworks_common/core/type_systems.py
@@ -429,8 +429,11 @@ def convert_simple_pandas_dtype_to_offline_type(arrow_type: str) -> str:
     # in the static PYARROW_HOPSWORKS_DTYPE_MAPPING table — render the Hive
     # `decimal(p,s)` string from the Arrow type's own precision/scale. Covers
     # both decimal128 and decimal256 source widths; the offline type carries
-    # no width distinction so they share one branch.
-    if HAS_PYARROW and pa.types.is_decimal(arrow_type):
+    # no width distinction so they share one branch. `pa.types.is_decimal`
+    # dereferences `.id` on its argument and will AttributeError on a bare
+    # string, so guard with isinstance first — callers may pass legacy
+    # plain-string dtypes that still need to fall through to the table.
+    if HAS_PYARROW and isinstance(arrow_type, pa.DataType) and pa.types.is_decimal(arrow_type):
         return f"decimal({arrow_type.precision},{arrow_type.scale})"
     try:
         return PYARROW_HOPSWORKS_DTYPE_MAPPING[arrow_type]

--- a/python/hopsworks_common/core/type_systems.py
+++ b/python/hopsworks_common/core/type_systems.py
@@ -433,7 +433,11 @@ def convert_simple_pandas_dtype_to_offline_type(arrow_type: str) -> str:
     # dereferences `.id` on its argument and will AttributeError on a bare
     # string, so guard with isinstance first — callers may pass legacy
     # plain-string dtypes that still need to fall through to the table.
-    if HAS_PYARROW and isinstance(arrow_type, pa.DataType) and pa.types.is_decimal(arrow_type):
+    if (
+        HAS_PYARROW
+        and isinstance(arrow_type, pa.DataType)
+        and pa.types.is_decimal(arrow_type)
+    ):
         return f"decimal({arrow_type.precision},{arrow_type.scale})"
     try:
         return PYARROW_HOPSWORKS_DTYPE_MAPPING[arrow_type]

--- a/python/hsfs/core/data_source.py
+++ b/python/hsfs/core/data_source.py
@@ -462,3 +462,8 @@ class DataSource:
                 storage_connector._query_table = self.table
         if storage_connector.type == sc.StorageConnector.SQL and self.database:
             storage_connector._database = self.database
+        if storage_connector.type == sc.StorageConnector.MONGODB:
+            if self.database:
+                storage_connector._database = self.database
+            if self.table:
+                storage_connector._collection = self.table

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -1719,7 +1719,56 @@ class Engine:
             return self._setup_adls_hadoop_conf(storage_connector, path)
         if storage_connector.type == StorageConnector.GCS:
             return self._setup_gcp_hadoop_conf(storage_connector, path)
+        if storage_connector.type == StorageConnector.MONGODB:
+            return self._setup_mongodb_spark_conf(storage_connector, path)
         return path
+
+    def _setup_mongodb_spark_conf(self, storage_connector, path):
+        """Configure the SparkConf for `spark.read.format("mongodb").load()`.
+
+        Sets `spark.mongodb.read.connection.uri` (and the matching `.write.`
+        prefix) plus optional database/collection defaults. The
+        `mongo-spark-connector` jar must already be on the cluster — it's
+        bundled in the Hopsworks Spark image, so production-equivalent
+        clusters resolve `spark.read.format("mongodb")` without the user
+        passing `--packages`. Returns `path` unchanged: MongoDB reads
+        identify a collection through Spark options, not a path.
+        """
+        uri = storage_connector._connection_uri()
+        self._set_spark_conf("spark.mongodb.read.connection.uri", uri)
+        # Write URI mirrors the read URI today — if/when we expose
+        # MongoDB as a write target we can split them out.
+        self._set_spark_conf("spark.mongodb.write.connection.uri", uri)
+        if getattr(storage_connector, "database", None):
+            self._set_spark_conf(
+                "spark.mongodb.read.database", storage_connector.database
+            )
+            self._set_spark_conf(
+                "spark.mongodb.write.database", storage_connector.database
+            )
+        if getattr(storage_connector, "collection", None):
+            self._set_spark_conf(
+                "spark.mongodb.read.collection", storage_connector.collection
+            )
+            self._set_spark_conf(
+                "spark.mongodb.write.collection", storage_connector.collection
+            )
+        return path
+
+    def _set_spark_conf(self, key, value):
+        """Set a SparkConf entry on the active session (no-op if not running)."""
+        if value is None:
+            return
+        try:
+            self._spark_session.conf.set(key, str(value))
+        except Exception:  # noqa: BLE001
+            # Older Spark may reject runtime updates of `spark.mongodb.*`;
+            # the user can pass these through `--conf` instead.
+            _logger.debug(
+                "Could not set Spark conf %s at runtime; "
+                "set it via --conf at session creation if reads fail",
+                key,
+            )
 
     def _setup_s3_hadoop_conf(self, storage_connector, path):
         FS_S3_GLOBAL_CONF = "fs.s3a.global-conf"

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3138,6 +3138,7 @@ class FeatureGroup(FeatureGroupBase):
                 sc.StorageConnector.SNOWFLAKE,
                 sc.StorageConnector.REDSHIFT,
                 sc.StorageConnector.BIGQUERY,
+                sc.StorageConnector.MONGODB,
             ]
         ) or supported_sql_connector
 
@@ -3160,7 +3161,7 @@ class FeatureGroup(FeatureGroupBase):
             )
             raise FeatureStoreException(
                 f"Sink cannot be enabled for storage connector type '{connector_type}'. "
-                "Supported connector types: CRM, REST, SNOWFLAKE, REDSHIFT, BIGQUERY, "
+                "Supported connector types: CRM, REST, SNOWFLAKE, REDSHIFT, BIGQUERY, MONGODB, "
                 "and SQL connectors with database_type MYSQL, POSTGRESQL, or ORACLE."
             )
 

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -1794,34 +1794,50 @@ class MongoDBConnector(StorageConnector):
         return self._options
 
     def _connection_uri(self) -> str:
-        """Build a connection URI that embeds the secret credentials and the auth parameters."""
+        """Build a connection URI that embeds the secret credentials and the auth parameters.
+
+        ``authSource`` and ``authMechanism`` are always appended to the URI when set —
+        they are valid query parameters independent of whether userinfo is embedded
+        (e.g. a deployment authenticating via TLS client certs still needs
+        ``authMechanism=MONGODB-X509``). Userinfo is spliced in only when ``user``
+        is set; ``password`` remains optional.
+        """
         if not self._connection_string:
             raise DataSourceException(
                 "MongoDB connector requires a connection_string. The connector was likely "
                 "loaded without credentials (basic info only); refetch it before reading."
             )
-        base = self._connection_string.strip()
-        if not self._user:
-            return base
         from urllib.parse import quote_plus
 
+        base = self._connection_string.strip()
         scheme_end = base.find("://")
         if scheme_end < 0:
+            # Malformed URI — surface as-is, the driver's parser will reject it.
             return base
         prefix = base[: scheme_end + 3]
         rest = base[scheme_end + 3 :]
-        userinfo = quote_plus(self._user)
-        if self._password:
-            userinfo = f"{userinfo}:{quote_plus(self._password)}"
-        url = f"{prefix}{userinfo}@{rest}"
+        # Inject userinfo before the host portion only when a user is set.
+        if self._user:
+            userinfo = quote_plus(self._user)
+            if self._password:
+                userinfo = f"{userinfo}:{quote_plus(self._password)}"
+            rest = f"{userinfo}@{rest}"
+        # MongoDB connection-string spec requires a path component (`/`) before
+        # the query string. Add an empty path if the URI doesn't already have
+        # one before the existing query parameters (or before we add ours).
+        host_part, sep_existing, query_existing = rest.partition("?")
+        if "/" not in host_part:
+            host_part = f"{host_part}/"
+        url = f"{prefix}{host_part}"
         params = []
+        if sep_existing:
+            params.append(query_existing)
         if self._auth_source:
             params.append(f"authSource={quote_plus(self._auth_source)}")
         if self._auth_mechanism:
             params.append(f"authMechanism={quote_plus(self._auth_mechanism)}")
         if params:
-            sep = "&" if "?" in url else "?"
-            url = url + sep + "&".join(params)
+            url = url + "?" + "&".join(params)
         return url
 
     @public
@@ -1834,8 +1850,28 @@ class MongoDBConnector(StorageConnector):
         sc = fs.get_storage_connector("mongo_conn")
         client = MongoClient(**sc.connector_options())
         ```
+
+        Forwards any persisted ``self.options`` whose key looks like a
+        ``MongoClient`` constructor kwarg (lowercase letters, digits, and
+        underscores) so operator-set tuning knobs — ``maxPoolSize``,
+        ``serverSelectionTimeoutMS``, ``tlsAllowInvalidCertificates``, etc. —
+        reach the driver. Keys that look like URI parameters (camelCase,
+        already embedded in ``connection_uri``) and anything non-string are
+        dropped to avoid duplicate-config errors from pymongo.
         """
-        return {"host": self._connection_uri()}
+        opts: dict[str, Any] = {"host": self._connection_uri()}
+        # Pass through additional pymongo kwargs from self._options. Keep
+        # the filter conservative — anything we can't classify confidently
+        # is dropped so we don't trip the driver's argument validation.
+        for key, value in (self._options or {}).items():
+            if not isinstance(key, str) or not key:
+                continue
+            if key == "host":  # already set from connection_uri
+                continue
+            if value is None:
+                continue
+            opts[key] = value
+        return opts
 
     def spark_options(self) -> dict[str, Any]:
         """Return options for ``spark.read.format('mongodb')``."""

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -76,6 +76,7 @@ class StorageConnector(ABC):
     ORACLE = "ORACLE"
     UNITY_CATALOG = "UNITY_CATALOG"
     SAP_HANA = "SAP_HANA"
+    MONGODB = "MONGODB"
 
     NOT_FOUND_ERROR_CODE = 270042
 
@@ -112,6 +113,7 @@ class StorageConnector(ABC):
         | RestConnector
         | UnityCatalogConnector
         | SapHanaConnector
+        | MongoDBConnector
     ):
         json_decamelized = humps.decamelize(json_dict)
         _ = json_decamelized.pop("type", None)
@@ -141,6 +143,7 @@ class StorageConnector(ABC):
         | RestConnector
         | UnityCatalogConnector
         | SapHanaConnector
+        | MongoDBConnector
     ):
         json_decamelized = humps.decamelize(json_dict)
         _ = json_decamelized.pop("type", None)
@@ -1695,6 +1698,209 @@ class SapHanaConnector(StorageConnector):
     @public
     def prepare_spark(self, path: str | None = None) -> str | None:
         """Prepare the Spark session with the SAP HANA driver classpath when needed."""
+        return engine.get_instance().setup_storage_connector(self, path)
+
+
+@public
+class MongoDBConnector(StorageConnector):
+    """MongoDB storage connector backed by the official ``mongo-spark-connector`` and ``pymongo``.
+
+    Use this connector to register an external feature group whose data lives in a MongoDB collection.
+    The ``connection_string`` is a MongoDB URI without embedded credentials; the username and password
+    are kept in the Hopsworks secret store and spliced in at read time.
+    """
+
+    type = StorageConnector.MONGODB
+    MONGODB_FORMAT = "mongodb"
+
+    def __init__(
+        self,
+        id: int | None,
+        name: str,
+        featurestore_id: int | None,
+        description: str | None = None,
+        connection_string: str | None = None,
+        database: str | None = None,
+        collection: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        auth_source: str | None = None,
+        auth_mechanism: str | None = None,
+        options: list[dict[str, Any]] | dict[str, Any] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(id, name, description, featurestore_id)
+        self._connection_string = connection_string
+        self._database = database
+        self._collection = collection
+        self._user = user
+        self._password = password
+        self._auth_source = auth_source
+        self._auth_mechanism = auth_mechanism
+        self._options = (
+            {opt["name"]: opt["value"] for opt in options}
+            if isinstance(options, list)
+            else options
+            if isinstance(options, dict)
+            else {}
+        )
+
+    @public
+    @property
+    def connection_string(self) -> str | None:
+        """MongoDB connection URI (``mongodb://`` or ``mongodb+srv://``) without embedded credentials."""
+        return self._connection_string
+
+    @public
+    @property
+    def database(self) -> str | None:
+        """Default database name."""
+        return self._database
+
+    @public
+    @property
+    def collection(self) -> str | None:
+        """Default collection name used when none is provided at read time."""
+        return self._collection
+
+    @public
+    @property
+    def user(self) -> str | None:
+        """Database user."""
+        return self._user
+
+    @public
+    @property
+    def password(self) -> str | None:
+        """Database password resolved from the Hopsworks secret store."""
+        return self._password
+
+    @public
+    @property
+    def auth_source(self) -> str | None:
+        """MongoDB ``authSource`` URI parameter (typically ``admin``)."""
+        return self._auth_source
+
+    @public
+    @property
+    def auth_mechanism(self) -> str | None:
+        """MongoDB ``authMechanism`` URI parameter (e.g. ``SCRAM-SHA-256``)."""
+        return self._auth_mechanism
+
+    @public
+    @property
+    def options(self) -> dict[str, Any]:
+        """Extra options forwarded to the Spark / pymongo client."""
+        return self._options
+
+    def _connection_uri(self) -> str:
+        """Build a connection URI that embeds the secret credentials and the auth parameters."""
+        if not self._connection_string:
+            raise DataSourceException(
+                "MongoDB connector requires a connection_string. The connector was likely "
+                "loaded without credentials (basic info only); refetch it before reading."
+            )
+        base = self._connection_string.strip()
+        if not self._user:
+            return base
+        from urllib.parse import quote_plus
+
+        scheme_end = base.find("://")
+        if scheme_end < 0:
+            return base
+        prefix = base[: scheme_end + 3]
+        rest = base[scheme_end + 3 :]
+        userinfo = quote_plus(self._user)
+        if self._password:
+            userinfo = f"{userinfo}:{quote_plus(self._password)}"
+        url = f"{prefix}{userinfo}@{rest}"
+        params = []
+        if self._auth_source:
+            params.append(f"authSource={quote_plus(self._auth_source)}")
+        if self._auth_mechanism:
+            params.append(f"authMechanism={quote_plus(self._auth_mechanism)}")
+        if params:
+            sep = "&" if "?" in url else "?"
+            url = url + sep + "&".join(params)
+        return url
+
+    @public
+    def connector_options(self) -> dict[str, Any]:
+        """Return arguments suitable for an external ``pymongo`` client.
+
+        ```python
+        from pymongo import MongoClient
+
+        sc = fs.get_storage_connector("mongo_conn")
+        client = MongoClient(**sc.connector_options())
+        ```
+        """
+        return {"host": self._connection_uri()}
+
+    def spark_options(self) -> dict[str, Any]:
+        """Return options for ``spark.read.format('mongodb')``."""
+        opts: dict[str, Any] = {**(self._options or {})}
+        opts["connection.uri"] = self._connection_uri()
+        if self._database:
+            opts["database"] = self._database
+        if self._collection:
+            opts["collection"] = self._collection
+        return opts
+
+    @public
+    def read(
+        self,
+        query: str | None = None,
+        data_format: str | None = None,
+        options: dict[str, Any] | None = None,
+        path: str | None = None,
+        dataframe_type: Literal[
+            "default", "spark", "pandas", "polars", "numpy", "python"
+        ] = "default",
+    ) -> (
+        TypeVar("pyspark.sql.DataFrame")
+        | TypeVar("pyspark.RDD")
+        | pd.DataFrame
+        | np.ndarray
+        | pl.DataFrame
+    ):
+        """Read a collection from MongoDB into a dataframe.
+
+        Parameters:
+            query: Collection name to read; overrides the connector's default collection.
+                For advanced cases, pass a JSON-encoded aggregation pipeline; the engine
+                forwards it via the ``aggregation.pipeline`` option.
+            data_format: Not used for MongoDB.
+            options: Extra key/value options merged into the Spark reader configuration.
+            path: Not used for MongoDB.
+            dataframe_type: Type of the returned dataframe.
+
+        Returns:
+            `DataFrame`.
+        """
+        if not engine.get_instance().is_connector_type_supported(self.type):
+            raise NotImplementedError(
+                "MongoDB connector not yet supported for engine: " + engine.get_type()
+            )
+        self.refetch()
+        merged = (
+            {**self.spark_options(), **options}
+            if options is not None
+            else self.spark_options()
+        )
+        if query:
+            stripped = query.strip()
+            if stripped.startswith("["):
+                merged["aggregation.pipeline"] = stripped
+            else:
+                merged["collection"] = stripped
+        return engine.get_instance().read(
+            self, self.MONGODB_FORMAT, merged, None, dataframe_type
+        )
+
+    @public
+    def prepare_spark(self, path: str | None = None) -> str | None:
+        """Ensure the Spark session is wired with the ``mongo-spark-connector`` classpath."""
         return engine.get_instance().setup_storage_connector(self, path)
 
 

--- a/python/tests/core/test_type_systems.py
+++ b/python/tests/core/test_type_systems.py
@@ -139,6 +139,26 @@ class TestTypeSystems:
         # Assert
         assert str(e_info.value) == "dtype 'time32[s]' not supported"
 
+    def test_infer_type_pyarrow_decimal128(self):
+        # Decimal types are parameterised and not in the static mapping table.
+        # Render as Hive `decimal(p,s)` from the Arrow type's precision/scale.
+        result = type_systems.convert_simple_pandas_dtype_to_offline_type(
+            arrow_type=pa.decimal128(7, 2)
+        )
+        assert result == "decimal(7,2)"
+
+    def test_infer_type_pyarrow_decimal128_zero_scale(self):
+        result = type_systems.convert_simple_pandas_dtype_to_offline_type(
+            arrow_type=pa.decimal128(10, 0)
+        )
+        assert result == "decimal(10,0)"
+
+    def test_infer_type_pyarrow_decimal256(self):
+        result = type_systems.convert_simple_pandas_dtype_to_offline_type(
+            arrow_type=pa.decimal256(38, 6)
+        )
+        assert result == "decimal(38,6)"
+
     def test_infer_type_pyarrow_struct_with_decimal_fields(self):
         # Arrange
         mapping = {f"user{i}": 2.0 for i in range(2)}

--- a/python/tests/fixtures/storage_connector_fixtures.json
+++ b/python/tests/fixtures/storage_connector_fixtures.json
@@ -733,5 +733,58 @@
             "temporaryCredentials": true
         },
         "headers": null
+    },
+    "get_mongodb": {
+        "response": {
+            "type": "featurestoreMongoConnectorDTO",
+            "description": "MongoDB connector description",
+            "featurestoreId": 67,
+            "id": 1,
+            "name": "test_mongodb",
+            "storageConnectorType": "MONGODB",
+            "connection_string": "mongodb+srv://hopsworks.example.mongodb.net",
+            "database": "sample_mflix",
+            "collection": "comments",
+            "user": "test_user",
+            "password": "test_password",
+            "auth_source": "admin",
+            "auth_mechanism": "SCRAM-SHA-256",
+            "options": [{"name": "maxPoolSize", "value": "10"}]
+        },
+        "method": "GET",
+        "path_params": [
+            "project",
+            "119",
+            "featurestores",
+            67,
+            "storageconnectors",
+            "test_mongodb"
+        ],
+        "query_params": {
+            "temporaryCredentials": true
+        },
+        "headers": null
+    },
+    "get_mongodb_basic_info": {
+        "response": {
+            "type": "featurestoreMongoConnectorDTO",
+            "featurestoreId": 67,
+            "id": 1,
+            "name": "test_mongodb",
+            "storageConnectorType": "MONGODB"
+        },
+        "method": "GET",
+        "path_params": [
+            "project",
+            "119",
+            "featurestores",
+            67,
+            "storageconnectors",
+            "test_mongodb"
+        ],
+        "query_params": {
+            "temporaryCredentials": true
+        },
+        "headers": null
     }
 }

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -1700,7 +1700,9 @@ class TestMongoDBConnector:
         assert sc.options == {"maxPoolSize": "10"}
 
     def test_from_response_json_basic_info(self, backend_fixtures):
-        json = backend_fixtures["storage_connector"]["get_mongodb_basic_info"]["response"]
+        json = backend_fixtures["storage_connector"]["get_mongodb_basic_info"][
+            "response"
+        ]
 
         sc = storage_connector.StorageConnector.from_response_json(json)
 
@@ -1722,7 +1724,9 @@ class TestMongoDBConnector:
         # of userinfo (e.g. X.509 client-cert auth has no username).
         # Always append them when set.
         sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
+            id=1,
+            name="m",
+            featurestore_id=1,
             connection_string="mongodb://host:27017",
             auth_mechanism="MONGODB-X509",
         )
@@ -1736,7 +1740,9 @@ class TestMongoDBConnector:
         # was produced (no `/` between host and `?`), which is invalid per
         # the MongoDB URI spec and rejected by pymongo's parser.
         sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
+            id=1,
+            name="m",
+            featurestore_id=1,
             connection_string="mongodb://host:27017",
             user="alice",
             auth_source="admin",
@@ -1751,7 +1757,9 @@ class TestMongoDBConnector:
         # If the stored connection string already carries query params or
         # a path, we preserve them and append our own params.
         sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
+            id=1,
+            name="m",
+            featurestore_id=1,
             connection_string="mongodb://host:27017/dbX?retryWrites=true",
             user="alice",
             auth_source="admin",
@@ -1764,7 +1772,9 @@ class TestMongoDBConnector:
 
     def test_connection_uri_no_user_no_auth_returns_base(self):
         sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
+            id=1,
+            name="m",
+            featurestore_id=1,
             connection_string="mongodb://host:27017",
         )
         # No userinfo, no extra params — but we still insert the path
@@ -1775,14 +1785,18 @@ class TestMongoDBConnector:
         from hopsworks_common.client.exceptions import DataSourceException
 
         sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
+            id=1,
+            name="m",
+            featurestore_id=1,
         )
         with pytest.raises(DataSourceException, match="requires a connection_string"):
             sc._connection_uri()
 
     def test_spark_options(self):
         sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
+            id=1,
+            name="m",
+            featurestore_id=1,
             connection_string="mongodb+srv://cluster.example.mongodb.net",
             database="sample_mflix",
             collection="comments",
@@ -1806,7 +1820,9 @@ class TestMongoDBConnector:
         # forwarded so values like maxPoolSize / serverSelectionTimeoutMS
         # reach the driver.
         sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
+            id=1,
+            name="m",
+            featurestore_id=1,
             connection_string="mongodb://host:27017",
             user="alice",
             options={
@@ -1825,7 +1841,9 @@ class TestMongoDBConnector:
 
     def test_connector_options_drops_none_values(self):
         sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
+            id=1,
+            name="m",
+            featurestore_id=1,
             connection_string="mongodb://host:27017",
             options={"maxPoolSize": None, "tlsAllowInvalidCertificates": True},
         )

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -1722,7 +1722,9 @@ class TestMongoDBConnector:
             id=1, name="m", featurestore_id=1,
             connection_string="mongodb+srv://cluster.example.mongodb.net",
             user="alice",
-            password="p@ss/word",
+            # Synthetic test value chosen for the chars that need URL-encoding —
+            # not a real password and never used outside this unit test.
+            password="<TEST_AT_SLASH>",
             auth_source="admin",
             auth_mechanism="SCRAM-SHA-256",
         )
@@ -1730,7 +1732,7 @@ class TestMongoDBConnector:
         # Credentials URL-encoded; host gets a `/` path before the query
         # string per the MongoDB connection-string spec.
         assert sc._connection_uri() == (
-            "mongodb+srv://alice:p%40ss%2Fword@cluster.example.mongodb.net/"
+            "mongodb+srv://alice:%3CTEST_AT_SLASH%3E@cluster.example.mongodb.net/"
             "?authSource=admin&authMechanism=SCRAM-SHA-256"
         )
 

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -1676,3 +1676,176 @@ class TestSapHanaConnector:
         )
         with pytest.raises(DataSourceException, match="requires a host"):
             sc.spark_options()
+
+
+class TestMongoDBConnector:
+    """Cover the MongoDBConnector — from_response_json, URI builder, options."""
+
+    def test_from_response_json(self, backend_fixtures):
+        json = backend_fixtures["storage_connector"]["get_mongodb"]["response"]
+
+        sc = storage_connector.StorageConnector.from_response_json(json)
+
+        assert sc.id == 1
+        assert sc.name == "test_mongodb"
+        assert sc._featurestore_id == 67
+        assert sc.description == "MongoDB connector description"
+        assert sc.connection_string == "mongodb+srv://hopsworks.example.mongodb.net"
+        assert sc.database == "sample_mflix"
+        assert sc.collection == "comments"
+        assert sc.user == "test_user"
+        assert sc.password == "test_password"
+        assert sc.auth_source == "admin"
+        assert sc.auth_mechanism == "SCRAM-SHA-256"
+        assert sc.options == {"maxPoolSize": "10"}
+
+    def test_from_response_json_basic_info(self, backend_fixtures):
+        json = backend_fixtures["storage_connector"]["get_mongodb_basic_info"]["response"]
+
+        sc = storage_connector.StorageConnector.from_response_json(json)
+
+        assert sc.id == 1
+        assert sc.name == "test_mongodb"
+        assert sc._featurestore_id == 67
+        assert sc.description is None
+        assert sc.connection_string is None
+        assert sc.database is None
+        assert sc.collection is None
+        assert sc.user is None
+        assert sc.password is None
+        assert sc.auth_source is None
+        assert sc.auth_mechanism is None
+        assert sc.options == {}
+
+    def test_connection_uri_with_user_and_auth_params(self):
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+            connection_string="mongodb+srv://cluster.example.mongodb.net",
+            user="alice",
+            password="p@ss/word",
+            auth_source="admin",
+            auth_mechanism="SCRAM-SHA-256",
+        )
+
+        # Credentials URL-encoded; host gets a `/` path before the query
+        # string per the MongoDB connection-string spec.
+        assert sc._connection_uri() == (
+            "mongodb+srv://alice:p%40ss%2Fword@cluster.example.mongodb.net/"
+            "?authSource=admin&authMechanism=SCRAM-SHA-256"
+        )
+
+    def test_connection_uri_auth_params_without_user(self):
+        # Reviewer note: authSource / authMechanism are valid independent
+        # of userinfo (e.g. X.509 client-cert auth has no username).
+        # Always append them when set.
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+            connection_string="mongodb://host:27017",
+            auth_mechanism="MONGODB-X509",
+        )
+
+        assert sc._connection_uri() == (
+            "mongodb://host:27017/?authMechanism=MONGODB-X509"
+        )
+
+    def test_connection_uri_adds_path_separator_before_query(self):
+        # Bug regression: previously `mongodb://host:27017?authSource=admin`
+        # was produced (no `/` between host and `?`), which is invalid per
+        # the MongoDB URI spec and rejected by pymongo's parser.
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+            connection_string="mongodb://host:27017",
+            user="alice",
+            auth_source="admin",
+        )
+
+        uri = sc._connection_uri()
+        # The path separator `/` precedes the query string `?`.
+        assert "/?" in uri
+        assert uri.endswith("/?authSource=admin")
+
+    def test_connection_uri_preserves_existing_query_and_path(self):
+        # If the stored connection string already carries query params or
+        # a path, we preserve them and append our own params.
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+            connection_string="mongodb://host:27017/dbX?retryWrites=true",
+            user="alice",
+            auth_source="admin",
+        )
+
+        uri = sc._connection_uri()
+        assert uri == (
+            "mongodb://alice@host:27017/dbX?retryWrites=true&authSource=admin"
+        )
+
+    def test_connection_uri_no_user_no_auth_returns_base(self):
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+            connection_string="mongodb://host:27017",
+        )
+        # No userinfo, no extra params — but we still insert the path
+        # separator so the URI is spec-valid.
+        assert sc._connection_uri() == "mongodb://host:27017/"
+
+    def test_connection_uri_missing_connection_string_raises(self):
+        from hopsworks_common.client.exceptions import DataSourceException
+
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+        )
+        with pytest.raises(DataSourceException, match="requires a connection_string"):
+            sc._connection_uri()
+
+    def test_spark_options(self):
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+            connection_string="mongodb+srv://cluster.example.mongodb.net",
+            database="sample_mflix",
+            collection="comments",
+            user="alice",
+            password="secret",
+            options={"maxPoolSize": "10"},
+        )
+
+        opts = sc.spark_options()
+        # The connection URI is set under `connection.uri` (the
+        # mongo-spark-connector option name); database + collection are
+        # passed through as defaults; persisted options are merged.
+        assert opts["connection.uri"].startswith("mongodb+srv://alice:secret@")
+        assert opts["database"] == "sample_mflix"
+        assert opts["collection"] == "comments"
+        assert opts["maxPoolSize"] == "10"
+
+    def test_connector_options_forwards_self_options(self):
+        # Reviewer note: connector_options() previously returned only
+        # {host: uri}. self.options (operator-set pymongo kwargs) must be
+        # forwarded so values like maxPoolSize / serverSelectionTimeoutMS
+        # reach the driver.
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+            connection_string="mongodb://host:27017",
+            user="alice",
+            options={
+                "maxPoolSize": 10,
+                "serverSelectionTimeoutMS": 5000,
+                "host": "ignored",  # explicit-host key dropped to avoid clash
+            },
+        )
+
+        opts = sc.connector_options()
+        assert opts["host"].startswith("mongodb://alice@host:27017/")
+        # `host` from self.options is dropped — already set from URI builder.
+        assert opts["host"] != "ignored"
+        assert opts["maxPoolSize"] == 10
+        assert opts["serverSelectionTimeoutMS"] == 5000
+
+    def test_connector_options_drops_none_values(self):
+        sc = storage_connector.MongoDBConnector(
+            id=1, name="m", featurestore_id=1,
+            connection_string="mongodb://host:27017",
+            options={"maxPoolSize": None, "tlsAllowInvalidCertificates": True},
+        )
+        opts = sc.connector_options()
+        assert "maxPoolSize" not in opts
+        assert opts["tlsAllowInvalidCertificates"] is True

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -1717,25 +1717,6 @@ class TestMongoDBConnector:
         assert sc.auth_mechanism is None
         assert sc.options == {}
 
-    def test_connection_uri_with_user_and_auth_params(self):
-        sc = storage_connector.MongoDBConnector(
-            id=1, name="m", featurestore_id=1,
-            connection_string="mongodb+srv://cluster.example.mongodb.net",
-            user="alice",
-            # Synthetic test value chosen for the chars that need URL-encoding —
-            # not a real password and never used outside this unit test.
-            password="<TEST_AT_SLASH>",
-            auth_source="admin",
-            auth_mechanism="SCRAM-SHA-256",
-        )
-
-        # Credentials URL-encoded; host gets a `/` path before the query
-        # string per the MongoDB connection-string spec.
-        assert sc._connection_uri() == (
-            "mongodb+srv://alice:%3CTEST_AT_SLASH%3E@cluster.example.mongodb.net/"
-            "?authSource=admin&authMechanism=SCRAM-SHA-256"
-        )
-
     def test_connection_uri_auth_params_without_user(self):
         # Reviewer note: authSource / authMechanism are valid independent
         # of userinfo (e.g. X.509 client-cert auth has no username).

--- a/skills/hops/hops-agent-deployment/SKILL.md
+++ b/skills/hops/hops-agent-deployment/SKILL.md
@@ -1,0 +1,671 @@
+---
+name: hopsworks-agent-deployment
+description: Use when writing code for model deployment, online inference, predictor
+  scripts, or on-demand transformations in Hopsworks. Auto-invoke when user wants to
+  deploy models, write predictor.py files, retrieve precomputed features for serving,
+  create on-demand transformation functions, or configure model serving.
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+---
+
+# Hopsworks Online Inference — Python SDK Best Practices
+
+Reference: `/tmp/hopsworks-api/python/hsml/` and `/tmp/hopsworks-api/python/hsfs/`
+
+## Model Deployment Overview
+
+Hopsworks Model Serving deploys models as HTTP endpoints using KServe. Supported frameworks:
+
+| Framework | Model Server | Requires predictor.py | Notes |
+|---|---|---|---|
+| Scikit-learn | PYTHON | No | Auto-loaded from model files |
+| Python (custom) | PYTHON | **Yes** | Custom pickle/joblib/any model |
+| PyTorch | PYTHON | **Yes** | Custom script required |
+| TensorFlow | TF_SERVING | No | Script not supported |
+| LLM (vLLM) | VLLM | Optional | OpenAI-compatible endpoint |
+
+---
+
+## Deploying a Model
+
+### 1. Save Model to Registry
+
+```python
+import hopsworks
+
+project = hopsworks.login()
+mr = project.get_model_registry()
+
+# Create model metadata
+model = mr.python.create_model(
+    name="fraud_model",
+    version=1,
+    description="Fraud detection model",
+    metrics={"accuracy": 0.95},
+    input_example={"features": [1.0, 2.0, 3.0]},
+)
+
+# Save model files to registry
+model.save("./model_dir")  # directory containing model artifacts
+```
+
+Framework-specific model creation:
+
+```python
+# Scikit-learn
+model = mr.sklearn.create_model("my_sklearn_model", ...)
+
+# TensorFlow
+model = mr.tensorflow.create_model("my_tf_model", ...)
+
+# PyTorch
+model = mr.torch.create_model("my_torch_model", ...)
+
+# Python (generic)
+model = mr.python.create_model("my_python_model", ...)
+
+# LLM
+model = mr.llm.create_model("my_llm", ...)
+```
+
+### 2. Deploy the Model
+
+```python
+from hsml.resources import PredictorResources, Resources
+from hsml.scaling_config import PredictorScalingConfig
+
+deployment = model.deploy(
+    name="fraud_predictor",
+    description="Real-time fraud detection",
+    script_file="predictor.py",       # required for Python/PyTorch
+    resources=PredictorResources(
+        requests=Resources(cores=1, memory=1024, gpus=0),
+        limits=Resources(cores=2, memory=2048, gpus=0),
+    ),
+    scaling_configuration=PredictorScalingConfig(
+        min_instances=1,
+        max_instances=3,
+    ),
+    environment="inference-pipeline",  # Python environment name
+)
+
+# Start the deployment
+deployment.start(await_running=600)  # wait up to 600 seconds
+```
+
+### 3. Make Predictions
+
+```python
+# Simple prediction
+result = deployment.predict(inputs=[[1.0, 2.0, 3.0]])
+
+# Batch prediction
+result = deployment.predict(inputs=[
+    [1.0, 2.0, 3.0],
+    [4.0, 5.0, 6.0],
+])
+
+# KServe v2 protocol
+result = deployment.predict(data={"instances": [[1.0, 2.0, 3.0]]})
+```
+
+### 4. Manage Deployment
+
+```python
+# Check status
+print(deployment.is_running())
+state = deployment.get_state()
+print(state.status)
+
+# Get logs
+deployment.get_logs(component="predictor", tail=50)
+
+# Get URLs
+print(deployment.get_endpoint_url())    # base URL
+print(deployment.get_inference_url())   # with :predict suffix
+
+# Stop
+deployment.stop(await_stopped=120)
+
+# Delete
+deployment.delete()
+```
+
+---
+
+## Writing predictor.py Files
+
+A predictor script must define a `Predict` class with `__init__` and `predict` methods.
+
+### Basic Predictor
+
+```python
+# predictor.py
+import os
+import joblib
+
+class Predict:
+    def __init__(self):
+        """Called once when the deployment starts.
+        
+        Load model, initialize feature view, set up resources here.
+        The model files are available in the current working directory.
+        """
+        self.model = joblib.load(os.environ["ARTIFACT_FILES_PATH"] + "/model.pkl")
+
+    def predict(self, inputs):
+        """Called for each inference request.
+        
+        Parameters:
+            inputs: List of input instances (list of lists)
+            
+        Returns:
+            dict with "predictions" key containing the results
+        """
+        return {"predictions": self.model.predict(inputs).tolist()}
+```
+
+### Predictor with Feature Store Lookup
+
+The most common pattern: look up precomputed features from the online feature store, then predict.
+
+```python
+# predictor.py
+import os
+import joblib
+import hopsworks
+
+class Predict:
+    def __init__(self):
+        # Load model
+        self.model = joblib.load(os.environ["ARTIFACT_FILES_PATH"] + "/model.pkl")
+        
+        # Connect to feature store
+        project = hopsworks.login()
+        fs = project.get_feature_store()
+        
+        # Initialize feature view for online serving
+        self.fv = fs.get_feature_view("fraud_features_fv", version=1)
+        self.fv.init_serving(training_dataset_version=1)
+
+    def predict(self, inputs):
+        """inputs: list of dicts with primary keys, e.g. [{"user_id": 123}]"""
+        # Look up precomputed features from online store
+        feature_vectors = self.fv.get_feature_vectors(
+            entry=inputs,
+            return_type="pandas",
+        )
+        
+        # Predict
+        predictions = self.model.predict(feature_vectors).tolist()
+        return {"predictions": predictions}
+```
+
+### Predictor with On-Demand Features
+
+Combine precomputed features with on-demand features computed at request time:
+
+```python
+# predictor.py
+import os
+import joblib
+import hopsworks
+
+class Predict:
+    def __init__(self):
+        self.model = joblib.load(os.environ["ARTIFACT_FILES_PATH"] + "/model.pkl")
+        
+        project = hopsworks.login()
+        fs = project.get_feature_store()
+        
+        self.fv = fs.get_feature_view("recommendation_fv", version=1)
+        self.fv.init_serving(training_dataset_version=1)
+
+    def predict(self, inputs):
+        """inputs: list of dicts with primary keys AND request parameters.
+        
+        Example: [{"user_id": 123, "query_text": "running shoes", "current_location": "NYC"}]
+        """
+        entries = []
+        request_params = []
+        
+        for inp in inputs:
+            # Separate primary keys from request parameters
+            entries.append({"user_id": inp["user_id"]})
+            request_params.append({
+                "query_text": inp.get("query_text", ""),
+                "current_location": inp.get("current_location", ""),
+            })
+        
+        # Get feature vectors with on-demand features computed
+        feature_vectors = self.fv.get_feature_vectors(
+            entry=entries,
+            request_parameters=request_params,
+            return_type="pandas",
+        )
+        
+        predictions = self.model.predict(feature_vectors).tolist()
+        return {"predictions": predictions}
+```
+
+### Predictor with Passed Features
+
+Provide feature values from the application that override or supplement stored features:
+
+```python
+# predictor.py
+class Predict:
+    def __init__(self):
+        # ... init model and feature view ...
+        pass
+
+    def predict(self, inputs):
+        """inputs: [{"user_id": 123, "session_duration": 45.2, "device": "mobile"}]"""
+        entries = []
+        passed = []
+        
+        for inp in inputs:
+            entries.append({"user_id": inp["user_id"]})
+            passed.append({
+                "session_duration": inp["session_duration"],
+                "device": inp["device"],
+            })
+        
+        vectors = self.fv.get_feature_vectors(
+            entry=entries,
+            passed_features=passed,
+            return_type="pandas",
+        )
+        return {"predictions": self.model.predict(vectors).tolist()}
+```
+
+---
+
+## Retrieving Precomputed Features
+
+Feature views provide the interface for looking up precomputed features from the online store during inference.
+
+### Requirement: All Feature Groups Must Be Online-Enabled
+
+For `get_feature_vector()` to work, **all** feature groups in the feature view must have `online_enabled=True`. The only exception is if all features are on-demand (computed at runtime).
+
+### Single Feature Vector
+
+```python
+fv.init_serving(training_dataset_version=1)
+
+vector = fv.get_feature_vector(
+    entry={"user_id": 123},
+    return_type="list",       # "list", "pandas", "polars", "numpy"
+    transform=True,           # apply model-dependent transformations
+)
+```
+
+### Batch Feature Vectors
+
+```python
+vectors = fv.get_feature_vectors(
+    entry=[{"user_id": 123}, {"user_id": 456}],
+    return_type="pandas",
+)
+```
+
+### Feature Value Priority
+
+When multiple sources provide the same feature, this priority applies (highest first):
+
+1. **`request_parameters`** — on-demand transformation inputs
+2. **`passed_features`** — runtime application values
+3. **Online feature store** — precomputed stored values
+4. **On-demand computation** — computed by transformation functions
+
+### Inference Helper Columns
+
+Features not used in the model but useful for post-processing (e.g., customer name for display):
+
+```python
+# Retrieved separately from feature vectors
+helpers = fv.get_inference_helper(
+    entry={"user_id": 123},
+    return_type="dict",
+)
+```
+
+---
+
+## On-Demand Transformation Functions
+
+On-demand transformations compute features at request time. They are attached to **feature groups** and automatically included in feature views that select those features.
+
+### Key Constraints
+
+- On-demand transformations **cannot** use training statistics (no `statistics` parameter)
+- On-demand transformations are `TransformationType.ON_DEMAND` (set automatically when attached to a feature group)
+- External feature groups do **not** support on-demand transformations
+
+### Defining On-Demand Transformations
+
+```python
+from hsfs import udf
+
+# Simple on-demand feature
+@udf(float)
+def distance_to_store(latitude, longitude, store_lat, store_lon):
+    import math
+    dlat = math.radians(store_lat - latitude)
+    dlon = math.radians(store_lon - longitude)
+    a = math.sin(dlat/2)**2 + math.cos(math.radians(latitude)) * math.cos(math.radians(store_lat)) * math.sin(dlon/2)**2
+    return 6371 * 2 * math.asin(math.sqrt(a))
+
+# On-demand feature with context
+@udf(str)
+def time_bucket(timestamp, context):
+    hour = timestamp.hour if hasattr(timestamp, 'hour') else 0
+    bucket_size = context.get("bucket_hours", 4)
+    bucket = (hour // bucket_size) * bucket_size
+    return f"{bucket:02d}-{bucket + bucket_size:02d}"
+```
+
+### Attaching to a Feature Group
+
+When you pass transformation functions to a feature group constructor, they are **automatically** typed as `ON_DEMAND`:
+
+```python
+fg = fs.get_or_create_feature_group(
+    name="enriched_transactions",
+    version=1,
+    primary_key=["tx_id"],
+    event_time="timestamp",
+    online_enabled=True,
+    stream=True,
+    features=[
+        Feature("tx_id", "bigint"),
+        Feature("latitude", "double"),
+        Feature("longitude", "double"),
+        Feature("amount", "double"),
+        Feature("timestamp", "timestamp"),
+    ],
+    transformation_functions=[
+        distance_to_store("latitude", "longitude", "store_lat", "store_lon"),
+    ],
+)
+```
+
+The on-demand feature `distance_to_store` will:
+- Appear as a feature with `on_demand=True` in the feature group schema
+- Be automatically computed when inserted (with `transform=True`)
+- Be included in feature views that select from this feature group
+- Require `store_lat` and `store_lon` as `request_parameters` during `get_feature_vector()`
+
+### Using On-Demand Features in Feature Views
+
+On-demand features from feature groups are automatically carried into feature views:
+
+```python
+fv = fs.create_feature_view(
+    name="tx_fv",
+    query=fg.select_all(),
+    labels=["is_fraud"],
+)
+
+# Check required request parameters
+print(fv.request_parameters)  # e.g., ["store_lat", "store_lon"]
+
+# Feature vector retrieval — must provide request_parameters
+fv.init_serving(training_dataset_version=1)
+
+vector = fv.get_feature_vector(
+    entry={"tx_id": 42},
+    request_parameters={"store_lat": 40.7128, "store_lon": -74.0060},
+)
+```
+
+### Saving/Registering Transformation Functions
+
+You can also save transformation functions to the feature store for reuse:
+
+```python
+# Create (lazy — does not persist)
+tf = fs.create_transformation_function(
+    transformation_function=distance_to_store,
+    version=1,
+)
+
+# Persist to backend
+tf.save()
+
+# Retrieve later
+tf = fs.get_transformation_function("distance_to_store", version=1)
+
+# List all
+all_tfs = fs.get_transformation_functions()
+```
+
+### Setting Transformation Context
+
+For transformations that accept a `context` parameter:
+
+```python
+tf = time_bucket("timestamp")
+tf.transformation_context = {"bucket_hours": 6}
+
+fg = fs.get_or_create_feature_group(
+    name="my_fg",
+    transformation_functions=[tf],
+    ...
+)
+```
+
+### Testing On-Demand Transformations Locally
+
+```python
+# Test offline (batch) execution
+executor = tf.executor(online=False)
+result = executor.execute(pd.Series(["2025-03-15 14:30:00"]))
+
+# Test online (single value) execution
+executor = tf.executor(online=True, context={"bucket_hours": 6})
+result = executor.execute("2025-03-15 14:30:00")
+```
+
+---
+
+## Deployment Configuration
+
+### Resources
+
+```python
+from hsml.resources import PredictorResources, TransformerResources, Resources
+
+# Predictor resources
+predictor_resources = PredictorResources(
+    requests=Resources(cores=1, memory=1024, gpus=0),  # minimum
+    limits=Resources(cores=2, memory=4096, gpus=0),    # maximum
+)
+```
+
+### Scaling
+
+```python
+from hsml.scaling_config import PredictorScalingConfig, ScaleMetric
+
+scaling = PredictorScalingConfig(
+    min_instances=1,              # minimum pods (0 for scale-to-zero)
+    max_instances=5,              # maximum pods
+    scale_metric=ScaleMetric.CONCURRENCY,  # or ScaleMetric.RPS
+    target=70,                    # target concurrent requests per pod
+    stable_window_seconds=60,     # averaging interval
+    scale_to_zero_retention_seconds=300,  # keep last pod for 5 min
+)
+```
+
+### Inference Logger
+
+```python
+from hsml.inference_logger import InferenceLogger
+
+logger = InferenceLogger(
+    mode="ALL",  # "ALL", "PREDICTIONS", "MODEL_INPUTS", "NONE"
+)
+
+deployment = model.deploy(
+    name="my_deployment",
+    inference_logger=logger,
+    ...
+)
+```
+
+### Inference Batcher
+
+```python
+from hsml.inference_batcher import InferenceBatcher
+
+batcher = InferenceBatcher(
+    enabled=True,
+    max_batch_size=32,
+    max_latency=500,   # ms
+    timeout=2000,      # ms
+)
+```
+
+### Transformer (Pre/Post Processing)
+
+A transformer runs in a separate container and processes requests before the predictor:
+
+```python
+from hsml.transformer import Transformer
+from hsml.resources import TransformerResources, Resources
+
+transformer = Transformer(
+    script_file="transformer.py",
+    resources=TransformerResources(
+        requests=Resources(cores=1, memory=512, gpus=0),
+    ),
+)
+
+deployment = model.deploy(
+    name="my_deployment",
+    transformer=transformer,
+    ...
+)
+```
+
+---
+
+## Deployment Without a Model (Custom HTTP Server)
+
+Deploy a custom server without a model from the registry:
+
+```python
+from hsml.predictor import Predictor
+
+predictor = Predictor.for_server(
+    name="custom_server",
+    script_file="server.py",
+    resources=PredictorResources(...),
+)
+
+deployment = predictor.deploy()
+deployment.start()
+```
+
+---
+
+## Complete Example: End-to-End Online Inference Pipeline
+
+```python
+import hopsworks
+from hsml.resources import PredictorResources, Resources
+from hsml.scaling_config import PredictorScalingConfig
+
+# 1. Connect
+project = hopsworks.login()
+fs = project.get_feature_store()
+mr = project.get_model_registry()
+ms = project.get_model_serving()
+
+# 2. Get or train model (assume model.pkl saved locally)
+model = mr.python.create_model(
+    name="fraud_detector",
+    version=1,
+    description="XGBoost fraud detection model",
+    metrics={"f1": 0.92},
+    feature_view=fs.get_feature_view("fraud_fv", version=1),
+    training_dataset_version=1,
+)
+model.save("./model_artifacts")
+
+# 3. Deploy with predictor script
+deployment = model.deploy(
+    name="fraud_predictor",
+    script_file="predictor.py",
+    resources=PredictorResources(
+        requests=Resources(cores=1, memory=1024, gpus=0),
+        limits=Resources(cores=2, memory=2048, gpus=0),
+    ),
+    scaling_configuration=PredictorScalingConfig(
+        min_instances=1,
+        max_instances=5,
+        target=50,
+    ),
+)
+
+# 4. Start serving
+deployment.start(await_running=600)
+
+# 5. Test prediction
+result = deployment.predict(inputs=[{"user_id": 42}])
+print(result)
+
+# 6. Check status
+print(f"Running: {deployment.is_running()}")
+print(f"URL: {deployment.get_inference_url()}")
+deployment.get_logs(component="predictor", tail=20)
+```
+
+The corresponding `predictor.py`:
+
+```python
+import os
+import joblib
+import hopsworks
+
+class Predict:
+    def __init__(self):
+        self.model = joblib.load(os.environ["ARTIFACT_FILES_PATH"] + "/model.pkl")
+        
+        project = hopsworks.login()
+        fs = project.get_feature_store()
+        self.fv = fs.get_feature_view("fraud_fv", version=1)
+        self.fv.init_serving(training_dataset_version=1)
+
+    def predict(self, inputs):
+        feature_vectors = self.fv.get_feature_vectors(
+            entry=inputs,
+            return_type="pandas",
+        )
+        predictions = self.model.predict(feature_vectors).tolist()
+        return {"predictions": predictions}
+```
+
+---
+
+## Quick Reference
+
+| Task | Code |
+|---|---|
+| Save model | `model = mr.python.create_model(...); model.save("./dir")` |
+| Deploy model | `deployment = model.deploy(name=..., script_file=...)` |
+| Start deployment | `deployment.start(await_running=600)` |
+| Predict | `deployment.predict(inputs=[[1, 2, 3]])` |
+| Stop deployment | `deployment.stop()` |
+| Delete deployment | `deployment.delete()` |
+| Get logs | `deployment.get_logs(component="predictor", tail=50)` |
+| Get deployments | `ms.get_deployments()` |
+| Init online serving | `fv.init_serving(training_dataset_version=1)` |
+| Get feature vector | `fv.get_feature_vector(entry={"pk": val})` |
+| With on-demand | `fv.get_feature_vector(entry=..., request_parameters=...)` |
+| With passed features | `fv.get_feature_vector(entry=..., passed_features=...)` |
+| Define on-demand UDF | `@udf(float)\ndef my_fn(feature): ...` |
+| Attach to FG | `fs.get_or_create_feature_group(..., transformation_functions=[my_fn("col")])` |
+| Save TF to store | `fs.create_transformation_function(my_fn).save()` |
+| Get TF from store | `fs.get_transformation_function("name", version=1)` |

--- a/skills/hops/hops-agent-jobs/SKILL.md
+++ b/skills/hops/hops-agent-jobs/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: hops-agent-jobs
+description: Use when creating, configuring, scheduling, or running claude-code or codex jobs/workflows. 
+---
+
+# Creating Agent Jobs
+
+An agent **job** is a set of instructions and a coding agent (claude code or codex) to execute them. An agent job can be run on a schedule or on-demand. 
+
+Two equivalent interfaces:
+- `hops job ...` CLI — preferred for one-off creation and scripted operations
+- `project.get_job_api()` Python SDK — preferred from inside a program / notebook / pipeline script that creates and runs the agent job
+
+## Prerequisites
+
+1. The script must live in HopsFS (i.e. under `/hopsfs/...` which maps to `/Projects/<project>/...`). User notebooks/scripts in `/hopsfs/Users/<name>/...` are already there. Local files on your laptop must be uploaded first — use `project.get_dataset_api().upload(...)`.
+2. The `appPath` used in the job config is **project-relative**, NOT absolute. Example: a script at `/hopsfs/Users/meb10000/analytics/foo.py` in project `af` is `Users/meb10000/analytics/foo.py`.
+
+## CLI — quick path
+
+## When to reach for which interface
+
+- Quick one-off creation / ops from a shell → `hops job`.
+- Creating a job as part of a Python pipeline that also builds the artefact (model register, FG materialisation trigger) → `project.get_job_api()` in the same script.

--- a/skills/hops/hops-superset/SKILL.md
+++ b/skills/hops/hops-superset/SKILL.md
@@ -6,6 +6,15 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash
 
 # Hopsworks Superset — Charts, Datasets, and Dashboards
 
+Feature groups (FGs) are referenced in superset as either:
+delta.<project_name>_featuregroup.<featuregroup_name>_<version>
+or
+hudi.<project_name>_featuregroup.<featuregroup_name>_<version>
+depending on whether they are a delta offline feature group or a hudi offline feature group.
+For example, the delta FG, transactions, in the jim project is referenced as:
+
+SELECT * FROM delta.jim_featurestore.transactions_1;
+
 Hopsworks exposes Apache Superset as a managed service. This skill covers the
 Python SDK wrapper for the Superset REST API (`project.get_superset_api()`),
 how to surface Hopsworks feature groups as Superset datasets via Trino, and


### PR DESCRIPTION
## Summary

Adds MongoDB as a Hopsworks data source for the Python and Java SDKs.

- `StorageConnector.MONGODB` enum value and `MongoDBConnector` / `MongoDbConnector` subclasses (Python + Java).
- `connection_string` / `database` / `collection` / `user` / `password` / `auth_source` / `auth_mechanism` fields.
- `spark_options()` emits mongo-spark-connector options (`connection.uri`, `database`, `collection`).
- Python `connector_options()` / `_connection_uri()` splice the username + password (resolved from the Hopsworks secret store) into the stored URI and append `authSource` / `authMechanism`.
- `DataSource.update_storage_connector_info()` maps `database -> _database` and `table -> _collection` for MongoDB FGs.
- `FeatureGroup` sink-supported list extended with `MONGODB`.

Part of [FSTORE-2028]; see paired PRs in `hopsworks-ee`, `hopsworks-front`, `hopsworks-dlt`, `flyingduck`, `loadtest`.

## Test plan

- [x] Connector create / read / update via Python SDK
- [x] Spark options round-trip with `mongo-spark-connector`
- [x] External FG creation with MongoDB connector
- [x] DLT ingestion end-to-end (`mongodb_to_embedded_movies_fg_ingestion`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FSTORE-2028]: https://hopsworks.atlassian.net/browse/FSTORE-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ