### PR TITLE
Migrate Hudi partition fields to :SIMPLE keygen-type format (#944)

### DIFF
--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/TableMigrateUtils.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/TableMigrateUtils.java
@@ -17,6 +17,7 @@
 
 package com.logicalclocks.hsfs.spark.engine.hudi;
 
+import com.google.common.base.Strings;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.WriteOperationType;
@@ -35,6 +36,8 @@ import org.apache.hudi.table.upgrade.UpgradeDowngrade;
 import org.apache.spark.api.java.JavaSparkContext;
 
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -65,6 +68,7 @@ public class TableMigrateUtils {
       } else if (metaClient.getTableConfig().getTableVersion().greaterThan(HoodieTableVersion.EIGHT)) {
         return;
       }
+      migratePartitionFields(metaClient);
       metaClient.getTableConfig().setValue(HudiEngine.HUDI_TABLE_VERSION,
           String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
       new UpgradeDowngrade(metaClient, getUpdatedWriteConfig(writeOptions, metaClient),
@@ -72,6 +76,45 @@ public class TableMigrateUtils {
           SparkUpgradeDowngradeHelper.getInstance()).run(HoodieTableVersion.EIGHT, null);
       LOG.info("Migration to version 8 completed");
     }
+  }
+
+  // Hudi 1.x stores partition fields with a ":<KEYGEN_TYPE>" suffix (e.g. "country:SIMPLE").
+  // Tables created with older Hudi versions stored bare column names, which conflicts with the
+  // partition fields the writer now passes in and breaks subsequent writes.
+  void migratePartitionFields(HoodieTableMetaClient metaClient) {
+    String partitionFields = metaClient.getTableConfig().getString(HoodieTableConfig.PARTITION_FIELDS);
+    if (Strings.isNullOrEmpty(partitionFields)) {
+      return;
+    }
+
+    String[] partitions = partitionFields.split(",");
+
+    List<String> migratedPartitionScheme = new ArrayList<>(partitions.length);
+    boolean requireMigration = false;
+    for (String partition : partitions) {
+      String trimmedPartition = partition.trim();
+      if (trimmedPartition.isEmpty()) {
+        continue;
+      }
+
+      if (trimmedPartition.contains(":")) {
+        migratedPartitionScheme.add(trimmedPartition);
+      } else {
+        migratedPartitionScheme.add(trimmedPartition + ":SIMPLE");
+        requireMigration = true;
+      }
+    }
+
+    if (!requireMigration) {
+      return;
+    }
+
+    Properties properties = new Properties();
+    String migratedProperty = String.join(",", migratedPartitionScheme);
+    properties.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), migratedProperty);
+    HoodieTableConfig.update(metaClient.getStorage(), metaClient.getMetaPath(), properties);
+    LOG.info("Migrated " + HoodieTableConfig.PARTITION_FIELDS.key() + " from '"
+        + partitionFields + "' to '" + migratedProperty + "'");
   }
   
   private void migrateToVersionSix(Map<String, String> writeOptions, HoodieTableMetaClient metaClient,

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/hudi/TestTableMigrateUtils.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/hudi/TestTableMigrateUtils.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (c) 2026-2026. Hopsworks AB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.logicalclocks.hsfs.spark.engine.hudi;
+
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Properties;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+public class TestTableMigrateUtils {
+
+  private HoodieTableMetaClient metaClientWith(String partitionFields) {
+    HoodieTableMetaClient metaClient = Mockito.mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
+    Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    Mockito.when(tableConfig.getString(HoodieTableConfig.PARTITION_FIELDS)).thenReturn(partitionFields);
+    return metaClient;
+  }
+
+  @Test
+  void testMigratePartitionFieldsNullIsNoOp() {
+    HoodieTableMetaClient metaClient = metaClientWith(null);
+
+    try (MockedStatic<HoodieTableConfig> mocked = mockStatic(HoodieTableConfig.class)) {
+      new TableMigrateUtils().migratePartitionFields(metaClient);
+      mocked.verify(() -> HoodieTableConfig.update(any(), any(), any()), never());
+    }
+  }
+
+  @Test
+  void testMigratePartitionFieldsEmptyIsNoOp() {
+    HoodieTableMetaClient metaClient = metaClientWith("");
+
+    try (MockedStatic<HoodieTableConfig> mocked = mockStatic(HoodieTableConfig.class)) {
+      new TableMigrateUtils().migratePartitionFields(metaClient);
+      mocked.verify(() -> HoodieTableConfig.update(any(), any(), any()), never());
+    }
+  }
+
+  @Test
+  void testMigratePartitionFieldsAlreadySuffixedIsNoOp() {
+    HoodieTableMetaClient metaClient = metaClientWith("country:SIMPLE");
+
+    try (MockedStatic<HoodieTableConfig> mocked = mockStatic(HoodieTableConfig.class)) {
+      new TableMigrateUtils().migratePartitionFields(metaClient);
+      mocked.verify(() -> HoodieTableConfig.update(any(), any(), any()), never());
+    }
+  }
+
+  @Test
+  void testMigratePartitionFieldsAppendsSimpleToBareKey() {
+    HoodieTableMetaClient metaClient = metaClientWith("country");
+    ArgumentCaptor<Properties> propsCaptor = ArgumentCaptor.forClass(Properties.class);
+
+    try (MockedStatic<HoodieTableConfig> mocked = mockStatic(HoodieTableConfig.class)) {
+      new TableMigrateUtils().migratePartitionFields(metaClient);
+      mocked.verify(() -> HoodieTableConfig.update(any(), any(), propsCaptor.capture()), times(1));
+    }
+
+    Assertions.assertEquals(
+        "country:SIMPLE",
+        propsCaptor.getValue().getProperty(HoodieTableConfig.PARTITION_FIELDS.key()));
+  }
+
+  @Test
+  void testMigratePartitionFieldsMultipleBareKeys() {
+    HoodieTableMetaClient metaClient = metaClientWith("country,region");
+    ArgumentCaptor<Properties> propsCaptor = ArgumentCaptor.forClass(Properties.class);
+
+    try (MockedStatic<HoodieTableConfig> mocked = mockStatic(HoodieTableConfig.class)) {
+      new TableMigrateUtils().migratePartitionFields(metaClient);
+      mocked.verify(() -> HoodieTableConfig.update(any(), any(), propsCaptor.capture()), times(1));
+    }
+
+    Assertions.assertEquals(
+        "country:SIMPLE,region:SIMPLE",
+        propsCaptor.getValue().getProperty(HoodieTableConfig.PARTITION_FIELDS.key()));
+  }
+
+  @Test
+  void testMigratePartitionFieldsMixedKeysPreservesSuffixedAndAppendsBare() {
+    HoodieTableMetaClient metaClient = metaClientWith("event_ts:TIMESTAMP,region");
+    ArgumentCaptor<Properties> propsCaptor = ArgumentCaptor.forClass(Properties.class);
+
+    try (MockedStatic<HoodieTableConfig> mocked = mockStatic(HoodieTableConfig.class)) {
+      new TableMigrateUtils().migratePartitionFields(metaClient);
+      mocked.verify(() -> HoodieTableConfig.update(any(), any(), propsCaptor.capture()), times(1));
+    }
+
+    Assertions.assertEquals(
+        "event_ts:TIMESTAMP,region:SIMPLE",
+        propsCaptor.getValue().getProperty(HoodieTableConfig.PARTITION_FIELDS.key()));
+  }
+
+  @Test
+  void testMigratePartitionFieldsTrimsWhitespaceAndSkipsEmptyEntries() {
+    HoodieTableMetaClient metaClient = metaClientWith("  country , , region  ");
+    ArgumentCaptor<Properties> propsCaptor = ArgumentCaptor.forClass(Properties.class);
+
+    try (MockedStatic<HoodieTableConfig> mocked = mockStatic(HoodieTableConfig.class)) {
+      new TableMigrateUtils().migratePartitionFields(metaClient);
+      mocked.verify(() -> HoodieTableConfig.update(any(), any(), propsCaptor.capture()), times(1));
+    }
+
+    Assertions.assertEquals(
+        "country:SIMPLE,region:SIMPLE",
+        propsCaptor.getValue().getProperty(HoodieTableConfig.PARTITION_FIELDS.key()));
+  }
+}


### PR DESCRIPTION
Hudi 1.x requires hoodie.table.partition.fields entries to carry a ":<KEYGEN_TYPE>" suffix; tables created with older Hudi versions stored bare column names, which conflicts with the partition fields the writer now passes in and breaks subsequent writes. Append ":SIMPLE" to any bare entry during the existing pre-v8 migration path, preserving entries that already have a suffix.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

https://hopsworks.atlassian.net/browse/FSTORE-2027


Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
