### PR TITLE
[HWORKS-2815][APPEND] Add visibility to env var

### DIFF
--- a/python/hopsworks_common/core/env_var_api.py
+++ b/python/hopsworks_common/core/env_var_api.py
@@ -94,7 +94,8 @@ class EnvVarsApi:
     def get(self, name: str) -> str | None:
         """Return just the value of an env var, or ``None`` if missing.
 
-        Convenience wrapper around [`get_env_var`][hopsworks.core.env_var_api.EnvVarsApi.get_env_var].
+        Convenience wrapper around
+        [`get_env_var`][hopsworks.core.env_var_api.EnvVarsApi.get_env_var].
 
         Example:
             ```python
@@ -116,6 +117,8 @@ class EnvVarsApi:
         name: str,
         value: str | None = None,
         secret_name: str | None = None,
+        visibility: str | None = None,
+        project_id_scope: int | None = None,
     ) -> env_var.EnvVar:
         """Add a new account-level env var.
 
@@ -132,6 +135,10 @@ class EnvVarsApi:
             value: Variable value. Up to 8192 characters. Ignored when
                 ``secret_name`` is provided.
             secret_name: Name of an existing secret to back the env var with.
+            visibility: Visibility of the env var. Use ``PROJECT`` to share it
+                with a project, or ``PRIVATE`` to keep it account-scoped.
+            project_id_scope: Project ID scope for a project-shared env var.
+                Required when creating a project-shared env var.
 
         Returns:
             The created [`EnvVar`][hopsworks.env_var.EnvVar].
@@ -141,7 +148,15 @@ class EnvVarsApi:
                 ``ENV_VAR_INVALID_NAME``, ``ENV_VAR_VALUE_TOO_LARGE``, or
                 ``ENV_VAR_LIMIT_EXCEEDED`` (default cap is 64 vars per user).
         """
-        return self._upsert("POST", ["users", "envvars"], name, value, secret_name)
+        return self._upsert(
+            "POST",
+            ["users", "envvars"],
+            name,
+            value,
+            secret_name,
+            visibility,
+            project_id_scope,
+        )
 
     @public
     def update_env_var(
@@ -149,6 +164,8 @@ class EnvVarsApi:
         name: str,
         value: str | None = None,
         secret_name: str | None = None,
+        visibility: str | None = None,
+        project_id_scope: int | None = None,
     ) -> env_var.EnvVar:
         """Replace the value of an existing env var.
 
@@ -160,6 +177,9 @@ class EnvVarsApi:
             value: New value. Up to 8192 characters. Ignored when
                 ``secret_name`` is provided.
             secret_name: Name of an existing secret to repoint the env var to.
+            visibility: Visibility of the env var. Use ``PROJECT`` to share it
+                with a project, or ``PRIVATE`` to keep it account-scoped.
+            project_id_scope: Project ID scope for a project-shared env var.
 
         Returns:
             The updated [`EnvVar`][hopsworks.env_var.EnvVar].
@@ -168,7 +188,15 @@ class EnvVarsApi:
             hopsworks.client.exceptions.RestAPIError: ``ENV_VAR_NOT_FOUND``
                 if no env var with that name exists.
         """
-        return self._upsert("PUT", ["users", "envvars", name], name, value, secret_name)
+        return self._upsert(
+            "PUT",
+            ["users", "envvars", name],
+            name,
+            value,
+            secret_name,
+            visibility,
+            project_id_scope,
+        )
 
     @public
     def set_env_var(
@@ -176,6 +204,8 @@ class EnvVarsApi:
         name: str,
         value: str | None = None,
         secret_name: str | None = None,
+        visibility: str | None = None,
+        project_id_scope: int | None = None,
     ) -> env_var.EnvVar:
         """Upsert: create the env var if missing, else update its value.
 
@@ -190,14 +220,21 @@ class EnvVarsApi:
             name: Variable name.
             value: Variable value. Ignored when ``secret_name`` is provided.
             secret_name: Name of an existing secret to back the env var with.
+            visibility: Visibility of the env var. Use ``PROJECT`` to share it
+                with a project, or ``PRIVATE`` to keep it account-scoped.
+            project_id_scope: Project ID scope for a project-shared env var.
 
         Returns:
             The created or updated [`EnvVar`][hopsworks.env_var.EnvVar].
         """
         existing = self.get_env_var(name)
         if existing is None:
-            return self.create_env_var(name, value, secret_name)
-        return self.update_env_var(name, value, secret_name)
+            return self.create_env_var(
+                name, value, secret_name, visibility, project_id_scope
+            )
+        return self.update_env_var(
+            name, value, secret_name, visibility, project_id_scope
+        )
 
     def _upsert(
         self,
@@ -206,6 +243,8 @@ class EnvVarsApi:
         name: str,
         value: str | None = None,
         secret_name: str | None = None,
+        visibility: str | None = None,
+        project_id_scope: int | None = None,
     ) -> env_var.EnvVar:
         _client = client.get_instance()
         headers = {"content-type": "application/json"}
@@ -217,6 +256,10 @@ class EnvVarsApi:
             payload["secretName"] = secret_name
         else:
             payload["value"] = value
+        if visibility is not None:
+            payload["visibility"] = visibility
+        if project_id_scope is not None:
+            payload["projectIdScope"] = project_id_scope
         env_vars = env_var.EnvVar.from_response_json(
             _client._send_request(
                 method,

--- a/python/hopsworks_common/env_var.py
+++ b/python/hopsworks_common/env_var.py
@@ -42,6 +42,8 @@ class EnvVar:
         expand=None,
         items=None,
         count=None,
+        visibility=None,
+        project_id_scope=None,
         **kwargs,
     ):
         self._name = name
@@ -50,6 +52,8 @@ class EnvVar:
         self._secret_backed = secret_backed
         self._added_on = added_on
         self._updated_on = updated_on
+        self._visibility = visibility
+        self._project_id_scope = project_id_scope
         self._env_var_api = env_var_api.EnvVarsApi()
 
     @classmethod
@@ -85,6 +89,18 @@ class EnvVar:
 
     @public
     @property
+    def visibility(self):
+        """Visibility of the environment variable."""
+        return self._visibility
+
+    @public
+    @property
+    def project_id_scope(self):
+        """Project ID scope for project-shared environment variables."""
+        return self._project_id_scope
+
+    @public
+    @property
     def created(self):
         """Date when the environment variable was created."""
         return self._added_on
@@ -115,6 +131,8 @@ class EnvVar:
         data = {
             "name": self._name,
             "value": "***" if self._value is not None else None,
+            "visibility": self._visibility,
+            "project_id_scope": self._project_id_scope,
             "added_on": self._added_on,
             "updated_on": self._updated_on,
         }

--- a/python/tests/core/test_env_var_api.py
+++ b/python/tests/core/test_env_var_api.py
@@ -288,7 +288,9 @@ class TestEnvVarsApi:
         client = MagicMock()
         client._send_request.side_effect = [
             _make_rest_api_error(EnvVar.NOT_FOUND_ERROR_CODE),  # get_env_var
-            _single_response("NEW_VAR", "v", visibility="PROJECT", project_id_scope=11),  # POST
+            _single_response(
+                "NEW_VAR", "v", visibility="PROJECT", project_id_scope=11
+            ),  # POST
         ]
         mocker.patch(
             "hopsworks_common.core.env_var_api.client.get_instance",
@@ -316,8 +318,12 @@ class TestEnvVarsApi:
         api = EnvVarsApi()
         client = MagicMock()
         client._send_request.side_effect = [
-            _single_response("EXISTING", "old", visibility="PRIVATE"),  # get_env_var returns hit
-            _single_response("EXISTING", "new", visibility="PROJECT", project_id_scope=11),  # PUT
+            _single_response(
+                "EXISTING", "old", visibility="PRIVATE"
+            ),  # get_env_var returns hit
+            _single_response(
+                "EXISTING", "new", visibility="PROJECT", project_id_scope=11
+            ),  # PUT
         ]
         mocker.patch(
             "hopsworks_common.core.env_var_api.client.get_instance",

--- a/python/tests/core/test_env_var_api.py
+++ b/python/tests/core/test_env_var_api.py
@@ -27,12 +27,33 @@ def _list_response(items: list[dict]) -> dict:
     return {"items": items, "type": "envVarDTO"}
 
 
-def _single_response(name: str, value: str) -> dict:
-    return _list_response([{"name": name, "value": value}])
+def _single_response(
+    name: str,
+    value: str,
+    visibility: str = "PRIVATE",
+    project_id_scope: int | None = None,
+) -> dict:
+    item = {"name": name, "value": value, "visibility": visibility}
+    if project_id_scope is not None:
+        item["projectIdScope"] = project_id_scope
+    return _list_response([item])
 
 
-def _secret_response(name: str, secret_name: str, value: str | None = None) -> dict:
-    item = {"name": name, "secretName": secret_name, "secretBacked": True}
+def _secret_response(
+    name: str,
+    secret_name: str,
+    value: str | None = None,
+    visibility: str = "PRIVATE",
+    project_id_scope: int | None = None,
+) -> dict:
+    item = {
+        "name": name,
+        "secretName": secret_name,
+        "secretBacked": True,
+        "visibility": visibility,
+    }
+    if project_id_scope is not None:
+        item["projectIdScope"] = project_id_scope
     if value is not None:
         item["value"] = value
     return _list_response([item])
@@ -71,8 +92,17 @@ class TestEnvVarsApi:
             mocker,
             _list_response(
                 [
-                    {"name": "OPENAI_API_KEY", "value": "sk-1"},
-                    {"name": "HF_TOKEN", "value": "hf-1"},
+                    {
+                        "name": "OPENAI_API_KEY",
+                        "value": "sk-1",
+                        "visibility": "PRIVATE",
+                    },
+                    {
+                        "name": "HF_TOKEN",
+                        "value": "hf-1",
+                        "visibility": "PROJECT",
+                        "projectIdScope": 11,
+                    },
                 ]
             ),
         )
@@ -80,7 +110,10 @@ class TestEnvVarsApi:
         assert len(result) == 2
         assert result[0].name == "OPENAI_API_KEY"
         assert result[0].value == "sk-1"
+        assert result[0].visibility == "PRIVATE"
         assert result[1].name == "HF_TOKEN"
+        assert result[1].visibility == "PROJECT"
+        assert result[1].project_id_scope == 11
 
     def test_get_env_vars_empty(self, mocker):
         api = EnvVarsApi()
@@ -94,16 +127,27 @@ class TestEnvVarsApi:
         assert isinstance(result, EnvVar)
         assert result.name == "OPENAI_API_KEY"
         assert result.value == "sk-1"
+        assert result.visibility == "PRIVATE"
 
     def test_get_env_var_returns_secret_backed_metadata(self, mocker):
         api = EnvVarsApi()
-        _patch_client(mocker, _secret_response("OPENAI_API_KEY", "my_secret"))
+        _patch_client(
+            mocker,
+            _secret_response(
+                "OPENAI_API_KEY",
+                "my_secret",
+                visibility="PROJECT",
+                project_id_scope=11,
+            ),
+        )
         result = api.get_env_var("OPENAI_API_KEY")
         assert isinstance(result, EnvVar)
         assert result.name == "OPENAI_API_KEY"
         assert result.value is None
         assert result.secret_name == "my_secret"
         assert result.secret_backed is True
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
 
     def test_get_env_var_not_found_returns_none(self, mocker):
         api = EnvVarsApi()
@@ -122,111 +166,247 @@ class TestEnvVarsApi:
 
     def test_create_env_var_posts(self, mocker):
         api = EnvVarsApi()
-        c = _patch_client(mocker, _single_response("OPENAI_API_KEY", "sk-1"))
-        result = api.create_env_var("OPENAI_API_KEY", "sk-1")
+        c = _patch_client(
+            mocker,
+            _single_response(
+                "OPENAI_API_KEY", "sk-1", visibility="PROJECT", project_id_scope=11
+            ),
+        )
+        result = api.create_env_var(
+            "OPENAI_API_KEY",
+            "sk-1",
+            visibility="PROJECT",
+            project_id_scope=11,
+        )
         assert result.name == "OPENAI_API_KEY"
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
         c._send_request.assert_called_once()
         method, path = c._send_request.call_args.args[:2]
         assert method == "POST"
         assert path == ["users", "envvars"]
         sent = json.loads(c._send_request.call_args.kwargs["data"])
-        assert sent == {"name": "OPENAI_API_KEY", "value": "sk-1"}
+        assert sent == {
+            "name": "OPENAI_API_KEY",
+            "value": "sk-1",
+            "visibility": "PROJECT",
+            "projectIdScope": 11,
+        }
 
     def test_create_env_var_from_secret_posts_secret_name(self, mocker):
         api = EnvVarsApi()
-        c = _patch_client(mocker, _secret_response("OPENAI_API_KEY", "my_secret"))
-        result = api.create_env_var("OPENAI_API_KEY", secret_name="my_secret")
+        c = _patch_client(
+            mocker,
+            _secret_response(
+                "OPENAI_API_KEY",
+                "my_secret",
+                visibility="PROJECT",
+                project_id_scope=11,
+            ),
+        )
+        result = api.create_env_var(
+            "OPENAI_API_KEY",
+            secret_name="my_secret",
+            visibility="PROJECT",
+            project_id_scope=11,
+        )
         assert result.name == "OPENAI_API_KEY"
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
         method, path = c._send_request.call_args.args[:2]
         assert method == "POST"
         assert path == ["users", "envvars"]
         sent = json.loads(c._send_request.call_args.kwargs["data"])
-        assert sent == {"name": "OPENAI_API_KEY", "secretName": "my_secret"}
+        assert sent == {
+            "name": "OPENAI_API_KEY",
+            "secretName": "my_secret",
+            "visibility": "PROJECT",
+            "projectIdScope": 11,
+        }
 
     def test_update_env_var_puts(self, mocker):
         api = EnvVarsApi()
-        c = _patch_client(mocker, _single_response("OPENAI_API_KEY", "sk-2"))
-        result = api.update_env_var("OPENAI_API_KEY", "sk-2")
+        c = _patch_client(
+            mocker,
+            _single_response(
+                "OPENAI_API_KEY", "sk-2", visibility="PROJECT", project_id_scope=11
+            ),
+        )
+        result = api.update_env_var(
+            "OPENAI_API_KEY",
+            "sk-2",
+            visibility="PROJECT",
+            project_id_scope=11,
+        )
         assert result.value == "sk-2"
-        method, path = c._send_request.call_args.args[:2]
-        assert method == "PUT"
-        assert path == ["users", "envvars", "OPENAI_API_KEY"]
-
-    def test_update_env_var_from_secret_puts_secret_name(self, mocker):
-        api = EnvVarsApi()
-        c = _patch_client(mocker, _secret_response("OPENAI_API_KEY", "my_secret"))
-        result = api.update_env_var("OPENAI_API_KEY", secret_name="my_secret")
-        assert result.secret_name == "my_secret"
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
         method, path = c._send_request.call_args.args[:2]
         assert method == "PUT"
         assert path == ["users", "envvars", "OPENAI_API_KEY"]
         sent = json.loads(c._send_request.call_args.kwargs["data"])
-        assert sent == {"name": "OPENAI_API_KEY", "secretName": "my_secret"}
+        assert sent == {
+            "name": "OPENAI_API_KEY",
+            "value": "sk-2",
+            "visibility": "PROJECT",
+            "projectIdScope": 11,
+        }
+
+    def test_update_env_var_from_secret_puts_secret_name(self, mocker):
+        api = EnvVarsApi()
+        c = _patch_client(
+            mocker,
+            _secret_response(
+                "OPENAI_API_KEY",
+                "my_secret",
+                visibility="PROJECT",
+                project_id_scope=11,
+            ),
+        )
+        result = api.update_env_var(
+            "OPENAI_API_KEY",
+            secret_name="my_secret",
+            visibility="PROJECT",
+            project_id_scope=11,
+        )
+        assert result.secret_name == "my_secret"
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
+        method, path = c._send_request.call_args.args[:2]
+        assert method == "PUT"
+        assert path == ["users", "envvars", "OPENAI_API_KEY"]
+        sent = json.loads(c._send_request.call_args.kwargs["data"])
+        assert sent == {
+            "name": "OPENAI_API_KEY",
+            "secretName": "my_secret",
+            "visibility": "PROJECT",
+            "projectIdScope": 11,
+        }
 
     def test_set_env_var_creates_when_absent(self, mocker):
         api = EnvVarsApi()
         client = MagicMock()
         client._send_request.side_effect = [
             _make_rest_api_error(EnvVar.NOT_FOUND_ERROR_CODE),  # get_env_var
-            _single_response("NEW_VAR", "v"),  # POST
+            _single_response("NEW_VAR", "v", visibility="PROJECT", project_id_scope=11),  # POST
         ]
         mocker.patch(
             "hopsworks_common.core.env_var_api.client.get_instance",
             return_value=client,
         )
-        result = api.set_env_var("NEW_VAR", "v")
+        result = api.set_env_var(
+            "NEW_VAR",
+            "v",
+            visibility="PROJECT",
+            project_id_scope=11,
+        )
         assert result.name == "NEW_VAR"
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
         assert client._send_request.call_args_list[1].args[0] == "POST"
+        sent = json.loads(client._send_request.call_args_list[1].kwargs["data"])
+        assert sent == {
+            "name": "NEW_VAR",
+            "value": "v",
+            "visibility": "PROJECT",
+            "projectIdScope": 11,
+        }
 
     def test_set_env_var_updates_when_present(self, mocker):
         api = EnvVarsApi()
         client = MagicMock()
         client._send_request.side_effect = [
-            _single_response("EXISTING", "old"),  # get_env_var returns hit
-            _single_response("EXISTING", "new"),  # PUT
+            _single_response("EXISTING", "old", visibility="PRIVATE"),  # get_env_var returns hit
+            _single_response("EXISTING", "new", visibility="PROJECT", project_id_scope=11),  # PUT
         ]
         mocker.patch(
             "hopsworks_common.core.env_var_api.client.get_instance",
             return_value=client,
         )
-        result = api.set_env_var("EXISTING", "new")
+        result = api.set_env_var(
+            "EXISTING",
+            "new",
+            visibility="PROJECT",
+            project_id_scope=11,
+        )
         assert result.value == "new"
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
         assert client._send_request.call_args_list[1].args[0] == "PUT"
+        sent = json.loads(client._send_request.call_args_list[1].kwargs["data"])
+        assert sent == {
+            "name": "EXISTING",
+            "value": "new",
+            "visibility": "PROJECT",
+            "projectIdScope": 11,
+        }
 
     def test_set_env_var_from_secret_creates_when_absent(self, mocker):
         api = EnvVarsApi()
         client = MagicMock()
         client._send_request.side_effect = [
             _make_rest_api_error(EnvVar.NOT_FOUND_ERROR_CODE),  # get_env_var
-            _secret_response("NEW_VAR", "my_secret"),  # POST
+            _secret_response(
+                "NEW_VAR", "my_secret", visibility="PROJECT", project_id_scope=11
+            ),  # POST
         ]
         mocker.patch(
             "hopsworks_common.core.env_var_api.client.get_instance",
             return_value=client,
         )
-        result = api.set_env_var("NEW_VAR", secret_name="my_secret")
+        result = api.set_env_var(
+            "NEW_VAR",
+            secret_name="my_secret",
+            visibility="PROJECT",
+            project_id_scope=11,
+        )
         assert result.name == "NEW_VAR"
         assert result.secret_name == "my_secret"
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
         assert client._send_request.call_args_list[1].args[0] == "POST"
         sent = json.loads(client._send_request.call_args_list[1].kwargs["data"])
-        assert sent == {"name": "NEW_VAR", "secretName": "my_secret"}
+        assert sent == {
+            "name": "NEW_VAR",
+            "secretName": "my_secret",
+            "visibility": "PROJECT",
+            "projectIdScope": 11,
+        }
 
     def test_set_env_var_from_secret_updates_when_present(self, mocker):
         api = EnvVarsApi()
         client = MagicMock()
         client._send_request.side_effect = [
-            _secret_response("EXISTING", "old_secret"),  # get_env_var returns hit
-            _secret_response("EXISTING", "new_secret"),  # PUT
+            _secret_response(
+                "EXISTING",
+                "old_secret",
+                visibility="PRIVATE",
+            ),  # get_env_var returns hit
+            _secret_response(
+                "EXISTING", "new_secret", visibility="PROJECT", project_id_scope=11
+            ),  # PUT
         ]
         mocker.patch(
             "hopsworks_common.core.env_var_api.client.get_instance",
             return_value=client,
         )
-        result = api.set_env_var("EXISTING", secret_name="new_secret")
+        result = api.set_env_var(
+            "EXISTING",
+            secret_name="new_secret",
+            visibility="PROJECT",
+            project_id_scope=11,
+        )
         assert result.secret_name == "new_secret"
+        assert result.visibility == "PROJECT"
+        assert result.project_id_scope == 11
         assert client._send_request.call_args_list[1].args[0] == "PUT"
         sent = json.loads(client._send_request.call_args_list[1].kwargs["data"])
-        assert sent == {"name": "EXISTING", "secretName": "new_secret"}
+        assert sent == {
+            "name": "EXISTING",
+            "secretName": "new_secret",
+            "visibility": "PROJECT",
+            "projectIdScope": 11,
+        }
 
     def test_delete_env_var_calls_delete(self, mocker):
         api = EnvVarsApi()
@@ -271,11 +451,24 @@ class TestEnvVar:
 
     def test_from_response_json_single(self):
         result = EnvVar.from_response_json(
-            {"items": [{"name": "X", "value": "y", "addedOn": None, "updatedOn": None}]}
+            {
+                "items": [
+                    {
+                        "name": "X",
+                        "value": "y",
+                        "visibility": "PROJECT",
+                        "projectIdScope": 11,
+                        "addedOn": None,
+                        "updatedOn": None,
+                    }
+                ]
+            }
         )
         assert len(result) == 1
         assert result[0].name == "X"
         assert result[0].value == "y"
+        assert result[0].visibility == "PROJECT"
+        assert result[0].project_id_scope == 11
 
     def test_from_response_json_secret_backed(self):
         result = EnvVar.from_response_json(
@@ -285,6 +478,8 @@ class TestEnvVar:
                         "name": "OPENAI_API_KEY",
                         "secretName": "my_secret",
                         "secretBacked": True,
+                        "visibility": "PROJECT",
+                        "projectIdScope": 11,
                         "addedOn": None,
                         "updatedOn": None,
                     }
@@ -296,14 +491,23 @@ class TestEnvVar:
         assert result[0].value is None
         assert result[0].secret_name == "my_secret"
         assert result[0].secret_backed is True
+        assert result[0].visibility == "PROJECT"
+        assert result[0].project_id_scope == 11
 
     def test_to_dict_secret_backed_includes_metadata(self):
         env_var = EnvVar(
-            name="X", value="y", secret_name="my_secret", secret_backed=True
+            name="X",
+            value="y",
+            secret_name="my_secret",
+            secret_backed=True,
+            visibility="PROJECT",
+            project_id_scope=11,
         )
         assert env_var.to_dict() == {
             "name": "X",
             "value": "***",
+            "visibility": "PROJECT",
+            "project_id_scope": 11,
             "added_on": None,
             "updated_on": None,
             "secret_name": "my_secret",


### PR DESCRIPTION
Thread visibility and project scope through EnvVar and EnvVarsApi so the SDK round-trips the backend contract for project-shared env vars.

- Expose visibility and project_id_scope on EnvVar instances.
- Send visibility and projectIdScope on create, update, and set requests.
- Preserve existing positional EnvVar construction order.
- Expand env-var tests for parsing, serialization, and request payloads.

Verification:
- python3 -m py_compile on the touched files
- direct runtime check with a local hopsworks_apigen stub

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
