### PR TITLE
[HWORKS-2799] Use feature group location to detect HopsFS storage for sink enabled feature groups

### DIFF
--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -21,6 +21,7 @@ import logging
 import time
 import warnings
 from datetime import date, datetime, timedelta
+from urllib.parse import urlparse
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -3113,8 +3114,10 @@ class FeatureGroup(FeatureGroupBase):
         reliable signal for how delta-rs should talk to storage.
         """
         location = getattr(self, "location", None)
-        if isinstance(location, str) and "://" in location:
-            return location.startswith(("hopsfs://", "hdfs://"))
+        if isinstance(location, str):
+            scheme = urlparse(location).scheme
+            if scheme in {"hopsfs", "hdfs"}:
+                return True
 
         return self.storage_connector is None or (
             self.storage_connector is not None

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3105,7 +3105,17 @@ class FeatureGroup(FeatureGroupBase):
             )
 
     def _is_hopsfs_storage(self) -> bool:
-        """Return True if storage is HopsFS."""
+        """Return True if the offline storage location is HopsFS.
+
+        Sink-enabled feature groups can keep the source storage connector
+        (for example Redshift) attached while their offline data still lives
+        on the default HopsFS warehouse path. In that case the location is the
+        reliable signal for how delta-rs should talk to storage.
+        """
+        location = getattr(self, "location", None)
+        if isinstance(location, str) and "://" in location:
+            return location.startswith(("hopsfs://", "hdfs://"))
+
         return self.storage_connector is None or (
             self.storage_connector is not None
             and self.storage_connector.type == sc.StorageConnector.HOPSFS

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3110,8 +3110,9 @@ class FeatureGroup(FeatureGroupBase):
 
         Sink-enabled feature groups can keep the source storage connector
         (for example Redshift) attached while their offline data still lives
-        on the default HopsFS warehouse path. In that case the location is the
-        reliable signal for how delta-rs should talk to storage.
+        on the default HopsFS warehouse path.
+        In that case the location is the reliable signal for how delta-rs
+        should talk to storage.
         """
         location = getattr(self, "location", None)
         if isinstance(location, str):

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -21,13 +21,13 @@ import logging
 import time
 import warnings
 from datetime import date, datetime, timedelta
-from urllib.parse import urlparse
 from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
     TypeVar,
 )
+from urllib.parse import urlparse
 
 import avro.schema
 import hsfs.expectation_suite

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -949,8 +949,7 @@ class TestFeatureGroup:
     ):
         fg = get_test_feature_group()
         fg._location = (
-            "hopsfs://rpc.namenode.service.consul:8020/apps/hive/warehouse/"
-            "fs.db/fg_1"
+            "hopsfs://rpc.namenode.service.consul:8020/apps/hive/warehouse/fs.db/fg_1"
         )
         fg.storage_connector = storage_connector.RedshiftConnector(
             id=1,
@@ -960,7 +959,9 @@ class TestFeatureGroup:
 
         assert fg._is_hopsfs_storage() is True
 
-    def test_is_hopsfs_storage_uses_single_slash_hopsfs_location(self):
+    def test_is_hopsfs_storage_uses_single_slash_hopsfs_location(
+        self,
+    ):
         fg = get_test_feature_group()
         fg._location = "hopsfs:/apps/hive/warehouse/fs.db/fg_1"
         fg.storage_connector = storage_connector.RedshiftConnector(

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -944,9 +944,14 @@ class TestFeatureGroup:
         fg.storage_connector = sc
         assert fg._is_hopsfs_storage() is expected
 
-    def test_is_hopsfs_storage_uses_location_when_source_connector_is_external(self):
+    def test_is_hopsfs_storage_uses_location_when_source_connector_is_external(
+        self,
+    ):
         fg = get_test_feature_group()
-        fg._location = "hopsfs://rpc.namenode.service.consul:8020/apps/hive/warehouse/fs.db/fg_1"
+        fg._location = (
+            "hopsfs://rpc.namenode.service.consul:8020/apps/hive/warehouse/"
+            "fs.db/fg_1"
+        )
         fg.storage_connector = storage_connector.RedshiftConnector(
             id=1,
             name="redshift",

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -960,6 +960,17 @@ class TestFeatureGroup:
 
         assert fg._is_hopsfs_storage() is True
 
+    def test_is_hopsfs_storage_uses_single_slash_hopsfs_location(self):
+        fg = get_test_feature_group()
+        fg._location = "hopsfs:/apps/hive/warehouse/fs.db/fg_1"
+        fg.storage_connector = storage_connector.RedshiftConnector(
+            id=1,
+            name="redshift",
+            featurestore_id=1,
+        )
+
+        assert fg._is_hopsfs_storage() is True
+
     def test_init_time_travel_and_stream_uses_resolvers_python(
         self, mocker, monkeypatch
     ):

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -944,6 +944,17 @@ class TestFeatureGroup:
         fg.storage_connector = sc
         assert fg._is_hopsfs_storage() is expected
 
+    def test_is_hopsfs_storage_uses_location_when_source_connector_is_external(self):
+        fg = get_test_feature_group()
+        fg._location = "hopsfs://rpc.namenode.service.consul:8020/apps/hive/warehouse/fs.db/fg_1"
+        fg.storage_connector = storage_connector.RedshiftConnector(
+            id=1,
+            name="redshift",
+            featurestore_id=1,
+        )
+
+        assert fg._is_hopsfs_storage() is True
+
     def test_init_time_travel_and_stream_uses_resolvers_python(
         self, mocker, monkeypatch
     ):


### PR DESCRIPTION
Sink-enabled feature groups created from external sources such as Redshift keep the source storage connector attached even when their offline storage location is the default HopsFS warehouse path. The Python SDK used storage_connector.type to decide whether delta-rs should be configured for HopsFS, which misclassified these feature groups as non-HopsFS storage.

That caused FeatureGroup.save() to skip the HopsFS-specific delta-rs setup and URI rewrite, leading sink-enabled Delta feature group creation to fail with Generic HdfsObjectStore / Connection to HopsFS failed errors while the feature group metadata and sink job were still created.

Fix _is_hopsfs_storage() to prefer the feature group location scheme when a location is available, and fall back to the storage connector only when the location does not indicate the backing store. Add a regression test covering a sink-enabled Redshift feature group whose location is on HopsFS.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
