### PR TITLE
[HWORKS-494] hsml: auto-upload local file paths on model.deploy()

### DIFF
--- a/python/hopsworks_common/constants.py
+++ b/python/hopsworks_common/constants.py
@@ -165,6 +165,8 @@ class MODEL_REGISTRY:
 class MODEL_SERVING:
     DEPLOYMENTS_DATASET = "Deployments"
     ARTIFACTS_DIR_NAME = "Artifacts"  # legacy, kept for backward compatibility (<4.6)
+    # Subfolder for user-uploaded files at Deployments/<name>/resources/<role>/
+    DEPLOYMENT_RESOURCES_DIR = "resources"
 
 
 class RESOURCES:

--- a/python/hsml/engine/local_engine.py
+++ b/python/hsml/engine/local_engine.py
@@ -38,7 +38,13 @@ class LocalEngine:
     def _delete(self, model_instance):
         self._model_api._delete(model_instance)
 
-    def _upload(self, local_path: str, remote_path: str, upload_configuration=None):
+    def _upload(
+        self,
+        local_path: str,
+        remote_path: str,
+        upload_configuration=None,
+        overwrite: bool = False,
+    ):
         local_path = self._get_abs_path(local_path)
         remote_path = self._prepend_project_path(remote_path)
 
@@ -50,6 +56,7 @@ class LocalEngine:
             self._hdfs_api._upload(
                 local_path=local_path,
                 upload_path=remote_path,
+                overwrite=overwrite,
                 buffer_size=upload_configuration.get(
                     "buffer_size", self._hdfs_api.DEFAULT_BUFFER_SIZE
                 ),
@@ -59,6 +66,7 @@ class LocalEngine:
             self._dataset_api.upload(
                 local_path,
                 remote_path,
+                overwrite=overwrite,
                 chunk_size=upload_configuration.get(
                     "chunk_size", self._dataset_api.DEFAULT_UPLOAD_FLOW_CHUNK_SIZE
                 ),

--- a/python/hsml/engine/model_engine.py
+++ b/python/hsml/engine/model_engine.py
@@ -29,7 +29,7 @@ from hopsworks_common.client.exceptions import ModelRegistryException, RestAPIEr
 from hopsworks_common.core import dataset_api, inode
 from hsml.core import model_api
 from hsml.engine import local_engine
-from hsml.utils.local_paths import normalize_hopsfs_mount_path
+from hsml.utils.local_paths import _normalize_hopsfs_mount_path
 from tqdm.auto import tqdm
 
 
@@ -296,7 +296,7 @@ class ModelEngine:
     ):
         """Save model files from a local path. The local path can be on hopsfs mount."""
         # check hopsfs mount
-        from_hdfs_model_path = normalize_hopsfs_mount_path(model_path)
+        from_hdfs_model_path = _normalize_hopsfs_mount_path(model_path)
         if from_hdfs_model_path is not None:
             self._copy_or_move_hopsfs_model(
                 from_hdfs_model_path=from_hdfs_model_path,

--- a/python/hsml/engine/model_engine.py
+++ b/python/hsml/engine/model_engine.py
@@ -29,6 +29,7 @@ from hopsworks_common.client.exceptions import ModelRegistryException, RestAPIEr
 from hopsworks_common.core import dataset_api, inode
 from hsml.core import model_api
 from hsml.engine import local_engine
+from hsml.utils.local_paths import normalize_hopsfs_mount_path
 from tqdm.auto import tqdm
 
 
@@ -190,22 +191,6 @@ class ModelEngine:
             n_files += 1
             update_upload_progress(n_dirs=n_dirs, n_files=n_files)
 
-    def _normalize_hopsfs_mount_path(self, model_path):
-        if model_path.startswith(constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX):
-            return model_path.replace(
-                constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX, "", 1
-            )
-        # /mnt/hopsfs/ is rooted at /Projects/, so the on-disk path is
-        # /mnt/hopsfs/<projectName>/<rest> — strip the project segment too
-        # so the result is project-relative, matching the /hopsfs/ branch.
-        base = constants.MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE
-        if model_path.startswith(base + "/"):
-            rest = model_path[len(base) + 1 :]
-            first_slash = rest.find("/")
-            if first_slash != -1 and first_slash + 1 < len(rest):
-                return rest[first_slash + 1 :]
-        return None
-
     def _download_model_from_hopsfs_recursive(
         self,
         from_hdfs_model_path: str,
@@ -311,7 +296,7 @@ class ModelEngine:
     ):
         """Save model files from a local path. The local path can be on hopsfs mount."""
         # check hopsfs mount
-        from_hdfs_model_path = self._normalize_hopsfs_mount_path(model_path)
+        from_hdfs_model_path = normalize_hopsfs_mount_path(model_path)
         if from_hdfs_model_path is not None:
             self._copy_or_move_hopsfs_model(
                 from_hdfs_model_path=from_hdfs_model_path,

--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -547,8 +547,12 @@ class ServingEngine:
         ]
         if predictor.transformer is not None:
             targets.append(
-                (predictor.transformer, "script_file", "transformer",
-                 "transformer.script_file"),
+                (
+                    predictor.transformer,
+                    "script_file",
+                    "transformer",
+                    "transformer.script_file",
+                ),
             )
 
         for obj, field, subdir, field_label in targets:

--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -33,6 +33,7 @@ from hopsworks_common.constants import INFERENCE_ENDPOINTS as IE
 from hopsworks_common.core import dataset_api, inode
 from hsml.core import serving_api
 from hsml.engine import local_engine
+from hsml.utils.local_paths import resolve_serving_file
 from tqdm.auto import tqdm
 
 
@@ -519,13 +520,46 @@ class ServingEngine:
         raise ValueError("Unknown deployment status: " + state.status)
 
     def _save(self, deployment_instance, await_update: int):
+        # Local paths on script_file / config_file are auto-uploaded under
+        # /Projects/<p>/Deployments/<name>/resources/ and rewritten to
+        # HopsFS paths in-memory. The fields then hold HopsFS paths, so
+        # re-saving without reassigning the field is a no-op for uploads.
+        self._upload_local_serving_files(deployment_instance)
+
         if deployment_instance.id is None:
-            # if new deployment
             self._create(deployment_instance)
             return
-
-        # if existing deployment
         self._update(deployment_instance, await_update)
+
+    def _upload_local_serving_files(self, deployment_instance):
+        """Upload local ``script_file`` / ``config_file`` paths.
+
+        Rewrites the in-memory fields to HopsFS paths. HopsFS / ``None`` are
+        left untouched. Each role uploads to its own subdirectory to avoid
+        basename collisions.
+        """
+        predictor = deployment_instance._predictor
+        deployment_name = deployment_instance.name
+
+        targets = [
+            (predictor, "script_file", "predictor", "script_file"),
+            (predictor, "config_file", "config", "config_file"),
+        ]
+        if predictor.transformer is not None:
+            targets.append(
+                (predictor.transformer, "script_file", "transformer",
+                 "transformer.script_file"),
+            )
+
+        for obj, field, subdir, field_label in targets:
+            resolved = resolve_serving_file(
+                self._engine,
+                deployment_name,
+                getattr(obj, field),
+                field_name=field_label,
+                subdir=subdir,
+            )
+            setattr(obj, field, resolved)
 
     def _delete(self, deployment_instance, force=False):
         state = deployment_instance.get_state()

--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -33,7 +33,7 @@ from hopsworks_common.constants import INFERENCE_ENDPOINTS as IE
 from hopsworks_common.core import dataset_api, inode
 from hsml.core import serving_api
 from hsml.engine import local_engine
-from hsml.utils.local_paths import resolve_serving_file
+from hsml.utils.local_paths import _resolve_serving_file
 from tqdm.auto import tqdm
 
 
@@ -556,7 +556,7 @@ class ServingEngine:
             )
 
         for obj, field, subdir, field_label in targets:
-            resolved = resolve_serving_file(
+            resolved = _resolve_serving_file(
                 self._engine,
                 deployment_name,
                 getattr(obj, field),

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -404,8 +404,8 @@ class Model:
             artifact_version: **Deprecated**. Version number of the model artifact to deploy, `CREATE` to create a new model artifact
             or `MODEL-ONLY` to reuse the shared artifact containing only the model files.
             serving_tool: Serving tool used to deploy the model server.
-            script_file: Path to a custom predictor script implementing the Predict class.
-            config_file: Model server configuration file to be passed to the model deployment.
+            script_file: Path to a custom predictor script implementing the Predict class, either local or already uploaded to HopsFS.
+            config_file: Model server configuration file to be passed to the model deployment, either local or already uploaded to HopsFS.
                 It can be accessed via `CONFIG_FILE_PATH` environment variable from a predictor or transformer script.
                 For LLM deployments without a predictor script, this file is used to configure the vLLM engine.
             resources: Resources to be allocated for the predictor.

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -245,8 +245,8 @@ class ModelServing:
             name: Name of the predictor.
             artifact_version: (**Deprecated**) Version number of the model artifact to deploy, `CREATE` to create a new model artifact or `MODEL-ONLY` to reuse the shared artifact containing only the model files.
             serving_tool: Serving tool used to deploy the model server.
-            script_file: Path to a custom predictor script implementing the Predict class.
-            config_file: Model server configuration file to be passed to the model deployment.
+            script_file: Path to a custom predictor script implementing the Predict class, either local or already uploaded to HopsFS. The script must implement a `Predictor` class with a `predict(self, inputs)` method that takes the model inputs and returns the model predictions. The script is passed to the model deployment and can be accessed via the `SCRIPT_FILE_PATH` environment variable from within the predictor script.
+            config_file: Model server configuration file to be passed to the model deployment, either local or already uploaded to HopsFS.
                 It can be accessed via `CONFIG_FILE_PATH` environment variable from a predictor script.
                 For LLM deployments without a predictor script, this file is used to configure the vLLM engine.
             resources: Resources to be allocated for the predictor.
@@ -301,9 +301,6 @@ class ModelServing:
             ```python
             # login into Hopsworks using hopsworks.login()
 
-            # get Dataset API instance
-            dataset_api = project.get_dataset_api()
-
             # get Hopsworks Model Serving handle
             ms = project.get_model_serving()
 
@@ -321,16 +318,17 @@ class ModelServing:
                     ''' Transform the predictions computed by the model before returning a response '''
                     return outputs
 
-            uploaded_file_path = dataset_api.upload("my_transformer.py", "Resources", overwrite=True)
-            transformer_script_path = os.path.join("/Projects", project.name, uploaded_file_path)
+            # Local path — auto-uploaded on save.
+            my_transformer = ms.create_transformer(script_file="my_transformer.py")
 
-            my_transformer = ms.create_transformer(script_file=uploaded_file_path)
+            # Or an already-uploaded HopsFS path:
+            my_transformer = ms.create_transformer(
+                script_file="/Projects/<project>/Resources/my_transformer.py"
+            )
 
-            # or
-
+            # Or the Transformer class directly:
             from hsml.transformer import Transformer
-
-            my_transformer = Transformer(script_file)
+            my_transformer = Transformer(script_file="my_transformer.py")
             ```
 
         Example: Create a deployment with the transformer
@@ -348,7 +346,7 @@ class ModelServing:
             This method is lazy and does not persist any metadata or deploy any transformer. To create a deployment using this transformer, set it in the `predictor.transformer` property.
 
         Parameters:
-            script_file: Path to a custom predictor script implementing the Transformer class.
+            script_file: Path to a custom predictor script implementing the Transformer class, either local or already uploaded to HopsFS.
             resources: Resources to be allocated for the transformer.
             scaling_configuration: Scaling configuration for the transformer.
             env_vars: Environment variables to set on the transformer.
@@ -402,7 +400,7 @@ class ModelServing:
 
         Parameters:
             name: Name of the endpoint.
-            script_file: Path to a custom script file implementing a HTTP server.
+            script_file: Path to a custom script file implementing a HTTP server, either local or already uploaded to HopsFS.
             description: Description of the endpoint.
             resources: Resources to be allocated for the predictor.
             inference_logger: Inference logger configuration.

--- a/python/hsml/utils/local_paths.py
+++ b/python/hsml/utils/local_paths.py
@@ -132,11 +132,11 @@ def _resolve_local_or_mount(
     ``Deployments/<deployment_name>/resources/<subdir>/``.
     """
     # Normalize away `./` and `../` segments that `os.path.join(cwd, path)`
-    # leaves intact, so the returned HopsFS path is clean. On Windows,
-    # `os.path.normpath` also converts forward slashes to backslashes — undo
-    # that so the FUSE-mount prefix check is platform-agnostic.
-    abs_path = os.path.normpath(abs_path).replace(os.sep, "/")
-    mount_relative = _normalize_hopsfs_mount_path(abs_path)
+    # leaves intact. The upload path stays in OS-native form (Windows uses
+    # backslashes); the FUSE-mount check needs forward slashes, so use a
+    # local variant for that comparison only.
+    abs_path = os.path.normpath(abs_path)
+    mount_relative = _normalize_hopsfs_mount_path(abs_path.replace(os.sep, "/"))
     if mount_relative is not None:
         return f"/Projects/{project_name}/{mount_relative}"
 

--- a/python/hsml/utils/local_paths.py
+++ b/python/hsml/utils/local_paths.py
@@ -132,8 +132,10 @@ def _resolve_local_or_mount(
     ``Deployments/<deployment_name>/resources/<subdir>/``.
     """
     # Normalize away `./` and `../` segments that `os.path.join(cwd, path)`
-    # leaves intact, so the returned HopsFS path is clean.
-    abs_path = os.path.normpath(abs_path)
+    # leaves intact, so the returned HopsFS path is clean. On Windows,
+    # `os.path.normpath` also converts forward slashes to backslashes — undo
+    # that so the FUSE-mount prefix check is platform-agnostic.
+    abs_path = os.path.normpath(abs_path).replace(os.sep, "/")
     mount_relative = _normalize_hopsfs_mount_path(abs_path)
     if mount_relative is not None:
         return f"/Projects/{project_name}/{mount_relative}"

--- a/python/hsml/utils/local_paths.py
+++ b/python/hsml/utils/local_paths.py
@@ -1,0 +1,147 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import os
+
+from hopsworks_common import client
+from hopsworks_common.constants import MODEL_REGISTRY, MODEL_SERVING
+
+
+def normalize_hopsfs_mount_path(path: str) -> str | None:
+    """Project-relative HopsFS path for a FUSE-mounted ``path``, or ``None``.
+
+    Recognizes ``/hopsfs/<rest>`` (per-project mount in Jobs/Jupyter pods)
+    and ``/mnt/hopsfs/<project>/<rest>`` (cluster-wide mount).
+    """
+    if path.startswith(MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX):
+        return path.replace(MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX, "", 1)
+    # /mnt/hopsfs/ is rooted at HopsFS root; strip the next path segment
+    # (project name) too so the result is project-relative.
+    base = MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE
+    if path.startswith(base + "/"):
+        rest = path[len(base) + 1:]
+        first_slash = rest.find("/")
+        if first_slash != -1 and first_slash + 1 < len(rest):
+            return rest[first_slash + 1:]
+    return None
+
+
+def resolve_serving_file(
+    local_engine,
+    deployment_name: str,
+    path: str | None,
+    field_name: str,
+    subdir: str,
+    overwrite: bool = True,
+) -> str | None:
+    """Resolve a user-supplied serving file path to an absolute HopsFS path.
+
+    Mirrors the classification used by
+    [`ModelEngine._save`][hsml.engine.model_engine.ModelEngine._save]:
+
+    1. ``None`` → return unchanged.
+    2. Absolute path that exists on disk → upload (or, if the path lives
+       under a HopsFS FUSE mount, rewrite to ``/Projects/<p>/...`` without
+       uploading).
+    3. Relative path that exists when joined with cwd → resolve to the
+       absolute form and treat as step 2.
+    4. ``DatasetApi.exists(path)`` is true → it's a HopsFS path (absolute,
+       project-relative, or ``hdfs://``); rewrite to the absolute
+       ``/Projects/<p>/...`` form and return.
+    5. Otherwise → raise ``ValueError``.
+
+    ``subdir`` is the per-role subfolder (``"predictor"``, ``"transformer"``,
+    ``"config"``) under ``Deployments/<name>/resources/``; it prevents
+    basename collisions across roles.
+
+    Extension and content validation is the backend's responsibility.
+    """
+    if path is None:
+        return path
+
+    project_name = client._get_instance()._project_name
+
+    # 1. Absolute local — may be a FUSE mount.
+    if os.path.isabs(path) and os.path.exists(path):
+        return _resolve_local_or_mount(
+            local_engine, project_name, deployment_name, path, subdir, overwrite
+        )
+
+    # 2. Relative local — resolve via cwd, then run the same
+    #    FUSE-mount-vs-upload decision on the absolute form. This catches
+    #    `./predictor.py` from a Jobs/Jupyter pod whose cwd lives under
+    #    /hopsfs/... or /mnt/hopsfs/<project>/...
+    abs_path = os.path.join(os.getcwd(), path)
+    if os.path.exists(abs_path):
+        return _resolve_local_or_mount(
+            local_engine, project_name, deployment_name, abs_path, subdir, overwrite
+        )
+
+    # 3. HopsFS — absolute /Projects/..., project-relative, or hdfs:// URI.
+    if local_engine._dataset_api.exists(path):
+        if path.startswith("hdfs:/"):
+            idx = path.find("/Projects")
+            return path[idx:] if idx != -1 else path
+        if path.startswith("/Projects/"):
+            return path
+        return f"/Projects/{project_name}/{path.lstrip('/')}"
+
+    raise ValueError(
+        f"Could not find {field_name}: '{path}' in the local filesystem "
+        f"or in Hopsworks File System."
+    )
+
+
+def _ensure_dataset_dir(local_engine, remote_dir: str) -> None:
+    """Recursively create every missing segment of ``remote_dir``.
+
+    ``DatasetApi.mkdir`` does not create parents.
+    The top-level dataset (first segment) is provisioned per project by the
+    platform; it is never created here.
+    """
+    segments = [s for s in remote_dir.split("/") if s]
+    if len(segments) < 2:
+        return
+    ds_api = local_engine._dataset_api
+    for i in range(2, len(segments) + 1):
+        sub_path = "/".join(segments[:i])
+        if not ds_api.exists(sub_path):
+            local_engine._mkdir(sub_path)
+
+
+def _resolve_local_or_mount(
+    local_engine, project_name, deployment_name, abs_path, subdir, overwrite
+):
+    """Rewrite or upload an absolute local path and return the HopsFS path.
+
+    If ``abs_path`` is a FUSE mount, rewrite it to ``/Projects/<p>/...``.
+    Otherwise upload it under
+    ``Deployments/<deployment_name>/resources/<subdir>/``.
+    """
+    # Normalize away `./` and `../` segments that `os.path.join(cwd, path)`
+    # leaves intact, so the returned HopsFS path is clean.
+    abs_path = os.path.normpath(abs_path)
+    mount_relative = normalize_hopsfs_mount_path(abs_path)
+    if mount_relative is not None:
+        return f"/Projects/{project_name}/{mount_relative}"
+
+    remote_dir = (
+        f"{MODEL_SERVING.DEPLOYMENTS_DATASET}/{deployment_name}/"
+        f"{MODEL_SERVING.DEPLOYMENT_RESOURCES_DIR}/{subdir}"
+    )
+    _ensure_dataset_dir(local_engine, remote_dir)
+    local_engine._upload(abs_path, remote_dir, overwrite=overwrite)
+    return f"/Projects/{project_name}/{remote_dir}/{os.path.basename(abs_path)}"

--- a/python/hsml/utils/local_paths.py
+++ b/python/hsml/utils/local_paths.py
@@ -20,7 +20,7 @@ from hopsworks_common import client
 from hopsworks_common.constants import MODEL_REGISTRY, MODEL_SERVING
 
 
-def normalize_hopsfs_mount_path(path: str) -> str | None:
+def _normalize_hopsfs_mount_path(path: str) -> str | None:
     """Project-relative HopsFS path for a FUSE-mounted ``path``, or ``None``.
 
     Recognizes ``/hopsfs/<rest>`` (per-project mount in Jobs/Jupyter pods)
@@ -39,7 +39,7 @@ def normalize_hopsfs_mount_path(path: str) -> str | None:
     return None
 
 
-def resolve_serving_file(
+def _resolve_serving_file(
     local_engine,
     deployment_name: str,
     path: str | None,
@@ -134,7 +134,7 @@ def _resolve_local_or_mount(
     # Normalize away `./` and `../` segments that `os.path.join(cwd, path)`
     # leaves intact, so the returned HopsFS path is clean.
     abs_path = os.path.normpath(abs_path)
-    mount_relative = normalize_hopsfs_mount_path(abs_path)
+    mount_relative = _normalize_hopsfs_mount_path(abs_path)
     if mount_relative is not None:
         return f"/Projects/{project_name}/{mount_relative}"
 

--- a/python/hsml/utils/local_paths.py
+++ b/python/hsml/utils/local_paths.py
@@ -32,10 +32,10 @@ def normalize_hopsfs_mount_path(path: str) -> str | None:
     # (project name) too so the result is project-relative.
     base = MODEL_REGISTRY.HOPSFS_MOUNT_PREFIX_BASE
     if path.startswith(base + "/"):
-        rest = path[len(base) + 1:]
+        rest = path[len(base) + 1 :]
         first_slash = rest.find("/")
         if first_slash != -1 and first_slash + 1 < len(rest):
-            return rest[first_slash + 1:]
+            return rest[first_slash + 1 :]
     return None
 
 

--- a/python/tests/test_constants.py
+++ b/python/tests/test_constants.py
@@ -75,6 +75,7 @@ class TestConstants:
         model_serving = {
             "DEPLOYMENTS_DATASET": "Deployments",
             "ARTIFACTS_DIR_NAME": "Artifacts",
+            "DEPLOYMENT_RESOURCES_DIR": "resources",
         }
 
         # Assert

--- a/python/tests/test_local_paths.py
+++ b/python/tests/test_local_paths.py
@@ -76,7 +76,9 @@ class TestNormalizeHopsfsMountPath:
 
     def test_non_mount_returns_none(self):
         assert normalize_hopsfs_mount_path("/tmp/foo.py") is None
-        assert normalize_hopsfs_mount_path("/Projects/myproject/Resources/foo.py") is None
+        assert (
+            normalize_hopsfs_mount_path("/Projects/myproject/Resources/foo.py") is None
+        )
         assert normalize_hopsfs_mount_path("./foo.py") is None
         assert normalize_hopsfs_mount_path("foo.py") is None
         assert normalize_hopsfs_mount_path("local/model.pkl") is None
@@ -92,9 +94,7 @@ class TestResolveServingFile:
         )
         local_engine._upload.assert_not_called()
 
-    def test_absolute_local_file_uploaded(
-        self, tmp_path, project_name, local_engine
-    ):
+    def test_absolute_local_file_uploaded(self, tmp_path, project_name, local_engine):
         local = tmp_path / "predictor.py"
         local.write_text("# noop\n")
 
@@ -195,9 +195,7 @@ class TestResolveServingFile:
         assert out == f"/Projects/{project_name}/Resources/foo.py"
         local_engine._upload.assert_not_called()
 
-    def test_absolute_hopsfs_path_passthrough(
-        self, project_name, local_engine
-    ):
+    def test_absolute_hopsfs_path_passthrough(self, project_name, local_engine):
         # /Projects/<p>/... that exists in HopsFS → return as-is, no upload.
         # `os.path.exists` is False (no FUSE mount), so step 3 runs.
         local_engine._dataset_api.exists.return_value = True
@@ -213,9 +211,7 @@ class TestResolveServingFile:
         assert out == f"/Projects/{project_name}/Resources/foo.py"
         local_engine._upload.assert_not_called()
 
-    def test_project_relative_hopsfs_path_expanded(
-        self, project_name, local_engine
-    ):
+    def test_project_relative_hopsfs_path_expanded(self, project_name, local_engine):
         # The form returned by `dataset_api.upload("file.py", "Resources")`.
         local_engine._dataset_api.exists.return_value = True
 
@@ -230,9 +226,7 @@ class TestResolveServingFile:
         assert out == f"/Projects/{project_name}/Resources/foo.py"
         local_engine._upload.assert_not_called()
 
-    def test_hdfs_uri_stripped_to_absolute(
-        self, project_name, local_engine
-    ):
+    def test_hdfs_uri_stripped_to_absolute(self, project_name, local_engine):
         local_engine._dataset_api.exists.return_value = True
 
         out = resolve_serving_file(
@@ -259,9 +253,7 @@ class TestResolveServingFile:
             )
         local_engine._upload.assert_not_called()
 
-    def test_local_uploads_to_role_subdir(
-        self, tmp_path, project_name, local_engine
-    ):
+    def test_local_uploads_to_role_subdir(self, tmp_path, project_name, local_engine):
         # Predictor and transformer with the same basename land in
         # different subdirs.
         f = tmp_path / "script.py"
@@ -278,16 +270,12 @@ class TestResolveServingFile:
             subdir="transformer",
         )
 
-        assert predictor_out.endswith(
-            "/Deployments/dep/resources/predictor/script.py"
-        )
+        assert predictor_out.endswith("/Deployments/dep/resources/predictor/script.py")
         assert transformer_out.endswith(
             "/Deployments/dep/resources/transformer/script.py"
         )
 
-    def test_overwrite_false_propagated(
-        self, tmp_path, project_name, local_engine
-    ):
+    def test_overwrite_false_propagated(self, tmp_path, project_name, local_engine):
         local = tmp_path / "predictor.py"
         local.write_text("# noop\n")
 

--- a/python/tests/test_local_paths.py
+++ b/python/tests/test_local_paths.py
@@ -16,8 +16,8 @@
 
 import pytest
 from hsml.utils.local_paths import (
-    normalize_hopsfs_mount_path,
-    resolve_serving_file,
+    _normalize_hopsfs_mount_path,
+    _resolve_serving_file,
 )
 
 
@@ -37,7 +37,7 @@ def project_name(mocker):
 def local_engine(mocker):
     # `_ensure_dataset_dir` consults engine._dataset_api.exists() per
     # intermediate segment; default to "nothing exists" so the resolver
-    # creates every parent. `resolve_serving_file` step 3 also calls
+    # creates every parent. `_resolve_serving_file` step 3 also calls
     # `_dataset_api.exists(path)` to detect HopsFS membership; tests that
     # exercise that branch override the return_value.
     engine = mocker.Mock()
@@ -72,22 +72,22 @@ class TestNormalizeHopsfsMountPath:
         ],
     )
     def test_mount_paths_normalized(self, path, expected):
-        assert normalize_hopsfs_mount_path(path) == expected
+        assert _normalize_hopsfs_mount_path(path) == expected
 
     def test_non_mount_returns_none(self):
-        assert normalize_hopsfs_mount_path("/tmp/foo.py") is None
+        assert _normalize_hopsfs_mount_path("/tmp/foo.py") is None
         assert (
-            normalize_hopsfs_mount_path("/Projects/myproject/Resources/foo.py") is None
+            _normalize_hopsfs_mount_path("/Projects/myproject/Resources/foo.py") is None
         )
-        assert normalize_hopsfs_mount_path("./foo.py") is None
-        assert normalize_hopsfs_mount_path("foo.py") is None
-        assert normalize_hopsfs_mount_path("local/model.pkl") is None
+        assert _normalize_hopsfs_mount_path("./foo.py") is None
+        assert _normalize_hopsfs_mount_path("foo.py") is None
+        assert _normalize_hopsfs_mount_path("local/model.pkl") is None
 
 
 class TestResolveServingFile:
     def test_none_returns_none(self, local_engine):
         assert (
-            resolve_serving_file(
+            _resolve_serving_file(
                 local_engine, "my_dep", None, "script_file", subdir="predictor"
             )
             is None
@@ -98,7 +98,7 @@ class TestResolveServingFile:
         local = tmp_path / "predictor.py"
         local.write_text("# noop\n")
 
-        out = resolve_serving_file(
+        out = _resolve_serving_file(
             local_engine,
             "my_dep",
             str(local),
@@ -130,7 +130,7 @@ class TestResolveServingFile:
         local.write_text("# noop\n")
         monkeypatch.chdir(tmp_path)
 
-        out = resolve_serving_file(
+        out = _resolve_serving_file(
             local_engine,
             "my_dep",
             "./predictor.py",
@@ -149,7 +149,7 @@ class TestResolveServingFile:
         mocker.patch("os.getcwd", return_value="/hopsfs/Resources")
         mocker.patch("os.path.exists", return_value=True)
 
-        out = resolve_serving_file(
+        out = _resolve_serving_file(
             local_engine,
             "my_dep",
             "./foo.py",
@@ -167,7 +167,7 @@ class TestResolveServingFile:
         # /Projects/<p>/<rest>.
         mocker.patch("os.path.exists", return_value=True)
 
-        out = resolve_serving_file(
+        out = _resolve_serving_file(
             local_engine,
             "my_dep",
             "/hopsfs/Resources/foo.py",
@@ -184,7 +184,7 @@ class TestResolveServingFile:
         # Absolute /mnt/hopsfs/<project>/<rest> on disk → no upload.
         mocker.patch("os.path.exists", return_value=True)
 
-        out = resolve_serving_file(
+        out = _resolve_serving_file(
             local_engine,
             "my_dep",
             "/mnt/hopsfs/myproject/Resources/foo.py",
@@ -200,7 +200,7 @@ class TestResolveServingFile:
         # `os.path.exists` is False (no FUSE mount), so step 3 runs.
         local_engine._dataset_api.exists.return_value = True
 
-        out = resolve_serving_file(
+        out = _resolve_serving_file(
             local_engine,
             "my_dep",
             f"/Projects/{project_name}/Resources/foo.py",
@@ -215,7 +215,7 @@ class TestResolveServingFile:
         # The form returned by `dataset_api.upload("file.py", "Resources")`.
         local_engine._dataset_api.exists.return_value = True
 
-        out = resolve_serving_file(
+        out = _resolve_serving_file(
             local_engine,
             "my_dep",
             "Resources/foo.py",
@@ -229,7 +229,7 @@ class TestResolveServingFile:
     def test_hdfs_uri_stripped_to_absolute(self, project_name, local_engine):
         local_engine._dataset_api.exists.return_value = True
 
-        out = resolve_serving_file(
+        out = _resolve_serving_file(
             local_engine,
             "my_dep",
             f"hdfs://namenode:8020/Projects/{project_name}/Resources/foo.py",
@@ -244,7 +244,7 @@ class TestResolveServingFile:
         # Not on disk; HopsFS says it doesn't exist either. Default fixture
         # has `_dataset_api.exists.return_value = False`.
         with pytest.raises(ValueError, match="Could not find script_file"):
-            resolve_serving_file(
+            _resolve_serving_file(
                 local_engine,
                 "my_dep",
                 "./does_not_exist.py",
@@ -259,10 +259,10 @@ class TestResolveServingFile:
         f = tmp_path / "script.py"
         f.write_text("# noop\n")
 
-        predictor_out = resolve_serving_file(
+        predictor_out = _resolve_serving_file(
             local_engine, "dep", str(f), "script_file", subdir="predictor"
         )
-        transformer_out = resolve_serving_file(
+        transformer_out = _resolve_serving_file(
             local_engine,
             "dep",
             str(f),
@@ -279,7 +279,7 @@ class TestResolveServingFile:
         local = tmp_path / "predictor.py"
         local.write_text("# noop\n")
 
-        resolve_serving_file(
+        _resolve_serving_file(
             local_engine,
             "my_dep",
             str(local),

--- a/python/tests/test_local_paths.py
+++ b/python/tests/test_local_paths.py
@@ -1,0 +1,307 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+from hsml.utils.local_paths import (
+    normalize_hopsfs_mount_path,
+    resolve_serving_file,
+)
+
+
+@pytest.fixture
+def project_name(mocker):
+    name = "myproject"
+    fake_client = mocker.Mock()
+    fake_client._project_name = name
+    mocker.patch(
+        "hsml.utils.local_paths.client._get_instance",
+        return_value=fake_client,
+    )
+    return name
+
+
+@pytest.fixture
+def local_engine(mocker):
+    # `_ensure_dataset_dir` consults engine._dataset_api.exists() per
+    # intermediate segment; default to "nothing exists" so the resolver
+    # creates every parent. `resolve_serving_file` step 3 also calls
+    # `_dataset_api.exists(path)` to detect HopsFS membership; tests that
+    # exercise that branch override the return_value.
+    engine = mocker.Mock()
+    engine._dataset_api.exists.return_value = False
+    return engine
+
+
+class TestNormalizeHopsfsMountPath:
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            # /hopsfs/<rest> — per-project FUSE mount in Jobs/Jupyter pods.
+            ("/hopsfs/Resources/foo.py", "Resources/foo.py"),
+            ("/hopsfs/Models/model.pkl", "Models/model.pkl"),
+            # /mnt/hopsfs/<project>/<rest> — cluster-wide mount; strip both
+            # the mount base and the next segment (the project name).
+            ("/mnt/hopsfs/demo/Models/model.pkl", "Models/model.pkl"),
+            (
+                "/mnt/hopsfs/demo/Resources/workflows/models/tensorflow",
+                "Resources/workflows/models/tensorflow",
+            ),
+            # Only the *leading* prefix is stripped — repeated segments
+            # deeper in the path stay intact (regression case).
+            (
+                "/hopsfs/Models/hopsfs/archive/model.pkl",
+                "Models/hopsfs/archive/model.pkl",
+            ),
+            (
+                "/mnt/hopsfs/demo/Models/mnt/hopsfs/archive/model.pkl",
+                "Models/mnt/hopsfs/archive/model.pkl",
+            ),
+        ],
+    )
+    def test_mount_paths_normalized(self, path, expected):
+        assert normalize_hopsfs_mount_path(path) == expected
+
+    def test_non_mount_returns_none(self):
+        assert normalize_hopsfs_mount_path("/tmp/foo.py") is None
+        assert normalize_hopsfs_mount_path("/Projects/myproject/Resources/foo.py") is None
+        assert normalize_hopsfs_mount_path("./foo.py") is None
+        assert normalize_hopsfs_mount_path("foo.py") is None
+        assert normalize_hopsfs_mount_path("local/model.pkl") is None
+
+
+class TestResolveServingFile:
+    def test_none_returns_none(self, local_engine):
+        assert (
+            resolve_serving_file(
+                local_engine, "my_dep", None, "script_file", subdir="predictor"
+            )
+            is None
+        )
+        local_engine._upload.assert_not_called()
+
+    def test_absolute_local_file_uploaded(
+        self, tmp_path, project_name, local_engine
+    ):
+        local = tmp_path / "predictor.py"
+        local.write_text("# noop\n")
+
+        out = resolve_serving_file(
+            local_engine,
+            "my_dep",
+            str(local),
+            "script_file",
+            subdir="predictor",
+        )
+
+        assert out == (
+            f"/Projects/{project_name}/Deployments/"
+            f"my_dep/resources/predictor/predictor.py"
+        )
+        local_engine._upload.assert_called_once_with(
+            str(local),
+            "Deployments/my_dep/resources/predictor",
+            overwrite=True,
+        )
+        mkdir_calls = [c.args[0] for c in local_engine._mkdir.mock_calls]
+        assert mkdir_calls == [
+            "Deployments/my_dep",
+            "Deployments/my_dep/resources",
+            "Deployments/my_dep/resources/predictor",
+        ]
+
+    def test_relative_local_file_uploaded(
+        self, tmp_path, project_name, local_engine, monkeypatch
+    ):
+        # `./predictor.py` from a non-HopsFS cwd → joined with cwd, uploaded.
+        local = tmp_path / "predictor.py"
+        local.write_text("# noop\n")
+        monkeypatch.chdir(tmp_path)
+
+        out = resolve_serving_file(
+            local_engine,
+            "my_dep",
+            "./predictor.py",
+            "script_file",
+            subdir="predictor",
+        )
+
+        assert out.endswith("/my_dep/resources/predictor/predictor.py")
+        local_engine._upload.assert_called_once()
+
+    def test_relative_path_from_hopsfs_cwd_skips_upload(
+        self, project_name, local_engine, mocker
+    ):
+        # User in a Jobs/Jupyter pod with cwd under /hopsfs/Resources/.
+        # `./foo.py` joined with cwd lands on a FUSE mount → no upload.
+        mocker.patch("os.getcwd", return_value="/hopsfs/Resources")
+        mocker.patch("os.path.exists", return_value=True)
+
+        out = resolve_serving_file(
+            local_engine,
+            "my_dep",
+            "./foo.py",
+            "script_file",
+            subdir="predictor",
+        )
+
+        assert out == f"/Projects/{project_name}/Resources/foo.py"
+        local_engine._upload.assert_not_called()
+
+    def test_hopsfs_fuse_mount_path_passthrough(
+        self, project_name, local_engine, mocker
+    ):
+        # Absolute /hopsfs/<rest> on disk → no upload, normalized to
+        # /Projects/<p>/<rest>.
+        mocker.patch("os.path.exists", return_value=True)
+
+        out = resolve_serving_file(
+            local_engine,
+            "my_dep",
+            "/hopsfs/Resources/foo.py",
+            "script_file",
+            subdir="predictor",
+        )
+
+        assert out == f"/Projects/{project_name}/Resources/foo.py"
+        local_engine._upload.assert_not_called()
+
+    def test_mnt_hopsfs_cluster_mount_passthrough(
+        self, project_name, local_engine, mocker
+    ):
+        # Absolute /mnt/hopsfs/<project>/<rest> on disk → no upload.
+        mocker.patch("os.path.exists", return_value=True)
+
+        out = resolve_serving_file(
+            local_engine,
+            "my_dep",
+            "/mnt/hopsfs/myproject/Resources/foo.py",
+            "script_file",
+            subdir="predictor",
+        )
+
+        assert out == f"/Projects/{project_name}/Resources/foo.py"
+        local_engine._upload.assert_not_called()
+
+    def test_absolute_hopsfs_path_passthrough(
+        self, project_name, local_engine
+    ):
+        # /Projects/<p>/... that exists in HopsFS → return as-is, no upload.
+        # `os.path.exists` is False (no FUSE mount), so step 3 runs.
+        local_engine._dataset_api.exists.return_value = True
+
+        out = resolve_serving_file(
+            local_engine,
+            "my_dep",
+            f"/Projects/{project_name}/Resources/foo.py",
+            "script_file",
+            subdir="predictor",
+        )
+
+        assert out == f"/Projects/{project_name}/Resources/foo.py"
+        local_engine._upload.assert_not_called()
+
+    def test_project_relative_hopsfs_path_expanded(
+        self, project_name, local_engine
+    ):
+        # The form returned by `dataset_api.upload("file.py", "Resources")`.
+        local_engine._dataset_api.exists.return_value = True
+
+        out = resolve_serving_file(
+            local_engine,
+            "my_dep",
+            "Resources/foo.py",
+            "script_file",
+            subdir="predictor",
+        )
+
+        assert out == f"/Projects/{project_name}/Resources/foo.py"
+        local_engine._upload.assert_not_called()
+
+    def test_hdfs_uri_stripped_to_absolute(
+        self, project_name, local_engine
+    ):
+        local_engine._dataset_api.exists.return_value = True
+
+        out = resolve_serving_file(
+            local_engine,
+            "my_dep",
+            f"hdfs://namenode:8020/Projects/{project_name}/Resources/foo.py",
+            "script_file",
+            subdir="predictor",
+        )
+
+        assert out == f"/Projects/{project_name}/Resources/foo.py"
+        local_engine._upload.assert_not_called()
+
+    def test_missing_path_raises(self, project_name, local_engine):
+        # Not on disk; HopsFS says it doesn't exist either. Default fixture
+        # has `_dataset_api.exists.return_value = False`.
+        with pytest.raises(ValueError, match="Could not find script_file"):
+            resolve_serving_file(
+                local_engine,
+                "my_dep",
+                "./does_not_exist.py",
+                "script_file",
+                subdir="predictor",
+            )
+        local_engine._upload.assert_not_called()
+
+    def test_local_uploads_to_role_subdir(
+        self, tmp_path, project_name, local_engine
+    ):
+        # Predictor and transformer with the same basename land in
+        # different subdirs.
+        f = tmp_path / "script.py"
+        f.write_text("# noop\n")
+
+        predictor_out = resolve_serving_file(
+            local_engine, "dep", str(f), "script_file", subdir="predictor"
+        )
+        transformer_out = resolve_serving_file(
+            local_engine,
+            "dep",
+            str(f),
+            "transformer.script_file",
+            subdir="transformer",
+        )
+
+        assert predictor_out.endswith(
+            "/Deployments/dep/resources/predictor/script.py"
+        )
+        assert transformer_out.endswith(
+            "/Deployments/dep/resources/transformer/script.py"
+        )
+
+    def test_overwrite_false_propagated(
+        self, tmp_path, project_name, local_engine
+    ):
+        local = tmp_path / "predictor.py"
+        local.write_text("# noop\n")
+
+        resolve_serving_file(
+            local_engine,
+            "my_dep",
+            str(local),
+            "script_file",
+            subdir="predictor",
+            overwrite=False,
+        )
+
+        local_engine._upload.assert_called_once_with(
+            str(local),
+            "Deployments/my_dep/resources/predictor",
+            overwrite=False,
+        )

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -549,7 +549,7 @@ class TestModel:
 
 
 class TestModelEngine:
-    # Note: `normalize_hopsfs_mount_path` itself is exercised in
+    # Note: `_normalize_hopsfs_mount_path` itself is exercised in
     # `tests/test_local_paths.py` since it now lives in `hsml.utils.local_paths`
     # and is shared between the model and serving engines.
 

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -549,69 +549,9 @@ class TestModel:
 
 
 class TestModelEngine:
-    @pytest.mark.parametrize(
-        "model_path,expected_hdfs_path",
-        [
-            # /hopsfs/ is the per-project mount: strip the prefix to get a
-            # project-relative dataset path.
-            (
-                "/hopsfs/Models/model.pkl",
-                "Models/model.pkl",
-            ),
-            # /mnt/hopsfs/ is the cluster-wide mount rooted at /Projects/, so
-            # the path is /mnt/hopsfs/<projectName>/<rest>. Strip both segments.
-            (
-                "/mnt/hopsfs/demo/Models/model.pkl",
-                "Models/model.pkl",
-            ),
-            # The actual failing case from the loadtest run on 2026-05-09.
-            (
-                "/mnt/hopsfs/demo/Resources/workflows/models/tensorflow",
-                "Resources/workflows/models/tensorflow",
-            ),
-        ],
-    )
-    def test_normalize_hopsfs_mount_path(self, mocker, model_path, expected_hdfs_path):
-        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
-        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
-        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
-
-        engine = model_engine.ModelEngine()
-
-        assert engine._normalize_hopsfs_mount_path(model_path) == expected_hdfs_path
-
-    def test_normalize_hopsfs_mount_path_returns_none_for_local_path(self, mocker):
-        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
-        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
-        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
-
-        engine = model_engine.ModelEngine()
-
-        assert engine._normalize_hopsfs_mount_path("local/model.pkl") is None
-
-    @pytest.mark.parametrize(
-        "model_path,expected_hdfs_path",
-        [
-            (
-                "/hopsfs/Models/hopsfs/archive/model.pkl",
-                "Models/hopsfs/archive/model.pkl",
-            ),
-            (
-                "/mnt/hopsfs/demo/Models/mnt/hopsfs/archive/model.pkl",
-                "Models/mnt/hopsfs/archive/model.pkl",
-            ),
-        ],
-    )
-    def test_normalize_hopsfs_mount_path_strips_only_leading_prefix(
-        self, mocker, model_path, expected_hdfs_path
-    ):
-        mocker.patch("hsml.engine.model_engine.model_api.ModelApi")
-        mocker.patch("hsml.engine.model_engine.dataset_api.DatasetApi")
-        mocker.patch("hsml.engine.model_engine.local_engine.LocalEngine")
-
-        engine = model_engine.ModelEngine()
-
-        assert engine._normalize_hopsfs_mount_path(model_path) == expected_hdfs_path
+    # Note: `normalize_hopsfs_mount_path` itself is exercised in
+    # `tests/test_local_paths.py` since it now lives in `hsml.utils.local_paths`
+    # and is shared between the model and serving engines.
 
     @pytest.mark.parametrize(
         "model_path,expected_hdfs_path",

--- a/python/tests/test_serving_engine.py
+++ b/python/tests/test_serving_engine.py
@@ -74,12 +74,8 @@ class TestUploadLocalServingFiles:
 
         eng._upload_local_serving_files(deployment)
 
-        assert (
-            predictor.script_file == "hopsfs::script_file::./predictor.py"
-        )
-        assert (
-            predictor.config_file == "hopsfs::config_file::./vllm.yaml"
-        )
+        assert predictor.script_file == "hopsfs::script_file::./predictor.py"
+        assert predictor.config_file == "hopsfs::config_file::./vllm.yaml"
         assert (
             predictor.transformer.script_file
             == "hopsfs::transformer.script_file::./transformer.py"
@@ -122,9 +118,7 @@ class TestUploadLocalServingFiles:
             side_effect=lambda engine, name, p, **kw: p,
         )
 
-        predictor = _FakePredictor(
-            script_file=None, config_file=None, transformer=None
-        )
+        predictor = _FakePredictor(script_file=None, config_file=None, transformer=None)
         deployment = _FakeDeployment(predictor, name="my_dep")
 
         eng._upload_local_serving_files(deployment)
@@ -206,9 +200,7 @@ class TestSave:
         eng._create.assert_called_once_with(deployment)
         eng._update.assert_not_called()
 
-    def test_upload_runs_and_update_called_for_existing_deployment(
-        self, mocker
-    ):
+    def test_upload_runs_and_update_called_for_existing_deployment(self, mocker):
         eng = self._engine(mocker)
         mock_upload = mocker.patch.object(eng, "_upload_local_serving_files")
 

--- a/python/tests/test_serving_engine.py
+++ b/python/tests/test_serving_engine.py
@@ -40,7 +40,7 @@ class TestUploadLocalServingFiles:
     """Tests for ServingEngine._upload_local_serving_files.
 
     The actual upload + path-rewrite logic lives in
-    `hsml.util.local_paths.resolve_serving_file` (covered by
+    `hsml.utils.local_paths._resolve_serving_file` (covered by
     test_local_paths.py). These tests focus on the engine wiring: that all
     three fields are processed, that the rewritten paths land back on the
     in-memory predictor/transformer, and that the transformer is skipped when
@@ -59,7 +59,7 @@ class TestUploadLocalServingFiles:
         # was passed in.
         mocker.patch.object(
             serving_engine,
-            "resolve_serving_file",
+            "_resolve_serving_file",
             side_effect=lambda engine, name, p, **kw: (
                 None if p is None else f"hopsfs::{kw['field_name']}::{p}"
             ),
@@ -87,7 +87,7 @@ class TestUploadLocalServingFiles:
         eng = self._engine(mocker)
         mock_resolve = mocker.patch.object(
             serving_engine,
-            "resolve_serving_file",
+            "_resolve_serving_file",
             side_effect=lambda engine, name, p, **kw: p,
         )
 
@@ -114,7 +114,7 @@ class TestUploadLocalServingFiles:
         eng = self._engine(mocker)
         mocker.patch.object(
             serving_engine,
-            "resolve_serving_file",
+            "_resolve_serving_file",
             side_effect=lambda engine, name, p, **kw: p,
         )
 
@@ -131,7 +131,7 @@ class TestUploadLocalServingFiles:
         eng = self._engine(mocker)
         mock_resolve = mocker.patch.object(
             serving_engine,
-            "resolve_serving_file",
+            "_resolve_serving_file",
             side_effect=lambda engine, name, p, **kw: p,
         )
 
@@ -155,7 +155,7 @@ class TestUploadLocalServingFiles:
         eng = self._engine(mocker)
         mock_resolve = mocker.patch.object(
             serving_engine,
-            "resolve_serving_file",
+            "_resolve_serving_file",
             side_effect=lambda engine, name, p, **kw: p,
         )
 

--- a/python/tests/test_serving_engine.py
+++ b/python/tests/test_serving_engine.py
@@ -180,8 +180,9 @@ class TestUploadLocalServingFiles:
 
 
 class TestSave:
-    """Tests for ServingEngine._save() — that save runs the upload pass
-    and then dispatches to create / update based on the deployment id.
+    """Tests for ServingEngine._save() method.
+
+    Tests for ServingEngine._save() - that save runs the upload pass and then dispatches to create / update based on the deployment id.
     """
 
     def _engine(self, mocker):

--- a/python/tests/test_serving_engine.py
+++ b/python/tests/test_serving_engine.py
@@ -1,0 +1,221 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hsml.engine import serving_engine
+
+
+class _FakePredictor:
+    def __init__(self, script_file=None, config_file=None, transformer=None):
+        self.script_file = script_file
+        self.config_file = config_file
+        self.transformer = transformer
+
+
+class _FakeTransformer:
+    def __init__(self, script_file=None):
+        self.script_file = script_file
+
+
+class _FakeDeployment:
+    def __init__(self, predictor, name, id=None):
+        self._predictor = predictor
+        self.name = name
+        self.id = id
+
+
+class TestUploadLocalServingFiles:
+    """Tests for ServingEngine._upload_local_serving_files.
+
+    The actual upload + path-rewrite logic lives in
+    `hsml.util.local_paths.resolve_serving_file` (covered by
+    test_local_paths.py). These tests focus on the engine wiring: that all
+    three fields are processed, that the rewritten paths land back on the
+    in-memory predictor/transformer, and that the transformer is skipped when
+    absent.
+    """
+
+    def _engine(self, mocker):
+        # Skip ServingApi/DatasetApi setup; we only need _engine attribute.
+        eng = serving_engine.ServingEngine.__new__(serving_engine.ServingEngine)
+        eng._engine = mocker.Mock()
+        return eng
+
+    def test_rewrites_all_three_fields(self, mocker):
+        eng = self._engine(mocker)
+        # Mock the resolver to echo back a sentinel so we can see which path
+        # was passed in.
+        mocker.patch.object(
+            serving_engine,
+            "resolve_serving_file",
+            side_effect=lambda engine, name, p, **kw: (
+                None if p is None else f"hopsfs::{kw['field_name']}::{p}"
+            ),
+        )
+
+        predictor = _FakePredictor(
+            script_file="./predictor.py",
+            config_file="./vllm.yaml",
+            transformer=_FakeTransformer(script_file="./transformer.py"),
+        )
+        deployment = _FakeDeployment(predictor, name="my_dep")
+
+        eng._upload_local_serving_files(deployment)
+
+        assert (
+            predictor.script_file == "hopsfs::script_file::./predictor.py"
+        )
+        assert (
+            predictor.config_file == "hopsfs::config_file::./vllm.yaml"
+        )
+        assert (
+            predictor.transformer.script_file
+            == "hopsfs::transformer.script_file::./transformer.py"
+        )
+
+    def test_each_field_uploads_to_its_own_subdir(self, mocker):
+        # Per-role subdirs prevent basename collisions when predictor and
+        # transformer scripts share the same filename.
+        eng = self._engine(mocker)
+        mock_resolve = mocker.patch.object(
+            serving_engine,
+            "resolve_serving_file",
+            side_effect=lambda engine, name, p, **kw: p,
+        )
+
+        predictor = _FakePredictor(
+            script_file="./p.py",
+            config_file="./c.yaml",
+            transformer=_FakeTransformer(script_file="./t.py"),
+        )
+        deployment = _FakeDeployment(predictor, name="my_dep")
+
+        eng._upload_local_serving_files(deployment)
+
+        subdirs = {
+            call.kwargs["field_name"]: call.kwargs["subdir"]
+            for call in mock_resolve.mock_calls
+        }
+        assert subdirs == {
+            "script_file": "predictor",
+            "config_file": "config",
+            "transformer.script_file": "transformer",
+        }
+
+    def test_none_paths_remain_none(self, mocker):
+        eng = self._engine(mocker)
+        mocker.patch.object(
+            serving_engine,
+            "resolve_serving_file",
+            side_effect=lambda engine, name, p, **kw: p,
+        )
+
+        predictor = _FakePredictor(
+            script_file=None, config_file=None, transformer=None
+        )
+        deployment = _FakeDeployment(predictor, name="my_dep")
+
+        eng._upload_local_serving_files(deployment)
+
+        assert predictor.script_file is None
+        assert predictor.config_file is None
+        assert predictor.transformer is None
+
+    def test_no_transformer_skipped(self, mocker):
+        eng = self._engine(mocker)
+        mock_resolve = mocker.patch.object(
+            serving_engine,
+            "resolve_serving_file",
+            side_effect=lambda engine, name, p, **kw: p,
+        )
+
+        predictor = _FakePredictor(
+            script_file="/Projects/x/y.py",
+            config_file=None,
+            transformer=None,
+        )
+        deployment = _FakeDeployment(predictor, name="my_dep")
+
+        eng._upload_local_serving_files(deployment)
+
+        # Only the predictor's two fields were processed, not the transformer.
+        assert mock_resolve.call_count == 2
+        fields = [call.kwargs["field_name"] for call in mock_resolve.mock_calls]
+        assert "script_file" in fields
+        assert "config_file" in fields
+        assert "transformer.script_file" not in fields
+
+    def test_passes_deployment_name_and_engine(self, mocker):
+        eng = self._engine(mocker)
+        mock_resolve = mocker.patch.object(
+            serving_engine,
+            "resolve_serving_file",
+            side_effect=lambda engine, name, p, **kw: p,
+        )
+
+        predictor = _FakePredictor(
+            script_file="./p.py",
+            config_file=None,
+            transformer=_FakeTransformer(script_file="./t.py"),
+        )
+        deployment = _FakeDeployment(predictor, name="my_dep_123")
+
+        eng._upload_local_serving_files(deployment)
+
+        for call in mock_resolve.mock_calls:
+            assert call.args[0] is eng._engine  # the LocalEngine
+            assert call.args[1] == "my_dep_123"  # deployment_name
+
+
+class TestSave:
+    """Tests for ServingEngine._save() — that save runs the upload pass
+    and then dispatches to create / update based on the deployment id.
+    """
+
+    def _engine(self, mocker):
+        eng = serving_engine.ServingEngine.__new__(serving_engine.ServingEngine)
+        eng._engine = mocker.Mock()
+        eng._serving_api = mocker.Mock()
+        eng._update = mocker.Mock()
+        eng._create = mocker.Mock()
+        return eng
+
+    def test_upload_runs_and_create_called_for_new_deployment(self, mocker):
+        eng = self._engine(mocker)
+        mock_upload = mocker.patch.object(eng, "_upload_local_serving_files")
+
+        predictor = _FakePredictor(script_file="./p.py")
+        deployment = _FakeDeployment(predictor, name="dep", id=None)
+
+        eng._save(deployment, await_update=0)
+
+        mock_upload.assert_called_once_with(deployment)
+        eng._create.assert_called_once_with(deployment)
+        eng._update.assert_not_called()
+
+    def test_upload_runs_and_update_called_for_existing_deployment(
+        self, mocker
+    ):
+        eng = self._engine(mocker)
+        mock_upload = mocker.patch.object(eng, "_upload_local_serving_files")
+
+        predictor = _FakePredictor(script_file="./p.py")
+        deployment = _FakeDeployment(predictor, name="dep", id=7)
+
+        eng._save(deployment, await_update=0)
+
+        mock_upload.assert_called_once_with(deployment)
+        eng._update.assert_called_once_with(deployment, 0)
+        eng._create.assert_not_called()


### PR DESCRIPTION
Accept local file paths for `script_file` / `config_file` on `Predictor`, `Transformer`, `Model.deploy()`,
`ModelServing.create_predictor()` / `create_transformer()` / `create_endpoint()`. When the user passes a local path, the SDK uploads the file to `/Projects/<project>/Deployments/<deployment_name>/resources/<role>/<basename>` on save and rewrites the in-memory field to the resulting HopsFS path before talking to the backend. Existing HopsFS paths and project- relative paths (e.g. the value returned by `dataset_api.upload`) still work unchanged.

Path classification rules (in priority):
1. None or absolute HopsFS prefix (`/Projects/`, `/hopsfs/`, `hdfs://`, `hopsfs://`) → pass through.
2. `realpath()` lands under a HopsFS prefix → pass through (handles the `/hopsfs/` FUSE mount + symlinks into HopsFS).
3. Local file on disk → upload, return HopsFS path.
4. Project-relative HopsFS-shaped path (e.g. `Resources/foo.py`) → expand to `/Projects/<p>/<path>`, no upload.
5. Else → ValueError with both interpretations.

Extension restriction: predictor `.py`; transformer `.py` / `.ipynb`; config_file `.yaml` / `.yml` (matches the backend's vLLM contract).

Stash mechanism: the original local source is remembered on the predictor / transformer (`_local_source_<field>`, `_resolved_<field>`) so a same-session `dep.save()` after editing the local file re-uploads from the stashed source. Snapshot/restore preserves the tracking across `ServingApi.put()`'s `update_from_response_json` reinit.

State check: existing deployments validate against `STARTING / UPDATING / STOPPING` before touching HopsFS, so a doomed save can't overwrite remote files.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
