### PR TITLE
[HWORKS-2876] Fix DataSourceData.features returning raw dicts

### DIFF
--- a/python/hsfs/core/data_source_data.py
+++ b/python/hsfs/core/data_source_data.py
@@ -43,8 +43,19 @@ class DataSourceData:
         supported_resources: list[str] | None = None,
         **kwargs,
     ):
+        # The backend returns features as raw JSON dicts and from_response_json passes
+        # them straight into this constructor.
+        # Build Feature objects so features matches its annotated type and consumers such
+        # as infer_metadata can read feature.name / feature.type rather than failing with
+        # AttributeError: 'dict' object has no attribute 'name'.
+        # Feature objects passed by direct construction are kept as-is.
+        from hsfs import feature as feature_mod
+
         self._limit = limit
-        self._features = features if features else []
+        self._features = [
+            feature_mod.Feature.from_response_json(f) if isinstance(f, dict) else f
+            for f in (features or [])
+        ]
         self._preview = preview if preview else []
         self._schema_fetch_failed = schema_fetch_failed
         self._schema_fetch_in_progress = schema_fetch_in_progress


### PR DESCRIPTION
## Problem

`DataSourceData.features` is annotated `list[Feature]`, but `from_response_json` passes the decamelized JSON straight into the constructor, so `features` actually held a `list[dict]`. Consumers that read `feature.name` / `feature.type` — notably `DataSourceApi.infer_metadata` — failed with:

```
AttributeError: 'dict' object has no attribute 'name'
```

This hit both the CLI and the SDK on the data-source metadata-inference path.

## Fix

Convert each feature dict to a `Feature` in `__init__` via `Feature.from_response_json`, leaving already-constructed `Feature` objects untouched. The import is local to avoid the circular import the annotation-only `TYPE_CHECKING` guard was protecting against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)