### PR TITLE
[FSTORE-2030] Add support for specifying lookback windows for PIT queries

### DIFF
--- a/python/hsfs/constructor/lookback.py
+++ b/python/hsfs/constructor/lookback.py
@@ -1,0 +1,431 @@
+#
+#   Copyright 2026 Logical Clocks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from hopsworks_apigen import public
+from hopsworks_common.util import convert_event_time_to_timestamp
+from hsfs.decorators import typechecked
+
+
+if TYPE_CHECKING:
+    from datetime import date, datetime
+
+
+EVENT_TIME = "event_time"
+PARTITION_KEY = "partition_key"
+_VALID_LOOKBACK_KEYS = (EVENT_TIME, PARTITION_KEY)
+
+_UNIFORM_LOOKBACK_DICT_KEYS = frozenset({"key", "start", "end"})
+_LOOKBACKS_DICT_KEYS = frozenset({"default", "feature_groups"})
+
+
+@public
+@typechecked
+class Lookback:
+    """A lookback window for PIT joins on a feature view.
+
+    Bounds the rows of the joined feature group(s) that participate in the
+    point-in-time join, so flyingduck and Spark can prune partitions before
+    reading files.
+
+    `key="partition_key"` emits the predicate against the FG's partition
+    column — flyingduck and Spark prune partitions before reading files.
+    `key="event_time"` emits against the event_time column — row-level
+    correctness only; partition pruning is engine-dependent.
+
+    Use this class for a uniform window across every FG; use
+    [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for per-FG
+    overrides.
+
+    Example:
+        ```python
+        fv.get_batch_data(
+            lookback=Lookback(
+                key="partition_key",
+                start=date(2026, 5, 5),
+                end=date(2026, 5, 17),
+            ),
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        key: str,
+        start: date | datetime | int | str,
+        end: date | datetime | int | str | None = None,
+    ) -> None:
+        if key not in _VALID_LOOKBACK_KEYS:
+            raise ValueError(
+                f"Lookback `key` must be one of {_VALID_LOOKBACK_KEYS!r}; got {key!r}."
+            )
+        if start is None:
+            raise ValueError("Lookback `start` is required.")
+        if end is not None:
+            start_ms = convert_event_time_to_timestamp(start)
+            end_ms = convert_event_time_to_timestamp(end)
+            if start_ms >= end_ms:
+                raise ValueError(
+                    f"Lookback `start` ({start!r}) must be strictly earlier "
+                    f"than `end` ({end!r})."
+                )
+        self._key = key
+        self._start = start
+        self._end = end
+
+    @property
+    def key(self) -> str:
+        """Column the lookback predicate targets on each joined feature group."""
+        return self._key
+
+    @property
+    def start(self) -> date | datetime | int | str:
+        """Required lower bound of the lookback window.
+
+        Holds whatever shape `__init__` accepted: a `date`/`datetime` for user-form
+        construction, or epoch-millis `int` / ISO `str` after `from_response_json`
+        reconstructs from the wire payload. `convert_event_time_to_timestamp` accepts
+        all four shapes uniformly.
+        """
+        return self._start
+
+    @property
+    def end(self) -> date | datetime | int | str | None:
+        """Optional upper bound; `None` emits a one-sided lower-bound predicate only.
+
+        Same value-shape contract as `start`.
+        """
+        return self._end
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the wire-format payload for the backend.
+
+        Bounds are emitted as epoch milliseconds; `key` is upper-cased to
+        match the backend enum; `end` is omitted when not provided.
+
+        Returns:
+            The wire-format dict with keys `lookbackKey`, `start`, and
+            optionally `end`.
+        """
+        payload: dict[str, Any] = {
+            "lookbackKey": self._key.upper(),
+            "start": convert_event_time_to_timestamp(self._start),
+        }
+        if self._end is not None:
+            payload["end"] = convert_event_time_to_timestamp(self._end)
+        return payload
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any] | Lookback | None) -> Lookback | None:
+        """Construct a `Lookback` from a user-form dict (or pass through an instance).
+
+        Accepts `{"key", "start", "end"}`, an existing `Lookback`, or `None`.
+
+        Args:
+            value: A user-form dict, an existing `Lookback`, or `None`.
+
+        Returns:
+            A `Lookback` instance, or `None` if `value` was `None`.
+        """
+        if value is None or isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"Lookback expects a dict or `Lookback` instance; got {type(value)!r}."
+            )
+        return cls(
+            key=value.get("key"),
+            start=value.get("start"),
+            end=value.get("end"),
+        )
+
+    @classmethod
+    def from_response_json(cls, value: dict[str, Any] | None) -> Lookback | None:
+        """Reconstruct a `Lookback` from the wire-format payload the backend echoes.
+
+        `Query.from_response_json` uses this to restore `_lookbacks` when the
+        materialization Spark job (or any cross-process consumer) rebuilds a
+        Query from its serialized form.
+        The decamelized wire dict uses `lookback_key` instead of `key`, and the
+        reconstructed `key` is lower-cased to match the SDK contract.
+
+        Args:
+            value: The decamelized wire dict (`lookback_key`, `start`, `end`), or `None`.
+
+        Returns:
+            A `Lookback` instance, or `None` when `value` is `None` or its `lookback_key` is missing.
+        """
+        if value is None:
+            return None
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"Lookback.from_response_json expects a dict; got {type(value)!r}."
+            )
+        key = value.get("lookback_key") or value.get("key")
+        if key is None:
+            return None
+        return cls(
+            key=str(key).lower(),
+            start=value.get("start"),
+            end=value.get("end"),
+        )
+
+
+@public
+@typechecked
+class Lookbacks:
+    """Lookback configuration with per-feature-group overrides.
+
+    `default` applies to every feature group in the query (root and joined)
+    that has no matching `feature_groups` entry; `feature_groups` overrides
+    the default for the named feature groups. At least one of the two must
+    be provided.
+
+    In per-FG-only mode (no `default`), feature groups not listed receive
+    no lookback and behave as they would with `lookback=None`.
+
+    For a uniform lookback across the whole feature view, use
+    [`Lookback`][hsfs.constructor.lookback.Lookback] directly.
+
+    `feature_groups` keys identify each FG one of two ways:
+
+    - `"name"` — matches every FG (root or joined) with that name, any
+      version. Covers the common case where each FG appears once in the FV.
+    - FG instance — matches every FG with the same `(name, version)`. Use
+      this to disambiguate when two versions of the same FG appear in the FV.
+
+    When a single key matches multiple join sites (e.g. the same FG joined
+    with two prefixes), the same lookback is applied to all matches.
+
+    When both shapes are supplied for the same name (a bare-string and an
+    FG-instance key that resolve to the same FG), the exact-version entry
+    takes precedence at its specific join site and the any-version entry
+    applies elsewhere — letting users express "lookback A for every version
+    of `dim_a`, except v1 which gets lookback B."
+
+    FG-instance keys are not JSON-serializable; for config files / serialised
+    payloads use string keys.
+
+    All matching, default fallback, and FG-eligibility validation happen on
+    the backend in `QueryController.resolveLookbacks`; this class is purely
+    the SDK-side container and wire serializer.
+
+    Example:
+        ```python
+        fv.get_batch_data(
+            lookback=Lookbacks(
+                default=Lookback(key="partition_key", start=date(2026, 5, 5)),
+                feature_groups={
+                    "transactions": Lookback(key="event_time",
+                                             start=datetime(2026, 5, 1, tzinfo=timezone.utc)),
+                },
+            ),
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        default: Lookback | dict[str, Any] | None = None,
+        feature_groups: dict[Any, Lookback | dict[str, Any]] | None = None,
+    ) -> None:
+        # Import done here to prevent circular dependencies
+        from hsfs.feature_group import FeatureGroupBase
+
+        self._default = Lookback.from_dict(default) if default is not None else None
+
+        entries: dict[Any, Lookback] = {}
+        for raw_key, raw_value in (feature_groups or {}).items():
+            if not isinstance(raw_key, (str, FeatureGroupBase)):
+                raise ValueError(
+                    f"feature_groups key must be a str or FeatureGroup instance; "
+                    f"got {type(raw_key).__name__}"
+                )
+            if raw_value is None:
+                raise ValueError(
+                    f"feature_groups[{raw_key!r}] must be a Lookback or dict; got None."
+                )
+            entries[raw_key] = Lookback.from_dict(raw_value)
+
+        if self._default is None and not entries:
+            raise ValueError(
+                "Lookbacks requires at least one of `default` or `feature_groups` "
+                "to be set."
+            )
+        self._feature_groups: dict[Any, Lookback] = entries
+
+    @property
+    def default(self) -> Lookback | None:
+        """Uniform default applied to FGs without a `feature_groups` entry."""
+        return self._default
+
+    @property
+    def feature_groups(self) -> dict[Any, Lookback]:
+        """User-supplied key → `Lookback` override map (keys returned verbatim).
+
+        Returns a copy to prevent external mutation of internal state.
+        """
+        return dict(self._feature_groups)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the wire-format payload for the backend.
+
+        Emits `{"defaultLookback": <LookbackDTO>, "featureGroups": [<entries>]}`.
+        Each entry carries `{"name", "version", "lookback"}`; bare-string keys
+        emit `version=None` (matches every version of the named FG on the
+        backend side), while FG-instance keys emit the FG's pinned version.
+
+        Returns:
+            The wire-format dict with the keys `defaultLookback` and
+            `featureGroups`; either may be omitted when not set.
+        """
+        payload: dict[str, Any] = {}
+        if self._default is not None:
+            payload["defaultLookback"] = self._default.to_dict()
+        if self._feature_groups:
+            payload["featureGroups"] = [
+                {
+                    "name": raw_key if isinstance(raw_key, str) else raw_key.name,
+                    "version": None if isinstance(raw_key, str) else raw_key.version,
+                    "lookback": lookback.to_dict(),
+                }
+                for raw_key, lookback in self._feature_groups.items()
+            ]
+        return payload
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any] | Lookbacks | None) -> Lookbacks | None:
+        """Construct a `Lookbacks` from its own user-form dict.
+
+        Accepts `{"default": ..., "feature_groups": {...}}`, an existing
+        `Lookbacks`, or `None`. For shapes that might be a uniform `Lookback`
+        dict instead, use `Lookbacks.from_user_input`.
+
+        Args:
+            value: A `Lookbacks`-shaped user-form dict, an existing
+                `Lookbacks`, or `None`.
+
+        Returns:
+            A `Lookbacks` instance, or `None` if `value` was `None`.
+        """
+        if value is None or isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"Lookbacks expects a dict or `Lookbacks` instance; got "
+                f"{type(value)!r}."
+            )
+        return cls(
+            default=value.get("default"),
+            feature_groups=value.get("feature_groups"),
+        )
+
+    @classmethod
+    def from_response_json(cls, value: dict[str, Any] | None) -> Lookbacks | None:
+        """Reconstruct a `Lookbacks` from the wire-format payload the backend echoes.
+
+        Per-feature-group entries are keyed by bare-string names because
+        Feature Group instances are not available at deserialization time;
+        version selection relies on the backend's `version=null` any-version
+        semantics.
+
+        Args:
+            value: The decamelized wire dict (`default_lookback`, `feature_groups`), or `None`.
+
+        Returns:
+            A `Lookbacks` instance, or `None` when `value` is `None` or carries no usable entries.
+        """
+        if value is None:
+            return None
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"Lookbacks.from_response_json expects a dict; got {type(value)!r}."
+            )
+        default = Lookback.from_response_json(value.get("default_lookback"))
+        feature_groups: dict[Any, Lookback] = {}
+        for entry in value.get("feature_groups", []) or []:
+            if not isinstance(entry, dict):
+                continue
+            lookback = Lookback.from_response_json(entry.get("lookback"))
+            if lookback is None:
+                continue
+            name = entry.get("name")
+            if name is None:
+                continue
+            feature_groups[name] = lookback
+        if default is None and not feature_groups:
+            return None
+        return cls(default=default, feature_groups=feature_groups or None)
+
+    @classmethod
+    def from_user_input(
+        cls,
+        value: Lookback | Lookbacks | dict[str, Any] | None,
+    ) -> Lookbacks | None:
+        """Normalize any user-supplied `lookback=` argument to a `Lookbacks`.
+
+        Accepts a `Lookback` (wrapped as `Lookbacks(default=value)`), a
+        `Lookbacks` (passthrough), a dict in either uniform shape
+        (`{key, start, end}`) or per-FG shape (`{default, feature_groups}`),
+        or `None`. Callers past the public API boundary then deal with a
+        single internal type.
+
+        Args:
+            value: A `Lookback`, `Lookbacks`, a user-form dict, or `None`.
+
+        Returns:
+            A `Lookbacks` instance, or `None` if `value` was `None`.
+        """
+        if value is None:
+            return None
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, Lookback):
+            return cls(default=value)
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"lookback must be Lookback, Lookbacks, dict, or None; "
+                f"got {type(value).__name__}"
+            )
+        if not value:
+            raise ValueError(
+                "lookback dict cannot be empty; pass a uniform shape with keys "
+                "{'key', 'start', 'end'} or a per-FG shape with keys "
+                "{'default', 'feature_groups'}, or omit the parameter entirely"
+            )
+        input_keys = set(value)
+        uniform_keys_present = input_keys & _UNIFORM_LOOKBACK_DICT_KEYS
+        lookbacks_keys_present = input_keys & _LOOKBACKS_DICT_KEYS
+        if uniform_keys_present and lookbacks_keys_present:
+            raise ValueError(
+                "lookback dict mixes uniform keys (key/start/end) with per-FG "
+                "keys (default/feature_groups); pick one shape"
+            )
+        unknown_keys = input_keys - _UNIFORM_LOOKBACK_DICT_KEYS - _LOOKBACKS_DICT_KEYS
+        if unknown_keys:
+            raise ValueError(
+                f"unknown lookback keys: {sorted(unknown_keys)}. "
+                "Allowed: {key, start, end} or {default, feature_groups}"
+            )
+        if uniform_keys_present:
+            return cls(default=Lookback.from_dict(value))
+        return cls.from_dict(value)

--- a/python/hsfs/constructor/lookback.py
+++ b/python/hsfs/constructor/lookback.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2026 Logical Clocks AB
+#   Copyright 2026 Hopsworks AB
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -26,37 +26,39 @@ if TYPE_CHECKING:
     from datetime import date, datetime
 
 
-EVENT_TIME = "event_time"
-PARTITION_KEY = "partition_key"
+EVENT_TIME = "EVENT_TIME"
+PARTITION_KEY = "PARTITION_KEY"
 _VALID_LOOKBACK_KEYS = (EVENT_TIME, PARTITION_KEY)
 
 _UNIFORM_LOOKBACK_DICT_KEYS = frozenset({"key", "start", "end"})
-_LOOKBACKS_DICT_KEYS = frozenset({"default", "feature_groups"})
+_LOOKBACK_DICT_KEYS = frozenset({"default", "feature_group_lookbacks"})
 
 
 @public
 @typechecked
-class Lookback:
-    """A lookback window for PIT joins on a feature view.
+class FeatureGroupLookback:
+    """A lookback window for point-in-time joins on a feature view.
 
-    Bounds the rows of the joined feature group(s) that participate in the
-    point-in-time join, so flyingduck and Spark can prune partitions before
-    reading files.
+    A lookback bounds how far back in time the joined feature group(s) may
+    contribute rows to a point-in-time join, so partition scans stay bounded
+    as feature groups grow.
 
-    `key="partition_key"` emits the predicate against the FG's partition
-    column — flyingduck and Spark prune partitions before reading files.
-    `key="event_time"` emits against the event_time column — row-level
-    correctness only; partition pruning is engine-dependent.
+    Use `key="PARTITION_KEY"` when the feature group is partitioned by a DATE
+    column aligned with the lookback bounds; the storage engine then prunes
+    whole partitions before reading any files.
+    Use `key="EVENT_TIME"` to bound on the event-time column; the result is
+    always correct, but whether the engine can also prune files depends on
+    the storage format.
 
-    Use this class for a uniform window across every FG; use
-    [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for per-FG
-    overrides.
+    Use this class for a uniform window across every feature group in the
+    view; use [`Lookback`][hsfs.constructor.lookback.Lookback] when
+    different feature groups need different windows.
 
     Example:
         ```python
         fv.get_batch_data(
-            lookback=Lookback(
-                key="partition_key",
+            lookback=FeatureGroupLookback(
+                key="PARTITION_KEY",
                 start=date(2026, 5, 5),
                 end=date(2026, 5, 17),
             ),
@@ -70,60 +72,55 @@ class Lookback:
         start: date | datetime | int | str,
         end: date | datetime | int | str | None = None,
     ) -> None:
-        if key not in _VALID_LOOKBACK_KEYS:
+        normalized_key = key.upper() if isinstance(key, str) else key
+        if normalized_key not in _VALID_LOOKBACK_KEYS:
             raise ValueError(
-                f"Lookback `key` must be one of {_VALID_LOOKBACK_KEYS!r}; got {key!r}."
+                f"FeatureGroupLookback `key` must be one of {_VALID_LOOKBACK_KEYS!r} "
+                f"(case-insensitive); got {key!r}."
             )
         if start is None:
-            raise ValueError("Lookback `start` is required.")
+            raise ValueError("FeatureGroupLookback `start` is required.")
         if end is not None:
             start_ms = convert_event_time_to_timestamp(start)
             end_ms = convert_event_time_to_timestamp(end)
             if start_ms >= end_ms:
                 raise ValueError(
-                    f"Lookback `start` ({start!r}) must be strictly earlier "
+                    f"FeatureGroupLookback `start` ({start!r}) must be strictly earlier "
                     f"than `end` ({end!r})."
                 )
-        self._key = key
+        self._key = normalized_key
         self._start = start
         self._end = end
 
+    @public
     @property
     def key(self) -> str:
-        """Column the lookback predicate targets on each joined feature group."""
+        """Column the lookback predicate targets on each joined feature group.
+
+        One of `"PARTITION_KEY"` or `"EVENT_TIME"`.
+        """
         return self._key
 
+    @public
     @property
     def start(self) -> date | datetime | int | str:
-        """Required lower bound of the lookback window.
-
-        Holds whatever shape `__init__` accepted: a `date`/`datetime` for user-form
-        construction, or epoch-millis `int` / ISO `str` after `from_response_json`
-        reconstructs from the wire payload. `convert_event_time_to_timestamp` accepts
-        all four shapes uniformly.
-        """
+        """Lower bound of the lookback window (inclusive)."""
         return self._start
 
+    @public
     @property
     def end(self) -> date | datetime | int | str | None:
-        """Optional upper bound; `None` emits a one-sided lower-bound predicate only.
-
-        Same value-shape contract as `start`.
-        """
+        """Upper bound of the lookback window (inclusive), or `None` for an open-ended upper side."""
         return self._end
 
     def to_dict(self) -> dict[str, Any]:
-        """Return the wire-format payload for the backend.
-
-        Bounds are emitted as epoch milliseconds; `key` is upper-cased to
-        match the backend enum; `end` is omitted when not provided.
+        """Serialize this lookback to a JSON-compatible dict.
 
         Returns:
-            The wire-format dict with keys `lookbackKey`, `start`, and
-            optionally `end`.
+            A dict carrying the lookback's key, start, and (when set) end.
         """
         payload: dict[str, Any] = {
-            "lookbackKey": self._key.upper(),
+            "lookbackKey": self._key,
             "start": convert_event_time_to_timestamp(self._start),
         }
         if self._end is not None:
@@ -131,13 +128,191 @@ class Lookback:
         return payload
 
     @classmethod
+    def from_dict(
+        cls, value: dict[str, Any] | FeatureGroupLookback | None
+    ) -> FeatureGroupLookback | None:
+        """Build a `FeatureGroupLookback` from a `{"key", "start", "end"}` dict.
+
+        An existing `FeatureGroupLookback` is returned unchanged; `None` is returned as
+        `None`.
+
+        Parameters:
+            value:
+                A `{"key", "start", "end"}` dict, an existing `FeatureGroupLookback`, or `None`.
+
+        Returns:
+            A `FeatureGroupLookback` instance, or `None` if `value` was `None`.
+        """
+        if value is None or isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"FeatureGroupLookback expects a dict or `FeatureGroupLookback` instance; got {type(value)!r}."
+            )
+        return cls(
+            key=value.get("key"),
+            start=value.get("start"),
+            end=value.get("end"),
+        )
+
+    @classmethod
+    def from_response_json(
+        cls, value: dict[str, Any] | None
+    ) -> FeatureGroupLookback | None:
+        """Reconstruct a `FeatureGroupLookback` from the payload returned by the Hopsworks backend.
+
+        Parameters:
+            value:
+                The payload dict, or `None`.
+
+        Returns:
+            A `FeatureGroupLookback` instance, or `None` if `value` was `None` or the key field was missing.
+        """
+        if value is None:
+            return None
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"FeatureGroupLookback.from_response_json expects a dict; got {type(value)!r}."
+            )
+        key = value.get("lookback_key") or value.get("key")
+        if key is None:
+            return None
+        return cls(
+            key=key,
+            start=value.get("start"),
+            end=value.get("end"),
+        )
+
+
+@public
+@typechecked
+class Lookback:
+    """Per-feature-group lookback windows for a point-in-time-joined feature view.
+
+    `default` applies to every feature group in the view (root and joined)
+    that does not have a matching `feature_group_lookbacks` override.
+    `feature_group_lookbacks` maps a specific feature group to its own lookback,
+    which wins over the default for that feature group.
+    At least one of `default` or `feature_group_lookbacks` must be set.
+
+    If `default` is omitted, feature groups not listed in `feature_group_lookbacks`
+    are read without any lookback (same as not passing `lookback=...`).
+
+    Use [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] directly for a
+    uniform window across every feature group in the view.
+
+    `feature_group_lookbacks` keys identify the feature group in one of two ways:
+
+    - `"name"` — matches every feature group with that name, regardless of
+      version. Covers the common case where each feature group appears once
+      in the view.
+    - Feature group instance — matches a specific `(name, version)`. Use
+      this when the view joins two versions of the same feature group.
+
+    If you supply both a name string and a feature group instance that
+    resolve to the same name, the instance entry wins for its specific
+    version and the name entry applies to the other versions.
+
+    Feature group instances are not JSON-serializable; if you need to
+    persist this configuration, use name strings as keys.
+
+    Example:
+        ```python
+        fv.get_batch_data(
+            lookback=Lookback(
+                default=FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5)),
+                feature_group_lookbacks={
+                    "transactions": FeatureGroupLookback(key="EVENT_TIME",
+                                             start=datetime(2026, 5, 1, tzinfo=timezone.utc)),
+                },
+            ),
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        default: FeatureGroupLookback | dict[str, Any] | None = None,
+        feature_group_lookbacks: dict[Any, FeatureGroupLookback | dict[str, Any]]
+        | None = None,
+    ) -> None:
+        # Import done here to prevent circular dependencies
+        from hsfs.feature_group import FeatureGroupBase
+
+        self._default = (
+            FeatureGroupLookback.from_dict(default) if default is not None else None
+        )
+
+        entries: dict[Any, FeatureGroupLookback] = {}
+        for raw_key, raw_value in (feature_group_lookbacks or {}).items():
+            if not isinstance(raw_key, (str, FeatureGroupBase)):
+                raise ValueError(
+                    f"feature_group_lookbacks key must be a str or FeatureGroup instance; "
+                    f"got {type(raw_key).__name__}"
+                )
+            if raw_value is None:
+                raise ValueError(
+                    f"feature_group_lookbacks[{raw_key!r}] must be a FeatureGroupLookback or dict; got None."
+                )
+            entries[raw_key] = FeatureGroupLookback.from_dict(raw_value)
+
+        if self._default is None and not entries:
+            raise ValueError(
+                "Lookback requires at least one of `default` or `feature_group_lookbacks` "
+                "to be set."
+            )
+        self._feature_groups: dict[Any, FeatureGroupLookback] = entries
+
+    @public
+    @property
+    def default(self) -> FeatureGroupLookback | None:
+        """FeatureGroupLookback applied to every feature group without a `feature_group_lookbacks` override."""
+        return self._default
+
+    @public
+    @property
+    def feature_group_lookbacks(self) -> dict[Any, FeatureGroupLookback]:
+        """Per-feature-group overrides keyed by feature group name or instance."""
+        return dict(self._feature_groups)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this configuration to a JSON-compatible dict.
+
+        Returns:
+            A dict carrying the default lookback (when set) and the
+            per-feature-group overrides (when any are set).
+        """
+        payload: dict[str, Any] = {}
+        if self._default is not None:
+            payload["defaultLookback"] = self._default.to_dict()
+        if self._feature_groups:
+            payload["featureGroupLookbacks"] = [
+                {
+                    "name": raw_key if isinstance(raw_key, str) else raw_key.name,
+                    "version": None if isinstance(raw_key, str) else raw_key.version,
+                    "lookback": lookback.to_dict(),
+                }
+                for raw_key, lookback in self._feature_groups.items()
+            ]
+        return payload
+
+    @classmethod
     def from_dict(cls, value: dict[str, Any] | Lookback | None) -> Lookback | None:
-        """Construct a `Lookback` from a user-form dict (or pass through an instance).
+        """Build a `Lookback` from a `{"default", "feature_group_lookbacks"}` dict.
 
-        Accepts `{"key", "start", "end"}`, an existing `Lookback`, or `None`.
+        An existing `Lookback` is returned unchanged; `None` is returned as
+        `None`.
+        If the dict shape might also be a uniform single-window payload
+        (`{key, start, end}`), use
+        [`from_user_input`][hsfs.constructor.lookback.Lookback.from_user_input]
+        instead, which accepts both shapes.
 
-        Args:
-            value: A user-form dict, an existing `Lookback`, or `None`.
+        Parameters:
+            value:
+                A `{"default", "feature_group_lookbacks"}` dict, an existing
+                `Lookback`, or `None`.
 
         Returns:
             A `Lookback` instance, or `None` if `value` was `None`.
@@ -149,26 +324,23 @@ class Lookback:
                 f"Lookback expects a dict or `Lookback` instance; got {type(value)!r}."
             )
         return cls(
-            key=value.get("key"),
-            start=value.get("start"),
-            end=value.get("end"),
+            default=value.get("default"),
+            feature_group_lookbacks=value.get("feature_group_lookbacks"),
         )
 
     @classmethod
     def from_response_json(cls, value: dict[str, Any] | None) -> Lookback | None:
-        """Reconstruct a `Lookback` from the wire-format payload the backend echoes.
+        """Reconstruct a `Lookback` from the payload returned by the Hopsworks backend.
 
-        `Query.from_response_json` uses this to restore `_lookbacks` when the
-        materialization Spark job (or any cross-process consumer) rebuilds a
-        Query from its serialized form.
-        The decamelized wire dict uses `lookback_key` instead of `key`, and the
-        reconstructed `key` is lower-cased to match the SDK contract.
+        Per-feature-group overrides come back keyed by name string only,
+        since feature group instances are not available when deserialising.
 
-        Args:
-            value: The decamelized wire dict (`lookback_key`, `start`, `end`), or `None`.
+        Parameters:
+            value:
+                The payload dict, or `None`.
 
         Returns:
-            A `Lookback` instance, or `None` when `value` is `None` or its `lookback_key` is missing.
+            A `Lookback` instance, or `None` if `value` was `None` or carried no usable entries.
         """
         if value is None:
             return None
@@ -178,254 +350,76 @@ class Lookback:
             raise TypeError(
                 f"Lookback.from_response_json expects a dict; got {type(value)!r}."
             )
-        key = value.get("lookback_key") or value.get("key")
-        if key is None:
-            return None
-        return cls(
-            key=str(key).lower(),
-            start=value.get("start"),
-            end=value.get("end"),
-        )
-
-
-@public
-@typechecked
-class Lookbacks:
-    """Lookback configuration with per-feature-group overrides.
-
-    `default` applies to every feature group in the query (root and joined)
-    that has no matching `feature_groups` entry; `feature_groups` overrides
-    the default for the named feature groups. At least one of the two must
-    be provided.
-
-    In per-FG-only mode (no `default`), feature groups not listed receive
-    no lookback and behave as they would with `lookback=None`.
-
-    For a uniform lookback across the whole feature view, use
-    [`Lookback`][hsfs.constructor.lookback.Lookback] directly.
-
-    `feature_groups` keys identify each FG one of two ways:
-
-    - `"name"` — matches every FG (root or joined) with that name, any
-      version. Covers the common case where each FG appears once in the FV.
-    - FG instance — matches every FG with the same `(name, version)`. Use
-      this to disambiguate when two versions of the same FG appear in the FV.
-
-    When a single key matches multiple join sites (e.g. the same FG joined
-    with two prefixes), the same lookback is applied to all matches.
-
-    When both shapes are supplied for the same name (a bare-string and an
-    FG-instance key that resolve to the same FG), the exact-version entry
-    takes precedence at its specific join site and the any-version entry
-    applies elsewhere — letting users express "lookback A for every version
-    of `dim_a`, except v1 which gets lookback B."
-
-    FG-instance keys are not JSON-serializable; for config files / serialised
-    payloads use string keys.
-
-    All matching, default fallback, and FG-eligibility validation happen on
-    the backend in `QueryController.resolveLookbacks`; this class is purely
-    the SDK-side container and wire serializer.
-
-    Example:
-        ```python
-        fv.get_batch_data(
-            lookback=Lookbacks(
-                default=Lookback(key="partition_key", start=date(2026, 5, 5)),
-                feature_groups={
-                    "transactions": Lookback(key="event_time",
-                                             start=datetime(2026, 5, 1, tzinfo=timezone.utc)),
-                },
-            ),
-        )
-        ```
-    """
-
-    def __init__(
-        self,
-        default: Lookback | dict[str, Any] | None = None,
-        feature_groups: dict[Any, Lookback | dict[str, Any]] | None = None,
-    ) -> None:
-        # Import done here to prevent circular dependencies
-        from hsfs.feature_group import FeatureGroupBase
-
-        self._default = Lookback.from_dict(default) if default is not None else None
-
-        entries: dict[Any, Lookback] = {}
-        for raw_key, raw_value in (feature_groups or {}).items():
-            if not isinstance(raw_key, (str, FeatureGroupBase)):
-                raise ValueError(
-                    f"feature_groups key must be a str or FeatureGroup instance; "
-                    f"got {type(raw_key).__name__}"
-                )
-            if raw_value is None:
-                raise ValueError(
-                    f"feature_groups[{raw_key!r}] must be a Lookback or dict; got None."
-                )
-            entries[raw_key] = Lookback.from_dict(raw_value)
-
-        if self._default is None and not entries:
-            raise ValueError(
-                "Lookbacks requires at least one of `default` or `feature_groups` "
-                "to be set."
-            )
-        self._feature_groups: dict[Any, Lookback] = entries
-
-    @property
-    def default(self) -> Lookback | None:
-        """Uniform default applied to FGs without a `feature_groups` entry."""
-        return self._default
-
-    @property
-    def feature_groups(self) -> dict[Any, Lookback]:
-        """User-supplied key → `Lookback` override map (keys returned verbatim).
-
-        Returns a copy to prevent external mutation of internal state.
-        """
-        return dict(self._feature_groups)
-
-    def to_dict(self) -> dict[str, Any]:
-        """Return the wire-format payload for the backend.
-
-        Emits `{"defaultLookback": <LookbackDTO>, "featureGroups": [<entries>]}`.
-        Each entry carries `{"name", "version", "lookback"}`; bare-string keys
-        emit `version=None` (matches every version of the named FG on the
-        backend side), while FG-instance keys emit the FG's pinned version.
-
-        Returns:
-            The wire-format dict with the keys `defaultLookback` and
-            `featureGroups`; either may be omitted when not set.
-        """
-        payload: dict[str, Any] = {}
-        if self._default is not None:
-            payload["defaultLookback"] = self._default.to_dict()
-        if self._feature_groups:
-            payload["featureGroups"] = [
-                {
-                    "name": raw_key if isinstance(raw_key, str) else raw_key.name,
-                    "version": None if isinstance(raw_key, str) else raw_key.version,
-                    "lookback": lookback.to_dict(),
-                }
-                for raw_key, lookback in self._feature_groups.items()
-            ]
-        return payload
-
-    @classmethod
-    def from_dict(cls, value: dict[str, Any] | Lookbacks | None) -> Lookbacks | None:
-        """Construct a `Lookbacks` from its own user-form dict.
-
-        Accepts `{"default": ..., "feature_groups": {...}}`, an existing
-        `Lookbacks`, or `None`. For shapes that might be a uniform `Lookback`
-        dict instead, use `Lookbacks.from_user_input`.
-
-        Args:
-            value: A `Lookbacks`-shaped user-form dict, an existing
-                `Lookbacks`, or `None`.
-
-        Returns:
-            A `Lookbacks` instance, or `None` if `value` was `None`.
-        """
-        if value is None or isinstance(value, cls):
-            return value
-        if not isinstance(value, dict):
-            raise TypeError(
-                f"Lookbacks expects a dict or `Lookbacks` instance; got "
-                f"{type(value)!r}."
-            )
-        return cls(
-            default=value.get("default"),
-            feature_groups=value.get("feature_groups"),
-        )
-
-    @classmethod
-    def from_response_json(cls, value: dict[str, Any] | None) -> Lookbacks | None:
-        """Reconstruct a `Lookbacks` from the wire-format payload the backend echoes.
-
-        Per-feature-group entries are keyed by bare-string names because
-        Feature Group instances are not available at deserialization time;
-        version selection relies on the backend's `version=null` any-version
-        semantics.
-
-        Args:
-            value: The decamelized wire dict (`default_lookback`, `feature_groups`), or `None`.
-
-        Returns:
-            A `Lookbacks` instance, or `None` when `value` is `None` or carries no usable entries.
-        """
-        if value is None:
-            return None
-        if isinstance(value, cls):
-            return value
-        if not isinstance(value, dict):
-            raise TypeError(
-                f"Lookbacks.from_response_json expects a dict; got {type(value)!r}."
-            )
-        default = Lookback.from_response_json(value.get("default_lookback"))
-        feature_groups: dict[Any, Lookback] = {}
-        for entry in value.get("feature_groups", []) or []:
+        default = FeatureGroupLookback.from_response_json(value.get("default_lookback"))
+        feature_group_lookbacks: dict[Any, FeatureGroupLookback] = {}
+        for entry in value.get("feature_group_lookbacks", []) or []:
             if not isinstance(entry, dict):
                 continue
-            lookback = Lookback.from_response_json(entry.get("lookback"))
+            lookback = FeatureGroupLookback.from_response_json(entry.get("lookback"))
             if lookback is None:
                 continue
             name = entry.get("name")
             if name is None:
                 continue
-            feature_groups[name] = lookback
-        if default is None and not feature_groups:
+            feature_group_lookbacks[name] = lookback
+        if default is None and not feature_group_lookbacks:
             return None
-        return cls(default=default, feature_groups=feature_groups or None)
+        return cls(
+            default=default, feature_group_lookbacks=feature_group_lookbacks or None
+        )
 
     @classmethod
     def from_user_input(
         cls,
-        value: Lookback | Lookbacks | dict[str, Any] | None,
-    ) -> Lookbacks | None:
-        """Normalize any user-supplied `lookback=` argument to a `Lookbacks`.
+        value: FeatureGroupLookback | Lookback | dict[str, Any] | None,
+    ) -> Lookback | None:
+        """Normalize any value accepted by the `lookback=` parameter to a `Lookback`.
 
-        Accepts a `Lookback` (wrapped as `Lookbacks(default=value)`), a
-        `Lookbacks` (passthrough), a dict in either uniform shape
-        (`{key, start, end}`) or per-FG shape (`{default, feature_groups}`),
-        or `None`. Callers past the public API boundary then deal with a
-        single internal type.
+        A `FeatureGroupLookback` is wrapped as a uniform default; a `Lookback` is
+        returned unchanged; a dict is interpreted as either the uniform
+        single-window shape (`{"key", "start", "end"}`) or the per-
+        feature-group shape (`{"default", "feature_group_lookbacks"}`); `None` is
+        returned as `None`.
+        Mixing keys from both dict shapes is rejected.
 
-        Args:
-            value: A `Lookback`, `Lookbacks`, a user-form dict, or `None`.
+        Parameters:
+            value:
+                A `FeatureGroupLookback`, `Lookback`, dict, or `None`.
 
         Returns:
-            A `Lookbacks` instance, or `None` if `value` was `None`.
+            A `Lookback` instance, or `None` if `value` was `None`.
         """
         if value is None:
             return None
         if isinstance(value, cls):
             return value
-        if isinstance(value, Lookback):
+        if isinstance(value, FeatureGroupLookback):
             return cls(default=value)
         if not isinstance(value, dict):
             raise TypeError(
-                f"lookback must be Lookback, Lookbacks, dict, or None; "
+                f"lookback must be FeatureGroupLookback, Lookback, dict, or None; "
                 f"got {type(value).__name__}"
             )
         if not value:
             raise ValueError(
                 "lookback dict cannot be empty; pass a uniform shape with keys "
                 "{'key', 'start', 'end'} or a per-FG shape with keys "
-                "{'default', 'feature_groups'}, or omit the parameter entirely"
+                "{'default', 'feature_group_lookbacks'}, or omit the parameter entirely"
             )
         input_keys = set(value)
         uniform_keys_present = input_keys & _UNIFORM_LOOKBACK_DICT_KEYS
-        lookbacks_keys_present = input_keys & _LOOKBACKS_DICT_KEYS
-        if uniform_keys_present and lookbacks_keys_present:
+        lookback_keys_present = input_keys & _LOOKBACK_DICT_KEYS
+        if uniform_keys_present and lookback_keys_present:
             raise ValueError(
                 "lookback dict mixes uniform keys (key/start/end) with per-FG "
-                "keys (default/feature_groups); pick one shape"
+                "keys (default/feature_group_lookbacks); pick one shape"
             )
-        unknown_keys = input_keys - _UNIFORM_LOOKBACK_DICT_KEYS - _LOOKBACKS_DICT_KEYS
+        unknown_keys = input_keys - _UNIFORM_LOOKBACK_DICT_KEYS - _LOOKBACK_DICT_KEYS
         if unknown_keys:
             raise ValueError(
                 f"unknown lookback keys: {sorted(unknown_keys)}. "
-                "Allowed: {key, start, end} or {default, feature_groups}"
+                "Allowed: {key, start, end} or {default, feature_group_lookbacks}"
             )
         if uniform_keys_present:
-            return cls(default=Lookback.from_dict(value))
+            return cls(default=FeatureGroupLookback.from_dict(value))
         return cls.from_dict(value)

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
     from hsfs.constructor.fs_query import FsQuery
+    from hsfs.constructor.lookback import Lookbacks
     from hsfs.feature import Feature
 
 
@@ -91,6 +92,11 @@ class Query:
         self._joins = joins or []
         self._filter = Logic.from_response_json(filter)
         self._limit = limit
+        # Lookbacks configuration for the feature view's joins. Only set on the root
+        # Query. Emitted in `to_dict` as the top-level `lookbacks` field; the backend
+        # resolves it against the Query tree (sent for batch-data, reconstructed for
+        # training-dataset) in `QueryController.resolveLookbacks`.
+        self._lookbacks: Lookbacks | None = None
         self._python_engine: bool = engine.get_type() == "python"
         self._query_constructor_api: query_constructor_api.QueryConstructorApi = (
             query_constructor_api.QueryConstructorApi()
@@ -710,7 +716,7 @@ class Query:
         return json.dumps(self, cls=util.Encoder)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "featureStoreName": self._feature_store_name,
             "featureStoreId": self._feature_store_id,
             "leftFeatureGroup": self._left_feature_group,
@@ -722,6 +728,9 @@ class Query:
             "limit": self._limit,
             "hiveEngine": self._python_engine,
         }
+        if self._lookbacks is not None:
+            payload["lookbacks"] = self._lookbacks.to_dict()
+        return payload
 
     @classmethod
     def from_response_json(cls, json_dict: dict[str, Any]) -> Query:
@@ -743,7 +752,7 @@ class Query:
             feature_group_obj = fg_mod.FeatureGroup.from_response_json(
                 feature_group_json
             )
-        return cls(
+        q = cls(
             left_feature_group=feature_group_obj,
             left_features=json_decamelized["left_features"],
             feature_store_name=json_decamelized.get("feature_store_name", None),
@@ -761,6 +770,18 @@ class Query:
             filter=json_decamelized.get("filter", None),
             limit=json_decamelized.get("limit", None),
         )
+        # Restore Lookbacks from the wire payload. Without this, any consumer
+        # that reconstructs a Query from JSON (notably the materialization
+        # Spark job that runs `Query.from_response_json` on the td_app_conf
+        # the SDK posted) would drop the lookback and run an unbounded PIT
+        # join. The SDK's local-process callers (get_batch_data, in-memory
+        # training_data) attach `_lookbacks` themselves after this method
+        # returns, so the only behavior change here is for cross-process
+        # reconstructions.
+        from hsfs.constructor.lookback import Lookbacks
+
+        q._lookbacks = Lookbacks.from_response_json(json_decamelized.get("lookbacks"))
+        return q
 
     def _check_read_supported(self, online: bool) -> None:
         if not online:

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -28,6 +28,7 @@ from hsfs import engine, storage_connector, util
 from hsfs import feature_group as fg_mod
 from hsfs.constructor import join as join_module
 from hsfs.constructor.filter import Filter, Logic
+from hsfs.constructor.lookback import Lookback
 from hsfs.core import query_constructor_api, storage_connector_api
 from hsfs.decorators import typechecked
 
@@ -38,7 +39,6 @@ if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
     from hsfs.constructor.fs_query import FsQuery
-    from hsfs.constructor.lookback import Lookbacks
     from hsfs.feature import Feature
 
 
@@ -92,11 +92,9 @@ class Query:
         self._joins = joins or []
         self._filter = Logic.from_response_json(filter)
         self._limit = limit
-        # Lookbacks configuration for the feature view's joins. Only set on the root
-        # Query. Emitted in `to_dict` as the top-level `lookbacks` field; the backend
-        # resolves it against the Query tree (sent for batch-data, reconstructed for
-        # training-dataset) in `QueryController.resolveLookbacks`.
-        self._lookbacks: Lookbacks | None = None
+        # Lookback configuration for the feature view's joins; set only on the
+        # root Query and emitted as the top-level `lookback` field on the wire.
+        self._lookback: Lookback | None = None
         self._python_engine: bool = engine.get_type() == "python"
         self._query_constructor_api: query_constructor_api.QueryConstructorApi = (
             query_constructor_api.QueryConstructorApi()
@@ -728,8 +726,8 @@ class Query:
             "limit": self._limit,
             "hiveEngine": self._python_engine,
         }
-        if self._lookbacks is not None:
-            payload["lookbacks"] = self._lookbacks.to_dict()
+        if self._lookback is not None:
+            payload["lookback"] = self._lookback.to_dict()
         return payload
 
     @classmethod
@@ -770,17 +768,10 @@ class Query:
             filter=json_decamelized.get("filter", None),
             limit=json_decamelized.get("limit", None),
         )
-        # Restore Lookbacks from the wire payload. Without this, any consumer
-        # that reconstructs a Query from JSON (notably the materialization
-        # Spark job that runs `Query.from_response_json` on the td_app_conf
-        # the SDK posted) would drop the lookback and run an unbounded PIT
-        # join. The SDK's local-process callers (get_batch_data, in-memory
-        # training_data) attach `_lookbacks` themselves after this method
-        # returns, so the only behavior change here is for cross-process
-        # reconstructions.
-        from hsfs.constructor.lookback import Lookbacks
-
-        q._lookbacks = Lookbacks.from_response_json(json_decamelized.get("lookbacks"))
+        # Restore Lookback from the wire payload so cross-process consumers
+        # that reconstruct a Query from JSON keep the lookback. Local-process
+        # callers attach `_lookback` themselves after this method returns.
+        q._lookback = Lookback.from_response_json(json_decamelized.get("lookback"))
         return q
 
     def _check_read_supported(self, online: bool) -> None:
@@ -901,6 +892,21 @@ class Query:
         self, left_feature_group_end_time: str | int | date | datetime | None
     ) -> None:
         self._left_feature_group_end_time = left_feature_group_end_time
+
+    @public
+    @property
+    def lookback(self) -> Lookback | None:
+        """Lookback configuration for the feature view's joins.
+
+        See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and
+        [`Lookback`][hsfs.constructor.lookback.Lookback] for usage and
+        per-feature-group override semantics.
+        """
+        return self._lookback
+
+    @lookback.setter
+    def lookback(self, lookback: Lookback | None) -> None:
+        self._lookback = lookback
 
     @public
     def append_feature(self, feature: str | Feature) -> Query:

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -52,6 +52,7 @@ if HAS_NUMPY:
 if TYPE_CHECKING:
     import pandas as pd
     import polars as pl
+    from hsfs.constructor import lookback as _lookback
     from hsfs.constructor.join import Join
     from hsfs.core import explicit_provenance
     from hsfs.core.feature_logging import LoggingMetaData
@@ -353,6 +354,7 @@ class FeatureViewEngine:
         training_dataset_version=None,
         spine=None,
         extra_filter=None,
+        lookback=None,
     ):
         extra_filter = self._normalize_extra_filter(extra_filter)
 
@@ -371,6 +373,11 @@ class FeatureViewEngine:
                 training_helper_columns=training_helper_columns,
                 extra_filter=extra_filter,
             )
+            # Attach the lookbacks config to the Query so it rides on the wire as
+            # `QueryDTO.lookbacks` (top-level). The backend resolves it against the
+            # query tree in `QueryController.resolveLookbacks`.
+            if lookback is not None:
+                query._lookbacks = lookback
             # verify whatever is passed 1. spine group with dataframe contained, or 2. dataframe
             # the schema has to be consistent
 
@@ -409,6 +416,7 @@ class FeatureViewEngine:
         end_time,
         training_dataset_version=None,
         extra_filter=None,
+        lookback: _lookback.Lookbacks | None = None,
     ):
         extra_filter = self._normalize_extra_filter(extra_filter)
 
@@ -431,6 +439,9 @@ class FeatureViewEngine:
                 ) from e
             raise e
 
+        if lookback is not None:
+            query_obj._lookbacks = lookback
+
         fs_query = self._query_constructor_api.construct_query(query_obj)
         if fs_query.pit_query is not None:
             return fs_query.pit_query
@@ -446,11 +457,31 @@ class FeatureViewEngine:
         event_time=True,
         training_helper_columns=True,
         transformation_context: dict[str, Any] = None,
+        lookback: _lookback.Lookbacks | None = None,
     ):
+        # Build the lookback list (one entry per FG in the Query tree) from
+        # the feature view's query. The backend's POST /trainingdatasets
+        # handler reconstructs the query from the persisted FeatureView and
+        # Attach the lookbacks config to the training dataset so it rides on the
+        # wire as `TrainingDatasetDTO.lookbacks` (top-level). The backend resolves
+        # it against the reconstructed query tree in
+        # `QueryController.resolveLookbacks`, the shared walker used by the
+        # batch-data path.
+        if lookback is not None:
+            training_dataset_obj._lookbacks = lookback
         self._set_event_time(feature_view_obj, training_dataset_obj)
         updated_instance = self._create_training_data_metadata(
             feature_view_obj, training_dataset_obj
         )
+        # `_create_training_data_metadata` calls
+        # `TrainingDataset.update_from_response_json` which re-runs
+        # `__init__(**response)` and silently resets `_lookbacks` when the
+        # backend response omits the field. Re-set it on both the local TD
+        # and the returned instance so `compute_training_dataset` and any
+        # caller that inspects either object still sees the lookback.
+        if lookback is not None:
+            training_dataset_obj._lookbacks = lookback
+            updated_instance._lookbacks = lookback
         td_job = self.compute_training_dataset(
             feature_view_obj,
             user_write_options,
@@ -477,6 +508,15 @@ class FeatureViewEngine:
         dataframe_type="default",
         transformation_context: dict[str, Any] = None,
     ):
+        # Snapshot the user-supplied lookback BEFORE the metadata POST.
+        # `_create_training_data_metadata` calls
+        # `TrainingDataset.update_from_response_json` which re-runs
+        # `__init__(**response)` and silently resets `_lookbacks` to None when
+        # the backend response omits the field. The in-memory branch below
+        # needs the original lookback, so capture it now.
+        local_lookback = None
+        if training_dataset_obj is not None:
+            local_lookback = getattr(training_dataset_obj, "_lookbacks", None)
         # check if provided td version has already existed.
         if training_dataset_version:
             td_updated = self._get_training_dataset_metadata(
@@ -534,6 +574,16 @@ class FeatureViewEngine:
             )
         else:
             self._check_feature_group_accessibility(feature_view_obj)
+            # In-memory training-data fetches go through get_batch_query, which
+            # accepts a `lookback` kwarg that attaches Lookbacks to the Query
+            # so the backend's `QueryController.resolveLookbacks` picks it up.
+            # `local_lookback` was snapshotted above before the metadata POST
+            # reset `training_dataset_obj._lookbacks`; fall back to the
+            # roundtripped TD only if the snapshot was empty (e.g. the engine
+            # was entered with `training_dataset_version`).
+            in_memory_lookback = local_lookback
+            if in_memory_lookback is None:
+                in_memory_lookback = getattr(td_updated, "_lookbacks", None)
             query = self.get_batch_query(
                 feature_view_obj,
                 training_dataset_version=td_updated.version,
@@ -545,6 +595,7 @@ class FeatureViewEngine:
                 event_time=event_time,
                 training_helper_columns=training_helper_columns,
                 spine=spine,
+                lookback=in_memory_lookback,
             )
             split_df = engine.get_instance().get_training_data(
                 td_updated,
@@ -820,6 +871,10 @@ class FeatureViewEngine:
         else:
             raise ValueError("No training dataset object or version is provided")
 
+        # The materialization Spark job runs the PIT query off the batch query
+        # this method builds, so any lookback set on the TD must ride along.
+        # `create_training_dataset` puts the user-supplied Lookbacks on
+        # `training_dataset_obj._lookbacks` before calling this helper.
         batch_query = self.get_batch_query(
             feature_view_obj,
             training_dataset_obj.event_start_time,
@@ -831,6 +886,7 @@ class FeatureViewEngine:
             training_helper_columns=training_helper_columns,
             training_dataset_version=training_dataset_obj.version,
             spine=spine,
+            lookback=getattr(training_dataset_obj, "_lookbacks", None),
         )
 
         # for spark job
@@ -997,6 +1053,7 @@ class FeatureViewEngine:
         transformation_context: dict[str, Any] = None,
         logging_data: bool = False,
         extra_filter=None,
+        lookback=None,
     ):
         self._check_feature_group_accessibility(feature_view_obj)
 
@@ -1022,6 +1079,7 @@ class FeatureViewEngine:
             training_dataset_version=training_dataset_version,
             spine=spine,
             extra_filter=extra_filter,
+            lookback=lookback,
         ).read(read_options=read_options, dataframe_type=dataframe_type)
         if (transformation_functions and transformed) or logging_data:
             try:

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -52,8 +52,8 @@ if HAS_NUMPY:
 if TYPE_CHECKING:
     import pandas as pd
     import polars as pl
-    from hsfs.constructor import lookback as _lookback
     from hsfs.constructor.join import Join
+    from hsfs.constructor.lookback import Lookback
     from hsfs.core import explicit_provenance
     from hsfs.core.feature_logging import LoggingMetaData
     from hsfs.feature_logger import FeatureLogger
@@ -373,11 +373,11 @@ class FeatureViewEngine:
                 training_helper_columns=training_helper_columns,
                 extra_filter=extra_filter,
             )
-            # Attach the lookbacks config to the Query so it rides on the wire as
-            # `QueryDTO.lookbacks` (top-level). The backend resolves it against the
+            # Attach the lookback config to the Query so it rides on the wire as
+            # `QueryDTO.lookback` (top-level). The backend resolves it against the
             # query tree in `QueryController.resolveLookbacks`.
             if lookback is not None:
-                query._lookbacks = lookback
+                query.lookback = lookback
             # verify whatever is passed 1. spine group with dataframe contained, or 2. dataframe
             # the schema has to be consistent
 
@@ -416,7 +416,7 @@ class FeatureViewEngine:
         end_time,
         training_dataset_version=None,
         extra_filter=None,
-        lookback: _lookback.Lookbacks | None = None,
+        lookback: Lookback | None = None,
     ):
         extra_filter = self._normalize_extra_filter(extra_filter)
 
@@ -440,7 +440,7 @@ class FeatureViewEngine:
             raise e
 
         if lookback is not None:
-            query_obj._lookbacks = lookback
+            query_obj.lookback = lookback
 
         fs_query = self._query_constructor_api.construct_query(query_obj)
         if fs_query.pit_query is not None:
@@ -457,31 +457,22 @@ class FeatureViewEngine:
         event_time=True,
         training_helper_columns=True,
         transformation_context: dict[str, Any] = None,
-        lookback: _lookback.Lookbacks | None = None,
+        lookback: Lookback | None = None,
     ):
         # Build the lookback list (one entry per FG in the Query tree) from
         # the feature view's query. The backend's POST /trainingdatasets
         # handler reconstructs the query from the persisted FeatureView and
-        # Attach the lookbacks config to the training dataset so it rides on the
-        # wire as `TrainingDatasetDTO.lookbacks` (top-level). The backend resolves
+        # Attach the lookback config to the training dataset so it rides on the
+        # wire as `TrainingDatasetDTO.lookback` (top-level). The backend resolves
         # it against the reconstructed query tree in
         # `QueryController.resolveLookbacks`, the shared walker used by the
         # batch-data path.
         if lookback is not None:
-            training_dataset_obj._lookbacks = lookback
+            training_dataset_obj._lookback = lookback
         self._set_event_time(feature_view_obj, training_dataset_obj)
         updated_instance = self._create_training_data_metadata(
             feature_view_obj, training_dataset_obj
         )
-        # `_create_training_data_metadata` calls
-        # `TrainingDataset.update_from_response_json` which re-runs
-        # `__init__(**response)` and silently resets `_lookbacks` when the
-        # backend response omits the field. Re-set it on both the local TD
-        # and the returned instance so `compute_training_dataset` and any
-        # caller that inspects either object still sees the lookback.
-        if lookback is not None:
-            training_dataset_obj._lookbacks = lookback
-            updated_instance._lookbacks = lookback
         td_job = self.compute_training_dataset(
             feature_view_obj,
             user_write_options,
@@ -508,15 +499,6 @@ class FeatureViewEngine:
         dataframe_type="default",
         transformation_context: dict[str, Any] = None,
     ):
-        # Snapshot the user-supplied lookback BEFORE the metadata POST.
-        # `_create_training_data_metadata` calls
-        # `TrainingDataset.update_from_response_json` which re-runs
-        # `__init__(**response)` and silently resets `_lookbacks` to None when
-        # the backend response omits the field. The in-memory branch below
-        # needs the original lookback, so capture it now.
-        local_lookback = None
-        if training_dataset_obj is not None:
-            local_lookback = getattr(training_dataset_obj, "_lookbacks", None)
         # check if provided td version has already existed.
         if training_dataset_version:
             td_updated = self._get_training_dataset_metadata(
@@ -575,15 +557,10 @@ class FeatureViewEngine:
         else:
             self._check_feature_group_accessibility(feature_view_obj)
             # In-memory training-data fetches go through get_batch_query, which
-            # accepts a `lookback` kwarg that attaches Lookbacks to the Query
-            # so the backend's `QueryController.resolveLookbacks` picks it up.
-            # `local_lookback` was snapshotted above before the metadata POST
-            # reset `training_dataset_obj._lookbacks`; fall back to the
-            # roundtripped TD only if the snapshot was empty (e.g. the engine
-            # was entered with `training_dataset_version`).
-            in_memory_lookback = local_lookback
-            if in_memory_lookback is None:
-                in_memory_lookback = getattr(td_updated, "_lookbacks", None)
+            # attaches Lookback to the Query so the backend's lookback resolver
+            # picks it up. The lookback rides on the persisted training dataset
+            # and comes back with `td_updated` regardless of whether we just
+            # created it or fetched an existing version.
             query = self.get_batch_query(
                 feature_view_obj,
                 training_dataset_version=td_updated.version,
@@ -595,7 +572,7 @@ class FeatureViewEngine:
                 event_time=event_time,
                 training_helper_columns=training_helper_columns,
                 spine=spine,
-                lookback=in_memory_lookback,
+                lookback=td_updated._lookback,
             )
             split_df = engine.get_instance().get_training_data(
                 td_updated,
@@ -873,8 +850,8 @@ class FeatureViewEngine:
 
         # The materialization Spark job runs the PIT query off the batch query
         # this method builds, so any lookback set on the TD must ride along.
-        # `create_training_dataset` puts the user-supplied Lookbacks on
-        # `training_dataset_obj._lookbacks` before calling this helper.
+        # `create_training_dataset` puts the user-supplied Lookback on
+        # `training_dataset_obj._lookback` before calling this helper.
         batch_query = self.get_batch_query(
             feature_view_obj,
             training_dataset_obj.event_start_time,
@@ -886,7 +863,7 @@ class FeatureViewEngine:
             training_helper_columns=training_helper_columns,
             training_dataset_version=training_dataset_obj.version,
             spine=spine,
-            lookback=getattr(training_dataset_obj, "_lookbacks", None),
+            lookback=getattr(training_dataset_obj, "_lookback", None),
         )
 
         # for spark job

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -45,7 +45,7 @@ from hsfs import (
 from hsfs import serving_key as skm
 from hsfs.constructor import filter, query
 from hsfs.constructor.filter import Filter, Logic
-from hsfs.constructor.lookback import Lookback, Lookbacks
+from hsfs.constructor.lookback import FeatureGroupLookback, Lookback
 from hsfs.core import data_source as ds
 from hsfs.core import (
     explicit_provenance,
@@ -556,7 +556,7 @@ class FeatureView:
         start_time: str | int | datetime | date | None = None,
         end_time: str | int | datetime | date | None = None,
         extra_filter: filter.Filter | filter.Logic | None = None,
-        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
+        lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
     ) -> str:
         """Get a query string of the batch query.
 
@@ -596,9 +596,9 @@ class FeatureView:
                 Filters are pushed down to the data layer and combined with existing filters using AND logic.
             lookback:
                 Optional lookback window to bound the PIT join.
-                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
-                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
-                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
+                For one window across every feature group, pass a `FeatureGroupLookback` — e.g. `FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "PARTITION_KEY", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookback` — e.g. `Lookback(default=FeatureGroupLookback(...), feature_group_lookbacks={"dim_a": FeatureGroupLookback(...)})` or its dict form `{"default": {...}, "feature_group_lookbacks": {"dim_a": {...}}}`.
+                See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and [`Lookback`][hsfs.constructor.lookback.Lookback] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             The batch query.
@@ -613,7 +613,7 @@ class FeatureView:
                 else None
             ),
             extra_filter=extra_filter,
-            lookback=Lookbacks.from_user_input(lookback),
+            lookback=Lookback.from_user_input(lookback),
         )
 
     @public
@@ -1192,7 +1192,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         logging_data: bool = False,
         extra_filter: filter.Filter | filter.Logic | None = None,
-        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
+        lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         **kwargs,
     ) -> TrainingDatasetDataFrameTypes | HopsworksLoggingMetadataType:
         """Get a batch of data from an event time interval from the offline feature store.
@@ -1296,9 +1296,9 @@ class FeatureView:
                 Filters are pushed down to the data layer and combined with existing filters using AND logic.
             lookback:
                 Optional lookback window to bound the PIT join.
-                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
-                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
-                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
+                For one window across every feature group, pass a `FeatureGroupLookback` — e.g. `FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "PARTITION_KEY", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookback` — e.g. `Lookback(default=FeatureGroupLookback(...), feature_group_lookbacks={"dim_a": FeatureGroupLookback(...)})` or its dict form `{"default": {...}, "feature_group_lookbacks": {"dim_a": {...}}}`.
+                See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and [`Lookback`][hsfs.constructor.lookback.Lookback] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             DataFrame: The spark dataframe containing the feature data.
@@ -1327,7 +1327,7 @@ class FeatureView:
             transformation_context=transformation_context,
             logging_data=logging_data,
             extra_filter=extra_filter,
-            lookback=Lookbacks.from_user_input(lookback),
+            lookback=Lookback.from_user_input(lookback),
         )
 
     @public
@@ -1553,7 +1553,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         data_source: ds.DataSource | dict[str, Any] | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
-        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
+        lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[int, job.Job]:
         """Create the metadata for a training dataset and save the corresponding training data into `location`.
@@ -1723,9 +1723,9 @@ class FeatureView:
             tags: Tags to attach to the training dataset for better discoverability.
             lookback:
                 Optional lookback window persisted with the training dataset so re-reading the same training-dataset version reconstructs the same per-join predicate.
-                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
-                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
-                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
+                For one window across every feature group, pass a `FeatureGroupLookback` — e.g. `FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "PARTITION_KEY", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookback` — e.g. `Lookback(default=FeatureGroupLookback(...), feature_group_lookbacks={"dim_a": FeatureGroupLookback(...)})` or its dict form `{"default": {...}, "feature_group_lookbacks": {"dim_a": {...}}}`.
+                See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and [`Lookback`][hsfs.constructor.lookback.Lookback] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             td_version: training dataset version
@@ -1763,7 +1763,7 @@ class FeatureView:
             write_options or {},
             spine=spine,
             transformation_context=transformation_context,
-            lookback=Lookbacks.from_user_input(lookback),
+            lookback=Lookback.from_user_input(lookback),
         )
         warnings.warn(
             f"Incremented version to `{td.version}`.",
@@ -1796,7 +1796,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         data_source: ds.DataSource | dict[str, Any] | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
-        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
+        lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[int, job.Job]:
         # TODO: Convert the docstrings from this point on:
@@ -2017,9 +2017,9 @@ class FeatureView:
             tags: Tags to attach to the training dataset for better discoverability.
             lookback:
                 Optional lookback window persisted with the training dataset and applied to all splits.
-                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
-                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
-                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
+                For one window across every feature group, pass a `FeatureGroupLookback` — e.g. `FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "PARTITION_KEY", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookback` — e.g. `Lookback(default=FeatureGroupLookback(...), feature_group_lookbacks={"dim_a": FeatureGroupLookback(...)})` or its dict form `{"default": {...}, "feature_group_lookbacks": {"dim_a": {...}}}`.
+                See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and [`Lookback`][hsfs.constructor.lookback.Lookback] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             td_version: The version of the created training dataset.
@@ -2064,7 +2064,7 @@ class FeatureView:
             write_options or {},
             spine=spine,
             transformation_context=transformation_context,
-            lookback=Lookbacks.from_user_input(lookback),
+            lookback=Lookback.from_user_input(lookback),
         )
         warnings.warn(
             f"Incremented version to `{td.version}`.",
@@ -2099,7 +2099,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         data_source: ds.DataSource | dict[str, Any] | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
-        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
+        lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[int, job.Job]:
         """Create the metadata for a training dataset and save the corresponding training data into `location`.
@@ -2305,9 +2305,9 @@ class FeatureView:
             tags: Tags to attach to the training dataset for better discoverability.
             lookback:
                 Optional lookback window persisted with the training dataset and applied to all splits.
-                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
-                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
-                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
+                For one window across every feature group, pass a `FeatureGroupLookback` — e.g. `FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "PARTITION_KEY", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookback` — e.g. `Lookback(default=FeatureGroupLookback(...), feature_group_lookbacks={"dim_a": FeatureGroupLookback(...)})` or its dict form `{"default": {...}, "feature_group_lookbacks": {"dim_a": {...}}}`.
+                See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and [`Lookback`][hsfs.constructor.lookback.Lookback] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             td_version: The training dataset version.
@@ -2360,7 +2360,7 @@ class FeatureView:
             write_options or {},
             spine=spine,
             transformation_context=transformation_context,
-            lookback=Lookbacks.from_user_input(lookback),
+            lookback=Lookback.from_user_input(lookback),
         )
         warnings.warn(
             f"Incremented version to `{td.version}`.",
@@ -2469,7 +2469,7 @@ class FeatureView:
         training_helper_columns: bool = False,
         dataframe_type: str | None = "default",
         transformation_context: dict[str, Any] = None,
-        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
+        lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -2573,9 +2573,9 @@ class FeatureView:
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
             lookback:
                 Optional lookback window applied to the PIT join before reading; bounds the rows each joined feature group contributes so the engine can prune partitions before opening files.
-                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
-                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
-                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
+                For one window across every feature group, pass a `FeatureGroupLookback` — e.g. `FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "PARTITION_KEY", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookback` — e.g. `Lookback(default=FeatureGroupLookback(...), feature_group_lookbacks={"dim_a": FeatureGroupLookback(...)})` or its dict form `{"default": {...}, "feature_group_lookbacks": {"dim_a": {...}}}`.
+                See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and [`Lookback`][hsfs.constructor.lookback.Lookback] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             (X, y): Tuple of dataframe of features and labels. If there are no labels, y returns `None`.
@@ -2593,7 +2593,7 @@ class FeatureView:
             statistics_config=statistics_config,
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
-            lookbacks=Lookbacks.from_user_input(lookback),
+            lookback=Lookback.from_user_input(lookback),
         )
         td, df = self._feature_view_engine.get_training_data(
             self,
@@ -2633,7 +2633,7 @@ class FeatureView:
         training_helper_columns: bool = False,
         dataframe_type: str | None = "default",
         transformation_context: dict[str, Any] = None,
-        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
+        lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -2749,9 +2749,9 @@ class FeatureView:
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
             lookback:
                 Optional lookback window applied to the PIT join before reading; bounds the rows each joined feature group contributes so the engine can prune partitions before opening files. The same window applies to both the train and test splits.
-                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
-                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
-                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
+                For one window across every feature group, pass a `FeatureGroupLookback` — e.g. `FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "PARTITION_KEY", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookback` — e.g. `Lookback(default=FeatureGroupLookback(...), feature_group_lookbacks={"dim_a": FeatureGroupLookback(...)})` or its dict form `{"default": {...}, "feature_group_lookbacks": {"dim_a": {...}}}`.
+                See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and [`Lookback`][hsfs.constructor.lookback.Lookback] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             (X_train, X_test, y_train, y_test):
@@ -2777,7 +2777,7 @@ class FeatureView:
             statistics_config=statistics_config,
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
-            lookbacks=Lookbacks.from_user_input(lookback),
+            lookback=Lookback.from_user_input(lookback),
         )
         td, df = self._feature_view_engine.get_training_data(
             self,
@@ -2834,7 +2834,7 @@ class FeatureView:
         training_helper_columns: bool = False,
         dataframe_type: str | None = "default",
         transformation_context: dict[str, Any] = None,
-        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
+        lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -2965,9 +2965,9 @@ class FeatureView:
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
             lookback:
                 Optional lookback window applied to the PIT join before reading; bounds the rows each joined feature group contributes so the engine can prune partitions before opening files. The same window applies to all three splits.
-                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
-                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
-                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
+                For one window across every feature group, pass a `FeatureGroupLookback` — e.g. `FeatureGroupLookback(key="PARTITION_KEY", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "PARTITION_KEY", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookback` — e.g. `Lookback(default=FeatureGroupLookback(...), feature_group_lookbacks={"dim_a": FeatureGroupLookback(...)})` or its dict form `{"default": {...}, "feature_group_lookbacks": {"dim_a": {...}}}`.
+                See [`FeatureGroupLookback`][hsfs.constructor.lookback.FeatureGroupLookback] and [`Lookback`][hsfs.constructor.lookback.Lookback] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             (X_train, X_val, X_test, y_train, y_val, y_test):
@@ -3001,7 +3001,7 @@ class FeatureView:
             statistics_config=statistics_config,
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
-            lookbacks=Lookbacks.from_user_input(lookback),
+            lookback=Lookback.from_user_input(lookback),
         )
         td, df = self._feature_view_engine.get_training_data(
             self,

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -45,6 +45,7 @@ from hsfs import (
 from hsfs import serving_key as skm
 from hsfs.constructor import filter, query
 from hsfs.constructor.filter import Filter, Logic
+from hsfs.constructor.lookback import Lookback, Lookbacks
 from hsfs.core import data_source as ds
 from hsfs.core import (
     explicit_provenance,
@@ -555,6 +556,7 @@ class FeatureView:
         start_time: str | int | datetime | date | None = None,
         end_time: str | int | datetime | date | None = None,
         extra_filter: filter.Filter | filter.Logic | None = None,
+        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
     ) -> str:
         """Get a query string of the batch query.
 
@@ -592,6 +594,11 @@ class FeatureView:
             extra_filter:
                 Additional filters to be applied to the batch query on top of any feature view or training dataset filters.
                 Filters are pushed down to the data layer and combined with existing filters using AND logic.
+            lookback:
+                Optional lookback window to bound the PIT join.
+                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
+                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             The batch query.
@@ -606,6 +613,7 @@ class FeatureView:
                 else None
             ),
             extra_filter=extra_filter,
+            lookback=Lookbacks.from_user_input(lookback),
         )
 
     @public
@@ -1184,6 +1192,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         logging_data: bool = False,
         extra_filter: filter.Filter | filter.Logic | None = None,
+        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
         **kwargs,
     ) -> TrainingDatasetDataFrameTypes | HopsworksLoggingMetadataType:
         """Get a batch of data from an event time interval from the offline feature store.
@@ -1285,6 +1294,11 @@ class FeatureView:
             extra_filter:
                 Additional filters to be applied to the batch data on top of any feature view or training dataset filters.
                 Filters are pushed down to the data layer and combined with existing filters using AND logic.
+            lookback:
+                Optional lookback window to bound the PIT join.
+                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
+                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             DataFrame: The spark dataframe containing the feature data.
@@ -1313,6 +1327,7 @@ class FeatureView:
             transformation_context=transformation_context,
             logging_data=logging_data,
             extra_filter=extra_filter,
+            lookback=Lookbacks.from_user_input(lookback),
         )
 
     @public
@@ -1538,6 +1553,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         data_source: ds.DataSource | dict[str, Any] | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
+        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[int, job.Job]:
         """Create the metadata for a training dataset and save the corresponding training data into `location`.
@@ -1705,6 +1721,11 @@ class FeatureView:
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution.
             data_source: The data source specifying the location of the data. Overrides the storage_connector and location arguments when specified.
             tags: Tags to attach to the training dataset for better discoverability.
+            lookback:
+                Optional lookback window persisted with the training dataset so re-reading the same training-dataset version reconstructs the same per-join predicate.
+                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
+                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             td_version: training dataset version
@@ -1742,6 +1763,7 @@ class FeatureView:
             write_options or {},
             spine=spine,
             transformation_context=transformation_context,
+            lookback=Lookbacks.from_user_input(lookback),
         )
         warnings.warn(
             f"Incremented version to `{td.version}`.",
@@ -1774,6 +1796,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         data_source: ds.DataSource | dict[str, Any] | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
+        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[int, job.Job]:
         # TODO: Convert the docstrings from this point on:
@@ -1992,6 +2015,11 @@ class FeatureView:
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
             data_source: The data source specifying the location of the data. Overrides the storage_connector and location arguments when specified.
             tags: Tags to attach to the training dataset for better discoverability.
+            lookback:
+                Optional lookback window persisted with the training dataset and applied to all splits.
+                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
+                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             td_version: The version of the created training dataset.
@@ -2036,6 +2064,7 @@ class FeatureView:
             write_options or {},
             spine=spine,
             transformation_context=transformation_context,
+            lookback=Lookbacks.from_user_input(lookback),
         )
         warnings.warn(
             f"Incremented version to `{td.version}`.",
@@ -2070,6 +2099,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         data_source: ds.DataSource | dict[str, Any] | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
+        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[int, job.Job]:
         """Create the metadata for a training dataset and save the corresponding training data into `location`.
@@ -2273,6 +2303,11 @@ class FeatureView:
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
             data_source: The data source specifying the location of the data. Overrides the storage_connector and location arguments when specified.
             tags: Tags to attach to the training dataset for better discoverability.
+            lookback:
+                Optional lookback window persisted with the training dataset and applied to all splits.
+                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
+                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             td_version: The training dataset version.
@@ -2325,6 +2360,7 @@ class FeatureView:
             write_options or {},
             spine=spine,
             transformation_context=transformation_context,
+            lookback=Lookbacks.from_user_input(lookback),
         )
         warnings.warn(
             f"Incremented version to `{td.version}`.",
@@ -2433,6 +2469,7 @@ class FeatureView:
         training_helper_columns: bool = False,
         dataframe_type: str | None = "default",
         transformation_context: dict[str, Any] = None,
+        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -2534,6 +2571,11 @@ class FeatureView:
             transformation_context:
                 A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
+            lookback:
+                Optional lookback window applied to the PIT join before reading; bounds the rows each joined feature group contributes so the engine can prune partitions before opening files.
+                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
+                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             (X, y): Tuple of dataframe of features and labels. If there are no labels, y returns `None`.
@@ -2551,6 +2593,7 @@ class FeatureView:
             statistics_config=statistics_config,
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
+            lookbacks=Lookbacks.from_user_input(lookback),
         )
         td, df = self._feature_view_engine.get_training_data(
             self,
@@ -2590,6 +2633,7 @@ class FeatureView:
         training_helper_columns: bool = False,
         dataframe_type: str | None = "default",
         transformation_context: dict[str, Any] = None,
+        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -2703,6 +2747,11 @@ class FeatureView:
             transformation_context:
                 A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
+            lookback:
+                Optional lookback window applied to the PIT join before reading; bounds the rows each joined feature group contributes so the engine can prune partitions before opening files. The same window applies to both the train and test splits.
+                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
+                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             (X_train, X_test, y_train, y_test):
@@ -2728,6 +2777,7 @@ class FeatureView:
             statistics_config=statistics_config,
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
+            lookbacks=Lookbacks.from_user_input(lookback),
         )
         td, df = self._feature_view_engine.get_training_data(
             self,
@@ -2784,6 +2834,7 @@ class FeatureView:
         training_helper_columns: bool = False,
         dataframe_type: str | None = "default",
         transformation_context: dict[str, Any] = None,
+        lookback: Lookback | Lookbacks | dict[str, Any] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -2912,6 +2963,11 @@ class FeatureView:
             transformation_context:
                 A dictionary mapping variable names to objects that will be provided as contextual information to the transformation function at runtime.
                 The `context` variable must be explicitly defined as parameters in the transformation function for these to be accessible during execution. If no context variables are provided, this parameter defaults to `None`.
+            lookback:
+                Optional lookback window applied to the PIT join before reading; bounds the rows each joined feature group contributes so the engine can prune partitions before opening files. The same window applies to all three splits.
+                For one window across every feature group, pass a `Lookback` — e.g. `Lookback(key="partition_key", start=date(2026, 5, 5), end=date(2026, 5, 17))` or its dict form `{"key": "partition_key", "start": date(2026, 5, 5), "end": date(2026, 5, 17)}`.
+                For different windows per feature group, pass a `Lookbacks` — e.g. `Lookbacks(default=Lookback(...), feature_groups={"dim_a": Lookback(...)})` or its dict form `{"default": {...}, "feature_groups": {"dim_a": {...}}}`.
+                See [`Lookback`][hsfs.constructor.lookback.Lookback] and [`Lookbacks`][hsfs.constructor.lookback.Lookbacks] for accepted key values, validation rules, and per-FG key matching semantics.
 
         Returns:
             (X_train, X_val, X_test, y_train, y_val, y_test):
@@ -2945,6 +3001,7 @@ class FeatureView:
             statistics_config=statistics_config,
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
+            lookbacks=Lookbacks.from_user_input(lookback),
         )
         td, df = self._feature_view_engine.get_training_data(
             self,

--- a/python/hsfs/training_dataset.py
+++ b/python/hsfs/training_dataset.py
@@ -25,7 +25,7 @@ from hopsworks_common.client.exceptions import RestAPIError
 from hsfs import engine, tag, training_dataset_feature, util
 from hsfs.constructor import filter
 from hsfs.constructor import query as query_module
-from hsfs.constructor.lookback import Lookbacks
+from hsfs.constructor.lookback import Lookback
 from hsfs.core import data_source as ds
 from hsfs.core import (
     statistics_engine,
@@ -588,7 +588,7 @@ class TrainingDataset(TrainingDatasetBase):
         data_source=None,
         missing_mandatory_tags=None,
         tags=None,
-        lookbacks=None,
+        lookback=None,
         **kwargs,
     ):
         super().__init__(
@@ -629,15 +629,15 @@ class TrainingDataset(TrainingDatasetBase):
         self._querydto = querydto
         self._feature_store_id = featurestore_id
         self._feature_store_name = featurestore_name
-        # Normalize so `_lookbacks` is always a `Lookbacks` instance or None.
+        # Normalize so `_lookback` is always a `Lookback` instance or None.
         # `update_from_response_json` calls `__init__(**response)` with the
-        # decamelized wire dict (`{"default_lookback": ..., "feature_groups": [...]}`),
-        # which would otherwise leak a raw dict into `_lookbacks` and crash the next
-        # `to_dict()` (it calls `self._lookbacks.to_dict()`).
-        if isinstance(lookbacks, Lookbacks) or lookbacks is None:
-            self._lookbacks = lookbacks
+        # decamelized wire dict (`{"default_lookback": ..., "feature_group_lookbacks": [...]}`),
+        # which would otherwise leak a raw dict into `_lookback` and crash the next
+        # `to_dict()` (it calls `self._lookback.to_dict()`).
+        if isinstance(lookback, Lookback) or lookback is None:
+            self._lookback = lookback
         else:
-            self._lookbacks = Lookbacks.from_response_json(lookbacks)
+            self._lookback = Lookback.from_response_json(lookback)
 
         self._training_dataset_api = training_dataset_api.TrainingDatasetApi(
             featurestore_id
@@ -992,8 +992,8 @@ class TrainingDataset(TrainingDatasetBase):
             "extraFilter": self._extra_filter,
             "type": "trainingDatasetDTO",
         }
-        if self._lookbacks is not None:
-            td_dict["lookbacks"] = self._lookbacks.to_dict()
+        if self._lookback is not None:
+            td_dict["lookback"] = self._lookback.to_dict()
         if self._data_source:
             td_dict["dataSource"] = self._data_source.to_dict()
         tags_dict = tag.Tag.tags_to_dict(self._tags)

--- a/python/hsfs/training_dataset.py
+++ b/python/hsfs/training_dataset.py
@@ -25,6 +25,7 @@ from hopsworks_common.client.exceptions import RestAPIError
 from hsfs import engine, tag, training_dataset_feature, util
 from hsfs.constructor import filter
 from hsfs.constructor import query as query_module
+from hsfs.constructor.lookback import Lookbacks
 from hsfs.core import data_source as ds
 from hsfs.core import (
     statistics_engine,
@@ -587,6 +588,7 @@ class TrainingDataset(TrainingDatasetBase):
         data_source=None,
         missing_mandatory_tags=None,
         tags=None,
+        lookbacks=None,
         **kwargs,
     ):
         super().__init__(
@@ -627,6 +629,15 @@ class TrainingDataset(TrainingDatasetBase):
         self._querydto = querydto
         self._feature_store_id = featurestore_id
         self._feature_store_name = featurestore_name
+        # Normalize so `_lookbacks` is always a `Lookbacks` instance or None.
+        # `update_from_response_json` calls `__init__(**response)` with the
+        # decamelized wire dict (`{"default_lookback": ..., "feature_groups": [...]}`),
+        # which would otherwise leak a raw dict into `_lookbacks` and crash the next
+        # `to_dict()` (it calls `self._lookbacks.to_dict()`).
+        if isinstance(lookbacks, Lookbacks) or lookbacks is None:
+            self._lookbacks = lookbacks
+        else:
+            self._lookbacks = Lookbacks.from_response_json(lookbacks)
 
         self._training_dataset_api = training_dataset_api.TrainingDatasetApi(
             featurestore_id
@@ -981,6 +992,8 @@ class TrainingDataset(TrainingDatasetBase):
             "extraFilter": self._extra_filter,
             "type": "trainingDatasetDTO",
         }
+        if self._lookbacks is not None:
+            td_dict["lookbacks"] = self._lookbacks.to_dict()
         if self._data_source:
             td_dict["dataSource"] = self._data_source.to_dict()
         tags_dict = tag.Tag.tags_to_dict(self._tags)

--- a/python/tests/constructor/test_lookback.py
+++ b/python/tests/constructor/test_lookback.py
@@ -1,0 +1,479 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from datetime import date, datetime, timezone
+
+import pytest
+from hsfs.constructor.lookback import (
+    EVENT_TIME,
+    PARTITION_KEY,
+    Lookback,
+    Lookbacks,
+)
+from hsfs.feature_group import FeatureGroup
+
+
+def _epoch_ms(d: date | datetime) -> int:
+    if isinstance(d, datetime):
+        if d.tzinfo is None:
+            d = d.replace(tzinfo=timezone.utc)
+        return int(d.timestamp() * 1000)
+    return int(datetime(d.year, d.month, d.day, tzinfo=timezone.utc).timestamp() * 1000)
+
+
+# ---------- Fixtures -----------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_client(mocker):
+    """Patch HTTP client + engine so `FeatureGroup` and `Query` construct cheaply.
+
+    `FeatureGroupBase.__init__` instantiates `VariableApi`/`AlertsApi`, both of
+    which look up the HTTP client. `Query.__init__` calls `engine.get_type()`.
+    Mocking these avoids any network or engine-init work in unit tests.
+    """
+    mocker.patch("hopsworks_common.client.get_instance")
+    mocker.patch("hsfs.engine.get_type", return_value="python")
+
+
+def _fg(name, version=1, featurestore_id=99):
+    """Construct a real `FeatureGroup` minimally."""
+    return FeatureGroup(
+        name, version, featurestore_id, id=hash((name, version)) & 0xFFFFFFFF
+    )
+
+
+# ---------- Lookback construction matrix --------------------------------------
+
+
+class TestLookbackConstruction:
+    def test_partition_key_both_bounds(self):
+        lb = Lookback(
+            key=PARTITION_KEY,
+            start=date(2026, 5, 10),
+            end=date(2026, 5, 17),
+        )
+        assert lb.key == "partition_key"
+        assert lb.start == date(2026, 5, 10)
+        assert lb.end == date(2026, 5, 17)
+
+    def test_event_time_with_datetime_bounds(self):
+        lb = Lookback(
+            key=EVENT_TIME,
+            start=datetime(2026, 5, 10, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 5, 17, 12, 30, tzinfo=timezone.utc),
+        )
+        assert lb.key == "event_time"
+
+    def test_end_optional(self):
+        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 10))
+        assert lb.end is None
+
+    def test_mixed_date_and_datetime_bounds(self):
+        lb = Lookback(
+            key=PARTITION_KEY,
+            start=date(2026, 5, 10),
+            end=datetime(2026, 5, 17, 23, 59, tzinfo=timezone.utc),
+        )
+        assert lb.start == date(2026, 5, 10)
+        assert isinstance(lb.end, datetime)
+
+    def test_invalid_key(self):
+        with pytest.raises(ValueError, match="`key` must be one of"):
+            Lookback(key="bogus", start=date(2026, 5, 10))
+
+    def test_inverted_range_rejected(self):
+        with pytest.raises(ValueError, match="must be strictly earlier than"):
+            Lookback(
+                key=PARTITION_KEY,
+                start=date(2026, 5, 17),
+                end=date(2026, 5, 10),
+            )
+
+    def test_equal_bounds_rejected(self):
+        with pytest.raises(ValueError, match="must be strictly earlier than"):
+            Lookback(
+                key=PARTITION_KEY,
+                start=date(2026, 5, 10),
+                end=date(2026, 5, 10),
+            )
+
+
+# ---------- Lookback serializers ----------------------------------------------
+
+
+class TestLookbackToDict:
+    def test_both_bounds_wire_format(self):
+        lb = Lookback(
+            key=PARTITION_KEY,
+            start=date(2026, 5, 10),
+            end=date(2026, 5, 17),
+        )
+        payload = lb.to_dict()
+        assert payload["lookbackKey"] == "PARTITION_KEY"
+        assert payload["start"] == _epoch_ms(date(2026, 5, 10))
+        assert payload["end"] == _epoch_ms(date(2026, 5, 17))
+
+    def test_end_omitted_from_payload(self):
+        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 10))
+        payload = lb.to_dict()
+        assert "end" not in payload
+        assert payload["start"] == _epoch_ms(date(2026, 5, 10))
+
+
+class TestLookbackFromDict:
+    def test_user_form_round_trip(self):
+        rebuilt = Lookback.from_dict(
+            {
+                "key": "partition_key",
+                "start": date(2026, 5, 10),
+                "end": date(2026, 5, 17),
+            }
+        )
+        assert rebuilt.key == "partition_key"
+        assert rebuilt.start == date(2026, 5, 10)
+        assert rebuilt.end == date(2026, 5, 17)
+
+    def test_passthrough_existing_instance(self):
+        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 10))
+        assert Lookback.from_dict(lb) is lb
+
+    def test_none_input(self):
+        assert Lookback.from_dict(None) is None
+
+    def test_rejects_non_dict_input(self):
+        with pytest.raises(TypeError):
+            Lookback.from_dict("not a dict")
+
+
+# ---------- Lookbacks construction -----------------------------------------
+
+
+class TestLookbacksConstruction:
+    def _lb(self):
+        return Lookback(
+            key=PARTITION_KEY, start=date(2026, 5, 5), end=date(2026, 5, 17)
+        )
+
+    def test_default_only(self):
+        plan = Lookbacks(default=self._lb())
+        assert plan.default is not None
+        assert plan.feature_groups == {}
+
+    def test_feature_groups_only(self):
+        plan = Lookbacks(feature_groups={"transactions": self._lb()})
+        assert plan.default is None
+        assert "transactions" in plan.feature_groups
+
+    def test_both(self):
+        plan = Lookbacks(
+            default=self._lb(), feature_groups={"transactions": self._lb()}
+        )
+        assert plan.default is not None
+        assert "transactions" in plan.feature_groups
+
+    def test_empty_plan_rejected(self):
+        with pytest.raises(
+            ValueError, match="at least one of `default` or `feature_groups`"
+        ):
+            Lookbacks()
+
+    def test_empty_feature_groups_rejected(self):
+        with pytest.raises(
+            ValueError, match="at least one of `default` or `feature_groups`"
+        ):
+            Lookbacks(feature_groups={})
+
+    def test_dict_values_in_feature_groups(self):
+        plan = Lookbacks(
+            feature_groups={
+                "transactions": {"key": "partition_key", "start": date(2026, 5, 5)}
+            }
+        )
+        assert plan.feature_groups["transactions"].key == "partition_key"
+
+    def test_dict_default(self):
+        plan = Lookbacks(default={"key": "partition_key", "start": date(2026, 5, 5)})
+        assert plan.default.key == "partition_key"
+
+
+# ---------- Key shape matrix ---------------------------------------------------
+
+
+class TestKeyShapes:
+    def _lb(self):
+        return Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+
+    def test_bare_string(self):
+        # Bare-string key encodes "any version" on the wire (backend matches every
+        # version of the named FG).
+        plan = Lookbacks(feature_groups={"dim_a": self._lb()})
+        assert "dim_a" in plan.feature_groups
+
+    def test_fg_instance(self):
+        # FG-instance key encodes the FG's specific (name, version) pair.
+        fg = _fg("dim_a", 1)
+        plan = Lookbacks(feature_groups={fg: self._lb()})
+        assert fg in plan.feature_groups
+
+
+# ---------- Malformed-key rejection -------------------------------------------
+
+
+class TestMalformedKeys:
+    def _lb(self):
+        return Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+
+    def test_none_key(self):
+        with pytest.raises(ValueError, match="must be a str or FeatureGroup"):
+            Lookbacks(feature_groups={None: self._lb()})
+
+    def test_int_key(self):
+        with pytest.raises(ValueError, match="must be a str or FeatureGroup"):
+            Lookbacks(feature_groups={42: self._lb()})
+
+    def test_tuple_key_rejected(self):
+        with pytest.raises(ValueError, match="must be a str or FeatureGroup"):
+            Lookbacks(feature_groups={("dim_a", 1): self._lb()})
+
+    def test_object_with_name_and_version_attrs_rejected(self):
+        # Anything that isn't an actual FeatureGroupBase subclass must be rejected,
+        # even if it happens to expose .name + .version.
+        class _NotAnFG:
+            name = "dim_a"
+            version = 1
+
+        with pytest.raises(ValueError, match="must be a str or FeatureGroup"):
+            Lookbacks(feature_groups={_NotAnFG(): self._lb()})
+
+    def test_none_value_rejected(self):
+        # A None value in feature_groups must be rejected up-front rather than
+        # silently stored (which would later crash to_dict with AttributeError).
+        with pytest.raises(ValueError, match="must be a Lookback or dict; got None"):
+            Lookbacks(feature_groups={"dim_a": None})
+
+
+# ---------- Dict disambiguation -----------------------------------------------
+
+
+class TestDictDisambiguation:
+    def test_empty_dict_rejected(self):
+        with pytest.raises(ValueError, match="lookback dict cannot be empty"):
+            Lookbacks.from_user_input({})
+
+    def test_mixed_keys_rejected(self):
+        with pytest.raises(ValueError, match="mixes uniform keys"):
+            Lookbacks.from_user_input(
+                {"key": "partition_key", "feature_groups": {"x": {"key": "event_time"}}}
+            )
+
+    def test_unknown_keys_rejected(self):
+        with pytest.raises(ValueError, match="unknown lookback keys"):
+            Lookbacks.from_user_input({"foo": "bar"})
+
+    def test_leaf_dict_returns_lookbacks_with_default(self):
+        # A uniform-shape dict is wrapped as Lookbacks(default=Lookback(...))
+        # so internal callers always see a single type. Every field on the
+        # inner Lookback must come through from the dict — this is the entry
+        # point used by `FeatureView.get_batch_data(lookback={...})`.
+        result = Lookbacks.from_user_input(
+            {
+                "key": "partition_key",
+                "start": date(2026, 5, 5),
+                "end": date(2026, 5, 17),
+            }
+        )
+        assert isinstance(result, Lookbacks)
+        assert isinstance(result.default, Lookback)
+        assert result.default.key == "partition_key"
+        assert result.default.start == date(2026, 5, 5)
+        assert result.default.end == date(2026, 5, 17)
+        assert result.feature_groups == {}
+
+    def test_plan_dict_returns_lookbacks(self):
+        result = Lookbacks.from_user_input(
+            {
+                "feature_groups": {
+                    "transactions": {"key": "partition_key", "start": date(2026, 5, 5)}
+                }
+            }
+        )
+        assert isinstance(result, Lookbacks)
+        assert "transactions" in result.feature_groups
+
+    def test_none_returns_none(self):
+        assert Lookbacks.from_user_input(None) is None
+
+    def test_lookback_instance_wrapped_as_lookbacks(self):
+        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        result = Lookbacks.from_user_input(lb)
+        assert isinstance(result, Lookbacks)
+        assert result.default is lb
+        assert result.feature_groups == {}
+
+    def test_lookbacks_instance_passthrough(self):
+        plan = Lookbacks(default=Lookback(key=PARTITION_KEY, start=date(2026, 5, 5)))
+        assert Lookbacks.from_user_input(plan) is plan
+
+    def test_non_dict_non_instance_rejected(self):
+        with pytest.raises(TypeError, match="lookback must be"):
+            Lookbacks.from_user_input(42)
+
+    def test_fully_dict_input_constructs_inner_lookbacks(self):
+        # Config-file style: a single deeply-nested dict with `default` and
+        # `feature_groups` as dicts and inner Lookback dicts as their values.
+        # Every field must round-trip through to a real `Lookback` instance.
+        result = Lookbacks.from_user_input(
+            {
+                "default": {
+                    "key": "partition_key",
+                    "start": date(2026, 5, 5),
+                    "end": date(2026, 5, 17),
+                },
+                "feature_groups": {
+                    "dim_a": {
+                        "key": "event_time",
+                        "start": date(2026, 5, 10),
+                    },
+                },
+            }
+        )
+        assert isinstance(result, Lookbacks)
+        assert isinstance(result.default, Lookback)
+        assert result.default.key == "partition_key"
+        assert result.default.start == date(2026, 5, 5)
+        assert result.default.end == date(2026, 5, 17)
+        dim_a_lb = result.feature_groups["dim_a"]
+        assert isinstance(dim_a_lb, Lookback)
+        assert dim_a_lb.key == "event_time"
+        assert dim_a_lb.start == date(2026, 5, 10)
+        assert dim_a_lb.end is None
+
+
+# ---------- Lookbacks wire serialization --------------------------------------
+
+
+class TestLookbacksToDict:
+    """Verifies the SDK→backend wire shape emitted by `Lookbacks.to_dict()`.
+
+    The backend's `QueryController.resolveLookbacks` consumes this shape: it reads
+    `defaultLookback` and walks `featureGroups`, matching entries to query nodes
+    by `(name, version)` with `version=None` encoding "any version".
+    """
+
+    def _lb_dict(self, start, end=None):
+        # Mirror Lookback.to_dict() so the assertion isn't tied to repr internals.
+        return Lookback(key=PARTITION_KEY, start=start, end=end).to_dict()
+
+    def test_default_only_emits_default_no_feature_groups(self):
+        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        wire = Lookbacks(default=lb).to_dict()
+        assert wire == {"defaultLookback": lb.to_dict()}
+
+    def test_bare_string_key_emits_null_version(self):
+        # version=None on the wire tells the backend "any version of this name".
+        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        wire = Lookbacks(feature_groups={"dim_a": lb}).to_dict()
+        assert wire == {
+            "featureGroups": [
+                {"name": "dim_a", "version": None, "lookback": lb.to_dict()},
+            ],
+        }
+
+    def test_fg_instance_key_emits_specific_version(self):
+        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        fg = _fg("dim_a", 3)
+        wire = Lookbacks(feature_groups={fg: lb}).to_dict()
+        assert wire == {
+            "featureGroups": [
+                {"name": "dim_a", "version": 3, "lookback": lb.to_dict()},
+            ],
+        }
+
+    def test_default_plus_feature_groups_emits_both(self):
+        default = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        override = Lookback(key=EVENT_TIME, start=date(2026, 5, 10))
+        wire = Lookbacks(
+            default=default,
+            feature_groups={"dim_a": override},
+        ).to_dict()
+        assert wire == {
+            "defaultLookback": default.to_dict(),
+            "featureGroups": [
+                {"name": "dim_a", "version": None, "lookback": override.to_dict()},
+            ],
+        }
+
+
+class TestLookbackFromResponseJsonRoundTrip:
+    """Cross-process reconstruction via the wire form.
+
+    The Spark materialization job and any other cross-process consumer rebuilds a Query
+    from its serialized payload via `Query.from_response_json`, which in turn calls
+    `Lookbacks.from_response_json` / `Lookback.from_response_json`. The reconstructed
+    `_start`/`_end` carry raw epoch-millis `int`s rather than the user-form
+    `date`/`datetime` shapes — `to_dict()` must still round-trip the integer bounds
+    losslessly because that's what the SDK re-sends to the backend.
+    """
+
+    def test_epoch_ms_int_bounds_survive_round_trip(self):
+        start_ms = _epoch_ms(date(2026, 5, 10))
+        end_ms = _epoch_ms(date(2026, 5, 17))
+        wire = {"lookback_key": "PARTITION_KEY", "start": start_ms, "end": end_ms}
+        lb = Lookback.from_response_json(wire)
+        assert lb is not None
+        # Properties expose the raw int (per widened type hints).
+        assert lb.start == start_ms
+        assert lb.end == end_ms
+        assert lb.key == PARTITION_KEY
+        # to_dict must re-emit the same epoch-ms ints (not strings, not None).
+        payload = lb.to_dict()
+        assert payload == {
+            "lookbackKey": "PARTITION_KEY",
+            "start": start_ms,
+            "end": end_ms,
+        }
+
+    def test_lookbacks_round_trip_with_default_and_overrides(self):
+        start_ms = _epoch_ms(date(2026, 5, 5))
+        end_ms = _epoch_ms(date(2026, 5, 12))
+        wire = {
+            "default_lookback": {
+                "lookback_key": "PARTITION_KEY",
+                "start": start_ms,
+                "end": end_ms,
+            },
+            "feature_groups": [
+                {
+                    "name": "dim_a",
+                    "version": None,
+                    "lookback": {
+                        "lookback_key": "EVENT_TIME",
+                        "start": start_ms,
+                    },
+                },
+            ],
+        }
+        looks = Lookbacks.from_response_json(wire)
+        assert looks is not None
+        # The reconstructed Lookbacks goes through to_dict cleanly — guards against
+        # the same `_lookbacks is dict` AttributeError class as the TD constructor fix.
+        payload = looks.to_dict()
+        assert payload["defaultLookback"]["lookbackKey"] == "PARTITION_KEY"
+        assert payload["defaultLookback"]["start"] == start_ms
+        assert payload["defaultLookback"]["end"] == end_ms
+        assert payload["featureGroups"][0]["name"] == "dim_a"
+        assert payload["featureGroups"][0]["lookback"]["lookbackKey"] == "EVENT_TIME"

--- a/python/tests/constructor/test_lookback.py
+++ b/python/tests/constructor/test_lookback.py
@@ -20,8 +20,8 @@ import pytest
 from hsfs.constructor.lookback import (
     EVENT_TIME,
     PARTITION_KEY,
+    FeatureGroupLookback,
     Lookback,
-    Lookbacks,
 )
 from hsfs.feature_group import FeatureGroup
 
@@ -56,34 +56,34 @@ def _fg(name, version=1, featurestore_id=99):
     )
 
 
-# ---------- Lookback construction matrix --------------------------------------
+# ---------- FeatureGroupLookback construction matrix --------------------------------------
 
 
-class TestLookbackConstruction:
+class TestFeatureGroupLookbackConstruction:
     def test_partition_key_both_bounds(self):
-        lb = Lookback(
+        lb = FeatureGroupLookback(
             key=PARTITION_KEY,
             start=date(2026, 5, 10),
             end=date(2026, 5, 17),
         )
-        assert lb.key == "partition_key"
+        assert lb.key == "PARTITION_KEY"
         assert lb.start == date(2026, 5, 10)
         assert lb.end == date(2026, 5, 17)
 
     def test_event_time_with_datetime_bounds(self):
-        lb = Lookback(
+        lb = FeatureGroupLookback(
             key=EVENT_TIME,
             start=datetime(2026, 5, 10, 0, 0, tzinfo=timezone.utc),
             end=datetime(2026, 5, 17, 12, 30, tzinfo=timezone.utc),
         )
-        assert lb.key == "event_time"
+        assert lb.key == "EVENT_TIME"
 
     def test_end_optional(self):
-        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 10))
+        lb = FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 10))
         assert lb.end is None
 
     def test_mixed_date_and_datetime_bounds(self):
-        lb = Lookback(
+        lb = FeatureGroupLookback(
             key=PARTITION_KEY,
             start=date(2026, 5, 10),
             end=datetime(2026, 5, 17, 23, 59, tzinfo=timezone.utc),
@@ -93,11 +93,21 @@ class TestLookbackConstruction:
 
     def test_invalid_key(self):
         with pytest.raises(ValueError, match="`key` must be one of"):
-            Lookback(key="bogus", start=date(2026, 5, 10))
+            FeatureGroupLookback(key="bogus", start=date(2026, 5, 10))
+
+    def test_key_is_case_insensitive(self):
+        # The validation check accepts any casing; the stored `.key` is the
+        # canonical upper-case form regardless of what the caller passed.
+        for raw in ("partition_key", "Partition_Key", "PARTITION_KEY"):
+            lb = FeatureGroupLookback(key=raw, start=date(2026, 5, 10))
+            assert lb.key == PARTITION_KEY
+        for raw in ("event_time", "Event_Time", "EVENT_TIME"):
+            lb = FeatureGroupLookback(key=raw, start=date(2026, 5, 10))
+            assert lb.key == EVENT_TIME
 
     def test_inverted_range_rejected(self):
         with pytest.raises(ValueError, match="must be strictly earlier than"):
-            Lookback(
+            FeatureGroupLookback(
                 key=PARTITION_KEY,
                 start=date(2026, 5, 17),
                 end=date(2026, 5, 10),
@@ -105,19 +115,19 @@ class TestLookbackConstruction:
 
     def test_equal_bounds_rejected(self):
         with pytest.raises(ValueError, match="must be strictly earlier than"):
-            Lookback(
+            FeatureGroupLookback(
                 key=PARTITION_KEY,
                 start=date(2026, 5, 10),
                 end=date(2026, 5, 10),
             )
 
 
-# ---------- Lookback serializers ----------------------------------------------
+# ---------- FeatureGroupLookback serializers ----------------------------------------------
 
 
-class TestLookbackToDict:
+class TestFeatureGroupLookbackToDict:
     def test_both_bounds_wire_format(self):
-        lb = Lookback(
+        lb = FeatureGroupLookback(
             key=PARTITION_KEY,
             start=date(2026, 5, 10),
             end=date(2026, 5, 17),
@@ -128,86 +138,86 @@ class TestLookbackToDict:
         assert payload["end"] == _epoch_ms(date(2026, 5, 17))
 
     def test_end_omitted_from_payload(self):
-        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 10))
+        lb = FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 10))
         payload = lb.to_dict()
         assert "end" not in payload
         assert payload["start"] == _epoch_ms(date(2026, 5, 10))
 
 
-class TestLookbackFromDict:
+class TestFeatureGroupLookbackFromDict:
     def test_user_form_round_trip(self):
-        rebuilt = Lookback.from_dict(
+        rebuilt = FeatureGroupLookback.from_dict(
             {
                 "key": "partition_key",
                 "start": date(2026, 5, 10),
                 "end": date(2026, 5, 17),
             }
         )
-        assert rebuilt.key == "partition_key"
+        assert rebuilt.key == "PARTITION_KEY"
         assert rebuilt.start == date(2026, 5, 10)
         assert rebuilt.end == date(2026, 5, 17)
 
     def test_passthrough_existing_instance(self):
-        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 10))
-        assert Lookback.from_dict(lb) is lb
+        lb = FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 10))
+        assert FeatureGroupLookback.from_dict(lb) is lb
 
     def test_none_input(self):
-        assert Lookback.from_dict(None) is None
+        assert FeatureGroupLookback.from_dict(None) is None
 
     def test_rejects_non_dict_input(self):
         with pytest.raises(TypeError):
-            Lookback.from_dict("not a dict")
+            FeatureGroupLookback.from_dict("not a dict")
 
 
-# ---------- Lookbacks construction -----------------------------------------
+# ---------- Lookback construction -----------------------------------------
 
 
-class TestLookbacksConstruction:
+class TestLookbackConstruction:
     def _lb(self):
-        return Lookback(
+        return FeatureGroupLookback(
             key=PARTITION_KEY, start=date(2026, 5, 5), end=date(2026, 5, 17)
         )
 
     def test_default_only(self):
-        plan = Lookbacks(default=self._lb())
+        plan = Lookback(default=self._lb())
         assert plan.default is not None
-        assert plan.feature_groups == {}
+        assert plan.feature_group_lookbacks == {}
 
     def test_feature_groups_only(self):
-        plan = Lookbacks(feature_groups={"transactions": self._lb()})
+        plan = Lookback(feature_group_lookbacks={"transactions": self._lb()})
         assert plan.default is None
-        assert "transactions" in plan.feature_groups
+        assert "transactions" in plan.feature_group_lookbacks
 
     def test_both(self):
-        plan = Lookbacks(
-            default=self._lb(), feature_groups={"transactions": self._lb()}
+        plan = Lookback(
+            default=self._lb(), feature_group_lookbacks={"transactions": self._lb()}
         )
         assert plan.default is not None
-        assert "transactions" in plan.feature_groups
+        assert "transactions" in plan.feature_group_lookbacks
 
     def test_empty_plan_rejected(self):
         with pytest.raises(
-            ValueError, match="at least one of `default` or `feature_groups`"
+            ValueError, match="at least one of `default` or `feature_group_lookbacks`"
         ):
-            Lookbacks()
+            Lookback()
 
     def test_empty_feature_groups_rejected(self):
         with pytest.raises(
-            ValueError, match="at least one of `default` or `feature_groups`"
+            ValueError, match="at least one of `default` or `feature_group_lookbacks`"
         ):
-            Lookbacks(feature_groups={})
+            Lookback(feature_group_lookbacks={})
 
     def test_dict_values_in_feature_groups(self):
-        plan = Lookbacks(
-            feature_groups={
+        plan = Lookback(
+            feature_group_lookbacks={
                 "transactions": {"key": "partition_key", "start": date(2026, 5, 5)}
             }
         )
-        assert plan.feature_groups["transactions"].key == "partition_key"
+        assert plan.feature_group_lookbacks["transactions"].key == "PARTITION_KEY"
 
     def test_dict_default(self):
-        plan = Lookbacks(default={"key": "partition_key", "start": date(2026, 5, 5)})
-        assert plan.default.key == "partition_key"
+        plan = Lookback(default={"key": "partition_key", "start": date(2026, 5, 5)})
+        assert plan.default.key == "PARTITION_KEY"
 
 
 # ---------- Key shape matrix ---------------------------------------------------
@@ -215,19 +225,19 @@ class TestLookbacksConstruction:
 
 class TestKeyShapes:
     def _lb(self):
-        return Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        return FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 5))
 
     def test_bare_string(self):
         # Bare-string key encodes "any version" on the wire (backend matches every
         # version of the named FG).
-        plan = Lookbacks(feature_groups={"dim_a": self._lb()})
-        assert "dim_a" in plan.feature_groups
+        plan = Lookback(feature_group_lookbacks={"dim_a": self._lb()})
+        assert "dim_a" in plan.feature_group_lookbacks
 
     def test_fg_instance(self):
         # FG-instance key encodes the FG's specific (name, version) pair.
         fg = _fg("dim_a", 1)
-        plan = Lookbacks(feature_groups={fg: self._lb()})
-        assert fg in plan.feature_groups
+        plan = Lookback(feature_group_lookbacks={fg: self._lb()})
+        assert fg in plan.feature_group_lookbacks
 
 
 # ---------- Malformed-key rejection -------------------------------------------
@@ -235,19 +245,19 @@ class TestKeyShapes:
 
 class TestMalformedKeys:
     def _lb(self):
-        return Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        return FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 5))
 
     def test_none_key(self):
         with pytest.raises(ValueError, match="must be a str or FeatureGroup"):
-            Lookbacks(feature_groups={None: self._lb()})
+            Lookback(feature_group_lookbacks={None: self._lb()})
 
     def test_int_key(self):
         with pytest.raises(ValueError, match="must be a str or FeatureGroup"):
-            Lookbacks(feature_groups={42: self._lb()})
+            Lookback(feature_group_lookbacks={42: self._lb()})
 
     def test_tuple_key_rejected(self):
         with pytest.raises(ValueError, match="must be a str or FeatureGroup"):
-            Lookbacks(feature_groups={("dim_a", 1): self._lb()})
+            Lookback(feature_group_lookbacks={("dim_a", 1): self._lb()})
 
     def test_object_with_name_and_version_attrs_rejected(self):
         # Anything that isn't an actual FeatureGroupBase subclass must be rejected,
@@ -257,13 +267,15 @@ class TestMalformedKeys:
             version = 1
 
         with pytest.raises(ValueError, match="must be a str or FeatureGroup"):
-            Lookbacks(feature_groups={_NotAnFG(): self._lb()})
+            Lookback(feature_group_lookbacks={_NotAnFG(): self._lb()})
 
     def test_none_value_rejected(self):
-        # A None value in feature_groups must be rejected up-front rather than
+        # A None value in feature_group_lookbacks must be rejected up-front rather than
         # silently stored (which would later crash to_dict with AttributeError).
-        with pytest.raises(ValueError, match="must be a Lookback or dict; got None"):
-            Lookbacks(feature_groups={"dim_a": None})
+        with pytest.raises(
+            ValueError, match="must be a FeatureGroupLookback or dict; got None"
+        ):
+            Lookback(feature_group_lookbacks={"dim_a": None})
 
 
 # ---------- Dict disambiguation -----------------------------------------------
@@ -272,78 +284,83 @@ class TestMalformedKeys:
 class TestDictDisambiguation:
     def test_empty_dict_rejected(self):
         with pytest.raises(ValueError, match="lookback dict cannot be empty"):
-            Lookbacks.from_user_input({})
+            Lookback.from_user_input({})
 
     def test_mixed_keys_rejected(self):
         with pytest.raises(ValueError, match="mixes uniform keys"):
-            Lookbacks.from_user_input(
-                {"key": "partition_key", "feature_groups": {"x": {"key": "event_time"}}}
+            Lookback.from_user_input(
+                {
+                    "key": "partition_key",
+                    "feature_group_lookbacks": {"x": {"key": "event_time"}},
+                }
             )
 
     def test_unknown_keys_rejected(self):
         with pytest.raises(ValueError, match="unknown lookback keys"):
-            Lookbacks.from_user_input({"foo": "bar"})
+            Lookback.from_user_input({"foo": "bar"})
 
     def test_leaf_dict_returns_lookbacks_with_default(self):
-        # A uniform-shape dict is wrapped as Lookbacks(default=Lookback(...))
+        # A uniform-shape dict is wrapped as Lookback(default=FeatureGroupLookback(...))
         # so internal callers always see a single type. Every field on the
-        # inner Lookback must come through from the dict — this is the entry
+        # inner FeatureGroupLookback must come through from the dict — this is the entry
         # point used by `FeatureView.get_batch_data(lookback={...})`.
-        result = Lookbacks.from_user_input(
+        result = Lookback.from_user_input(
             {
                 "key": "partition_key",
                 "start": date(2026, 5, 5),
                 "end": date(2026, 5, 17),
             }
         )
-        assert isinstance(result, Lookbacks)
-        assert isinstance(result.default, Lookback)
-        assert result.default.key == "partition_key"
+        assert isinstance(result, Lookback)
+        assert isinstance(result.default, FeatureGroupLookback)
+        assert result.default.key == "PARTITION_KEY"
         assert result.default.start == date(2026, 5, 5)
         assert result.default.end == date(2026, 5, 17)
-        assert result.feature_groups == {}
+        assert result.feature_group_lookbacks == {}
 
     def test_plan_dict_returns_lookbacks(self):
-        result = Lookbacks.from_user_input(
+        result = Lookback.from_user_input(
             {
-                "feature_groups": {
+                "feature_group_lookbacks": {
                     "transactions": {"key": "partition_key", "start": date(2026, 5, 5)}
                 }
             }
         )
-        assert isinstance(result, Lookbacks)
-        assert "transactions" in result.feature_groups
+        assert isinstance(result, Lookback)
+        assert "transactions" in result.feature_group_lookbacks
 
     def test_none_returns_none(self):
-        assert Lookbacks.from_user_input(None) is None
+        assert Lookback.from_user_input(None) is None
 
     def test_lookback_instance_wrapped_as_lookbacks(self):
-        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
-        result = Lookbacks.from_user_input(lb)
-        assert isinstance(result, Lookbacks)
+        lb = FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        result = Lookback.from_user_input(lb)
+        assert isinstance(result, Lookback)
         assert result.default is lb
-        assert result.feature_groups == {}
+        assert result.feature_group_lookbacks == {}
 
     def test_lookbacks_instance_passthrough(self):
-        plan = Lookbacks(default=Lookback(key=PARTITION_KEY, start=date(2026, 5, 5)))
-        assert Lookbacks.from_user_input(plan) is plan
+        plan = Lookback(
+            default=FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        )
+        assert Lookback.from_user_input(plan) is plan
 
     def test_non_dict_non_instance_rejected(self):
         with pytest.raises(TypeError, match="lookback must be"):
-            Lookbacks.from_user_input(42)
+            Lookback.from_user_input(42)
 
     def test_fully_dict_input_constructs_inner_lookbacks(self):
         # Config-file style: a single deeply-nested dict with `default` and
-        # `feature_groups` as dicts and inner Lookback dicts as their values.
-        # Every field must round-trip through to a real `Lookback` instance.
-        result = Lookbacks.from_user_input(
+        # `feature_group_lookbacks` as dicts and inner FeatureGroupLookback dicts as their values.
+        # Every field must round-trip through to a real `FeatureGroupLookback` instance.
+        result = Lookback.from_user_input(
             {
                 "default": {
                     "key": "partition_key",
                     "start": date(2026, 5, 5),
                     "end": date(2026, 5, 17),
                 },
-                "feature_groups": {
+                "feature_group_lookbacks": {
                     "dim_a": {
                         "key": "event_time",
                         "start": date(2026, 5, 10),
@@ -351,79 +368,79 @@ class TestDictDisambiguation:
                 },
             }
         )
-        assert isinstance(result, Lookbacks)
-        assert isinstance(result.default, Lookback)
-        assert result.default.key == "partition_key"
+        assert isinstance(result, Lookback)
+        assert isinstance(result.default, FeatureGroupLookback)
+        assert result.default.key == "PARTITION_KEY"
         assert result.default.start == date(2026, 5, 5)
         assert result.default.end == date(2026, 5, 17)
-        dim_a_lb = result.feature_groups["dim_a"]
-        assert isinstance(dim_a_lb, Lookback)
-        assert dim_a_lb.key == "event_time"
+        dim_a_lb = result.feature_group_lookbacks["dim_a"]
+        assert isinstance(dim_a_lb, FeatureGroupLookback)
+        assert dim_a_lb.key == "EVENT_TIME"
         assert dim_a_lb.start == date(2026, 5, 10)
         assert dim_a_lb.end is None
 
 
-# ---------- Lookbacks wire serialization --------------------------------------
+# ---------- Lookback wire serialization --------------------------------------
 
 
-class TestLookbacksToDict:
-    """Verifies the SDK→backend wire shape emitted by `Lookbacks.to_dict()`.
+class TestLookbackToDict:
+    """Verifies the SDK→backend wire shape emitted by `Lookback.to_dict()`.
 
-    The backend's `QueryController.resolveLookbacks` consumes this shape: it reads
+    The backend's `QueryController.resolveLookback` consumes this shape: it reads
     `defaultLookback` and walks `featureGroups`, matching entries to query nodes
     by `(name, version)` with `version=None` encoding "any version".
     """
 
     def _lb_dict(self, start, end=None):
-        # Mirror Lookback.to_dict() so the assertion isn't tied to repr internals.
-        return Lookback(key=PARTITION_KEY, start=start, end=end).to_dict()
+        # Mirror FeatureGroupLookback.to_dict() so the assertion isn't tied to repr internals.
+        return FeatureGroupLookback(key=PARTITION_KEY, start=start, end=end).to_dict()
 
     def test_default_only_emits_default_no_feature_groups(self):
-        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
-        wire = Lookbacks(default=lb).to_dict()
+        lb = FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        wire = Lookback(default=lb).to_dict()
         assert wire == {"defaultLookback": lb.to_dict()}
 
     def test_bare_string_key_emits_null_version(self):
         # version=None on the wire tells the backend "any version of this name".
-        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
-        wire = Lookbacks(feature_groups={"dim_a": lb}).to_dict()
+        lb = FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        wire = Lookback(feature_group_lookbacks={"dim_a": lb}).to_dict()
         assert wire == {
-            "featureGroups": [
+            "featureGroupLookbacks": [
                 {"name": "dim_a", "version": None, "lookback": lb.to_dict()},
             ],
         }
 
     def test_fg_instance_key_emits_specific_version(self):
-        lb = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        lb = FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 5))
         fg = _fg("dim_a", 3)
-        wire = Lookbacks(feature_groups={fg: lb}).to_dict()
+        wire = Lookback(feature_group_lookbacks={fg: lb}).to_dict()
         assert wire == {
-            "featureGroups": [
+            "featureGroupLookbacks": [
                 {"name": "dim_a", "version": 3, "lookback": lb.to_dict()},
             ],
         }
 
     def test_default_plus_feature_groups_emits_both(self):
-        default = Lookback(key=PARTITION_KEY, start=date(2026, 5, 5))
-        override = Lookback(key=EVENT_TIME, start=date(2026, 5, 10))
-        wire = Lookbacks(
+        default = FeatureGroupLookback(key=PARTITION_KEY, start=date(2026, 5, 5))
+        override = FeatureGroupLookback(key=EVENT_TIME, start=date(2026, 5, 10))
+        wire = Lookback(
             default=default,
-            feature_groups={"dim_a": override},
+            feature_group_lookbacks={"dim_a": override},
         ).to_dict()
         assert wire == {
             "defaultLookback": default.to_dict(),
-            "featureGroups": [
+            "featureGroupLookbacks": [
                 {"name": "dim_a", "version": None, "lookback": override.to_dict()},
             ],
         }
 
 
-class TestLookbackFromResponseJsonRoundTrip:
+class TestFeatureGroupLookbackFromResponseJsonRoundTrip:
     """Cross-process reconstruction via the wire form.
 
     The Spark materialization job and any other cross-process consumer rebuilds a Query
     from its serialized payload via `Query.from_response_json`, which in turn calls
-    `Lookbacks.from_response_json` / `Lookback.from_response_json`. The reconstructed
+    `Lookback.from_response_json` / `FeatureGroupLookback.from_response_json`. The reconstructed
     `_start`/`_end` carry raw epoch-millis `int`s rather than the user-form
     `date`/`datetime` shapes — `to_dict()` must still round-trip the integer bounds
     losslessly because that's what the SDK re-sends to the backend.
@@ -433,7 +450,7 @@ class TestLookbackFromResponseJsonRoundTrip:
         start_ms = _epoch_ms(date(2026, 5, 10))
         end_ms = _epoch_ms(date(2026, 5, 17))
         wire = {"lookback_key": "PARTITION_KEY", "start": start_ms, "end": end_ms}
-        lb = Lookback.from_response_json(wire)
+        lb = FeatureGroupLookback.from_response_json(wire)
         assert lb is not None
         # Properties expose the raw int (per widened type hints).
         assert lb.start == start_ms
@@ -456,7 +473,7 @@ class TestLookbackFromResponseJsonRoundTrip:
                 "start": start_ms,
                 "end": end_ms,
             },
-            "feature_groups": [
+            "feature_group_lookbacks": [
                 {
                     "name": "dim_a",
                     "version": None,
@@ -467,13 +484,16 @@ class TestLookbackFromResponseJsonRoundTrip:
                 },
             ],
         }
-        looks = Lookbacks.from_response_json(wire)
+        looks = Lookback.from_response_json(wire)
         assert looks is not None
-        # The reconstructed Lookbacks goes through to_dict cleanly — guards against
+        # The reconstructed Lookback goes through to_dict cleanly — guards against
         # the same `_lookbacks is dict` AttributeError class as the TD constructor fix.
         payload = looks.to_dict()
         assert payload["defaultLookback"]["lookbackKey"] == "PARTITION_KEY"
         assert payload["defaultLookback"]["start"] == start_ms
         assert payload["defaultLookback"]["end"] == end_ms
-        assert payload["featureGroups"][0]["name"] == "dim_a"
-        assert payload["featureGroups"][0]["lookback"]["lookbackKey"] == "EVENT_TIME"
+        assert payload["featureGroupLookbacks"][0]["name"] == "dim_a"
+        assert (
+            payload["featureGroupLookbacks"][0]["lookback"]["lookbackKey"]
+            == "EVENT_TIME"
+        )

--- a/python/tests/test_training_dataset.py
+++ b/python/tests/test_training_dataset.py
@@ -170,24 +170,24 @@ class TestTrainingDataset:
         # Assert
         assert len(td_list) == 0
 
-    def test_from_response_json_omits_lookbacks(self, mocker, backend_fixtures):
+    def test_from_response_json_omits_lookback(self, mocker, backend_fixtures):
         # Older training datasets persisted before lookback support have no `lookbacks`
         # field on the response. `from_response_json` must accept that and leave
-        # `_lookbacks` as None.
+        # `_lookback` as None.
         mocker.patch("hopsworks_common.client.get_instance")
         json = backend_fixtures["training_dataset"]["get"]["response"]
         td = training_dataset.TrainingDataset.from_response_json(json)
         if isinstance(td, list):
             td = td[0]
-        assert td._lookbacks is None
+        assert td._lookback is None
 
-    def test_training_dataset_to_dict_emits_lookbacks_when_set(self, mocker):
-        # When the engine layer attaches a Lookbacks during create_training_*,
+    def test_training_dataset_to_dict_emits_lookback_when_set(self, mocker):
+        # When the engine layer attaches a Lookback during create_training_*,
         # `to_dict` emits the `lookbacks` wire shape so the backend's
         # `QueryController.resolveLookbacks` can pick it up.
         from datetime import date
 
-        from hsfs.constructor.lookback import Lookback, Lookbacks
+        from hsfs.constructor.lookback import FeatureGroupLookback, Lookback
 
         mocker.patch("hopsworks_common.client.get_instance")
         td = training_dataset.TrainingDataset(
@@ -196,24 +196,24 @@ class TestTrainingDataset:
             data_format="parquet",
             featurestore_id=1,
         )
-        lb = Lookback(
+        lb = FeatureGroupLookback(
             key="partition_key", start=date(2026, 5, 10), end=date(2026, 5, 17)
         )
-        td._lookbacks = Lookbacks(default=lb)
+        td._lookback = Lookback(default=lb)
         payload = td.to_dict()
-        assert payload["lookbacks"] == {"defaultLookback": lb.to_dict()}
+        assert payload["lookback"] == {"defaultLookback": lb.to_dict()}
 
-    def test_training_dataset_accepts_lookbacks_via_constructor(self, mocker):
+    def test_training_dataset_accepts_lookback_via_constructor(self, mocker):
         # The in-memory training_data / train_test_split / train_validation_test_split
-        # methods construct the TD directly with `lookbacks=Lookbacks.from_user_input(lookback)`
+        # methods construct the TD directly with `lookbacks=Lookback.from_user_input(lookback)`
         # rather than threading through an engine kwarg, so the constructor must accept
-        # a Lookbacks instance and emit it on the wire via to_dict().
+        # a Lookback instance and emit it on the wire via to_dict().
         from datetime import date
 
-        from hsfs.constructor.lookback import Lookback, Lookbacks
+        from hsfs.constructor.lookback import FeatureGroupLookback, Lookback
 
         mocker.patch("hopsworks_common.client.get_instance")
-        lb = Lookback(
+        lb = FeatureGroupLookback(
             key="partition_key", start=date(2026, 5, 10), end=date(2026, 5, 17)
         )
         td = training_dataset.TrainingDataset(
@@ -221,18 +221,18 @@ class TestTrainingDataset:
             version=None,
             data_format="tsv",
             featurestore_id=1,
-            lookbacks=Lookbacks(default=lb),
+            lookback=Lookback(default=lb),
         )
         payload = td.to_dict()
-        assert payload["lookbacks"] == {"defaultLookback": lb.to_dict()}
+        assert payload["lookback"] == {"defaultLookback": lb.to_dict()}
 
-    def test_training_dataset_normalizes_wire_lookbacks_dict(self, mocker):
+    def test_training_dataset_normalizes_wire_lookback_dict(self, mocker):
         # `update_from_response_json` runs `self.__init__(**response)` with the decamelized
         # backend payload. If the response carries `lookbacks`, the constructor must
-        # normalize that dict into a `Lookbacks` instance — otherwise `_lookbacks` ends up
+        # normalize that dict into a `Lookback` instance — otherwise `_lookback` ends up
         # a raw dict and the next `to_dict()` blows up with `AttributeError: 'dict' object
         # has no attribute 'to_dict'`.
-        from hsfs.constructor.lookback import Lookbacks
+        from hsfs.constructor.lookback import Lookback
 
         mocker.patch("hopsworks_common.client.get_instance")
         wire = {
@@ -247,10 +247,10 @@ class TestTrainingDataset:
             version=1,
             data_format="parquet",
             featurestore_id=1,
-            lookbacks=wire,
+            lookback=wire,
         )
-        assert isinstance(td._lookbacks, Lookbacks)
+        assert isinstance(td._lookback, Lookback)
         # Round-trips through to_dict() so wire-form lookbacks restored from the backend
         # remain serialisable for subsequent requests.
         payload = td.to_dict()
-        assert payload["lookbacks"]["defaultLookback"]["lookbackKey"] == "PARTITION_KEY"
+        assert payload["lookback"]["defaultLookback"]["lookbackKey"] == "PARTITION_KEY"

--- a/python/tests/test_training_dataset.py
+++ b/python/tests/test_training_dataset.py
@@ -169,3 +169,88 @@ class TestTrainingDataset:
 
         # Assert
         assert len(td_list) == 0
+
+    def test_from_response_json_omits_lookbacks(self, mocker, backend_fixtures):
+        # Older training datasets persisted before lookback support have no `lookbacks`
+        # field on the response. `from_response_json` must accept that and leave
+        # `_lookbacks` as None.
+        mocker.patch("hopsworks_common.client.get_instance")
+        json = backend_fixtures["training_dataset"]["get"]["response"]
+        td = training_dataset.TrainingDataset.from_response_json(json)
+        if isinstance(td, list):
+            td = td[0]
+        assert td._lookbacks is None
+
+    def test_training_dataset_to_dict_emits_lookbacks_when_set(self, mocker):
+        # When the engine layer attaches a Lookbacks during create_training_*,
+        # `to_dict` emits the `lookbacks` wire shape so the backend's
+        # `QueryController.resolveLookbacks` can pick it up.
+        from datetime import date
+
+        from hsfs.constructor.lookback import Lookback, Lookbacks
+
+        mocker.patch("hopsworks_common.client.get_instance")
+        td = training_dataset.TrainingDataset(
+            name="td_lb",
+            version=1,
+            data_format="parquet",
+            featurestore_id=1,
+        )
+        lb = Lookback(
+            key="partition_key", start=date(2026, 5, 10), end=date(2026, 5, 17)
+        )
+        td._lookbacks = Lookbacks(default=lb)
+        payload = td.to_dict()
+        assert payload["lookbacks"] == {"defaultLookback": lb.to_dict()}
+
+    def test_training_dataset_accepts_lookbacks_via_constructor(self, mocker):
+        # The in-memory training_data / train_test_split / train_validation_test_split
+        # methods construct the TD directly with `lookbacks=Lookbacks.from_user_input(lookback)`
+        # rather than threading through an engine kwarg, so the constructor must accept
+        # a Lookbacks instance and emit it on the wire via to_dict().
+        from datetime import date
+
+        from hsfs.constructor.lookback import Lookback, Lookbacks
+
+        mocker.patch("hopsworks_common.client.get_instance")
+        lb = Lookback(
+            key="partition_key", start=date(2026, 5, 10), end=date(2026, 5, 17)
+        )
+        td = training_dataset.TrainingDataset(
+            name="td_inmem_lb",
+            version=None,
+            data_format="tsv",
+            featurestore_id=1,
+            lookbacks=Lookbacks(default=lb),
+        )
+        payload = td.to_dict()
+        assert payload["lookbacks"] == {"defaultLookback": lb.to_dict()}
+
+    def test_training_dataset_normalizes_wire_lookbacks_dict(self, mocker):
+        # `update_from_response_json` runs `self.__init__(**response)` with the decamelized
+        # backend payload. If the response carries `lookbacks`, the constructor must
+        # normalize that dict into a `Lookbacks` instance — otherwise `_lookbacks` ends up
+        # a raw dict and the next `to_dict()` blows up with `AttributeError: 'dict' object
+        # has no attribute 'to_dict'`.
+        from hsfs.constructor.lookback import Lookbacks
+
+        mocker.patch("hopsworks_common.client.get_instance")
+        wire = {
+            "default_lookback": {
+                "lookback_key": "PARTITION_KEY",
+                "start": 1747008000000,
+                "end": 1747612800000,
+            },
+        }
+        td = training_dataset.TrainingDataset(
+            name="td_wire_lb",
+            version=1,
+            data_format="parquet",
+            featurestore_id=1,
+            lookbacks=wire,
+        )
+        assert isinstance(td._lookbacks, Lookbacks)
+        # Round-trips through to_dict() so wire-form lookbacks restored from the backend
+        # remain serialisable for subsequent requests.
+        payload = td.to_dict()
+        assert payload["lookbacks"]["defaultLookback"]["lookbackKey"] == "PARTITION_KEY"


### PR DESCRIPTION
## Summary

- Adds a `Lookback` dataclass under `hsfs.constructor.lookback` and a `lookback` parameter on `FeatureView.get_batch_data`, `create_training_data`, and the split variants. The window applies uniformly to every joined feature group in the PIT join.
- Two modes: `partition_key` (constant-bound predicate on each FG's partition column — flyingduck and Spark prune partitions before reading files), `event_time` (predicate on the FG's `event_time` column — row-level correctness; partition pruning is engine-dependent).
- Wire format is camelCase (`lookbackKey`, `startWindow`, `endWindow`) with bounds as epoch ms; the SDK fans the uniform lookback out across the query tree's joins and also emits a `joinsLookback` map keyed by `prefix + fg.name` on the training-dataset POST.

## JIRA

[FSTORE-2030](https://hopsworks.atlassian.net/browse/FSTORE-2030)

## Test plan

- [x] 27 unit tests on `Lookback` (validation matrix, dict/dataclass round-trip, date+datetime coercion, nested-map serialization).
- [x] `feature_view` and `training_dataset` tests pass.
- [x] `ruff` + `docsig` clean on the new module and the modified public methods.
- [x] End-to-end on cluster `manu-test` via the `loadtest` integration tests (companion PR).

## Companion PRs

- Backend: `logicalclocks/hopsworks-ee` → branch `FSTORE-2030`
- Integration tests: `logicalclocks/loadtest` → branch `FSTORE-2030`
- Docs: `logicalclocks/logicalclocks.github.io` → branch `FSTORE-2030`

[FSTORE-2030]: https://hopsworks.atlassian.net/browse/FSTORE-2030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ