### PR TITLE
[HWORKS-2876] Infer a feature group description in infer_metadata

### DIFF
--- a/python/hopsworks/cli/commands/datasource.py
+++ b/python/hopsworks/cli/commands/datasource.py
@@ -530,6 +530,8 @@ def connector_infer_metadata(
         )
     if inferred.suggested_event_time:
         click.echo(f"Suggested event time: {inferred.suggested_event_time}")
+    if inferred.suggested_description:
+        click.echo(f"Suggested description: {inferred.suggested_description}")
 
 
 def _create_connector(ctx: click.Context, body: dict[str, Any]) -> None:

--- a/python/hsfs/core/data_source.py
+++ b/python/hsfs/core/data_source.py
@@ -345,13 +345,14 @@ class DataSource:
                 print(f.original_name, "->", f.new_name, f.type, f.description)
             print("primary key:", inferred.suggested_primary_key)
             print("event time:", inferred.suggested_event_time)
+            print("description:", inferred.suggested_description)
             ```
 
         Parameters:
             preview_data: Pre-fetched preview data to skip a server round-trip; if `None`, a preview is fetched via `get_data`.
 
         Returns:
-            An object containing the suggested feature renames, types, descriptions, primary key, and event time.
+            An object containing the suggested feature renames, types, descriptions, primary key, event time, and feature group description.
 
         Raises:
             hopsworks.client.exceptions.PlatformIntelligenceException: If platform intelligence is not enabled on the cluster, or the LLM call fails.

--- a/python/hsfs/core/inferred_metadata.py
+++ b/python/hsfs/core/inferred_metadata.py
@@ -103,8 +103,9 @@ class InferredFeature:
 class InferredMetadata:
     """The metadata suggestions returned by `DataSource.infer_metadata`.
 
-    Holds per-feature renames, types, and descriptions, plus suggestions for the
-    primary key and event-time columns.
+    Holds per-feature renames, types, and descriptions, suggestions for the
+    primary key and event-time columns, and a description for the feature group
+    as a whole.
     """
 
     def __init__(
@@ -112,6 +113,7 @@ class InferredMetadata:
         features: list[InferredFeature] | list[dict] | None = None,
         suggested_primary_key: list[str] | None = None,
         suggested_event_time: str | None = None,
+        suggested_description: str | None = None,
         **kwargs,
     ):
         if features is None:
@@ -123,6 +125,7 @@ class InferredMetadata:
             ]
         self._suggested_primary_key = suggested_primary_key or []
         self._suggested_event_time = suggested_event_time
+        self._suggested_description = suggested_description
 
     @classmethod
     def from_response_json(cls, json_dict: dict[str, Any]) -> InferredMetadata:
@@ -156,6 +159,12 @@ class InferredMetadata:
         """The feature name (using `new_name`) suggested as the event time, or `None`."""
         return self._suggested_event_time
 
+    @public
+    @property
+    def suggested_description(self) -> str | None:
+        """The suggested description for the feature group built from this table, or `None`."""
+        return self._suggested_description
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize this InferredMetadata back to the camelCase JSON shape.
 
@@ -166,11 +175,13 @@ class InferredMetadata:
             "features": [f.to_dict() for f in self._features],
             "suggestedPrimaryKey": self._suggested_primary_key,
             "suggestedEventTime": self._suggested_event_time,
+            "suggestedDescription": self._suggested_description,
         }
 
     def __repr__(self) -> str:
         return (
             f"InferredMetadata(features={len(self._features)}, "
             f"suggested_primary_key={self._suggested_primary_key!r}, "
-            f"suggested_event_time={self._suggested_event_time!r})"
+            f"suggested_event_time={self._suggested_event_time!r}, "
+            f"suggested_description={self._suggested_description!r})"
         )

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -536,7 +536,7 @@ class StorageConnector(ABC):
             preview_data: Pre-fetched preview data to skip a server round-trip; if `None`, a preview is fetched via `get_data`.
 
         Returns:
-            An object containing the suggested feature renames, types, descriptions, primary key, and event time.
+            An object containing the suggested feature renames, types, descriptions, primary key, event time, and feature group description.
 
         Raises:
             hopsworks.client.exceptions.PlatformIntelligenceException: If platform intelligence is not enabled on the cluster, or the LLM call fails.

--- a/python/tests/cli/test_reads.py
+++ b/python/tests/cli/test_reads.py
@@ -195,6 +195,7 @@ def test_datasource_infer_metadata(mock_project):
     inferred.features = [inferred_feature]
     inferred.suggested_primary_key = ["user_id"]
     inferred.suggested_event_time = None
+    inferred.suggested_description = "User events, one row per event."
     target_table.infer_metadata.return_value = inferred
 
     other_table = mock.MagicMock()
@@ -215,6 +216,7 @@ def test_datasource_infer_metadata(mock_project):
     assert "USER_ID" in result.output
     assert "bigint" in result.output
     assert "Suggested primary key" in result.output
+    assert "Suggested description: User events, one row per event." in result.output
 
 
 def test_datasource_infer_metadata_table_not_found(mock_project):

--- a/python/tests/core/test_data_source.py
+++ b/python/tests/core/test_data_source.py
@@ -180,6 +180,7 @@ class TestInferredMetadata:
             ],
             "suggestedPrimaryKey": ["user_id"],
             "suggestedEventTime": "event_time",
+            "suggestedDescription": "User events, one row per event.",
         }
 
         # Act
@@ -192,6 +193,10 @@ class TestInferredMetadata:
         assert inferred.features[0].type == "bigint"
         assert inferred.suggested_primary_key == ["user_id"]
         assert inferred.suggested_event_time == "event_time"
+        assert inferred.suggested_description == "User events, one row per event."
+        assert inferred.to_dict()["suggestedDescription"] == (
+            "User events, one row per event."
+        )
 
 
 class TestDataSourceApiInferMetadata:


### PR DESCRIPTION
## Problem

The metadata-inference path (`DataSource.infer_metadata`) suggested per-column renames, types, and descriptions plus a primary key and event time, but nothing described the table as a whole. A feature group created from an inferred table therefore had no suggested description.

## Change (client side)

- `InferredMetadata` exposes the new backend `suggestedDescription` field as `suggested_description`, threaded through `to_dict` and `__repr__`.
- The `datasource infer-metadata` CLI command prints the suggested description.
- Data source / storage connector docstrings now list the feature group description among the returned suggestions.

Pairs with the backend change in logicalclocks/hopsworks-ee `infer-metadata-fg-description`, which adds the `suggestedDescription` field to `InferredMetadataDTO` and instructs the LLM to produce it.

## Tests

`pytest python/tests/core/test_data_source.py python/tests/cli/test_reads.py` — 40 passed. Ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)