### PR TITLE
[FSTORE-1970]Append. Opensearch and fg sharing fixes

### DIFF
--- a/python/hsfs/core/vector_db_client.py
+++ b/python/hsfs/core/vector_db_client.py
@@ -133,18 +133,17 @@ class VectorDbClient:
                 )
         self._check_filter(filter, embedding_feature.feature_group)
         col_name = embedding_feature.embedding_index.col_prefix + embedding_feature.name
-        filter_clauses = [
-            {"exists": {"field": col_name}},
-        ] + self._get_query_filter(filter, embedding_feature.embedding_index.col_prefix)
         query = {
             "size": k,
             "query": {
-                "knn": {
-                    col_name: {
-                        "vector": embedding,
-                        "k": k,
-                        "filter": {"bool": {"must": filter_clauses}},
-                    }
+                "bool": {
+                    "must": [
+                        {"knn": {col_name: {"vector": embedding, "k": k}}},
+                        {"exists": {"field": col_name}},
+                    ]
+                    + self._get_query_filter(
+                        filter, embedding_feature.embedding_index.col_prefix
+                    )
                 }
             },
             "_source": list(
@@ -171,7 +170,7 @@ class VectorDbClient:
             # Get the max number of results allowed to request if it is not available.
             # This is expected to be executed once only.
             if not VectorDbClient._index_result_limit_k.get(index_name):
-                query["query"]["knn"][col_name]["k"] = 2**31 - 1
+                query["query"]["bool"]["must"][0]["knn"][col_name]["k"] = 2**31 - 1
                 try:
                     # It is expected that this request ALWAYS fails because requested k is too large.
                     # The purpose here is to get the max k allowed from the vector database, and cache it.
@@ -190,7 +189,7 @@ class VectorDbClient:
                         )
                     else:
                         raise e
-            query["query"]["knn"][col_name]["k"] = min(
+            query["query"]["bool"]["must"][0]["knn"][col_name]["k"] = min(
                 VectorDbClient._index_result_limit_k.get(index_name, k), 3 * k
             )
             results = opensearch_client._search(

--- a/python/tests/core/test_vector_db_client.py
+++ b/python/tests/core/test_vector_db_client.py
@@ -494,12 +494,14 @@ class TestVectorDbClient:
 
         body = self.mock_os_wrapper._search.call_args.kwargs["body"]
         assert body["size"] == 5
-        knn = body["query"]["knn"]["f2"]
+        # The knn clause and filters are combined in a bool query. OpenSearch
+        # 2.19 rejects a `filter` nested inside the knn clause.
+        must = body["query"]["bool"]["must"]
+        knn = must[0]["knn"]["f2"]
         assert knn["vector"] == [1.0, 2.0, 3.0]
         assert knn["k"] == 5
-        # The filter lives inside the knn clause (OpenSearch 2.x KNN syntax),
-        # not as a sibling bool/post_filter.
-        assert knn["filter"] == {"bool": {"must": [{"exists": {"field": "f2"}}]}}
+        assert "filter" not in knn
+        assert must[1] == {"exists": {"field": "f2"}}
 
     def test_find_neighbors_builds_knn_query_with_filter(self):
         self.target._find_neighbors(
@@ -507,12 +509,10 @@ class TestVectorDbClient:
         )
 
         body = self.mock_os_wrapper._search.call_args.kwargs["body"]
-        knn = body["query"]["knn"]["f2"]
-        assert knn["filter"] == {
-            "bool": {
-                "must": [
-                    {"exists": {"field": "f2"}},
-                    {"range": {"f3": {"gt": 10}}},
-                ]
-            }
-        }
+        must = body["query"]["bool"]["must"]
+        knn = must[0]["knn"]["f2"]
+        assert "filter" not in knn
+        assert must[1:] == [
+            {"exists": {"field": "f2"}},
+            {"range": {"f3": {"gt": 10}}},
+        ]


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-1970

## Problem

After the OpenSearch 2.19.5 upgrade, the kNN similarity-search query builder produced a query OpenSearch rejects:

```
RequestError(400, 'parsing_exception', '[knn] unknown token [START_OBJECT] after [filter]')
```

OpenSearch 2.19 no longer accepts a `filter` nested inside the `knn` clause. This broke the `test_similarity_search` loadtests (HUDI and Python-driver variants).

## Fix

Rewrite the query to the post-filter form that OpenSearch 2.19 supports: the `knn` clause moves under `bool.must`, alongside the `exists` clause and the user-supplied filter clauses. The two `k`-limit reassignments now index through `bool.must[0].knn`.

Unit tests in `python/tests/core/test_vector_db_client.py` updated to assert the `bool.must` structure and that no `filter` key remains inside `knn`. Full `test_vector_db_client.py` suite passes; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)