### PR TITLE
[HWORKS-2818] Upload a file as a Secret (#973)

### DIFF
--- a/python/hopsworks_common/core/secret_api.py
+++ b/python/hopsworks_common/core/secret_api.py
@@ -15,12 +15,21 @@
 #
 from __future__ import annotations
 
+import base64
 import getpass
 import json
+from pathlib import Path
 
 from hopsworks_apigen import public
 from hopsworks_common import client, decorators, secret
 from hopsworks_common.core import project_api
+
+
+# Mirrors the static MAX_SECRET_VALUE_LENGTH on SecretsController in hopsworks-ee.
+# Derived from the VARBINARY(10000) column the encrypted ciphertext is persisted
+# to, minus AES/GCM salt+IV+auth-tag; widening it requires a schema change, so
+# this constant tracks the backend by hand rather than being fetched at runtime.
+MAX_SECRET_VALUE_LENGTH = 9000
 
 
 @public("hopsworks.core.secret_api.SecretsApi")
@@ -167,6 +176,51 @@ class SecretsApi:
         created_secret = self.get_secret(name)
         print(f"Secret created successfully, explore it at {created_secret.get_url()}")
         return created_secret
+
+    @public
+    def create_secret_from_file(
+        self, name: str, local_path: str, project: str | None = None
+    ) -> secret.Secret:
+        """Create a new secret from the contents of a local file.
+
+        The file is base64-encoded in memory and stored as the secret value.
+        Reads return the same base64 string and the caller is responsible for
+        decoding it back to the original bytes.
+
+        ```python
+        import base64
+        import hopsworks
+
+        project = hopsworks.login()
+
+        secrets_api = hopsworks.get_secrets_api()
+
+        secret = secrets_api.create_secret_from_file("my_key", "~/.ssh/id_ed25519")
+        raw_bytes = base64.b64decode(secrets_api.get("my_key"))
+        ```
+
+        Parameters:
+            name: Name of the secret.
+            local_path: Path to the file whose contents become the secret value.
+            project: Name of the project to share the secret with.
+
+        Returns:
+            The Secret object.
+
+        Raises:
+            ValueError: If the base64-encoded length exceeds the server-side ceiling.
+            FileNotFoundError: If `local_path` does not exist.
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        path = Path(local_path).expanduser()
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        if len(encoded) > MAX_SECRET_VALUE_LENGTH:
+            raise ValueError(
+                f"File at {local_path} is too large after base64 encoding "
+                f"({len(encoded)} characters, max {MAX_SECRET_VALUE_LENGTH}). "
+                "Pick a smaller file."
+            )
+        return self.create_secret(name, encoded, project=project)
 
     def _delete(self, name: str):
         """Delete the secret.

--- a/python/tests/core/test_secret_api.py
+++ b/python/tests/core/test_secret_api.py
@@ -1,0 +1,107 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import base64
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.core.secret_api import MAX_SECRET_VALUE_LENGTH, SecretsApi
+
+
+def _secret_response(name: str, value: str, visibility: str = "PRIVATE") -> dict:
+    return {
+        "items": [{"name": name, "secret": value, "visibility": visibility}],
+        "type": "secretDTO",
+    }
+
+
+def _patch_client(mocker, send_request_return):
+    client_instance = MagicMock()
+    client_instance._send_request.return_value = send_request_return
+    # Secret.get_url -> util.get_hostname_replaced_url calls urljoin(_base_url, ...),
+    # which raises if _base_url is a MagicMock instead of a string.
+    client_instance._base_url = "https://localhost"
+    mocker.patch(
+        "hopsworks_common.core.secret_api.client.get_instance",
+        return_value=client_instance,
+    )
+    mocker.patch(
+        "hopsworks_common.util.client.get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+class TestSecretsApi:
+    def test_create_secret_posts_value_as_string(self, mocker):
+        api = SecretsApi()
+        client_instance = _patch_client(mocker, _secret_response("MY_KEY", "sk-1"))
+        result = api.create_secret("MY_KEY", "sk-1")
+        assert result.name == "MY_KEY"
+        assert result.value == "sk-1"
+        post_calls = [
+            call
+            for call in client_instance._send_request.call_args_list
+            if call.args[0] == "POST"
+        ]
+        assert len(post_calls) == 1
+        body = json.loads(post_calls[0].kwargs["data"])
+        assert body["name"] == "MY_KEY"
+        assert body["secret"] == "sk-1"
+        assert body["visibility"] == "PRIVATE"
+        assert "scope" not in body
+
+    def test_create_secret_from_file_base64_encodes_and_creates(self, mocker, tmp_path):
+        api = SecretsApi()
+        path = tmp_path / "key.pem"
+        path.write_bytes(b"hello-from-a-file")
+        create_secret = mocker.patch.object(SecretsApi, "create_secret")
+        api.create_secret_from_file("KEY_PEM", str(path))
+        create_secret.assert_called_once_with(
+            "KEY_PEM",
+            base64.b64encode(b"hello-from-a-file").decode("ascii"),
+            project=None,
+        )
+
+    def test_create_secret_from_file_at_limit_accepted(self, mocker, tmp_path):
+        # base64 length is a multiple of 4 and equals ceil(N / 3) * 4.
+        # MAX_SECRET_VALUE_LENGTH = 9000 chars -> raw 6750 bytes is exactly at limit.
+        api = SecretsApi()
+        raw_size = (MAX_SECRET_VALUE_LENGTH // 4) * 3
+        path = tmp_path / "at-limit.bin"
+        path.write_bytes(b"\x00" * raw_size)
+        create_secret = mocker.patch.object(SecretsApi, "create_secret")
+        api.create_secret_from_file("AT_LIMIT", str(path))
+        encoded = create_secret.call_args.args[1]
+        assert len(encoded) == MAX_SECRET_VALUE_LENGTH
+
+    def test_create_secret_from_file_over_limit_raises(self, mocker, tmp_path):
+        api = SecretsApi()
+        raw_size = (MAX_SECRET_VALUE_LENGTH // 4) * 3 + 1
+        path = tmp_path / "too-big.bin"
+        path.write_bytes(b"\x00" * raw_size)
+        create_secret = mocker.patch.object(SecretsApi, "create_secret")
+        with pytest.raises(ValueError, match="too large after base64 encoding"):
+            api.create_secret_from_file("TOO_BIG", str(path))
+        create_secret.assert_not_called()
+
+    def test_create_secret_from_file_missing_file_raises(self, mocker, tmp_path):
+        api = SecretsApi()
+        create_secret = mocker.patch.object(SecretsApi, "create_secret")
+        with pytest.raises(FileNotFoundError):
+            api.create_secret_from_file("MISSING", str(tmp_path / "nope.bin"))
+        create_secret.assert_not_called()


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-2818

Hopsworks Secrets accept only strings from the UI today. Anything binary has to be base64-encoded by hand and pasted as a string, which is awkward for SSH keys, small certificates, service-account JSON, and similar artifacts. This ticket adds a file path to the create-Secret flow: the UI and the Python client base64-encode the file locally and submit through the existing JSON endpoint, so the on-the-wire and on- disk contracts are unchanged. Reads continue to return the stored string and the caller decodes if it was a file.

The Python client gains create_secret_from_file(name, local_path, project) on SecretsApi: open the file, base64-encode, raise ValueError if the encoded length exceeds the mirrored 9000-character cap, then delegate to create_secret. The cap is a module-level constant rather than fetched from a discovery endpoint; widening it requires a schema change in hopsworks-ee, so duplicating the literal is acceptable.

Reviewed-by: OpenAI Codex (GPT-5 via codex-plugin-cc 1.0.4) <codex@openai.com>

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
