### PR TITLE
[FSTORE-2030][APPEND] Accept equal start and end bounds for lookback windows

### DIFF
--- a/python/hsfs/constructor/lookback.py
+++ b/python/hsfs/constructor/lookback.py
@@ -83,9 +83,9 @@ class FeatureGroupLookback:
         if end is not None:
             start_ms = _convert_event_time_to_timestamp(start)
             end_ms = _convert_event_time_to_timestamp(end)
-            if start_ms >= end_ms:
+            if start_ms > end_ms:
                 raise ValueError(
-                    f"FeatureGroupLookback `start` ({start!r}) must be strictly earlier "
+                    f"FeatureGroupLookback `start` ({start!r}) must not be later "
                     f"than `end` ({end!r})."
                 )
         self._key = normalized_key

--- a/python/tests/constructor/test_lookback.py
+++ b/python/tests/constructor/test_lookback.py
@@ -106,20 +106,22 @@ class TestFeatureGroupLookbackConstruction:
             assert lb.key == EVENT_TIME
 
     def test_inverted_range_rejected(self):
-        with pytest.raises(ValueError, match="must be strictly earlier than"):
+        with pytest.raises(ValueError, match="must not be later than"):
             FeatureGroupLookback(
                 key=PARTITION_KEY,
                 start=date(2026, 5, 17),
                 end=date(2026, 5, 10),
             )
 
-    def test_equal_bounds_rejected(self):
-        with pytest.raises(ValueError, match="must be strictly earlier than"):
-            FeatureGroupLookback(
-                key=PARTITION_KEY,
-                start=date(2026, 5, 10),
-                end=date(2026, 5, 10),
-            )
+    def test_equal_bounds_accepted(self):
+        # Bounds are inclusive, so start == end is a valid window: a single
+        # partition day for PARTITION_KEY, a single instant for EVENT_TIME.
+        lb = FeatureGroupLookback(
+            key=PARTITION_KEY,
+            start=date(2026, 5, 10),
+            end=date(2026, 5, 10),
+        )
+        assert lb.start == lb.end == date(2026, 5, 10)
 
 
 # ---------- FeatureGroupLookback serializers ----------------------------------------------


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2030

Lookback windows shipped with both bounds inclusive but rejected `start == end` as an inverted range, a leftover from an earlier half-open window design. Under inclusive bounds an equal-bounds window is meaningful: exactly one partition day for `PARTITION_KEY` and a single instant for `EVENT_TIME`. The natural spelling of a one-day window (`start = end = the day`) failed validation.

This relaxes the `FeatureGroupLookback` constructor check to reject only truly inverted ranges (`start > end`) and rewords the error. Emitted wire format and predicates are unchanged.

Siblings: backend relaxation in logicalclocks/hopsworks-ee, end-to-end coverage in logicalclocks/loadtest (same branch name).

Testing: `python/tests/constructor/test_lookback.py` (44 passed); equal-bounds case flipped from rejected to accepted. Ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)