### PR TITLE
[HWORKS-2813] Backend override for vllm-omni serve command to work with v0.20 arg-ordering

### DIFF
--- a/python/tests/fixtures/predictor_fixtures.json
+++ b/python/tests/fixtures/predictor_fixtures.json
@@ -599,7 +599,7 @@
       "api_protocol": "REST",
       "config_file": "config.yaml",
       "vllmVariant": "VLLM_OMNI",
-      "vllmImageTag": "v0.14.0",
+      "vllmImageTag": "v0.20.0",
       "requested_instances": 0,
       "predictor_resources": {
         "requested_instances": 0,

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1211,11 +1211,11 @@ class TestPredictor:
 
         # Assert
         assert p.vllm_variant == "VLLM_OMNI"
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
         assert p2.vllm_variant == p.vllm_variant
         assert p2.vllm_image_tag == p.vllm_image_tag
         assert serialized["vllmVariant"] == "VLLM_OMNI"
-        assert serialized["vllmImageTag"] == "v0.14.0"
+        assert serialized["vllmImageTag"] == "v0.20.0"
 
     def test_llm_predictor_default_variant(self, mocker):
         # Arrange
@@ -1238,12 +1238,12 @@ class TestPredictor:
         p = LLMPredictor(
             name="my_llm",
             vllm_variant=PREDICTOR.VLLM_VARIANT_OMNI,
-            vllm_image_tag="v0.14.0",
+            vllm_image_tag="v0.20.0",
         )
 
         # Assert
         assert p.vllm_variant == PREDICTOR.VLLM_VARIANT_OMNI
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     def test_llm_predictor_invalid_variant_raises(self, mocker):
         # Arrange
@@ -1321,14 +1321,14 @@ class TestPredictor:
         p = predictor.Predictor.for_model(
             mock_model,
             vllm_variant=PREDICTOR.VLLM_VARIANT_OMNI,
-            vllm_image_tag="v0.14.0",
+            vllm_image_tag="v0.20.0",
         )
 
         # Assert
         assert captured_kwargs["vllm_variant"] == PREDICTOR.VLLM_VARIANT_OMNI
-        assert captured_kwargs["vllm_image_tag"] == "v0.14.0"
+        assert captured_kwargs["vllm_image_tag"] == "v0.20.0"
         assert p.vllm_variant == PREDICTOR.VLLM_VARIANT_OMNI
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     def test_update_from_response_json_preserves_vllm_fields(
         self, mocker, backend_fixtures
@@ -1346,7 +1346,7 @@ class TestPredictor:
 
         # Assert both fields survive the refresh
         assert p.vllm_variant == "VLLM_OMNI"
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     # auxiliary methods
 


### PR DESCRIPTION
## Summary

Refresh the vllm image-tag literals in `LLMPredictor` unit tests / fixtures from v0.14.0 → v0.20.0 to match the new helm-chart defaults landing in [HWORKS-2813] hopsworks-helm. Value-agnostic — the tests round-trip whatever string is supplied; the bump just keeps the sample data current.

Files:
- `python/tests/fixtures/predictor_fixtures.json` — one `vllmImageTag` value
- `python/tests/test_predictor.py` — five assertions

Sibling [HWORKS-2813] PRs in: docker-images, hopsworks-ee, hopsworks-helm, hopsworks-front, loadtest, logicalclocks.github.io.

## Test plan

- [ ] `pytest python/tests/test_predictor.py` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[HWORKS-2813]: https://hopsworks.atlassian.net/browse/HWORKS-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-2813]: https://hopsworks.atlassian.net/browse/HWORKS-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ