### PR TITLE
[HWORKS-2849][APPEND] Fix nightly regressions from the privatization refactor

### DIFF
--- a/python/hopsworks_common/client/online_store_rest_client.py
+++ b/python/hopsworks_common/client/online_store_rest_client.py
@@ -42,14 +42,14 @@ def _init_or_reset_online_store_rest_client(
     | requests.adapters.BaseAdapter
     | None = None,
     optional_config: dict[str, Any] | None = None,
-    _reset_client: bool = False,
+    reset_client: bool = False,
 ):
     global _online_store_rest_client
     if not _online_store_rest_client:
         _online_store_rest_client = OnlineStoreRestClientSingleton(
             transport=transport, optional_config=optional_config
         )
-    elif _reset_client:
+    elif reset_client:
         _online_store_rest_client._reset_client(
             transport=transport, optional_config=optional_config
         )

--- a/python/hsfs/__init__.py
+++ b/python/hsfs/__init__.py
@@ -36,6 +36,7 @@ from hsfs.connection import (  # noqa: E402,  Module level import not at top of 
 
 __version__ = version.__version__
 
+
 @deprecated("hopsworks.login", public_name="hsfs.connection")
 def connection(*args: Any, **kwargs: Any) -> Connection:
     """Create a connection to a Hopsworks instance.

--- a/python/hsfs/__init__.py
+++ b/python/hsfs/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import warnings
+from typing import Any
 
 
 # Setting polars skip cpu flag to suppress CPU false positive warning messages printed while importing hsfs
@@ -36,7 +37,7 @@ from hsfs.connection import (  # noqa: E402,  Module level import not at top of 
 __version__ = version.__version__
 
 @deprecated("hopsworks.login", public_name="hsfs.connection")
-def connection(*args, **kwargs) -> Connection:
+def connection(*args: Any, **kwargs: Any) -> Connection:
     """Create a connection to a Hopsworks instance.
 
     Deprecated, use [`hopsworks.login`][hopsworks.login] instead, which connects and returns a project handle directly.

--- a/python/hsfs/__init__.py
+++ b/python/hsfs/__init__.py
@@ -22,7 +22,7 @@ import warnings
 # Setting polars skip cpu flag to suppress CPU false positive warning messages printed while importing hsfs
 os.environ["POLARS_SKIP_CPU_CHECK"] = "1"
 
-from hopsworks_apigen import public  # noqa: E402
+from hopsworks_apigen import deprecated, public  # noqa: E402
 from hsfs import (  # noqa: E402,  Module level import not at top of file because os.environ must be set before importing hsfs
     usage,
     util,
@@ -35,7 +35,20 @@ from hsfs.connection import (  # noqa: E402,  Module level import not at top of 
 
 __version__ = version.__version__
 
-connection = Connection._connection
+@deprecated("hopsworks.login", public_name="hsfs.connection")
+def connection(*args, **kwargs) -> Connection:
+    """Create a connection to a Hopsworks instance.
+
+    Deprecated, use [`hopsworks.login`][hopsworks.login] instead, which connects and returns a project handle directly.
+
+    Parameters:
+        *args: Positional arguments forwarded to the connection factory.
+        **kwargs: Keyword arguments forwarded to the connection factory.
+
+    Returns:
+        A new connection to the Hopsworks instance.
+    """
+    return Connection._connection(*args, **kwargs)
 
 
 def fs_formatwarning(message, category, filename, lineno, line=None):

--- a/python/hsfs/__init__.py
+++ b/python/hsfs/__init__.py
@@ -44,8 +44,7 @@ def connection(*args: Any, **kwargs: Any) -> Connection:
     Deprecated, use [`hopsworks.login`][hopsworks.login] instead, which connects and returns a project handle directly.
 
     Parameters:
-        *args: Positional arguments forwarded to the connection factory.
-        **kwargs: Keyword arguments forwarded to the connection factory.
+        args: Positional arguments forwarded to the connection factory.
 
     Returns:
         A new connection to the Hopsworks instance.

--- a/python/hsfs/core/feature_group_base_engine.py
+++ b/python/hsfs/core/feature_group_base_engine.py
@@ -38,8 +38,10 @@ class FeatureGroupBaseEngine:
         self._storage_connector_api = storage_connector_api.StorageConnectorApi()
         self._kafka_api = kafka_api.KafkaApi()
 
-    def _delete(self, feature_group):
-        self._feature_group_api._delete(feature_group)
+    def _delete(self, feature_group, force=False, delete_feature_views=False):
+        self._feature_group_api._delete(
+            feature_group, force=force, delete_feature_views=delete_feature_views
+        )
 
     def _add_tag(self, feature_group: FeatureGroup, name: str, value: Any):
         """Attach a name/value tag to a feature group.

--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -326,11 +326,6 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
             ge_report,
         )
 
-    def _delete(self, feature_group, force=False, delete_feature_views=False):
-        self._feature_group_api._delete(
-            feature_group, force=force, delete_feature_views=delete_feature_views
-        )
-
     def _commit_details(self, feature_group, wallclock_time, limit):
         if (
             feature_group._time_travel_format is None

--- a/python/hsfs/core/storage_connector_api.py
+++ b/python/hsfs/core/storage_connector_api.py
@@ -30,8 +30,10 @@ class StorageConnectorApi:
     @decorators._catch_not_found(
         "hsfs.storage_connector.StorageConnector", fallback_return=None
     )
-    def _get_response(self, feature_store_id: int, name: str) -> dict[str, Any]:
-        """Returning response dict instead of initialized object."""
+    def _get_response(
+        self, feature_store_id: int, name: str
+    ) -> dict[str, Any] | None:
+        """Returning response dict, or None if the connector is not found."""
         _client = client._get_instance()
         path_params = [
             "project",

--- a/python/hsfs/core/storage_connector_api.py
+++ b/python/hsfs/core/storage_connector_api.py
@@ -30,7 +30,7 @@ class StorageConnectorApi:
     @decorators._catch_not_found(
         "hsfs.storage_connector.StorageConnector", fallback_return=None
     )
-    def _get(self, feature_store_id: int, name: str) -> dict[str, Any]:
+    def _get_response(self, feature_store_id: int, name: str) -> dict[str, Any]:
         """Returning response dict instead of initialized object."""
         _client = client._get_instance()
         path_params = [
@@ -118,7 +118,7 @@ class StorageConnectorApi:
         Returns:
             the storage connector
         """
-        storage_connector_json = self._get(feature_store_id, name)
+        storage_connector_json = self._get_response(feature_store_id, name)
         if storage_connector_json:
             return storage_connector.StorageConnector.from_response_json(
                 storage_connector_json
@@ -137,7 +137,7 @@ class StorageConnectorApi:
             The updated storage connector instance.
         """
         return storage_connector_instance.update_from_response_json(
-            self._get(
+            self._get_response(
                 storage_connector_instance._featurestore_id,
                 storage_connector_instance.name,
             )

--- a/python/hsfs/core/storage_connector_api.py
+++ b/python/hsfs/core/storage_connector_api.py
@@ -30,9 +30,7 @@ class StorageConnectorApi:
     @decorators._catch_not_found(
         "hsfs.storage_connector.StorageConnector", fallback_return=None
     )
-    def _get_response(
-        self, feature_store_id: int, name: str
-    ) -> dict[str, Any] | None:
+    def _get_response(self, feature_store_id: int, name: str) -> dict[str, Any] | None:
         """Returning response dict, or None if the connector is not found."""
         _client = client._get_instance()
         path_params = [

--- a/python/hsfs/core/vector_db_client.py
+++ b/python/hsfs/core/vector_db_client.py
@@ -474,7 +474,7 @@ class VectorDbClient:
     ) -> list:
         if feature_group.embedding_index:
             vector_db_client = VectorDbClient(feature_group.select_all())
-            results = vector_db_client.read(
+            results = vector_db_client._read(
                 feature_group.id,
                 feature_group.columns,
                 pk=feature_group.embedding_index.col_prefix

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -590,7 +590,7 @@ class Engine:
         dataframe_type = dataframe_type.lower()
         self._validate_dataframe_type(dataframe_type)
 
-        results = VectorDbClient.read_feature_group(feature_group, n, filter=filter)
+        results = VectorDbClient._read_feature_group(feature_group, n, filter=filter)
         feature_names = [f.name for f in feature_group.columns]
         if dataframe_type == "polars":
             if not HAS_POLARS:

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -262,7 +262,7 @@ class Engine:
         dataframe_type: str = "default",
         filter: Filter | Logic = None,
     ) -> pd.DataFrame | np.ndarray | list[list[Any]] | TypeVar("pyspark.sql.DataFrame"):
-        results = VectorDbClient.read_feature_group(feature_group, n, filter=filter)
+        results = VectorDbClient._read_feature_group(feature_group, n, filter=filter)
         feature_names = [f.name for f in feature_group.columns]
         dataframe_type = dataframe_type.lower()
         if dataframe_type in ["default", "spark"]:

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -1197,9 +1197,9 @@ class RedshiftConnector(StorageConnector):
         )
 
     @public
-    def _refetch(self) -> None:
+    def refetch(self) -> None:
         """Refetch storage connector in order to retrieve updated temporary credentials."""
-        self._storage_connector_api._refetch(self)
+        self._refetch()
 
 
 @public

--- a/python/hsml/__init__.py
+++ b/python/hsml/__init__.py
@@ -16,11 +16,25 @@
 
 import warnings
 
+from hopsworks_apigen import deprecated
 from hopsworks_common import util, version
 from hopsworks_common.connection import Connection
 
 
-connection = Connection._connection
+@deprecated("hopsworks.login", public_name="hsml.connection")
+def connection(*args, **kwargs) -> Connection:
+    """Create a connection to a Hopsworks instance.
+
+    Deprecated, use [`hopsworks.login`][hopsworks.login] instead, which connects and returns a project handle directly.
+
+    Parameters:
+        *args: Positional arguments forwarded to the connection factory.
+        **kwargs: Keyword arguments forwarded to the connection factory.
+
+    Returns:
+        A new connection to the Hopsworks instance.
+    """
+    return Connection._connection(*args, **kwargs)
 
 __version__ = version.__version__
 

--- a/python/hsml/__init__.py
+++ b/python/hsml/__init__.py
@@ -29,8 +29,7 @@ def connection(*args: Any, **kwargs: Any) -> Connection:
     Deprecated, use [`hopsworks.login`][hopsworks.login] instead, which connects and returns a project handle directly.
 
     Parameters:
-        *args: Positional arguments forwarded to the connection factory.
-        **kwargs: Keyword arguments forwarded to the connection factory.
+        args: Positional arguments forwarded to the connection factory.
 
     Returns:
         A new connection to the Hopsworks instance.

--- a/python/hsml/__init__.py
+++ b/python/hsml/__init__.py
@@ -15,6 +15,7 @@
 #
 
 import warnings
+from typing import Any
 
 from hopsworks_apigen import deprecated
 from hopsworks_common import util, version
@@ -22,7 +23,7 @@ from hopsworks_common.connection import Connection
 
 
 @deprecated("hopsworks.login", public_name="hsml.connection")
-def connection(*args, **kwargs) -> Connection:
+def connection(*args: Any, **kwargs: Any) -> Connection:
     """Create a connection to a Hopsworks instance.
 
     Deprecated, use [`hopsworks.login`][hopsworks.login] instead, which connects and returns a project handle directly.

--- a/python/hsml/__init__.py
+++ b/python/hsml/__init__.py
@@ -37,6 +37,7 @@ def connection(*args: Any, **kwargs: Any) -> Connection:
     """
     return Connection._connection(*args, **kwargs)
 
+
 __version__ = version.__version__
 
 

--- a/python/hsml/scaling_config.py
+++ b/python/hsml/scaling_config.py
@@ -49,7 +49,6 @@ class ScaleMetric(Enum):
 class ComponentScalingConfig(ABC):
     """Scaling configuration for a predictor or transformer."""
 
-    @public
     def __init__(
         self,
         min_instances: int,
@@ -345,7 +344,6 @@ class PredictorScalingConfig(ComponentScalingConfig):
 
     SCALING_CONFIG_KEY = "predictor_scaling_config"
 
-    @public
     def __init__(self, **kwargs):
         """Initialize a PredictorScalingConfig instance.
 
@@ -387,7 +385,6 @@ class TransformerScalingConfig(ComponentScalingConfig):
 
     SCALING_CONFIG_KEY = "transformer_scaling_config"
 
-    @public
     def __init__(self, **kwargs):
         """Initialize a TransformerScalingConfig instance.
 

--- a/python/scripts/check_pep8_public.py
+++ b/python/scripts/check_pep8_public.py
@@ -30,6 +30,10 @@ Any public-named symbol (no leading ``_``) that is none of these is a
 violation: it is an internal symbol that should be ``_``-prefixed, or a
 genuinely public one that is missing its ``@public`` annotation.
 
+The inverse also holds: a ``_``-prefixed symbol annotated ``@public`` or
+``@deprecated`` is a violation — the two signals contradict each other,
+typically a privatization rename that forgot to drop the annotation.
+
 The check parses the packages statically with griffe and never imports them.
 
 Run it with::
@@ -266,8 +270,15 @@ def _compliance(
     """Return None if compliant, else a short violation reason string."""
     name = func.name
 
-    # Rule 1: PEP-8 private (also covers dunders).
+    # Rule 1: PEP-8 private (also covers dunders) — but a private-named symbol
+    # must not carry @public/@deprecated: that is a contradictory state, usually
+    # a rename that forgot to drop the annotation (or an annotation that should
+    # have kept the symbol public-named).
     if name.startswith("_"):
+        if _has_public(func):
+            return "private-named (leading '_') but annotated @public"
+        if _has_deprecated(func):
+            return "private-named (leading '_') but annotated @deprecated"
         return None
 
     # Rule 2/3: @public / @deprecated.


### PR DESCRIPTION
## Summary

The PEP-8 privatization PR (#997) introduced stale-rename regressions that surfaced in the [nightly workflow/load tests](https://github.com/logicalclocks/hopsworks-helm/actions/runs/27239252689) (202 failures + 4 errors). ~185 of those trace to a handful of stale-rename bugs in the SDK. This PR fixes the SDK-side ones; a companion loadtest PR fixes the test-code-side ones.

## Root causes fixed

| # | Root cause | ~Failures |
|---|---|---|
| 1 | `storage_connector_api`: `get`→`_get` collided with the pre-existing raw `_get` dict helper → the survivor called itself → **RecursionError** on every storage-connector/data-source resolution. Renamed the raw helper to `_get_response`. | 92 |
| 2 | `online_store_rest_client`: the global rename wrongly underscored a function **parameter** (`reset_client`→`_reset_client`), breaking `vector_server` which passes `reset_client=` → **TypeError**. Reverted the parameter name (the singleton method `_reset_client` stays private). | 76 |
| 3 | `engine/spark.py` + `engine/python.py`: call `VectorDbClient._read_feature_group` (renamed from `read_feature_group`). | 8 |
| 3b | `vector_db_client`: `_read_feature_group`'s body still called the now-private `_read` by its old public name `read` → **AttributeError** on the same path. | (same path) |
| 4 | `feature_group_base_engine._delete` now accepts/forwards `force`/`delete_feature_views` so external & spine feature groups can delete (they inherit the base engine); dropped the now-identical override in `feature_group_engine`. | 5 |

## Verification

- Edited modules import cleanly; signatures verified; `ruff` clean.
- Relevant unit tests green (storage connector, feature group engines, online store rest client, vector db client). The only failures (`test_feature_group.py` JSON-parsing) pre-exist on `main` and are unrelated.
- Two code-review agents + ten regional search agents audited the original refactor and this diff; the duplicate-`def` and wrongly-underscored-parameter bug classes were scanned exhaustively (these were their only members).

The remaining ~21 nightly failures are backend/infra/env (k8s 500s, GE/tfds version drift, proxy 500) — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)