### PR TITLE
Release 4.8.2

### DIFF
--- a/java/beam/pom.xml
+++ b/java/beam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>4.8.1</version>
+    <version>4.8.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>4.8.1</version>
+    <version>4.8.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>4.8.1</version>
+    <version>4.8.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.8.1</version>
+    <version>4.8.2</version>
     <modules>
         <module>hsfs</module>
         <module>spark</module>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>hsfs-parent</artifactId>
         <groupId>com.logicalclocks</groupId>
-        <version>4.8.1</version>
+        <version>4.8.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/python/hopsworks_common/version.py
+++ b/python/hopsworks_common/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "4.8.1"
+__version__ = "4.8.2"

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2</version>
 
     <properties>
         <hops.version>3.2.0.19-EE-RC0</hops.version>


### PR DESCRIPTION
Bumps version 4.8.1 → 4.8.2 across the Python package (`hopsworks_common/version.py`) and the Java Maven poms (parent, hsfs, spark, flink, beam, utils).

JIRA Issue: -

Priority for Review: -

Related PRs: #911 (Release 4.8.1)

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```