### PR TITLE
[FSTORE-1970][APPEND] Fix similarity-search find_neighbors on OpenSearch 2.19.5 (k-too-large parsing + faiss efficient filtering)

### DIFF
--- a/python/hopsworks_common/core/opensearch.py
+++ b/python/hopsworks_common/core/opensearch.py
@@ -231,9 +231,19 @@ class ProjectOpenSearchClient:
 
     def _create_vector_database_exception(self, message):
         """Create appropriate VectorDatabaseException based on error message."""
-        if "[knn] requires k" in message:
-            pattern = r"\[knn\] requires k <= (\d+)"
-            match = re.search(pattern, message)
+        # Only an upper-bound violation means "k too large". Older OpenSearch
+        # reported "[knn] requires k <= N"; newer versions (2.x) report
+        # "[knn] requires k to be in the range (0, N]". The upper bound N is the
+        # inclusive max in both forms. Other "[knn] requires k ..." messages
+        # (e.g. "requires k > 0") are not too-large errors and fall through to
+        # OTHERS.
+        if (
+            "[knn] requires k <=" in message
+            or "[knn] requires k to be in the range" in message
+        ):
+            match = re.search(r"\[knn\] requires k <= (\d+)", message) or re.search(
+                r"\[knn\] requires k to be in the range \(\d+, (\d+)\]", message
+            )
             if match:
                 k = match.group(1)
                 reason = VectorDatabaseException.REQUESTED_K_TOO_LARGE

--- a/python/hsfs/core/vector_db_client.py
+++ b/python/hsfs/core/vector_db_client.py
@@ -133,17 +133,18 @@ class VectorDbClient:
                 )
         self._check_filter(filter, embedding_feature.feature_group)
         col_name = embedding_feature.embedding_index.col_prefix + embedding_feature.name
+        filter_clauses = [
+            {"exists": {"field": col_name}},
+        ] + self._get_query_filter(filter, embedding_feature.embedding_index.col_prefix)
         query = {
             "size": k,
             "query": {
-                "bool": {
-                    "must": [
-                        {"knn": {col_name: {"vector": embedding, "k": k}}},
-                        {"exists": {"field": col_name}},
-                    ]
-                    + self._get_query_filter(
-                        filter, embedding_feature.embedding_index.col_prefix
-                    )
+                "knn": {
+                    col_name: {
+                        "vector": embedding,
+                        "k": k,
+                        "filter": {"bool": {"must": filter_clauses}},
+                    }
                 }
             },
             "_source": list(
@@ -170,7 +171,7 @@ class VectorDbClient:
             # Get the max number of results allowed to request if it is not available.
             # This is expected to be executed once only.
             if not VectorDbClient._index_result_limit_k.get(index_name):
-                query["query"]["bool"]["must"][0]["knn"][col_name]["k"] = 2**31 - 1
+                query["query"]["knn"][col_name]["k"] = 2**31 - 1
                 try:
                     # It is expected that this request ALWAYS fails because requested k is too large.
                     # The purpose here is to get the max k allowed from the vector database, and cache it.
@@ -189,7 +190,7 @@ class VectorDbClient:
                         )
                     else:
                         raise e
-            query["query"]["bool"]["must"][0]["knn"][col_name]["k"] = min(
+            query["query"]["knn"][col_name]["k"] = min(
                 VectorDbClient._index_result_limit_k.get(index_name, k), 3 * k
             )
             results = opensearch_client._search(

--- a/python/tests/core/test_opensearch.py
+++ b/python/tests/core/test_opensearch.py
@@ -37,6 +37,12 @@ class TestOpenSearchClientSingleton:
                 {},
             ),
             (
+                # Newer OpenSearch k-NN range format
+                "[knn] requires k to be in the range (0, 10000]",
+                VectorDatabaseException.REQUESTED_K_TOO_LARGE,
+                {VectorDatabaseException.REQUESTED_K_TOO_LARGE_INFO_K: 10000},
+            ),
+            (
                 "Result window is too large, from + size must be less than or equal to: [10000] but was [80000]",
                 VectorDatabaseException.REQUESTED_NUM_RESULT_TOO_LARGE,
                 {VectorDatabaseException.REQUESTED_NUM_RESULT_TOO_LARGE_INFO_N: 10000},
@@ -45,6 +51,18 @@ class TestOpenSearchClientSingleton:
                 # Removed the bracket from numbers
                 "Result window is too large, from + size must be less than or equal to: 10000 but was 80000",
                 VectorDatabaseException.REQUESTED_NUM_RESULT_TOO_LARGE,
+                {},
+            ),
+            (
+                # Lower-bound violation is not a "too large" error
+                "[knn] requires k > 0",
+                VectorDatabaseException.OTHERS,
+                {},
+            ),
+            (
+                # Unrelated knn validation must not be misclassified as too large
+                "[knn] requires exactly one of k, distance or score to be set",
+                VectorDatabaseException.OTHERS,
                 {},
             ),
             (

--- a/python/tests/core/test_vector_db_client.py
+++ b/python/tests/core/test_vector_db_client.py
@@ -494,14 +494,12 @@ class TestVectorDbClient:
 
         body = self.mock_os_wrapper._search.call_args.kwargs["body"]
         assert body["size"] == 5
-        # The knn clause and filters are combined in a bool query. OpenSearch
-        # 2.19 rejects a `filter` nested inside the knn clause.
-        must = body["query"]["bool"]["must"]
-        knn = must[0]["knn"]["f2"]
+        knn = body["query"]["knn"]["f2"]
         assert knn["vector"] == [1.0, 2.0, 3.0]
         assert knn["k"] == 5
-        assert "filter" not in knn
-        assert must[1] == {"exists": {"field": "f2"}}
+        # The filter lives inside the knn clause (OpenSearch 2.x KNN syntax),
+        # not as a sibling bool/post_filter.
+        assert knn["filter"] == {"bool": {"must": [{"exists": {"field": "f2"}}]}}
 
     def test_find_neighbors_builds_knn_query_with_filter(self):
         self.target._find_neighbors(
@@ -509,10 +507,12 @@ class TestVectorDbClient:
         )
 
         body = self.mock_os_wrapper._search.call_args.kwargs["body"]
-        must = body["query"]["bool"]["must"]
-        knn = must[0]["knn"]["f2"]
-        assert "filter" not in knn
-        assert must[1:] == [
-            {"exists": {"field": "f2"}},
-            {"range": {"f3": {"gt": 10}}},
-        ]
+        knn = body["query"]["knn"]["f2"]
+        assert knn["filter"] == {
+            "bool": {
+                "must": [
+                    {"exists": {"field": "f2"}},
+                    {"range": {"f3": {"gt": 10}}},
+                ]
+            }
+        }


### PR DESCRIPTION
## Summary

Two SDK fixes for similarity search under the FSTORE-1970 OpenSearch **1.3.6 → 2.19.5** upgrade (which also switched the embedding-index engine **nmslib → faiss** in the backend). Together they fix `find_neighbors` on OpenSearch 2.19.5, which currently crashes and/or returns fewer than `k` results.

## Fix 1 — Parse the 2.19.5 k-NN "k too large" error message

`ProjectOpenSearchClient._create_vector_database_exception` only recognized the 1.3.6 wording `[knn] requires k <= N`. OpenSearch 2.19.5 (from `KNNQueryBuilder.Builder.validate()`) instead reports:

```
[knn] requires k to be in the range (0, N]
```

The old regex didn't match, so the max-`k` value was never extracted (`info` left empty) and the max-`k` discovery probe in `VectorDbClient._find_neighbors` (which deliberately issues `k = 2**31 - 1` expecting a parseable failure) re-raised instead of caching the limit — surfacing as `VectorDatabaseException: Requested k is too large`.

**Change** (`hopsworks_common/core/opensearch.py`): match both message forms, and tighten the guard so only genuine *upper-bound* violations are classified as `REQUESTED_K_TOO_LARGE` (`requires k > 0` and `requires exactly one of k …` now fall through to `OTHERS`).

**Why correct:** verified against the upstream k-NN plugin source at both tags — `[knn] requires k <= N` (1.3.6 + a deprecated 2.19.5 ctor) and `[knn] requires k to be in the range (0, N]` (the 2.19.5 active path); `N` is the inclusive max in both, so the extracted value is identical in meaning. The `Result window is too large` parser was checked against `DefaultSearchContext.java`@2.19.5 and left unchanged (already correct).

## Fix 2 — Use faiss efficient k-NN filtering so `find_neighbors` returns `k`

The backend upgrade switched the embedding-index engine to **faiss**. PR #951 had moved the similarity-search query to faiss **efficient filtering** (filter nested inside the `knn` clause), but PR #1005 reverted it to **post-filtering** (`bool.must` with `knn` + `exists` as siblings) after hitting `[knn] unknown token [START_OBJECT] after [filter]` — the signature of an engine that does **not** support in-knn filtering (nmslib), most likely seen against an index not yet recreated under faiss.

Post-filtering fetches the `k` nearest *first*, then drops the ones failing the filter — so on a **shared project index**, the per-feature-group `exists` filter (which excludes every other FG's rows) returns fewer than `k` results (e.g. `find_neighbors(k=10)` returning 7).

**Change** (`hsfs/core/vector_db_client.py`): re-apply the efficient-filter query form (revert #1005), now that indexes are faiss:

```json
{"query": {"knn": {"<col>": {"vector": [...], "k": k,
                             "filter": {"bool": {"must": [{"exists": ...}, ...]}}}}}}
```

**Why correct:** per OpenSearch docs, post-filtering "may return significantly fewer than k results," whereas efficient filtering applies the filter during graph traversal and **guarantees `k` results when at least `k` exist**; it is supported by the **faiss** engine since OpenSearch **2.9** (GA in 2.19). The two fixes are complementary: efficient filtering covers the normal path, and Fix 1 still keeps the explicit oversized-`k` path (`find_neighbors(k=2**31-1)`, which the tests assert must raise) parseable.

## Testing

Cluster-verified on a live OpenSearch **2.19.5.2 / faiss** cluster via the `test_similarity_search.py` loadtest (python_driver):

- `test_workflow[HUDI]` and `test_workflow[DELTA]` — the cases that exercise `find_neighbors` — **pass** end-to-end in isolation. `find_neighbors` returns the full `k` with **zero** max-`k` compensation probes (vs 18 with the old post-filter form), and the `VectorDatabaseException: Requested k is too large` crash is gone.
- `test_all_data_types`, `test_index_mapping_limit`, `test_feature_group_default_offline[HUDI/DELTA]` also pass in isolation.
- Unit tests added/updated for both message-format parsing (`tests/core/test_opensearch.py`) and the efficient-filter query shape (`tests/core/test_vector_db_client.py`).

Note: the full pytest suite could not be run locally because `uv sync` fails building `pandas==1.5.3` (`pkg_resources`); parser logic and query shape were validated directly, with the rest covered by the cluster loadtest. CI is relied on for the unit-test run.

## Out of scope

- `test_embedding_types` fails on 2.19.5 at `ext_fg.show(online=True)` returning empty — the external embedding FG's `index_name` is not populated by the backend create/insert response (the SDK read path is unchanged by this upgrade). This requires a **backend (hopsworks-ee)** fix, not an SDK change.
- Shared-session test contamination (some cases fail when run after another test in the same pytest session but pass in isolation) is a test-harness characteristic, not addressed here.