### PR TITLE
[HFRONT-1550] hopsworks-api skills + CLI hardening (frontend hackathon)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ ml/ — develop and operate ML systems with FTI pipeline architecture
 agents/ — develop and operate scheduled agents and agent deployments
 dashboards/ — design Streamlit apps and Superset dashboards
 data/ — data discovery, Trino SQL, storage connectors
+platform/ — cross-cutting platform knowledge (UI navigation), not tied to one FTI stage
 hops/ — legacy flat layout (superseded by the categorized folders above)
 deprecated/ — no longer used
-Every skill in ml/, agents/, dashboards/, data/ must have a reference in the top-level README.md. Skills in deprecated/ must not appear there.
+Every skill in ml/, agents/, dashboards/, data/, platform/ must have a reference in the top-level README.md. Skills in deprecated/ must not appear there.
 
 Each skill entry in the top-level README.md must link the skill name to its SKILL.md.
 

--- a/python/hopsworks/cli/commands/fg.py
+++ b/python/hopsworks/cli/commands/fg.py
@@ -979,13 +979,8 @@ def _build_features(spec: str | None) -> list[Any]:
         # after the second colon, so it may contain colons but not a comma,
         # which separates items. CLI-expressible types carry no inner colon.
         col, dtype, *desc = item.split(":", 2)
-        out.append(
-            Feature(
-                col.strip(),
-                dtype.strip(),
-                description=desc[0].strip() if desc else None,
-            )
-        )
+        description = desc[0].strip() if desc else None
+        out.append(Feature(col.strip(), dtype.strip(), description=description or None))
     return out
 
 

--- a/python/hopsworks/cli/commands/fg.py
+++ b/python/hopsworks/cli/commands/fg.py
@@ -284,7 +284,7 @@ def _fg_to_dict(fg: Any) -> dict[str, Any]:
 @click.option(
     "--features",
     "features_spec",
-    help='Comma-separated schema, e.g. "id:bigint,amount:double".',
+    help='Comma-separated schema "name:type[:description]", e.g. "id:bigint:User id,amount:double".',
 )
 @click.option("--event-time", "event_time", help="Name of the event-time column.")
 @click.option(
@@ -319,7 +319,7 @@ def fg_create(
         name: Feature group name.
         version: Version; auto-assigned when omitted.
         primary_key: Comma-separated primary keys.
-        features_spec: Comma-separated ``name:type`` pairs.
+        features_spec: Comma-separated ``name:type[:description]`` items.
         event_time: Event-time column name.
         partition_key: Comma-separated partition keys.
         online: Whether to enable the online store.
@@ -660,7 +660,7 @@ def fg_derive(
     "--features",
     "features_spec",
     required=True,
-    help='New columns as comma-separated name:type pairs, e.g. "score:double,tier:string".',
+    help='New columns "name:type[:description]", e.g. "score:double:Risk score,tier:string".',
 )
 @click.option("--version", type=int, help="Feature group version; defaults to latest.")
 @click.pass_context
@@ -680,7 +680,7 @@ def fg_append_features(
     Args:
         ctx: Click context.
         name: Feature group name.
-        features_spec: New columns as comma-separated ``name:type`` pairs.
+        features_spec: New columns as comma-separated ``name:type[:description]`` items.
         version: Feature group version; defaults to latest.
     """
     fg = _get_fg(ctx, name, version)
@@ -972,11 +972,20 @@ def _build_features(spec: str | None) -> list[Any]:
             continue
         if ":" not in item:
             raise click.BadParameter(
-                f"Feature '{item}' must be 'name:type'.",
+                f"Feature '{item}' must be 'name:type[:description]'.",
                 param_hint="--features",
             )
-        col, dtype = item.split(":", 1)
-        out.append(Feature(col.strip(), dtype.strip()))
+        # name:type[:description]; the description (optional) is everything
+        # after the second colon, so it may contain colons but not a comma,
+        # which separates items. CLI-expressible types carry no inner colon.
+        col, dtype, *desc = item.split(":", 2)
+        out.append(
+            Feature(
+                col.strip(),
+                dtype.strip(),
+                description=desc[0].strip() if desc else None,
+            )
+        )
     return out
 
 

--- a/python/hopsworks/cli/templates/SKILL.md
+++ b/python/hopsworks/cli/templates/SKILL.md
@@ -64,7 +64,7 @@ hops fg create <name> --primary-key <cols> [flags]
 
 Flags:
 - `--primary-key <cols>` — comma-separated primary-key columns (required)
-- `--features "name:type,..."` — schema (bigint, double, boolean, timestamp, string, `array<float>`)
+- `--features "name:type[:description],..."` — schema (bigint, double, boolean, timestamp, string, `array<float>`); the optional third field is a per-column description
 - `--partition-key <cols>` — comma-separated partition columns
 - `--online` — enable online storage (Kafka + RonDB + Spark materialization)
 - `--event-time <col>` — event-time column for time-travel queries

--- a/python/tests/cli/test_writes.py
+++ b/python/tests/cli/test_writes.py
@@ -55,16 +55,17 @@ def test_fg_append_features_parses_and_calls_sdk(mock_project):
             "append-features",
             "txn",
             "--features",
-            "score:double:Risk score,tier:string",
+            "score:double:Risk score,tier:string,extra:int:",
         ],
     )
     assert result.exit_code == 0, result.output
     fg.append_features.assert_called_once()
     appended = fg.append_features.call_args.args[0]
-    assert [f.name for f in appended] == ["score", "tier"]
-    assert [f.type for f in appended] == ["double", "string"]
-    # Optional per-column description: parsed for the first, None for the second.
-    assert [f.description for f in appended] == ["Risk score", None]
+    assert [f.name for f in appended] == ["score", "tier", "extra"]
+    assert [f.type for f in appended] == ["double", "string", "int"]
+    # Optional per-column description: parsed when given, None when omitted
+    # (no third field) or empty (a trailing colon).
+    assert [f.description for f in appended] == ["Risk score", None, None]
 
 
 def test_fg_append_features_rejects_bad_spec(mock_project):

--- a/python/tests/cli/test_writes.py
+++ b/python/tests/cli/test_writes.py
@@ -50,13 +50,21 @@ def test_fg_append_features_parses_and_calls_sdk(mock_project):
     fs.get_feature_group.return_value = fg
     result = CliRunner().invoke(
         cli,
-        ["fg", "append-features", "txn", "--features", "score:double,tier:string"],
+        [
+            "fg",
+            "append-features",
+            "txn",
+            "--features",
+            "score:double:Risk score,tier:string",
+        ],
     )
     assert result.exit_code == 0, result.output
     fg.append_features.assert_called_once()
     appended = fg.append_features.call_args.args[0]
     assert [f.name for f in appended] == ["score", "tier"]
     assert [f.type for f in appended] == ["double", "string"]
+    # Optional per-column description: parsed for the first, None for the second.
+    assert [f.description for f in appended] == ["Risk score", None]
 
 
 def test_fg_append_features_rejects_bad_spec(mock_project):

--- a/skills/README.md
+++ b/skills/README.md
@@ -20,6 +20,9 @@ into bucket folders:
 - [hops-eda](ml/hops-eda/SKILL.md) — EDA before training.
 - [hops-eda-checklist](ml/hops-eda-checklist/SKILL.md) — reference: EDA dimensions (profiling, target, leakage).
 
+## platform/ — cross-cutting platform knowledge
+- [hops-ui-navigation](platform/hops-ui-navigation/SKILL.md) — where things live in the Hopsworks UI (project sidebar map).
+
 ## hops/ — feature store, training, inference, jobs, apps, agents
 - [hops-fg](hops/hops-fg/SKILL.md) — feature groups.
 - [hops-fv](hops/hops-fv/SKILL.md) — feature views, training data, online vectors.

--- a/skills/data/hops-data-sources/SKILL.md
+++ b/skills/data/hops-data-sources/SKILL.md
@@ -69,6 +69,8 @@ hops datasource create bigquery <name> --project-id proj --dataset ds --key-path
 hops datasource delete <name> --yes
 ```
 
+**Confirm before deleting.** `hops datasource delete` removes the storage connector irreversibly; confirm the exact name with the user, and never delete one that feature groups still read from unless they asked.
+
 ## Ingest into a new feature group with DLTHub
 
 DLTHub copies a source into a managed feature group for the cases mounting cannot serve: loading the online store or a vector index, or pulling from an API/SaaS/REST endpoint. Ingestion runs server-side in the `dlthub-ingestion-pipeline` environment, driven by a `SinkJobConfiguration` attached to a sink-enabled feature group. It is configuration plus a server job, not an in-process `dlt` call.

--- a/skills/hops/hops-agent-deployment/SKILL.md
+++ b/skills/hops/hops-agent-deployment/SKILL.md
@@ -51,6 +51,8 @@ hops agent stop my_agent
 hops agent delete my_agent --yes
 ```
 
+**Confirm before deleting.** `hops agent delete` tears down the served agent irreversibly; confirm the exact name with the user, and never tear down an agent you created as a side effect (temp or test ones included) unless they asked.
+
 `create` re-run uploads the latest code and rewrites the predictor; a running agent is left untouched (use `start`, or `restart` via the SDK, to roll onto new code).
 
 ## Deploy — SDK

--- a/skills/hops/hops-app/SKILL.md
+++ b/skills/hops/hops-app/SKILL.md
@@ -33,6 +33,7 @@ Full CLI surface is in **Manage Apps from the CLI** below.
 
 - Does the app need **custom libraries** not in `python-app-pipeline`? If so, clone the env and install `app-requirements.txt` (see **Your App uses Custom libraries**).
 - What **memory / cores** should the app get? Defaults are `memory=2048` MB, `cores=1.0`.
+- **Before deleting** — `app.delete()` / `hops app delete --yes` tears down the app irreversibly; confirm the exact name with the user, and never tear down an app you created as a side effect (temp or test ones included) unless they asked.
 
 ---
 

--- a/skills/hops/hops-environments/SKILL.md
+++ b/skills/hops/hops-environments/SKILL.md
@@ -77,6 +77,8 @@ env.delete()                               # remove the environment
 - Which base matches the workload (training vs inference vs app vs agent)?
 - Is there a `requirements.txt` already? If not, prompt for one before cloning —
   a clone with nothing to install is wasted minutes.
+- **Before deleting** — `env.delete()` is irreversible; confirm with the user, and
+  never delete an environment a job, app, or deployment still references.
 
 ## Caveats
 - **Clone and install each block for minutes.** Use `await_creation=False` /

--- a/skills/hops/hops-fg/SKILL.md
+++ b/skills/hops/hops-fg/SKILL.md
@@ -105,6 +105,8 @@ fg = fs.get_or_create_feature_group(
 )
 ```
 
+**Always describe what you create.** Pass `description=` on the feature group and a `description=` on every `Feature(...)`. A feature group or column with no description shows as an empty envelope in the UI and is not discoverable in search. If the user gave none, write concise ones from what each feature means; never leave them blank.
+
 ### Key Parameters
 
 | Parameter | When to use |
@@ -507,7 +509,7 @@ from hsfs.feature import Feature
 fg.append_features([Feature("score", "double"), Feature("tier", "string")])
 ```
 
-CLI: `hops fg append-features <name> --features "score:double,tier:string"`.
+CLI: `hops fg append-features <name> --features "score:double:Risk score,tier:string"` — the spec is `name:type[:description]`, so set a description per column.
 
 Rules and consequences:
 - Append-only. New columns cannot be primary or partition keys.
@@ -551,7 +553,11 @@ derived_fg = fs.get_or_create_feature_group(
     description="Features derived from source_data for XYZ model",
     primary_key=["id"],
     event_time="event_ts",
-    features=[...],
+    features=[
+        Feature("id", "bigint", description="Entity id"),
+        Feature("event_ts", "timestamp", description="When the value was valid"),
+        # one Feature(..., description=...) per column — never leave a feature undescribed
+    ],
     online_enabled=True,        # ask user: online or offline?
     stream=True,
     parents=[source_fg],        # provenance

--- a/skills/hops/hops-fg/SKILL.md
+++ b/skills/hops/hops-fg/SKILL.md
@@ -464,6 +464,13 @@ Only rows matching on all key columns are deleted.
 
 ---
 
+## Deleting a Feature Group
+
+**Confirm before deleting.** `fg.delete()` (CLI `hops fg delete <name> --version N --yes`) drops the feature group and all its data irreversibly; confirm the exact name and version with the user first.
+Never tear down a feature group you created as a side effect — temp or test ones included — unless the user asked; default to keeping resources.
+
+---
+
 ## Evolving the Schema
 
 Two cases, split by whether downstream consumers can be disturbed.

--- a/skills/hops/hops-fg/SKILL.md
+++ b/skills/hops/hops-fg/SKILL.md
@@ -56,6 +56,25 @@ Before creating a feature group, clarify these decisions with the user:
 
 ---
 
+## Feature data types & online-store constraints
+
+Pick a supported type up front: a write with an unsupported type fails, and retrying the same type just loops.
+
+**Supported feature types:**
+- Scalars: `int`, `bigint`, `float`, `double`, `boolean`, `string`, `date`, `timestamp`, `binary`.
+- Composite: `array<type>` and `struct<field:type,...>` — e.g. `array<float>`, `struct<lat:double,lon:double>`.
+- `decimal` is **not** supported. Use `double`, or `string` when you need exact precision.
+
+**Online store (`online_enabled=True`):**
+- Scalars map straight to RonDB. Strings become `varchar(n)`, auto-sized to the longest value seen (rounded up to 100) and widened on later inserts; very long text falls back to `text`.
+- Composite types (`array`, `struct`) **do** write online — they are stored Avro-encoded and decoded by the SDK on read. An online FG with an `array<float>` column is fine; you do not need to drop or flatten it.
+- For **similarity search**, declare the vector as `array<float>` **and** attach an `EmbeddingIndex` (see Vector Embeddings): the FG is then backed by the vector DB (OpenSearch) instead of RonDB. Without an embedding index an `array<float>` is stored data, not a searchable index.
+- Online is an upsert: one row per primary key, a new write for an existing key overwrites it.
+
+Let the schema be inferred from the DataFrame when you can; pass an explicit `features=[Feature(name, type, ...)]` list only to pin a type (e.g. `bigint` over an inferred `int`, or an `array<float>` embedding column).
+
+---
+
 ## Creating a Feature Group
 
 ```python

--- a/skills/hops/hops-fv/SKILL.md
+++ b/skills/hops/hops-fv/SKILL.md
@@ -65,6 +65,7 @@ rather than assuming `1`.
 - **Label column** — which selected feature is the prediction target (or none, for an unsupervised / retrieval view). It must be in the query selection.
 - **Which features** — which feature groups and columns to select, and how they join.
 - **Online vs offline source FGs** — whether the view needs online serving. If yes, every source feature group must be `online_enabled`; confirm before relying on `init_serving()`.
+- **Before deleting** — `fv.delete()` / `hops fv delete --yes --force` is irreversible; confirm the exact name and version with the user, and never tear down a feature view you created as a side effect (temp or test ones included) unless they asked.
 
 ---
 

--- a/skills/hops/hops-fv/SKILL.md
+++ b/skills/hops/hops-fv/SKILL.md
@@ -152,6 +152,8 @@ feature_view = fs.get_or_create_feature_view(
 )
 ```
 
+**Set a description.** Pass `description=` on the feature view so it is not an empty envelope in the UI. Per-feature descriptions come from the source feature groups, so describe the columns at the FG (see hops-fg), not here.
+
 > **The label must be in the query selection.** `labels=[...]` only marks which *already-selected* columns are targets; it does not add them. If the label is not in your `select(...)` (or is dropped by `select_except([...])`), create fails with `FeatureStoreException: Feature name '<label>' could not be found in query`. Select the label, then name it in `labels=`. (The examples above assume `is_fraud` is part of `query`.)
 
 ### Key Parameters

--- a/skills/hops/hops-monitoring/SKILL.md
+++ b/skills/hops/hops-monitoring/SKILL.md
@@ -45,6 +45,7 @@ hops fg stats <name> --compute     # recompute on current data
 - Statistics-only, or **drift detection** against a reference (rolling window / fixed
   value / training dataset)?
 - Hard gate on bad data (`validation_ingestion_policy="strict"`) or log-and-pass (`"always"`)?
+- **Before deleting** — `config.delete()` removes the monitoring config; confirm with the user before deleting one you did not just create.
 
 ## Steps (generic, non-binding)
 1. Confirm what the cluster allows: statistics, validation, and alerts always work; feature monitoring needs the cluster service (see above).

--- a/skills/hops/hops-online-inference/SKILL.md
+++ b/skills/hops/hops-online-inference/SKILL.md
@@ -18,6 +18,7 @@ An **online inference pipeline** is one of the three FTI pipelines (Feature, Tra
 - **Resources:** CPU cores, memory, GPUs for the predictor (requests vs limits).
 - **Environment:** which Python environment the predictor runs in.
 - **Scaling:** min/max instances, scale-to-zero, and target concurrency (`ScaleMetric.CONCURRENCY`).
+- **Before deleting** — `deployment.delete()` / `hops deployment delete --yes` tears down the running endpoint irreversibly; confirm the exact name with the user, and never tear down a deployment you created as a side effect (temp or test ones included) unless they asked.
 
 ## Model Deployment Overview
 

--- a/skills/hops/hops-superset/SKILL.md
+++ b/skills/hops/hops-superset/SKILL.md
@@ -35,6 +35,7 @@ quickest path to list/inspect/clean up (delete takes `--yes`). Re-run
 - Which feature group (and version) to chart.
 - Which columns / metrics to visualize, and which chart types (see the viz_type
   enum in §3).
+- **Before deleting** — `api.delete_chart/dataset/dashboard(id)` / `hops superset ... delete --yes` is irreversible; confirm with the user which object to remove, and never delete one you created as a side effect (temp or test ones included) unless they asked.
 
 ---
 

--- a/skills/hops/hops-superset/SKILL.md
+++ b/skills/hops/hops-superset/SKILL.md
@@ -122,12 +122,11 @@ api.update_dashboard(dashboard_id: int, **kwargs) -> dict
 api.delete_dashboard(dashboard_id: int) -> dict
 ```
 
-Raw requests (for paging, or endpoints the SDK doesn't wrap) go through
-`api._request("GET", "/api/v1/...")` — the same client, auth headers included.
+`_request(...)` is **internal** (underscore-prefixed, not `@public`): it carries no cross-release stability guarantee. Prefer the `@public` methods above (`list_*`, `create_*`, `get_*`, `update_*`, `delete_*`) as the supported surface. Reach for `api._request("GET", "/api/v1/...")` only for what the public API does not cover yet — paging, or endpoints the SDK doesn't wrap — knowing it may break on upgrade.
 
 ### Paging helper
 
-`list_*()` returns only the first page (~25 rows). Paginate manually:
+`list_*()` returns only the first page (~25 rows). There is no public paged-list method yet, so paginate via the internal `_request` (escape hatch — see the note above):
 
 ```python
 def list_all(api, resource):

--- a/skills/hops/hops-train/SKILL.md
+++ b/skills/hops/hops-train/SKILL.md
@@ -178,6 +178,11 @@ Non-interactive cleanup needs flags: `hops model delete <name> --yes`,
 `hops fv delete <name> --version <v> --yes --force` (a FV with training data
 needs `--force`).
 
+**Confirm before deleting.** These remove the registered model or feature view
+irreversibly; confirm the exact name and version with the user, and never tear
+down a model or feature view you created as a side effect (temp or test ones
+included) unless they asked.
+
 ## Next Steps
 
 - Serve the model online: **hops-online-inference**. Batch scoring: **hops-batch-inference**.

--- a/skills/hops/hops-train/SKILL.md
+++ b/skills/hops/hops-train/SKILL.md
@@ -151,6 +151,8 @@ hw_model = mr.python.create_model(
 hw_model.save(model_dir)                    # uploads the whole dir (model + plots)
 ```
 
+**Set `description=`** on the model (and keep `metrics=`): an undescribed model is an empty envelope in the registry.
+
 Hints:
 - `save()` moves the local files into the registry; pass `keep_original_files=True`
   to also keep them locally.

--- a/skills/ml/hops-features/SKILL.md
+++ b/skills/ml/hops-features/SKILL.md
@@ -41,7 +41,7 @@ Is it a batch or streamining job? The same program should both backfill historic
 Will it be a simple job execution or a scheduled job (optionally with incremental reads from feature groups and/or data sources). Load hops-job skill.
 
 ## Sink
-One or more feature groups should be the sink of the feature pipelines. Use the **hops-fg** skill to create and write them (online vs offline, schema, provenance). For external/source data, use **hops-data-sources**; for PySpark processing, **hops-spark**.
+One or more feature groups should be the sink of the feature pipelines. Use the **hops-fg** skill to create and write them (online vs offline, schema, provenance). For external/source data, use **hops-data-sources**; for PySpark processing, **hops-spark**. Set a `description=` on each sink feature group and on every `Feature(...)`: undescribed features land as empty envelopes in the UI and are not discoverable.
 
 ## Next Steps
 

--- a/skills/platform/README.md
+++ b/skills/platform/README.md
@@ -1,0 +1,6 @@
+# Platform skills
+
+Cross-cutting Hopsworks platform knowledge that is not tied to one FTI stage or
+data path. The live, canonical list is `hops skills list --bucket platform`.
+
+- [hops-ui-navigation](hops-ui-navigation/SKILL.md) — Where things live in the Hopsworks UI: the project sidebar layout and how to reach each page.

--- a/skills/platform/hops-ui-navigation/SKILL.md
+++ b/skills/platform/hops-ui-navigation/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: hops-ui-navigation
+description: Use when the user asks where something lives in the Hopsworks UI or how to reach a page (Data Sources, Feature Groups, Feature Views, Model Registry, Deployments, Apps, Agents, Jobs, Jupyter, Project Settings). Knowledge skill: the project-scoped sidebar layout and what sits under each section, so you can point users to the right place.
+---
+
+# Hopsworks UI — Navigation Map
+
+A knowledge skill: it describes where things live in the Hopsworks web UI so you can guide a user to the right page.
+It is not a workflow. For creating or operating resources, use the matching action skill (links at the bottom).
+
+The UI is **project-scoped**: pick a project, then everything below is a left sidebar inside that project.
+The sidebar is grouped into section headers (AI/ML, Agents, Compute, Analytics, Configuration) with pages under each.
+
+## Source of truth
+
+This map is derived by hand from the frontend, not maintained independently.
+When routes or sidebar entries change, re-derive it from:
+
+- `hopsworks-front/src/layouts/app/navigation/useAppNavigation.tsx` — the sidebar tree, order, and section headers.
+- `hopsworks-front/src/routes/routeNames.ts` — the route paths behind each entry.
+- `hopsworks-front/src/modules/feature-group/hooks/useTabsNavigation.tsx` and `src/modules/deployments/index.tsx` — titles for the dynamic Feature Groups / Deployments entries.
+
+## Sidebar layout (top to bottom)
+
+- **Home** — project landing page.
+- **Files** — HopsFS file browser (datasets, `Resources/`, `Models/`, `Jupyter/`). Opens at the user's own folder.
+- **Data Sources** — storage connectors (JDBC, S3, Snowflake, BigQuery, Redshift, GCS, ADLS, …). Create / edit / preview connectors here.
+- **Feature Groups** — list and inspect feature groups; drill into a group for its schema, data preview, statistics, and provenance.
+
+- **AI/ML** *(section)*
+  - **Feature Views** — list feature views; a selected view exposes its Feature List, **Training Data** (Statistics, Correlations, New Training Data), Feature Logging, Provenance, Tags, API, and Query.
+  - **Model Registry** — registered models and versions; a version shows Metrics, Evaluation, Model Card, Schema, Tags, Code Snippets (VLLM Config for LLM models).
+  - **Model Deployments** — KServe model-serving endpoints; status, logs, predict, metrics.
+  - **Apps** — Python / Streamlit app deployments and their URLs.
+
+- **Agents** *(section)*
+  - **Agent Deployments** — served interactive agents (server-only KServe deployments).
+  - **Agent Jobs** — fire-and-forget agent executions; Overview and Executions.
+
+- **Compute** *(section)*
+  - **Environment** — Python environments (clone a base, install requirements/wheels).
+  - **Jobs** — jobs and executions (Job Details, Configuration, Schedule, Scheduler, Alerts). Shown as **Ingestions** for service users.
+  - **Airflow** — Airflow UI (only when `airflow_enabled`).
+  - **Jupyter** — JupyterLab servers (hidden/disabled when Jupyter is off).
+
+- **Analytics** *(section, only when Trino or Superset is enabled)*
+  - **Queries** — Trino SQL query engine (history, runner).
+  - **Superset** — opens the external Superset dashboard in a new tab.
+
+- **Configuration** *(section)*
+  - **Project Settings** — General, Integrations, Compute Configuration, Git, Kubernetes Scheduler, Governance Policies, OnlineFS Metrics, IAM Role Chaining, Kafka, Alerts.
+
+## Conditional visibility
+
+Some entries depend on edition, role, or service flags, so a user may not see all of them:
+
+- **Enterprise-only** — Integrations, Compute Configuration, Kubernetes Scheduler, Governance Policies, OnlineFS Metrics, IAM Role Chaining (and Provenance / Tags on a feature view). A non-enterprise user sees these greyed out or hidden.
+- **Service users** see **Ingestions** instead of **Jobs**, and have several settings disabled.
+- **Feature flags** — Airflow (`airflow_enabled`), Jupyter (`enable_terminal` / enablement), Feature Monitoring, Trino, Superset gate their entries.
+
+## Where do I find…?
+
+| User asks | Sidebar path |
+|---|---|
+| A storage connector / external source | Data Sources |
+| A feature group's schema or data | Feature Groups → (group) |
+| Training data, statistics, correlations | AI/ML → Feature Views → (view) → Training Data |
+| A registered model | AI/ML → Model Registry |
+| A serving endpoint / predict | AI/ML → Model Deployments |
+| A Streamlit app URL | AI/ML → Apps |
+| A served agent / agent job | Agents → Agent Deployments / Agent Jobs |
+| Python env / install a package | Compute → Environment |
+| Run / schedule a job, see executions | Compute → Jobs |
+| Notebooks | Compute → Jupyter |
+| Trino SQL / Superset dashboard | Analytics → Queries / Superset |
+| Git, Kafka, alerts, project config | Configuration → Project Settings |
+
+Full docs: https://docs.hopsworks.ai
+
+## Related skills and commands
+
+- Discover resources without the UI: **hops-data-discovery** (`hops fg list`, `hops fv list`, `hops search ls`).
+- Operate the resource behind a page: **hops-fg**, **hops-fv**, **hops-train**, **hops-online-inference**, **hops-app**, **hops-agent-deployment**, **hops-job**, **hops-environments**, **hops-superset**, **hops-data-sources**.
+- A quick UI-equivalent snapshot from the CLI: `hops context`.


### PR DESCRIPTION
Grouped hackathon work on the hopsworks-api product skills (+ hops CLI), one commit per ticket under epic [HFRONT-1550](https://hopsworks.atlassian.net/browse/HFRONT-1550).

## Tickets

- **[HFRONT-1570](https://hopsworks.atlassian.net/browse/HFRONT-1570)** — teardown safety. Every skill that deletes an artifact now confirms with the user first, folded into each skill's "Ask the user" section.
- **[HFRONT-1572](https://hopsworks.atlassian.net/browse/HFRONT-1572)** — feature data types + online-store constraints, documented in hops-fg and sourced from the client's own type tables. Corrects the premise that arrays cannot go online: complex types write as Avro-encoded values; embeddings via `EmbeddingIndex`.
- **[HFRONT-1571](https://hopsworks.atlassian.net/browse/HFRONT-1571)** — new knowledge skill `platform/hops-ui-navigation`: the project sidebar map, derived from the frontend (`useAppNavigation.tsx`, `routeNames.ts`) with a source-of-truth header for re-derivation.
- **[HFRONT-1566](https://hopsworks.atlassian.net/browse/HFRONT-1566)** — descriptions. Skills now require a description on every created resource and per feature/column; the `hops fg` schema spec gains an optional `name:type[:description]` field (create + append-features). The client already supported per-feature descriptions end to end.
- **[HFRONT-1573](https://hopsworks.atlassian.net/browse/HFRONT-1573)** — public vs internal API. The `@public` convention already exists and is documented; steered the one offending skill (hops-superset) off the internal `api._request`.

## Notes

- No product-client code change: per-feature description was already wired (`hsfs/feature.py`). The only Python change is the CLI `--features` parser.
- Full `uv` test run did not execute locally (dependency resolution fails on a docs extra pinned to Python 3.13). `ruff check` is clean; the CLI description parser is covered by an extended `append-features` test.

## Follow-ups (separate tickets)

- HFRONT-1573: add a public paged-list method to `SupersetApi` to close the gap behind the `_request` escape hatch, and audit `@public` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[HFRONT-1550]: https://hopsworks.atlassian.net/browse/HFRONT-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HFRONT-1570]: https://hopsworks.atlassian.net/browse/HFRONT-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HFRONT-1572]: https://hopsworks.atlassian.net/browse/HFRONT-1572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HFRONT-1571]: https://hopsworks.atlassian.net/browse/HFRONT-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HFRONT-1566]: https://hopsworks.atlassian.net/browse/HFRONT-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HFRONT-1573]: https://hopsworks.atlassian.net/browse/HFRONT-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ