### PR TITLE
[HWORKS-2819] Bump HopsFS to 3.4.3.1-EE-RC0

### DIFF
--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -169,7 +169,7 @@
                 <dependency>
                     <groupId>io.hops</groupId>
                     <artifactId>hadoop-client</artifactId>
-                    <version>3.4.3.0-EE-RC4</version>
+                    <version>3.4.3.1-EE-RC0</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -8,7 +8,7 @@
     <version>5.0.0-SNAPSHOT</version>
 
     <properties>
-        <hops.version>3.4.3.0-EE-RC4</hops.version>
+        <hops.version>3.4.3.1-EE-RC0</hops.version>
         <hsfs.version>${project.version}</hsfs.version>
         <slf4j.version>2.0.17</slf4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.hops</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>${hops.version}</version>
+            <version>3.4.3.1-EE-RC0</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Bumps HopsFS to 3.4.3.1-EE-RC0.
Tracked by HWORKS-2819.
