### PR TITLE
[HWORKS-2796] Bump vllm version literals in predictor tests to v0.20.0

### DIFF
--- a/python/tests/fixtures/predictor_fixtures.json
+++ b/python/tests/fixtures/predictor_fixtures.json
@@ -599,7 +599,7 @@
       "api_protocol": "REST",
       "config_file": "config.yaml",
       "vllmVariant": "VLLM_OMNI",
-      "vllmImageTag": "v0.14.0",
+      "vllmImageTag": "v0.20.0",
       "requested_instances": 0,
       "predictor_resources": {
         "requested_instances": 0,

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1211,11 +1211,11 @@ class TestPredictor:
 
         # Assert
         assert p.vllm_variant == "VLLM_OMNI"
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
         assert p2.vllm_variant == p.vllm_variant
         assert p2.vllm_image_tag == p.vllm_image_tag
         assert serialized["vllmVariant"] == "VLLM_OMNI"
-        assert serialized["vllmImageTag"] == "v0.14.0"
+        assert serialized["vllmImageTag"] == "v0.20.0"
 
     def test_llm_predictor_default_variant(self, mocker):
         # Arrange
@@ -1238,12 +1238,12 @@ class TestPredictor:
         p = LLMPredictor(
             name="my_llm",
             vllm_variant=PREDICTOR.VLLM_VARIANT_OMNI,
-            vllm_image_tag="v0.14.0",
+            vllm_image_tag="v0.20.0",
         )
 
         # Assert
         assert p.vllm_variant == PREDICTOR.VLLM_VARIANT_OMNI
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     def test_llm_predictor_invalid_variant_raises(self, mocker):
         # Arrange
@@ -1321,14 +1321,14 @@ class TestPredictor:
         p = predictor.Predictor.for_model(
             mock_model,
             vllm_variant=PREDICTOR.VLLM_VARIANT_OMNI,
-            vllm_image_tag="v0.14.0",
+            vllm_image_tag="v0.20.0",
         )
 
         # Assert
         assert captured_kwargs["vllm_variant"] == PREDICTOR.VLLM_VARIANT_OMNI
-        assert captured_kwargs["vllm_image_tag"] == "v0.14.0"
+        assert captured_kwargs["vllm_image_tag"] == "v0.20.0"
         assert p.vllm_variant == PREDICTOR.VLLM_VARIANT_OMNI
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     def test_update_from_response_json_preserves_vllm_fields(
         self, mocker, backend_fixtures
@@ -1346,7 +1346,7 @@ class TestPredictor:
 
         # Assert both fields survive the refresh
         assert p.vllm_variant == "VLLM_OMNI"
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     # auxiliary methods
 


### PR DESCRIPTION
## Summary

Track the HWORKS-2796 vllm runtime image bump (v0.14.0 → v0.20.0) in the SDK's test fixtures:

- \`python/tests/test_predictor.py\` — round-trip getter/setter + constructor cases (Predictor.from_response_json / to_dict)
- \`python/tests/fixtures/predictor_fixtures.json\` — the kserve vllm-omni deployment fixture's \`vllmImageTag\` value

The SDK round-trip tests are value-agnostic — they assert that a string set on the predictor comes back identical and serialises through to JSON. Refreshing the literal to match the new helm-chart default keeps the test data aligned with what users will actually see.

Sibling PRs in [docker-images](https://github.com/logicalclocks/docker-images/pull/835), hopsworks-helm, hopsworks-ee, hopsworks-front.

## Test plan

- [ ] \`uv run --project python pytest python/tests/test_predictor.py\` green
- [ ] No other test file references the old version literal

🤖 Generated with [Claude Code](https://claude.com/claude-code)