### PR TITLE
Add --verify/--no-verify flag to the hops CLI and fix external Trino TLS

### DIFF
--- a/python/hopsworks/cli/auth.py
+++ b/python/hopsworks/cli/auth.py
@@ -60,6 +60,7 @@ def login(
     project: str | None = None,
     engine: str | None = None,
     internal: bool = False,
+    hostname_verification: bool = False,
 ) -> Project:
     """Call ``hopsworks.login()`` with a stable argument shape.
 
@@ -83,6 +84,9 @@ def login(
         engine: Optional SDK engine override (``python``, ``spark``, …).
         internal: When True, call ``hopsworks.login()`` with no args so the
             SDK reads its in-pod credentials from environment variables.
+        hostname_verification: Whether to verify Hopsworks' TLS certificate;
+            False skips verification (the SDK default). Passed straight through
+            to ``hopsworks.login(hostname_verification=...)``.
 
     Returns:
         The authenticated SDK ``Project`` object.
@@ -92,7 +96,7 @@ def login(
     if internal:
         # Let the SDK do its own ``REST_ENDPOINT`` + ``$SECRETS_DIR/token.jwt``
         # discovery. ``project``/``engine`` still apply at the SDK layer.
-        kwargs: dict[str, Any] = {}
+        kwargs: dict[str, Any] = {"hostname_verification": hostname_verification}
         if project:
             kwargs["project"] = project
         if engine:
@@ -109,6 +113,7 @@ def login(
     kwargs = {
         "host": hostname,
         "port": port,
+        "hostname_verification": hostname_verification,
     }
     if api_key_value:
         kwargs["api_key_value"] = api_key_value
@@ -119,7 +124,12 @@ def login(
     return hopsworks.login(**kwargs)
 
 
-def verify(host: str, api_key_value: str, project: str | None = None) -> Project:
+def verify(
+    host: str,
+    api_key_value: str,
+    project: str | None = None,
+    hostname_verification: bool = False,
+) -> Project:
     """Run a minimal login to confirm ``api_key_value`` works against ``host``.
 
     Raises whatever ``hopsworks.login()`` raises on failure so the caller can
@@ -129,8 +139,14 @@ def verify(host: str, api_key_value: str, project: str | None = None) -> Project
         host: Hopsworks host.
         api_key_value: API key to validate.
         project: Optional project to attach to.
+        hostname_verification: Whether to verify Hopsworks' TLS certificate.
 
     Returns:
         The authenticated SDK ``Project`` object.
     """
-    return login(host=host, api_key_value=api_key_value, project=project)
+    return login(
+        host=host,
+        api_key_value=api_key_value,
+        project=project,
+        hostname_verification=hostname_verification,
+    )

--- a/python/hopsworks/cli/commands/login.py
+++ b/python/hopsworks/cli/commands/login.py
@@ -20,6 +20,13 @@ from hopsworks.cli import auth, config, output
 )
 @click.option("--project", "project_flag", help="Default project to attach to.")
 @click.option(
+    "--verify/--no-verify",
+    "verify_flag",
+    default=None,
+    help="Verify the Hopsworks TLS certificate; --no-verify skips verification "
+    "for self-signed / IP-SAN-mismatched certs. Persisted with --save-key.",
+)
+@click.option(
     "--save-key/--no-save-key",
     default=True,
     help="Persist the API key to ~/.hops.toml. On by default; use --no-save-key to skip.",
@@ -28,6 +35,7 @@ def login_cmd(
     host_flag: str | None,
     api_key_flag: str | None,
     project_flag: str | None,
+    verify_flag: bool | None,
     save_key: bool,
 ) -> None:
     """Authenticate non-interactively with an existing API key.
@@ -39,10 +47,14 @@ def login_cmd(
         host_flag: Value of ``--host``; prompted if neither flag, env, nor config has it.
         api_key_flag: Value of ``--api-key``; prompted with hidden input if absent.
         project_flag: Value of ``--project``; may be None.
+        verify_flag: True for ``--verify``, False for ``--no-verify``, None if neither was passed.
         save_key: When True, persist the validated key to ``~/.hops.toml``.
     """
     cfg = config.load(
-        flag_host=host_flag, flag_api_key=api_key_flag, flag_project=project_flag
+        flag_host=host_flag,
+        flag_api_key=api_key_flag,
+        flag_project=project_flag,
+        flag_hostname_verification=verify_flag,
     )
 
     host = cfg.host or click.prompt("Hopsworks host", default=config.DEFAULT_HOST)
@@ -51,7 +63,12 @@ def login_cmd(
     project = cfg.project or project_flag
 
     try:
-        project_obj = auth.verify(host=host, api_key_value=api_key, project=project)
+        project_obj = auth.verify(
+            host=host,
+            api_key_value=api_key,
+            project=project,
+            hostname_verification=cfg.hostname_verification,
+        )
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Login failed: {exc}") from exc
 

--- a/python/hopsworks/cli/commands/trino.py
+++ b/python/hopsworks/cli/commands/trino.py
@@ -50,8 +50,17 @@ def _connect(ctx: click.Context, catalog: str | None, schema: str | None) -> Any
     api = _api(ctx)
     cat = catalog or "iceberg"
     sch = schema or _project_schema(ctx)
+    # hops sql verifies the Trino coordinator's TLS certificate by default,
+    # independent of the REST/login default (which is off). An explicit
+    # --verify/--no-verify or HOPSWORKS_HOSTNAME_VERIFICATION still wins, so a
+    # cluster whose Trino load balancer serves a self-signed or IP-SAN-mismatched
+    # certificate stays reachable with --no-verify (the trino driver otherwise
+    # raises an SSL CERTIFICATE_VERIFY_FAILED). Forwarding it here matters because
+    # the flag reaches hopsworks.login() but never the Trino connection on its own.
+    cfg = session.get_config(ctx)
+    verify = cfg.hostname_verification if cfg.hostname_verification_explicit else True
     try:
-        return api.connect(catalog=cat, schema=sch)
+        return api.connect(catalog=cat, schema=sch, verify=verify)
     except Exception as exc:  # noqa: BLE001 - SDK raises a mix of types
         raise click.ClickException(f"Trino connect failed: {exc}") from exc
 

--- a/python/hopsworks/cli/config.py
+++ b/python/hopsworks/cli/config.py
@@ -44,6 +44,15 @@ class HopsConfig:
     module level.
     The ``internal`` flag is set when the process is running inside a Hopsworks
     pod and auth uses the mounted JWT instead of an API key.
+    The ``hostname_verification`` flag mirrors the SDK's
+    ``hopsworks.login(hostname_verification=...)`` argument: ``True`` verifies
+    the Hopsworks TLS certificate, ``False`` (the default) skips verification so
+    a cluster serving a self-signed or IP-SAN-mismatched certificate is reachable.
+    ``hostname_verification_explicit`` records whether that value came from a real
+    source (CLI flag, ``HOPSWORKS_HOSTNAME_VERIFICATION``, or the saved config)
+    rather than the default. ``hops sql`` reads it to verify the Trino coordinator
+    by default while still honouring an explicit ``--no-verify``; the REST/login
+    path always uses ``hostname_verification`` directly and stays off by default.
     """
 
     host: str | None = None
@@ -54,6 +63,8 @@ class HopsConfig:
     feature_store_id: int | None = None
     jwt_token: str | None = None
     internal: bool = False
+    hostname_verification: bool = False
+    hostname_verification_explicit: bool = False
 
     def mode(self) -> str:
         """Describe which auth mode the CLI is operating in.
@@ -159,10 +170,26 @@ def _migrate_legacy_yaml() -> dict[str, Any]:
     return remapped
 
 
+def _env_truthy(value: str | None) -> bool:
+    """Parse a ``HOPSWORKS_HOSTNAME_VERIFICATION``-style env string into a bool.
+
+    Mirrors the parsing in ``hopsworks.login`` so the CLI and the SDK agree on
+    which values count as enabled.
+
+    Args:
+        value: Raw environment-variable string, or None when unset.
+
+    Returns:
+        True when the string is one of ``true``/``1``/``y``/``yes`` (case-insensitive).
+    """
+    return (value or "").strip().lower() in ("true", "1", "y", "yes")
+
+
 def load(
     flag_host: str | None = None,
     flag_api_key: str | None = None,
     flag_project: str | None = None,
+    flag_hostname_verification: bool | None = None,
     profile: str = "default",
 ) -> HopsConfig:
     """Resolve configuration from flags, environment, and ``~/.hops.toml``.
@@ -171,6 +198,7 @@ def load(
         flag_host: Value of the ``--host`` CLI flag, if set.
         flag_api_key: Value of the ``--api-key`` CLI flag, if set.
         flag_project: Value of the ``--project`` CLI flag, if set.
+        flag_hostname_verification: Value of the ``--verify/--no-verify`` CLI flag, or None when neither was passed.
         profile: TOML table to read from; defaults to ``default``.
 
     Returns:
@@ -187,7 +215,9 @@ def load(
         project_id = os.environ.get("HOPSWORKS_PROJECT_ID")
         if project_id and project_id.isdigit():
             cfg.project_id = int(project_id)
-        return _apply_overrides(cfg, flag_host, flag_api_key, flag_project)
+        return _apply_overrides(
+            cfg, flag_host, flag_api_key, flag_project, flag_hostname_verification
+        )
 
     _migrate_legacy_yaml()
     file_data = _read_toml(CONFIG_PATH).get(profile, {})
@@ -198,6 +228,9 @@ def load(
         cfg.project = file_data.get("project") or None
         cfg.project_id = file_data.get("project_id")
         cfg.feature_store_id = file_data.get("feature_store_id")
+        if "hostname_verification" in file_data:
+            cfg.hostname_verification = bool(file_data.get("hostname_verification"))
+            cfg.hostname_verification_explicit = True
 
     env_host = os.environ.get("HOPSWORKS_HOST") or os.environ.get("REST_ENDPOINT")
     env_api_key = os.environ.get("HOPSWORKS_API_KEY")
@@ -213,7 +246,9 @@ def load(
     if env_project_id and env_project_id.isdigit():
         cfg.project_id = int(env_project_id)
 
-    return _apply_overrides(cfg, flag_host, flag_api_key, flag_project)
+    return _apply_overrides(
+        cfg, flag_host, flag_api_key, flag_project, flag_hostname_verification
+    )
 
 
 def _apply_overrides(
@@ -221,6 +256,7 @@ def _apply_overrides(
     flag_host: str | None,
     flag_api_key: str | None,
     flag_project: str | None,
+    flag_hostname_verification: bool | None = None,
 ) -> HopsConfig:
     if flag_host:
         cfg.host = flag_host
@@ -228,6 +264,17 @@ def _apply_overrides(
         cfg.api_key = flag_api_key
     if flag_project:
         cfg.project = flag_project
+    # Hostname verification precedence: CLI flag > HOPSWORKS_HOSTNAME_VERIFICATION
+    # env var > saved file value > default (off).
+    # The env var is applied here (not only in the external branch) so it is
+    # honoured in internal mode too, matching the SDK, which reads it regardless.
+    env_hv = os.environ.get("HOPSWORKS_HOSTNAME_VERIFICATION")
+    if env_hv is not None:
+        cfg.hostname_verification = _env_truthy(env_hv)
+        cfg.hostname_verification_explicit = True
+    if flag_hostname_verification is not None:
+        cfg.hostname_verification = flag_hostname_verification
+        cfg.hostname_verification_explicit = True
     return cfg
 
 
@@ -252,6 +299,9 @@ def save(cfg: HopsConfig, profile: str = "default") -> None:
             "project": cfg.project,
             "project_id": cfg.project_id,
             "feature_store_id": cfg.feature_store_id,
+            # Written only when enabled: off is the default, so persisting it
+            # would add a line to every existing user's config on resave.
+            "hostname_verification": cfg.hostname_verification or None,
         }.items()
         if v is not None
     }

--- a/python/hopsworks/cli/main.py
+++ b/python/hopsworks/cli/main.py
@@ -67,23 +67,40 @@ def _json_eager_callback(
     return value
 
 
-def _inject_json_option(cmd: click.Command) -> None:
-    """Recursively add ``--json`` to *cmd* and every nested subcommand.
+def _verify_eager_callback(
+    ctx: click.Context, _param: click.Parameter, value: bool | None
+) -> bool | None:
+    """Apply a ``--verify/--no-verify`` flag parsed at any command level.
 
-    Click only honours the ``--json`` flag at the level it was declared on. The
-    root ``cli`` group already has it (so ``hops --json fg list`` works), but
-    callers — especially LLM-driven tools that compose commands left-to-right
-    — naturally write ``hops fg list --json``. Walking the loaded command's
-    subtree on first dispatch and appending an eager ``--json`` to every node
-    that doesn't already have one makes both forms work without touching
-    every command file. ``expose_value=False`` keeps the existing leaf
-    callbacks (which don't take a ``json_flag`` kwarg) source-compatible; the
-    eager callback flips :func:`output.set_json_mode` before the leaf runs.
+    The root command resolves the config before subcommands parse, so a flag
+    written after the subcommand (``hops sql ... --no-verify``) cannot reach
+    :func:`config.load`. Instead it is applied here by overriding the
+    already-resolved config that :mod:`hopsworks.cli.session` reads at login.
+    ``None`` means neither flag was passed, so the resolved value stands.
     """
-    already_has_json = any(
-        "--json" in (getattr(p, "opts", None) or []) for p in cmd.params
-    )
-    if not already_has_json:
+    if value is not None:
+        cfg = ctx.ensure_object(dict).get("config")
+        if cfg is not None:
+            cfg.hostname_verification = value
+            cfg.hostname_verification_explicit = True
+    return value
+
+
+def _inject_global_options(cmd: click.Command) -> None:
+    """Recursively add the global ``--json`` and ``--verify/--no-verify`` flags.
+
+    Click only honours a flag at the level it was declared on. The root ``cli``
+    group already has both (so ``hops --json fg list`` works), but callers —
+    especially LLM-driven tools that compose commands left-to-right — naturally
+    write ``hops fg list --json`` or ``hops sql ... --no-verify``. Walking the
+    loaded command's subtree on first dispatch and appending the flags to every
+    node that does not already declare them makes both forms work without
+    touching every command file. ``expose_value=False`` keeps the existing leaf
+    callbacks (which take neither kwarg) source-compatible; the eager callbacks
+    run before the leaf, flipping JSON mode and the resolved hostname-verification
+    setting respectively.
+    """
+    if not any("--json" in (getattr(p, "opts", None) or []) for p in cmd.params):
         cmd.params.append(
             click.Option(
                 ["--json"],
@@ -94,12 +111,26 @@ def _inject_json_option(cmd: click.Command) -> None:
                 help="Output as JSON (machine-readable; for LLMs and scripts).",
             )
         )
-    # ``LazyGroup`` does its own json injection on demand — recursing into it
-    # would force-load every subcommand and defeat the lazy import. Recurse
-    # only for already-loaded ordinary groups.
+    if not any("--verify" in (getattr(p, "opts", None) or []) for p in cmd.params):
+        cmd.params.append(
+            click.Option(
+                ["--verify/--no-verify"],
+                default=None,
+                expose_value=False,
+                is_eager=True,
+                callback=_verify_eager_callback,
+                help=(
+                    "Verify the Hopsworks TLS certificate; --no-verify skips "
+                    "verification for self-signed / IP-SAN-mismatched certs."
+                ),
+            )
+        )
+    # ``LazyGroup`` does its own injection on demand — recursing into it would
+    # force-load every subcommand and defeat the lazy import. Recurse only for
+    # already-loaded ordinary groups.
     if isinstance(cmd, click.Group) and not isinstance(cmd, LazyGroup):
         for sub in cmd.commands.values():
-            _inject_json_option(sub)
+            _inject_global_options(sub)
 
 
 class LazyGroup(click.Group):
@@ -110,9 +141,9 @@ class LazyGroup(click.Group):
     --help), keeping cold paths (``hops --help``, ``hops setup``) free of
     SDK / pandas / pyarrow import cost.
 
-    Loaded commands have :func:`_inject_json_option` applied to them so the
-    ``--json`` flag works at every nesting level — exactly the behaviour the
-    eager pre-load used to provide.
+    Loaded commands have :func:`_inject_global_options` applied to them so the
+    ``--json`` and ``--verify/--no-verify`` flags work at every nesting level —
+    exactly the behaviour the eager pre-load used to provide.
     """
 
     def __init__(
@@ -136,7 +167,7 @@ class LazyGroup(click.Group):
         module_path, _, attr = target.partition(":")
         module = importlib.import_module(module_path)
         cmd = getattr(module, attr)
-        _inject_json_option(cmd)
+        _inject_global_options(cmd)
         # Cache the loaded command so subsequent lookups (and Click's own
         # bookkeeping) reuse the same instance.
         self.commands[name] = cmd
@@ -157,6 +188,18 @@ class LazyGroup(click.Group):
 @click.option("--host", "host_flag", help="Hopsworks host URL (overrides config).")
 @click.option("--api-key", "api_key_flag", help="API key (overrides config).")
 @click.option("--project", "project_flag", help="Project name (overrides config).")
+@click.option(
+    "--verify/--no-verify",
+    "verify_flag",
+    default=None,
+    help=(
+        "Verify the Hopsworks TLS certificate (hostname verification). Use "
+        "--no-verify to skip verification when a cluster serves a self-signed "
+        "or IP-SAN-mismatched certificate. Maps to the SDK's "
+        "hopsworks.login(hostname_verification=...); overridden by "
+        "HOPSWORKS_HOSTNAME_VERIFICATION when that env var is set."
+    ),
+)
 @click.option("--json", "json_flag", is_flag=True, help="Output as JSON (for LLMs).")
 @click.pass_context
 def cli(
@@ -164,6 +207,7 @@ def cli(
     host_flag: str | None,
     api_key_flag: str | None,
     project_flag: str | None,
+    verify_flag: bool | None,
     json_flag: bool,
 ) -> None:
     """Root ``hops`` command; child commands pull the resolved config via ``ctx.obj``.
@@ -173,6 +217,7 @@ def cli(
         host_flag: Value of ``--host`` if provided.
         api_key_flag: Value of ``--api-key`` if provided.
         project_flag: Value of ``--project`` if provided.
+        verify_flag: True for ``--verify``, False for ``--no-verify``, None if neither was passed.
         json_flag: When True, every output helper switches to JSON mode.
     """
     output.set_json_mode(json_flag)
@@ -181,6 +226,7 @@ def cli(
         flag_host=host_flag,
         flag_api_key=api_key_flag,
         flag_project=project_flag,
+        flag_hostname_verification=verify_flag,
     )
 
 

--- a/python/hopsworks/cli/session.py
+++ b/python/hopsworks/cli/session.py
@@ -85,6 +85,7 @@ def get_project(ctx: click.Context) -> Project:
                 api_key_value=cfg.api_key,
                 project=cfg.project,
                 internal=cfg.internal,
+                hostname_verification=cfg.hostname_verification,
             )
     except Exception as exc:  # noqa: BLE001 - SDK raises a mix of types
         raise click.ClickException(f"Login failed: {exc}") from exc

--- a/python/hopsworks_common/core/trino_api.py
+++ b/python/hopsworks_common/core/trino_api.py
@@ -134,7 +134,13 @@ class TrinoApi:
             The file path of the downloaded SSL certificate if it was downloaded.
             The original verify value if verification is handled by the caller or disabled.
         """
-        if not client._is_external() and verify is True:
+        # When verify is True, point the trino driver at the cluster's CA chain
+        # rather than the system trust store. The internal CA that signs the
+        # Trino certificate is not in the OS bundle, so external clients would
+        # otherwise fail with "unable to get local issuer certificate". The
+        # external client downloads this CA chain to disk at login (python
+        # engine), so the path resolves in both internal and external modes.
+        if verify is True:
             _client = client._get_instance()
             return _client._get_ca_chain_path()
         return verify

--- a/python/tests/cli/conftest.py
+++ b/python/tests/cli/conftest.py
@@ -24,6 +24,7 @@ def tmp_home(tmp_path, monkeypatch):
         "HOPSWORKS_API_KEY",
         "HOPSWORKS_PROJECT",
         "HOPSWORKS_PROJECT_ID",
+        "HOPSWORKS_HOSTNAME_VERIFICATION",
         "REST_ENDPOINT",
         "PROJECT_NAME",
         "SECRETS_DIR",

--- a/python/tests/cli/test_config.py
+++ b/python/tests/cli/test_config.py
@@ -26,6 +26,7 @@ def tmp_home(tmp_path, monkeypatch):
         "HOPSWORKS_API_KEY",
         "HOPSWORKS_PROJECT",
         "HOPSWORKS_PROJECT_ID",
+        "HOPSWORKS_HOSTNAME_VERIFICATION",
         "REST_ENDPOINT",
         "PROJECT_NAME",
         "SECRETS_DIR",
@@ -141,3 +142,67 @@ def test_clear_removes_profile(tmp_home):
     assert config.CONFIG_PATH.exists()
     config.clear()
     assert not config.CONFIG_PATH.exists()
+
+
+# --- hostname verification -------------------------------------------------
+
+
+def test_hostname_verification_defaults_off(tmp_home):
+    assert config.load().hostname_verification is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("TRUE", True),
+        ("1", True),
+        ("y", True),
+        ("yes", True),
+        ("  Yes  ", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_env_truthy_matches_sdk_parsing(raw, expected):
+    assert config._env_truthy(raw) is expected
+
+
+def test_hostname_verification_read_from_file(tmp_home):
+    config.save(config.HopsConfig(host="h", api_key="k", hostname_verification=True))
+    assert config.load().hostname_verification is True
+
+
+def test_save_omits_hostname_verification_when_off(tmp_home):
+    config.save(config.HopsConfig(host="h", api_key="k"))
+    assert "hostname_verification" not in config.CONFIG_PATH.read_text()
+
+
+def test_env_overrides_file_for_hostname_verification(tmp_home, monkeypatch):
+    config.save(config.HopsConfig(host="h", api_key="k", hostname_verification=True))
+    monkeypatch.setenv("HOPSWORKS_HOSTNAME_VERIFICATION", "false")
+    assert config.load().hostname_verification is False
+
+
+def test_flag_overrides_env_for_hostname_verification(tmp_home, monkeypatch):
+    monkeypatch.setenv("HOPSWORKS_HOSTNAME_VERIFICATION", "true")
+    assert config.load(flag_hostname_verification=False).hostname_verification is False
+    assert config.load(flag_hostname_verification=True).hostname_verification is True
+    # None means "not passed" — the env value stands.
+    assert config.load(flag_hostname_verification=None).hostname_verification is True
+
+
+def test_env_applies_in_internal_mode(tmp_home, monkeypatch):
+    secrets = tmp_home / "secrets"
+    secrets.mkdir()
+    (secrets / "token.jwt").write_text("jwt\n")
+    monkeypatch.setenv("REST_ENDPOINT", "https://cluster.internal")
+    monkeypatch.setenv("SECRETS_DIR", str(secrets))
+    monkeypatch.setenv("HOPSWORKS_HOSTNAME_VERIFICATION", "true")
+
+    cfg = config.load()
+    assert cfg.internal is True
+    assert cfg.hostname_verification is True

--- a/python/tests/cli/test_verify_flag.py
+++ b/python/tests/cli/test_verify_flag.py
@@ -1,0 +1,225 @@
+"""Tests for the ``--verify/--no-verify`` flag wiring.
+
+The flag mirrors the SDK's ``hopsworks.login(hostname_verification=...)``: it
+threads from the CLI (root flag, the ``login`` command, or appended after any
+subcommand) through :mod:`hopsworks.cli.config` and
+:mod:`hopsworks.cli.session` down to ``hopsworks.login``. These tests assert
+each hand-off without touching the real SDK.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import click
+from click.testing import CliRunner
+from hopsworks.cli import auth, config, main, session
+from hopsworks.cli.main import cli
+
+
+# --- root flag -> config.load ----------------------------------------------
+
+
+def _capture_load(monkeypatch):
+    """Replace ``main.config.load`` with a spy and return the captured kwargs."""
+    captured: dict = {}
+
+    def spy(**kwargs):
+        captured.update(kwargs)
+        return config.HopsConfig()
+
+    monkeypatch.setattr(main.config, "load", spy)
+    return captured
+
+
+def test_root_no_verify_forwarded_to_config_load(tmp_home, monkeypatch):
+    captured = _capture_load(monkeypatch)
+    CliRunner().invoke(cli, ["--no-verify", "fg", "list"])
+    assert captured["flag_hostname_verification"] is False
+
+
+def test_root_verify_forwarded_to_config_load(tmp_home, monkeypatch):
+    captured = _capture_load(monkeypatch)
+    CliRunner().invoke(cli, ["--verify", "fg", "list"])
+    assert captured["flag_hostname_verification"] is True
+
+
+def test_root_without_flag_forwards_none(tmp_home, monkeypatch):
+    captured = _capture_load(monkeypatch)
+    CliRunner().invoke(cli, ["fg", "list"])
+    assert captured["flag_hostname_verification"] is None
+
+
+# --- explicitness tracking (drives the hops sql default) --------------------
+
+
+def test_default_is_not_explicit(tmp_home):
+    cfg = config.load()
+    assert cfg.hostname_verification is False
+    assert cfg.hostname_verification_explicit is False
+
+
+def test_flag_marks_explicit(tmp_home):
+    assert config.load(flag_hostname_verification=False).hostname_verification_explicit
+    assert config.load(flag_hostname_verification=True).hostname_verification_explicit
+
+
+def test_env_marks_explicit(tmp_home, monkeypatch):
+    monkeypatch.setenv("HOPSWORKS_HOSTNAME_VERIFICATION", "false")
+    cfg = config.load()
+    assert cfg.hostname_verification is False
+    assert cfg.hostname_verification_explicit is True
+
+
+# --- flag appended after a subcommand (LLM-style, left-to-right) ------------
+
+
+def _run_capturing_login(tmp_home, argv):
+    """Invoke ``argv`` and return the ``hostname_verification`` seen at login."""
+    config.save(config.HopsConfig(host="https://h", api_key="k", project="p"))
+    seen: dict = {}
+
+    def capture(ctx):
+        seen["hv"] = ctx.obj["config"].hostname_verification
+        raise click.exceptions.Exit(0)
+
+    with mock.patch.object(session, "get_project", side_effect=capture):
+        CliRunner().invoke(cli, argv)
+    return seen.get("hv")
+
+
+def test_no_verify_after_subcommand(tmp_home):
+    assert _run_capturing_login(tmp_home, ["context", "--no-verify"]) is False
+
+
+def test_verify_after_subcommand(tmp_home):
+    assert _run_capturing_login(tmp_home, ["context", "--verify"]) is True
+
+
+def test_subcommand_without_flag_uses_saved_value(tmp_home):
+    config.save(
+        config.HopsConfig(
+            host="https://h", api_key="k", project="p", hostname_verification=True
+        )
+    )
+    seen: dict = {}
+
+    def capture(ctx):
+        seen["hv"] = ctx.obj["config"].hostname_verification
+        raise click.exceptions.Exit(0)
+
+    with mock.patch.object(session, "get_project", side_effect=capture):
+        CliRunner().invoke(cli, ["context"])
+    assert seen["hv"] is True
+
+
+# --- session.get_project -> auth.login -------------------------------------
+
+
+def test_get_project_passes_hostname_verification():
+    cfg = config.HopsConfig(
+        host="https://h", api_key="k", project="p", hostname_verification=True
+    )
+    ctx = click.Context(cli)
+    ctx.obj = {"config": cfg}
+    fake_project = mock.MagicMock(name="Project")
+    captured: dict = {}
+
+    def fake_login(**kwargs):
+        captured.update(kwargs)
+        return fake_project
+
+    with mock.patch.object(session.auth, "login", side_effect=fake_login):
+        out = session.get_project(ctx)
+
+    assert out is fake_project
+    assert captured["hostname_verification"] is True
+
+
+# --- auth.login / auth.verify -> hopsworks.login ---------------------------
+
+
+def test_auth_login_forwards_to_sdk(monkeypatch):
+    fake_hopsworks = mock.MagicMock()
+    monkeypatch.setitem(sys.modules, "hopsworks", fake_hopsworks)
+
+    auth.login(host="https://h", api_key_value="k", hostname_verification=False)
+    assert fake_hopsworks.login.call_args.kwargs["hostname_verification"] is False
+
+    auth.login(host="https://h", api_key_value="k", hostname_verification=True)
+    assert fake_hopsworks.login.call_args.kwargs["hostname_verification"] is True
+
+
+def test_auth_login_internal_forwards_to_sdk(monkeypatch):
+    fake_hopsworks = mock.MagicMock()
+    monkeypatch.setitem(sys.modules, "hopsworks", fake_hopsworks)
+
+    auth.login(host="ignored", internal=True, hostname_verification=True)
+    assert fake_hopsworks.login.call_args.kwargs["hostname_verification"] is True
+
+
+def test_auth_verify_forwards_to_sdk(monkeypatch):
+    fake_hopsworks = mock.MagicMock()
+    monkeypatch.setitem(sys.modules, "hopsworks", fake_hopsworks)
+
+    auth.verify(host="https://h", api_key_value="k", hostname_verification=False)
+    assert fake_hopsworks.login.call_args.kwargs["hostname_verification"] is False
+
+
+# --- trino _connect -> TrinoApi.connect(verify=...) ------------------------
+
+
+def _trino_connect_verify(hostname_verification, *, explicit=True):
+    """Return the ``verify`` kwarg ``trino._connect`` passes to ``api.connect``."""
+    from hopsworks.cli.commands import trino
+
+    cfg = config.HopsConfig(
+        host="https://h",
+        api_key="k",
+        project="p",
+        hostname_verification=hostname_verification,
+        hostname_verification_explicit=explicit,
+    )
+    ctx = click.Context(cli)
+    ctx.obj = {"config": cfg}
+
+    fake_api = mock.MagicMock(name="TrinoApi")
+    fake_project = mock.MagicMock(name="Project")
+    fake_project.get_trino_api.return_value = fake_api
+    fake_project.name = "p"
+
+    with mock.patch.object(session, "get_project", return_value=fake_project):
+        trino._connect(ctx, catalog="iceberg", schema="db")
+    return fake_api.connect.call_args.kwargs["verify"]
+
+
+def test_trino_connect_defaults_to_verify():
+    # hops sql verifies the Trino coordinator by default (unlike REST/login),
+    # so a query against a properly-certed cluster is secure with no flag.
+    assert _trino_connect_verify(False, explicit=False) is True
+
+
+def test_trino_connect_forwards_no_verify():
+    # An explicit --no-verify must disable Trino TLS verification, otherwise a
+    # self-signed / IP-SAN-mismatched coordinator cert makes ``hops sql``
+    # unreachable.
+    assert _trino_connect_verify(False, explicit=True) is False
+
+
+def test_trino_connect_forwards_verify():
+    assert _trino_connect_verify(True, explicit=True) is True
+
+
+# --- discoverability --------------------------------------------------------
+
+
+def test_root_help_lists_verify():
+    out = CliRunner().invoke(cli, ["--help"]).output
+    assert "--verify" in out
+    assert "--no-verify" in out
+
+
+def test_login_help_lists_verify():
+    out = CliRunner().invoke(cli, ["login", "--help"]).output
+    assert "--no-verify" in out

--- a/python/tests/core/test_trino_api.py
+++ b/python/tests/core/test_trino_api.py
@@ -145,17 +145,31 @@ class TestTrinoApi:
         assert result == os.path.join("path", "to", "custom", "ca.pem")
 
     def test_get_ca_chain_path_external_client(self, mocker, trino_api):
-        """Test SSL certificate for external client."""
+        """Test SSL certificate for external client.
+
+        The external client downloads the cluster CA chain to disk at login, so
+        ``verify=True`` must point the trino driver at that chain rather than
+        the system trust store; otherwise verification fails with "unable to get
+        local issuer certificate" because the internal CA is not in the OS bundle.
+        """
         # Arrange
         mocker.patch(
             "hopsworks_common.core.trino_api.client._is_external", return_value=True
+        )
+        mock_client = Mock()
+        mocker.patch(
+            "hopsworks_common.core.trino_api.client._get_instance",
+            return_value=mock_client,
+        )
+        mock_client._get_ca_chain_path.return_value = os.path.join(
+            "/tmp", "trino_ca_chain.pem"
         )
 
         # Act
         result = trino_api._get_ca_chain_path(verify=True)
 
         # Assert
-        assert result is True
+        assert result == os.path.join("/tmp", "trino_ca_chain.pem")
 
         # Act with verify disabled
         result = trino_api._get_ca_chain_path(verify=False)
@@ -306,6 +320,14 @@ class TestTrinoApi:
         trino_api._variable_api._get_loadbalancer_external_domain.return_value = (
             "trino.example.com"
         )
+        mock_client = Mock()
+        mocker.patch(
+            "hopsworks_common.core.trino_api.client._get_instance",
+            return_value=mock_client,
+        )
+        mock_client._get_ca_chain_path.return_value = os.path.join(
+            "/tmp", "trino_ca_chain.pem"
+        )
         mock_connection = Mock()
         mock_trino_connect = mocker.patch(
             "hopsworks_common.core.trino_api._trino_connect",
@@ -327,7 +349,9 @@ class TestTrinoApi:
         assert call_kwargs["catalog"] == "iceberg"
         assert call_kwargs["schema"] == "my_db"
         assert call_kwargs["isolation_level"] == IsolationLevel.READ_UNCOMMITTED
-        assert call_kwargs["verify"] is True
+        # External client verifies against the downloaded cluster CA chain, not
+        # the system trust store (which lacks the internal CA).
+        assert call_kwargs["verify"] == os.path.join("/tmp", "trino_ca_chain.pem")
 
     def test_connect_with_custom_parameters(self, mocker, trino_api):
         """Test connecting to Trino with custom parameters."""
@@ -337,6 +361,14 @@ class TestTrinoApi:
         )
         trino_api._variable_api._get_loadbalancer_external_domain.return_value = (
             "trino.example.com"
+        )
+        mock_client = Mock()
+        mocker.patch(
+            "hopsworks_common.core.trino_api.client._get_instance",
+            return_value=mock_client,
+        )
+        mock_client._get_ca_chain_path.return_value = os.path.join(
+            "/tmp", "trino_ca_chain.pem"
         )
         mock_connection = Mock()
         mock_trino_connect = mocker.patch(
@@ -419,6 +451,14 @@ class TestTrinoApi:
         trino_api._variable_api._get_loadbalancer_external_domain.return_value = (
             "trino.example.com"
         )
+        mock_client = Mock()
+        mocker.patch(
+            "hopsworks_common.core.trino_api.client._get_instance",
+            return_value=mock_client,
+        )
+        mock_client._get_ca_chain_path.return_value = os.path.join(
+            "/tmp", "trino_ca_chain.pem"
+        )
         mock_engine = Mock()
         mock_create_engine = mocker.patch(
             "sqlalchemy.create_engine",
@@ -438,7 +478,8 @@ class TestTrinoApi:
         assert "trino.example.com" in url_str
         assert "iceberg" in url_str
         assert "my_db" in url_str
-        assert connect_args["verify"] is True
+        # External client verifies against the downloaded cluster CA chain.
+        assert connect_args["verify"] == os.path.join("/tmp", "trino_ca_chain.pem")
 
     def test_create_engine_with_custom_parameters(self, mocker, trino_api):
         """Test creating SQLAlchemy engine with custom parameters."""
@@ -448,6 +489,14 @@ class TestTrinoApi:
         )
         trino_api._variable_api._get_loadbalancer_external_domain.return_value = (
             "trino.example.com"
+        )
+        mock_client = Mock()
+        mocker.patch(
+            "hopsworks_common.core.trino_api.client._get_instance",
+            return_value=mock_client,
+        )
+        mock_client._get_ca_chain_path.return_value = os.path.join(
+            "/tmp", "trino_ca_chain.pem"
         )
         mock_engine = Mock()
         mock_create_engine = mocker.patch(


### PR DESCRIPTION
## What

Adds a `--verify/--no-verify` flag to the `hops` CLI that mirrors the SDK's `hopsworks.login(hostname_verification=...)`, **and** fixes the Trino TLS path so the flag actually makes `hops sql` reachable on a cluster whose Trino coordinator serves a self-signed or IP-SAN-mismatched certificate.

Previously the SDK exposed certificate (hostname) verification and the MCP server exposed `--hostname_verification`, but the `hops` CLI had no way to control it. While wiring the flag I found that even with it, `hops sql` (Trino) still failed: the flag only reached `hopsworks.login()`, never the Trino DBAPI connection, and the Trino path had a separate bug that broke verification for external clients regardless.

`hops sql` also now **verifies the Trino coordinator by default**, independently of the REST/login default (which stays off). A SQL query against a properly-certed cluster is therefore secure out of the box, while `--no-verify` remains the escape hatch for self-signed / IP-SAN-mismatched coordinators.

## How

**CLI flag wiring**
- `HopsConfig` gains a `hostname_verification` field, resolved with precedence **flag > `HOPSWORKS_HOSTNAME_VERIFICATION` env > saved file value > default (off)**, matching the SDK's own env parsing (`true/1/y/yes`). This governs the **REST/login** path.
- Threaded through `session.get_project` → `auth.login`/`auth.verify` → `hopsworks.login(hostname_verification=...)`.
- `--verify/--no-verify` is available at the root (`hops --no-verify sql ...`), on `hops login` (persisted to `~/.hops.toml` with `--save-key`), and injected into every subcommand level alongside `--json`, so `hops sql ... --no-verify` works too.

**`hops sql` verifies by default**
- `HopsConfig` also gains `hostname_verification_explicit`, set whenever the value came from a real source (CLI flag, env var, or saved config) rather than the default. It is set in `config.load`/`_apply_overrides` and in the subcommand-level eager callback in `main.py`.
- `hopsworks/cli/commands/trino.py`: `_connect` resolves `verify = cfg.hostname_verification if cfg.hostname_verification_explicit else True` and forwards it to `api.connect(verify=...)`. So a bare `hops sql` verifies, while an explicit `--no-verify` / `HOPSWORKS_HOSTNAME_VERIFICATION=false` still skips Trino verification. Previously `_connect` never passed `verify`, so `--no-verify` could not reach the Trino connection at all.

**Trino TLS fix** (without this the flag is inert for `hops sql`)
- `hopsworks_common/core/trino_api.py`: `TrinoApi._get_ca_chain_path` supplied the downloaded `ca_chain.pem` only to **internal** clients (`not client._is_external()`), so external clients with `verify=True` fell back to the system trust store — which lacks the internal CA — and failed with `unable to get local issuer certificate`. The external client already writes `ca_chain.pem` to disk at login (python engine), so the gate is dropped: `verify=True` now validates against the cluster CA chain in both modes. `False` and custom CA paths still pass straight through.

## Verified live

Against a cluster whose Trino LB is a bare IP (`10.112.103.122:8443`), whose certificate has no matching IP SAN:

| Command | Result |
|---|---|
| `hops sql "SELECT 1"` (default — now verifies) | fails on IP-SAN mismatch — correct; the cert genuinely does not cover the bare IP. Use `--no-verify`. |
| `hops sql --no-verify "SELECT 1"` | returns `[{"one":1}]` |
| `hops --verify sql "SELECT 1"` | fails on IP-SAN mismatch (explicit verify) |

Before the CA-chain fix the verify path failed earlier with `unable to get local issuer certificate`; afterwards it reaches `IP address mismatch`, confirming the internal CA is now trusted. The default flip means a no-flag `hops sql` now takes the verify path (and so requires `--no-verify` on such a cluster), where it previously connected with verification off.

## Compatibility

The **REST/login** default is unchanged: with no flag and no env var, `hopsworks.login` still receives its default (verification off), so existing CLI invocations authenticate identically. The env var continues to win when set. The SDK `TrinoApi.connect`/`create_engine` default stays `verify=True`.

The one behavior change is **`hops sql`**: with no flag it now verifies the Trino coordinator by default (previously off). On clusters with a self-signed / IP-SAN-mismatched coordinator cert, `hops sql` now needs an explicit `--no-verify` (or `HOPSWORKS_HOSTNAME_VERIFICATION=false`).

## Tests

- `tests/cli/test_config.py`: env parsing, resolution precedence, internal-mode env handling, persistence.
- `tests/cli/test_verify_flag.py`: the flag's hand-off through `config.load`, the post-subcommand injected form, `session.get_project`, the `auth.login`/`auth.verify` → SDK boundary, `--help` discoverability, explicitness tracking (default / flag / env), and `trino._connect` — both its default-verify behavior and explicit `--verify`/`--no-verify` override.
- `tests/core/test_trino_api.py`: external-client `connect`/`create_engine`/`_get_ca_chain_path` assert the CA chain path is used.

Full CLI suite (206 tests) and `tests/core/test_trino_api.py` (21 tests) pass.
