### PR TITLE
[HWORKS-2813][4.8] Bump vllm version literals in predictor tests to v0.20.0

### DIFF
--- a/python/tests/fixtures/predictor_fixtures.json
+++ b/python/tests/fixtures/predictor_fixtures.json
@@ -599,7 +599,7 @@
       "api_protocol": "REST",
       "config_file": "config.yaml",
       "vllmVariant": "VLLM_OMNI",
-      "vllmImageTag": "v0.14.0",
+      "vllmImageTag": "v0.20.0",
       "requested_instances": 0,
       "predictor_resources": {
         "requested_instances": 0,

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1211,11 +1211,11 @@ class TestPredictor:
 
         # Assert
         assert p.vllm_variant == "VLLM_OMNI"
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
         assert p2.vllm_variant == p.vllm_variant
         assert p2.vllm_image_tag == p.vllm_image_tag
         assert serialized["vllmVariant"] == "VLLM_OMNI"
-        assert serialized["vllmImageTag"] == "v0.14.0"
+        assert serialized["vllmImageTag"] == "v0.20.0"
 
     def test_llm_predictor_default_variant(self, mocker):
         # Arrange
@@ -1238,12 +1238,12 @@ class TestPredictor:
         p = LLMPredictor(
             name="my_llm",
             vllm_variant=PREDICTOR.VLLM_VARIANT_OMNI,
-            vllm_image_tag="v0.14.0",
+            vllm_image_tag="v0.20.0",
         )
 
         # Assert
         assert p.vllm_variant == PREDICTOR.VLLM_VARIANT_OMNI
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     def test_llm_predictor_invalid_variant_raises(self, mocker):
         # Arrange
@@ -1321,14 +1321,14 @@ class TestPredictor:
         p = predictor.Predictor.for_model(
             mock_model,
             vllm_variant=PREDICTOR.VLLM_VARIANT_OMNI,
-            vllm_image_tag="v0.14.0",
+            vllm_image_tag="v0.20.0",
         )
 
         # Assert
         assert captured_kwargs["vllm_variant"] == PREDICTOR.VLLM_VARIANT_OMNI
-        assert captured_kwargs["vllm_image_tag"] == "v0.14.0"
+        assert captured_kwargs["vllm_image_tag"] == "v0.20.0"
         assert p.vllm_variant == PREDICTOR.VLLM_VARIANT_OMNI
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     def test_update_from_response_json_preserves_vllm_fields(
         self, mocker, backend_fixtures
@@ -1346,7 +1346,7 @@ class TestPredictor:
 
         # Assert both fields survive the refresh
         assert p.vllm_variant == "VLLM_OMNI"
-        assert p.vllm_image_tag == "v0.14.0"
+        assert p.vllm_image_tag == "v0.20.0"
 
     # auxiliary methods
 


### PR DESCRIPTION
## Summary

4.8 backport of the literal-bump commit on the HWORKS-2813 branch. Bumps vllm version literals in predictor tests from v0.14.0 → v0.20.0 to match the new default in [docker-images#838](https://github.com/logicalclocks/docker-images/pull/838) and the runtime tags in [hopsworks-helm#1935](https://github.com/logicalclocks/hopsworks-helm/pull/1935).

Sibling 4.8 PRs in: docker-images, hopsworks-ee, hopsworks-helm, hopsworks-front, loadtest.

## Test plan

- [ ] Predictor test suite passes against the new version literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)