### PR TITLE
[FSTORE-2048] Improve monitoring on feature embeddings and model re-training automation

### DIFF
--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/metadata/FeatureDescriptiveStatistics.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/metadata/FeatureDescriptiveStatistics.java
@@ -138,6 +138,9 @@ public class FeatureDescriptiveStatistics extends RestDto<FeatureDescriptiveStat
     if (statsJson.has("unique_values")) {
       extendedStatistics.put("unique_values", statsJson.getJSONArray("unique_values"));
     }
+    if (statsJson.has("embedding")) {
+      extendedStatistics.put("embedding", statsJson.getJSONObject("embedding"));
+    }
     if (extendedStatistics.length() > 0) {
       fds.setExtendedStatistics(extendedStatistics.toString());
     }

--- a/java/hsfs/src/test/java/com/logicalclocks/hsfs/metadata/TestFeatureDescriptiveStatistics.java
+++ b/java/hsfs/src/test/java/com/logicalclocks/hsfs/metadata/TestFeatureDescriptiveStatistics.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2024. Hopsworks AB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+package com.logicalclocks.hsfs.metadata;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestFeatureDescriptiveStatistics {
+
+  @Test
+  public void testFromDeequStatisticsJsonPreservesEmbedding() {
+    // Arrange: a profiler column-stats JSON for an embedding/vector feature
+    JSONObject kll = new JSONObject();
+    kll.put("kllFormat", "datasketches-native-v1");
+    kll.put("bytes", "AQIDBA==");
+    kll.put("buckets", new JSONArray().put(new JSONObject().put("count", 3)));
+
+    JSONObject norm = new JSONObject();
+    norm.put("histogram", new JSONArray().put(1).put(2).put(3));
+    norm.put("kll", kll);
+
+    JSONObject embedding = new JSONObject();
+    embedding.put("dimension", 4);
+    embedding.put("count", 100L);
+    embedding.put("norm", norm);
+    embedding.put("centroid", new JSONArray().put(0.1).put(0.2).put(0.3).put(0.4));
+
+    JSONObject statsJson = new JSONObject();
+    statsJson.put("column", "embedding_feature");
+    statsJson.put("dataType", "Embedding");
+    statsJson.put("count", 100L);
+    statsJson.put("numRecordsNull", 0);
+    statsJson.put("numRecordsNonNull", 100);
+    statsJson.put("embedding", embedding);
+
+    // Act
+    FeatureDescriptiveStatistics fds = FeatureDescriptiveStatistics.fromDeequStatisticsJson(statsJson);
+
+    // Assert: the Embedding data type is preserved, not coerced or dropped
+    Assertions.assertEquals("Embedding", fds.getFeatureType());
+    Assertions.assertEquals("embedding_feature", fds.getFeatureName());
+
+    // Assert: the embedding block round-trips into extendedStatistics
+    Assertions.assertNotNull(fds.getExtendedStatistics());
+    JSONObject extended = new JSONObject(fds.getExtendedStatistics());
+    Assertions.assertTrue(extended.has("embedding"));
+
+    JSONObject parsedEmbedding = extended.getJSONObject("embedding");
+    Assertions.assertEquals(4, parsedEmbedding.getInt("dimension"));
+    Assertions.assertEquals(100L, parsedEmbedding.getLong("count"));
+    Assertions.assertEquals(4, parsedEmbedding.getJSONArray("centroid").length());
+
+    // Assert: the nested norm.kll block is preserved
+    JSONObject parsedNorm = parsedEmbedding.getJSONObject("norm");
+    Assertions.assertEquals(3, parsedNorm.getJSONArray("histogram").length());
+    JSONObject parsedKll = parsedNorm.getJSONObject("kll");
+    Assertions.assertEquals("datasketches-native-v1", parsedKll.getString("kllFormat"));
+    Assertions.assertEquals("AQIDBA==", parsedKll.getString("bytes"));
+    Assertions.assertEquals(1, parsedKll.getJSONArray("buckets").length());
+  }
+
+  @Test
+  public void testFromDeequStatisticsJsonWithoutEmbedding() {
+    // Arrange: a numerical feature with no embedding key
+    JSONObject statsJson = new JSONObject();
+    statsJson.put("column", "numeric_feature");
+    statsJson.put("dataType", "Fractional");
+    statsJson.put("count", 10L);
+    statsJson.put("mean", 5.0);
+
+    // Act
+    FeatureDescriptiveStatistics fds = FeatureDescriptiveStatistics.fromDeequStatisticsJson(statsJson);
+
+    // Assert: no extendedStatistics is produced when only base fields are present
+    Assertions.assertNull(fds.getExtendedStatistics());
+    Assertions.assertEquals(5.0, fds.getMean());
+  }
+}

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfile.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfile.java
@@ -51,6 +51,8 @@ class ColumnProfile {
   private final byte[] kllBytes;
   private final double[] approxPercentiles;
 
+  private final EmbeddingStats embedding;
+
   private ColumnProfile(Builder builder) {
     this.columnName = builder.columnName;
     this.dataType = builder.dataType;
@@ -71,10 +73,15 @@ class ColumnProfile {
     this.histogram = builder.histogram;
     this.kllBytes = builder.kllBytes;
     this.approxPercentiles = builder.approxPercentiles;
+    this.embedding = builder.embedding;
   }
 
   boolean isNumeric() {
     return "Fractional".equals(dataType) || "Integral".equals(dataType);
+  }
+
+  boolean isEmbedding() {
+    return "Embedding".equals(dataType);
   }
 
   String getColumnName() {
@@ -153,6 +160,10 @@ class ColumnProfile {
     return approxPercentiles;
   }
 
+  EmbeddingStats getEmbedding() {
+    return embedding;
+  }
+
   static final class Builder {
 
     private String columnName;
@@ -174,6 +185,7 @@ class ColumnProfile {
     private List<Map<String, Object>> histogram;
     private byte[] kllBytes;
     private double[] approxPercentiles;
+    private EmbeddingStats embedding;
 
     Builder columnName(String value) {
       this.columnName = value;
@@ -270,8 +282,136 @@ class ColumnProfile {
       return this;
     }
 
+    Builder embedding(EmbeddingStats value) {
+      this.embedding = value;
+      return this;
+    }
+
     ColumnProfile build() {
       return new ColumnProfile(this);
+    }
+  }
+
+  /**
+   * Statistics for an embedding (numeric-array) column.
+   *
+   * <p>Carries the embedding dimension, the count of rows with a valid vector, the per-row
+   * L2-norm distribution (reusing the scalar numeric histogram + KLL machinery), and the
+   * element-wise mean (centroid). Consumed by {@link ProfileJsonSerializer} to emit the
+   * {@code embedding} key.
+   *
+   * <p>The norm fields ({@code normMin}, {@code normMax}, {@code normNonNull}) feed
+   * {@link ProfileJsonSerializer#buildKllMap} exactly as the scalar numeric path does, so the
+   * emitted {@code embedding.norm.kll} shape is identical to a scalar column's {@code kll}.
+   */
+  static final class EmbeddingStats {
+
+    private final int dimension;
+    private final long validCount;
+    private final List<Map<String, Object>> normHistogram;
+    private final byte[] normKllBytes;
+    private final double normMin;
+    private final double normMax;
+    private final long normNonNull;
+    private final double[] centroid;
+
+    private EmbeddingStats(Builder builder) {
+      this.dimension = builder.dimension;
+      this.validCount = builder.validCount;
+      this.normHistogram = builder.normHistogram;
+      this.normKllBytes = builder.normKllBytes;
+      this.normMin = builder.normMin;
+      this.normMax = builder.normMax;
+      this.normNonNull = builder.normNonNull;
+      this.centroid = builder.centroid;
+    }
+
+    int getDimension() {
+      return dimension;
+    }
+
+    long getValidCount() {
+      return validCount;
+    }
+
+    List<Map<String, Object>> getNormHistogram() {
+      return normHistogram;
+    }
+
+    byte[] getNormKllBytes() {
+      return normKllBytes;
+    }
+
+    double getNormMin() {
+      return normMin;
+    }
+
+    double getNormMax() {
+      return normMax;
+    }
+
+    long getNormNonNull() {
+      return normNonNull;
+    }
+
+    double[] getCentroid() {
+      return centroid;
+    }
+
+    static final class Builder {
+
+      private int dimension;
+      private long validCount;
+      private List<Map<String, Object>> normHistogram;
+      private byte[] normKllBytes;
+      private double normMin;
+      private double normMax;
+      private long normNonNull;
+      private double[] centroid;
+
+      Builder dimension(int value) {
+        this.dimension = value;
+        return this;
+      }
+
+      Builder validCount(long value) {
+        this.validCount = value;
+        return this;
+      }
+
+      Builder normHistogram(List<Map<String, Object>> value) {
+        this.normHistogram = value;
+        return this;
+      }
+
+      Builder normKllBytes(byte[] value) {
+        this.normKllBytes = value;
+        return this;
+      }
+
+      Builder normMin(double value) {
+        this.normMin = value;
+        return this;
+      }
+
+      Builder normMax(double value) {
+        this.normMax = value;
+        return this;
+      }
+
+      Builder normNonNull(long value) {
+        this.normNonNull = value;
+        return this;
+      }
+
+      Builder centroid(double[] value) {
+        this.centroid = value;
+        return this;
+      }
+
+      EmbeddingStats build() {
+        return new EmbeddingStats(this);
+      }
     }
   }
 }

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -23,6 +23,7 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.BooleanType;
 import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
@@ -71,6 +72,41 @@ import java.util.Map;
  *
  * <p>Uses Spark's {@code stddev_pop()} (population standard deviation, dividing by n). Deequ's
  * StandardDeviation metric also uses population stddev — verified against the baseline.
+ *
+ * <h3>Embedding (numeric-array) columns</h3>
+ *
+ * <p>Columns of type {@code array<T>} where {@code T} is numeric (Float/Double/Decimal/Integer/
+ * Long/Short/Byte) are profiled as {@code dataType="Embedding"}. Non-numeric-element arrays
+ * (e.g. {@code array<string>}) remain unsupported and are skipped with the existing warn.
+ *
+ * <p>An embedding column carries the standard count/completeness/null fields (computed over the
+ * array column itself, so a null array row counts as null exactly like a scalar null), plus an
+ * {@code embedding} block holding:
+ * <ul>
+ *   <li>{@code dimension} — the modal (most common) valid vector length;</li>
+ *   <li>{@code count} — rows with a valid vector (non-null, non-empty, length == dimension,
+ *       and free of null/NaN/infinite elements);</li>
+ *   <li>{@code norm} — the distribution of the per-row L2 norm {@code sqrt(sum(x_i^2))} over
+ *       valid rows, computed via the scalar numeric histogram + KLL path on the derived norm
+ *       series (so {@code embedding.norm.kll} matches a scalar column's {@code kll} shape);</li>
+ *   <li>{@code centroid} — the element-wise mean vector over valid rows, length == dimension.</li>
+ * </ul>
+ *
+ * <h3>Embedding row-validity rules</h3>
+ *
+ * <ul>
+ *   <li><b>null array</b>: excluded from the norm series and centroid; counted as null in the
+ *       standard null/completeness fields (consistent with scalar null handling).</li>
+ *   <li><b>empty array {@code []}</b>: skipped — contributes to neither norm, centroid, nor the
+ *       embedding {@code count}.</li>
+ *   <li><b>null, NaN or infinite element</b>: the whole row is dropped from the norm series and
+ *       centroid (we never feed NaN or an infinite norm to the KLL sketch). A vector with any
+ *       invalid element is not counted.</li>
+ *   <li><b>ragged length</b>: {@code dimension} is the modal valid length across rows; any row
+ *       whose length differs from {@code dimension} is skipped, and a single WARN is emitted.</li>
+ *   <li><b>all rows invalid</b>: the {@code embedding} block is still emitted with
+ *       {@code count=0}, an empty {@code centroid}, and no {@code norm.kll}.</li>
+ * </ul>
  */
 public class ColumnProfiler {
 
@@ -161,12 +197,8 @@ public class ColumnProfiler {
   }
 
   private String inferProfileType(DataType dt) {
-    if (dt instanceof IntegerType || dt instanceof LongType
-        || dt instanceof ShortType || dt instanceof ByteType) {
-      return "Integral";
-    }
-    if (dt instanceof FloatType || dt instanceof DoubleType || dt instanceof DecimalType) {
-      return "Fractional";
+    if (isNumericType(dt)) {
+      return isIntegralType(dt) ? "Integral" : "Fractional";
     }
     if (dt instanceof StringType) {
       return "String";
@@ -174,7 +206,20 @@ public class ColumnProfiler {
     if (dt instanceof BooleanType) {
       return "Boolean";
     }
+    if (dt instanceof ArrayType && isNumericType(((ArrayType) dt).elementType())) {
+      return "Embedding";
+    }
     return null;
+  }
+
+  private boolean isNumericType(DataType dt) {
+    return isIntegralType(dt)
+        || dt instanceof FloatType || dt instanceof DoubleType || dt instanceof DecimalType;
+  }
+
+  private boolean isIntegralType(DataType dt) {
+    return dt instanceof IntegerType || dt instanceof LongType
+        || dt instanceof ShortType || dt instanceof ByteType;
   }
 
   // ---------------------------------------------------------------------------
@@ -216,6 +261,10 @@ public class ColumnProfiler {
   private Map<String, Double> computeEntropy(Dataset<Row> df, List<ColumnInfo> columns) {
     Map<String, Double> result = new LinkedHashMap<String, Double>();
     for (ColumnInfo col : columns) {
+      // Entropy over distinct vectors is not meaningful for embedding columns; skip them.
+      if (isEmbedding(col.profileType)) {
+        continue;
+      }
       result.put(col.name, computeColumnEntropy(df, col.name));
     }
     return result;
@@ -322,6 +371,8 @@ public class ColumnProfiler {
     if (isNumeric(col.profileType)) {
       buildNumericFields(df, col, aggRow, nonNull, correlationMap, histogram, histogramBins, kll,
           builder);
+    } else if (isEmbedding(col.profileType)) {
+      builder.embedding(buildEmbeddingStats(df, nn, histogram, histogramBins, kll));
     } else {
       if (histogram) {
         List<Map<String, Object>> hist = histogramBuilder.buildCategorical(
@@ -373,6 +424,143 @@ public class ColumnProfiler {
   }
 
   // ---------------------------------------------------------------------------
+  // Embedding (numeric-array) profiling
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds the embedding statistics for a numeric-array column.
+   *
+   * <p>Validity, norm and length are derived with Spark SQL higher-order functions
+   * ({@code size}, {@code exists}, {@code aggregate}) rather than a UDF. A row is valid when its
+   * vector is non-null, non-empty, free of null/NaN/infinite elements, and its length equals the
+   * modal length across all such rows ({@code dimension}). The per-row L2 norm of valid rows feeds
+   * the existing scalar numeric histogram + KLL path, and the centroid is the element-wise mean
+   * over valid rows.
+   *
+   * <p>See the class Javadoc for the full row-validity rules.
+   */
+  private ColumnProfile.EmbeddingStats buildEmbeddingStats(Dataset<Row> df, String columnName,
+      boolean histogram, int histogramBins, boolean kll) {
+    String quoted = "`" + columnName.replace("`", "``") + "`";
+
+    // wellFormed: non-null, non-empty, and every element non-null, non-NaN and finite. A
+    // well-formed vector still has to match the modal dimension to be counted as valid. An
+    // infinite element would yield an infinite L2 norm and poison the norm histogram/KLL, so
+    // such rows are dropped exactly like null/NaN-element rows.
+    Column wellFormed = functions.expr(
+        "(" + quoted + " IS NOT NULL) AND (size(" + quoted + ") > 0) AND "
+            + "(NOT exists(" + quoted + ", x -> x IS NULL OR isnan(CAST(x AS DOUBLE)) "
+            + "OR abs(CAST(x AS DOUBLE)) = double('inf')))");
+    Column lenExpr = functions.expr("size(" + quoted + ")");
+    // L2 norm = sqrt(sum(x_i^2)); aggregate over the array avoids a UDF and stays in the engine.
+    Column normExpr = functions.expr(
+        "sqrt(aggregate(" + quoted + ", CAST(0.0 AS DOUBLE), "
+            + "(acc, x) -> acc + CAST(x AS DOUBLE) * CAST(x AS DOUBLE)))");
+
+    Dataset<Row> wellFormedRows = df
+        .filter(wellFormed)
+        .select(lenExpr.alias("_len"), normExpr.alias("_norm"), functions.col(columnName));
+    wellFormedRows = wellFormedRows.persist();
+
+    try {
+      // Modal dimension: most common well-formed length (ties broken by smaller length).
+      List<Row> lengthCounts = wellFormedRows.groupBy("_len").count()
+          .orderBy(functions.desc("count"), functions.asc("_len"))
+          .collectAsList();
+
+      if (lengthCounts.isEmpty()) {
+        // All rows invalid (all null/empty/with bad elements): emit an empty embedding block.
+        return new ColumnProfile.EmbeddingStats.Builder()
+            .dimension(0)
+            .validCount(0L)
+            .centroid(new double[0])
+            .build();
+      }
+
+      int dimension = lengthCounts.get(0).getInt(0);
+      long validCount = lengthCounts.get(0).getLong(1);
+      long raggedCount = 0L;
+      for (Row row : lengthCounts) {
+        if (row.getInt(0) != dimension) {
+          raggedCount += row.getLong(1);
+        }
+      }
+      if (raggedCount > 0) {
+        LOG.warn("Embedding column '{}': {} row(s) skipped due to length != modal dimension {}",
+            columnName, raggedCount, dimension);
+      }
+
+      Dataset<Row> validRows = wellFormedRows.filter(functions.col("_len").equalTo(dimension));
+
+      ColumnProfile.EmbeddingStats.Builder builder = new ColumnProfile.EmbeddingStats.Builder()
+          .dimension(dimension)
+          .validCount(validCount);
+
+      buildNormStats(validRows, validCount, histogram, histogramBins, kll, builder);
+      builder.centroid(computeCentroid(validRows, columnName, dimension));
+
+      return builder.build();
+    } finally {
+      wellFormedRows.unpersist();
+    }
+  }
+
+  /**
+   * Runs the scalar numeric histogram + KLL path on the derived {@code _norm} column so the
+   * emitted {@code embedding.norm} block matches a scalar numeric column's shape.
+   */
+  private void buildNormStats(Dataset<Row> validRows, long validCount,
+      boolean histogram, int histogramBins, boolean kll,
+      ColumnProfile.EmbeddingStats.Builder builder) {
+    if (validCount == 0) {
+      return;
+    }
+
+    Row minMax = validRows.agg(
+        functions.min("_norm").alias("_min"),
+        functions.max("_norm").alias("_max")).first();
+    Double normMin = minMax.getAs("_min");
+    Double normMax = minMax.getAs("_max");
+    if (normMin == null || normMax == null) {
+      return;
+    }
+    builder.normMin(normMin).normMax(normMax).normNonNull(validCount);
+
+    if (histogram) {
+      List<Map<String, Object>> hist = histogramBuilder.buildNumeric(
+          validRows, "_norm", normMin, normMax, histogramBins, validCount);
+      builder.normHistogram(hist);
+    }
+
+    if (kll) {
+      builder.normKllBytes(computeKll(validRows, "_norm"));
+    }
+  }
+
+  /**
+   * Computes the element-wise mean vector (centroid) over the valid rows.
+   *
+   * <p>Uses {@code posexplode} to map each vector to {@code (pos, value)} rows, averages per
+   * position, and collects ordered by position into a dense {@code double[]} of length
+   * {@code dimension}.
+   */
+  private double[] computeCentroid(Dataset<Row> validRows, String columnName, int dimension) {
+    Dataset<Row> exploded = validRows
+        .select(functions.posexplode(functions.col(columnName)))
+        .groupBy(functions.col("pos"))
+        .agg(functions.avg(functions.col("col").cast("double")).alias("_avg"));
+
+    double[] centroid = new double[dimension];
+    for (Row row : exploded.collectAsList()) {
+      int pos = row.getInt(0);
+      if (pos >= 0 && pos < dimension) {
+        centroid[pos] = row.getDouble(1);
+      }
+    }
+    return centroid;
+  }
+
+  // ---------------------------------------------------------------------------
   // KLL per-column aggregation
   // ---------------------------------------------------------------------------
 
@@ -408,6 +596,10 @@ public class ColumnProfiler {
 
   private boolean isNumeric(String profileType) {
     return "Fractional".equals(profileType) || "Integral".equals(profileType);
+  }
+
+  private boolean isEmbedding(String profileType) {
+    return "Embedding".equals(profileType);
   }
 
   static final class ColumnInfo {

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -76,6 +76,8 @@ class ProfileJsonSerializer {
   private Map<String, Object> toMap(ColumnProfile profile) {
     if (profile.isNumeric()) {
       return toNumericMap(profile);
+    } else if (profile.isEmbedding()) {
+      return toEmbeddingMap(profile);
     } else {
       return toCategoricalMap(profile);
     }
@@ -132,6 +134,62 @@ class ProfileJsonSerializer {
       map.put("histogram", profile.getHistogram());
     }
     return map;
+  }
+
+  /**
+   * Builds the JSON map for an embedding (numeric-array) column.
+   *
+   * <p>Emits the standard count/completeness/null fields (computed over the array column itself)
+   * plus an {@code embedding} block:
+   * <pre>{@code
+   *   "embedding": {
+   *     "dimension": <int>,
+   *     "count": <long>,
+   *     "norm": {
+   *       "histogram": [ {value, count, ratio}, ... ],   // when histogram=true
+   *       "kll": { "kllFormat":..., "bytes":..., "buckets":[...] }   // when kll=true
+   *     },
+   *     "centroid": [ <double>, ... ]
+   *   }
+   * }</pre>
+   *
+   * <p>The {@code norm.kll} map reuses {@link #buildKllMap} so its shape matches a scalar
+   * numeric column's {@code kll} exactly.
+   */
+  private Map<String, Object> toEmbeddingMap(ColumnProfile profile) {
+    Map<String, Object> map = new LinkedHashMap<String, Object>();
+    map.put("column", profile.getColumnName());
+    map.put("dataType", profile.getDataType());
+    map.put("isDataTypeInferred", "false");
+    map.put("completeness", profile.getCompleteness());
+    map.put("numRecordsNonNull", profile.getNumRecordsNonNull());
+    map.put("numRecordsNull", profile.getNumRecordsNull());
+    map.put("distinctness", profile.getDistinctness());
+    map.put("entropy", profile.getEntropy());
+    map.put("uniqueness", profile.getUniqueness());
+    map.put("approximateNumDistinctValues", profile.getApproximateNumDistinctValues());
+    map.put("exactNumDistinctValues", profile.getExactNumDistinctValues());
+
+    ColumnProfile.EmbeddingStats stats = profile.getEmbedding();
+    Map<String, Object> embedding = new LinkedHashMap<String, Object>();
+    embedding.put("dimension", stats.getDimension());
+    embedding.put("count", stats.getValidCount());
+    embedding.put("norm", buildNormMap(stats));
+    embedding.put("centroid", toDoubleList(stats.getCentroid()));
+    map.put("embedding", embedding);
+    return map;
+  }
+
+  private Map<String, Object> buildNormMap(ColumnProfile.EmbeddingStats stats) {
+    Map<String, Object> norm = new LinkedHashMap<String, Object>();
+    if (stats.getNormHistogram() != null) {
+      norm.put("histogram", stats.getNormHistogram());
+    }
+    if (stats.getNormKllBytes() != null) {
+      norm.put("kll", buildKllMap(stats.getNormKllBytes(), stats.getNormMin(),
+          stats.getNormMax(), stats.getNormNonNull()));
+    }
+    return norm;
   }
 
   private List<Map<String, Object>> buildCorrelationsList(Map<String, Double> correlations) {

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerEmbeddingTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerEmbeddingTest.java
@@ -1,0 +1,350 @@
+/*
+ *  Copyright (c) 2026. Hopsworks AB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.logicalclocks.hsfs.spark.engine.profile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.logicalclocks.hsfs.spark.engine.SparkEngine;
+import org.apache.datasketches.kll.KllDoublesSketch;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Structural test for embedding (numeric-array) profiling in {@link ColumnProfiler}.
+ *
+ * <p>Verifies the {@code embedding} JSON block (dimension, count, centroid, norm histogram/KLL),
+ * every documented row-validity edge case, and that non-embedding columns are unchanged.
+ */
+public class ColumnProfilerEmbeddingTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * Recreate a fresh SparkSession before every test.
+   *
+   * <p>The Spark test suite shares a single JVM-wide SparkContext. Other test classes
+   * (e.g. {@code TestStorageConnector}) register credential files via
+   * {@code SparkContext.addFile()} from JUnit {@code @TempDir} paths that JUnit deletes
+   * once those tests finish. Spark has no {@code removeFile}, so the stale registrations
+   * linger on the shared context; the first profiler test to run a real Spark job then
+   * fails in {@code Executor.updateDependencies} when it re-fetches the now-missing files.
+   * Starting each test from a clean SparkContext keeps these tests independent of that state.
+   */
+  @BeforeEach
+  void recreateSparkSession() {
+    if (SparkSession.getDefaultSession().isDefined()) {
+      SparkSession.getDefaultSession().get().stop();
+    }
+    SparkSession.clearActiveSession();
+    SparkSession.clearDefaultSession();
+    SparkEngine.setInstance(null);
+  }
+
+  // -------------------------------------------------------------------------
+  // Embedding block shape + edge cases
+  // -------------------------------------------------------------------------
+
+  @Test
+  void embeddingBlockShapeAndEdgeCases() throws Exception {
+    Dataset<Row> df = buildEmbeddingDataset();
+
+    // correlation=true, histogram=true, bins=20, exactUniqueness=true, kll=true.
+    String json = new ColumnProfiler().profile(df, null, true, true, 20, true, true);
+    JsonNode columns = MAPPER.readTree(json).get("columns");
+
+    JsonNode emb = findColumn(columns, "emb");
+    Assertions.assertNotNull(emb, "emb column profile must be present");
+
+    // (a) top-level dataType is the stable "Embedding" string.
+    Assertions.assertEquals("Embedding", emb.get("dataType").asText());
+
+    // (b) standard count/completeness/null fields reflect the array column (1 null row of 7).
+    Assertions.assertEquals(7, emb.get("numRecordsNonNull").asLong() + emb.get("numRecordsNull").asLong());
+    Assertions.assertEquals(1, emb.get("numRecordsNull").asLong(),
+        "exactly one null array row");
+    Assertions.assertEquals(6, emb.get("numRecordsNonNull").asLong(),
+        "six non-null array rows (including empty/ragged/null-element)");
+
+    JsonNode embedding = emb.get("embedding");
+    Assertions.assertNotNull(embedding, "emb must carry an 'embedding' block");
+
+    // (c) dimension is the modal valid length (2): the [1,2,3] ragged row is dropped.
+    Assertions.assertEquals(2, embedding.get("dimension").asInt(),
+        "dimension must be the modal valid length");
+
+    // (d) count = rows with a fully valid vector of the modal length. The valid rows are
+    //     [3,4], [0,5], [6,8]. Null/empty/null-element/ragged rows are all excluded.
+    Assertions.assertEquals(3, embedding.get("count").asLong(),
+        "only three vectors are valid (correct length, no null/NaN elements)");
+
+    // (e) centroid is the element-wise mean over the three valid rows.
+    //     mean([3,0,6]) = 3.0 ; mean([4,5,8]) = 17/3.
+    JsonNode centroid = embedding.get("centroid");
+    Assertions.assertTrue(centroid.isArray(), "centroid must be an array");
+    Assertions.assertEquals(2, centroid.size(), "centroid length must equal dimension");
+    Assertions.assertEquals(3.0, centroid.get(0).asDouble(), 1e-9);
+    Assertions.assertEquals(17.0 / 3.0, centroid.get(1).asDouble(), 1e-9);
+
+    // (f) norm block: histogram has the same shape as the numeric histogram.
+    JsonNode norm = embedding.get("norm");
+    Assertions.assertNotNull(norm, "embedding must carry a 'norm' block");
+    JsonNode histogram = norm.get("histogram");
+    Assertions.assertNotNull(histogram, "norm.histogram must be present when histogram=true");
+    Assertions.assertEquals(20, histogram.size(), "norm histogram must have 20 bins");
+    long histCountSum = 0;
+    for (JsonNode entry : histogram) {
+      Assertions.assertTrue(entry.has("value"), "histogram entry must have 'value'");
+      Assertions.assertTrue(entry.has("count"), "histogram entry must have 'count'");
+      Assertions.assertTrue(entry.has("ratio"), "histogram entry must have 'ratio'");
+      histCountSum += entry.get("count").asLong();
+    }
+    Assertions.assertEquals(3, histCountSum, "norm histogram counts must sum to the valid count");
+
+    // (g) norm KLL has the same shape as a scalar column's kll, and its median is a valid norm.
+    //     Norms are {5, 5, 10}; the median is 5.0.
+    JsonNode kll = norm.get("kll");
+    Assertions.assertNotNull(kll, "norm.kll must be present when kll=true");
+    Assertions.assertEquals("datasketches-native-v1", kll.get("kllFormat").asText());
+    String base64 = kll.get("bytes").asText();
+    Assertions.assertFalse(base64.isEmpty(), "norm.kll.bytes must not be empty");
+    Assertions.assertNotNull(kll.get("buckets"), "norm.kll.buckets must be present");
+    KllDoublesSketch sketch = KllAggregator.heapify(Base64.getDecoder().decode(base64));
+    Assertions.assertEquals(5.0, sketch.getQuantile(0.5), 1e-9,
+        "KLL median of norms {5,5,10} must be 5.0");
+    Assertions.assertEquals(5.0, sketch.getMinItem(), 1e-9);
+    Assertions.assertEquals(10.0, sketch.getMaxItem(), 1e-9);
+  }
+
+  // -------------------------------------------------------------------------
+  // kll=false: norm block has histogram but no kll
+  // -------------------------------------------------------------------------
+
+  @Test
+  void embeddingNormOmitsKllWhenDisabled() throws Exception {
+    Dataset<Row> df = buildEmbeddingDataset();
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, true, false);
+    JsonNode columns = MAPPER.readTree(json).get("columns");
+    JsonNode norm = findColumn(columns, "emb").get("embedding").get("norm");
+
+    Assertions.assertNotNull(norm.get("histogram"), "norm.histogram present when histogram=true");
+    Assertions.assertNull(norm.get("kll"), "norm.kll absent when kll=false");
+  }
+
+  // -------------------------------------------------------------------------
+  // all-rows-invalid: count=0, empty centroid, no norm kll, no throw
+  // -------------------------------------------------------------------------
+
+  @Test
+  void allInvalidEmbeddingEmitsEmptyBlock() throws Exception {
+    StructType schema = new StructType(new StructField[]{
+        DataTypes.createStructField("emb",
+            DataTypes.createArrayType(DataTypes.DoubleType, true), true),
+    });
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create((Object) null));                       // null
+    rows.add(RowFactory.create((Object) new ArrayList<Double>()));    // empty
+    rows.add(RowFactory.create(Arrays.asList(1.0, null)));            // null element
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, true, true);
+    JsonNode embedding = findColumn(MAPPER.readTree(json).get("columns"), "emb").get("embedding");
+
+    Assertions.assertEquals(0, embedding.get("dimension").asInt());
+    Assertions.assertEquals(0, embedding.get("count").asLong());
+    Assertions.assertEquals(0, embedding.get("centroid").size(), "centroid must be empty");
+    Assertions.assertNull(embedding.get("norm").get("kll"), "no norm.kll when count=0");
+    Assertions.assertNull(embedding.get("norm").get("histogram"), "no norm.histogram when count=0");
+  }
+
+  // -------------------------------------------------------------------------
+  // NaN element drops the row (never fed to KLL)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void nanElementDropsRow() throws Exception {
+    StructType schema = new StructType(new StructField[]{
+        DataTypes.createStructField("emb",
+            DataTypes.createArrayType(DataTypes.DoubleType, true), true),
+    });
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(Arrays.asList(3.0, 4.0)));             // norm 5, valid
+    rows.add(RowFactory.create(Arrays.asList(Double.NaN, 1.0)));     // NaN element, dropped
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, true, true);
+    JsonNode embedding = findColumn(MAPPER.readTree(json).get("columns"), "emb").get("embedding");
+
+    Assertions.assertEquals(1, embedding.get("count").asLong(), "NaN-element row must be dropped");
+    Assertions.assertEquals(3.0, embedding.get("centroid").get(0).asDouble(), 1e-9);
+    Assertions.assertEquals(4.0, embedding.get("centroid").get(1).asDouble(), 1e-9);
+  }
+
+  // -------------------------------------------------------------------------
+  // Infinite element drops the row (never poisons the norm histogram/KLL)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void infiniteElementDropsRow() throws Exception {
+    StructType schema = new StructType(new StructField[]{
+        DataTypes.createStructField("emb",
+            DataTypes.createArrayType(DataTypes.DoubleType, true), true),
+    });
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(Arrays.asList(3.0, 4.0)));                          // norm 5, valid
+    rows.add(RowFactory.create(Arrays.asList(Double.POSITIVE_INFINITY, 1.0)));    // +Inf, dropped
+    rows.add(RowFactory.create(Arrays.asList(1.0, Double.NEGATIVE_INFINITY)));    // -Inf, dropped
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, true, true);
+    JsonNode embedding = findColumn(MAPPER.readTree(json).get("columns"), "emb").get("embedding");
+
+    // (a) only the finite [3,4] vector is counted; both infinite rows are excluded.
+    Assertions.assertEquals(1, embedding.get("count").asLong(),
+        "rows with an infinite element must be dropped");
+    Assertions.assertEquals(3.0, embedding.get("centroid").get(0).asDouble(), 1e-9);
+    Assertions.assertEquals(4.0, embedding.get("centroid").get(1).asDouble(), 1e-9);
+
+    // (b) the norm histogram and KLL stay finite (an infinite norm would poison both).
+    //     The histogram bin "value" is a string label ("5.00 to 5.25"), not a number,
+    //     so finiteness must be checked against the numeric KLL bucket boundaries
+    //     (low_value/high_value are real doubles) and the sketch min/max.
+    JsonNode norm = embedding.get("norm");
+    KllDoublesSketch sketch =
+        KllAggregator.heapify(Base64.getDecoder().decode(norm.get("kll").get("bytes").asText()));
+    JsonNode buckets = norm.get("kll").get("buckets");
+    Assertions.assertNotNull(buckets, "norm.kll.buckets must be present");
+    for (JsonNode bucket : buckets) {
+      Assertions.assertTrue(Double.isFinite(bucket.get("low_value").asDouble()),
+          "norm KLL bucket low_value must be finite");
+      Assertions.assertTrue(Double.isFinite(bucket.get("high_value").asDouble()),
+          "norm KLL bucket high_value must be finite");
+    }
+    // The only finite vector is [3,4] (norm 5); an infinite norm would push min/max to
+    // +/-Infinity, so asserting exact finite bounds fails the test if one leaked in.
+    Assertions.assertTrue(Double.isFinite(sketch.getMinItem()), "norm KLL min must be finite");
+    Assertions.assertTrue(Double.isFinite(sketch.getMaxItem()), "norm KLL max must be finite");
+    Assertions.assertEquals(5.0, sketch.getMinItem(), 1e-9);
+    Assertions.assertEquals(5.0, sketch.getMaxItem(), 1e-9);
+    Assertions.assertTrue(Double.isFinite(sketch.getQuantile(0.5)), "norm KLL median must be finite");
+  }
+
+  // -------------------------------------------------------------------------
+  // array<string> stays skipped; non-embedding columns are unchanged
+  // -------------------------------------------------------------------------
+
+  @Test
+  void nonNumericArraySkippedAndScalarsUnchanged() throws Exception {
+    StructType schema = new StructType(new StructField[]{
+        DataTypes.createStructField("c_double", DataTypes.DoubleType, true),
+        DataTypes.createStructField("tags",
+            DataTypes.createArrayType(DataTypes.StringType, true), true),
+    });
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(1.0, Arrays.asList("a", "b")));
+    rows.add(RowFactory.create(2.0, Arrays.asList("c")));
+    rows.add(RowFactory.create(3.0, null));
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, true, false);
+    JsonNode columns = MAPPER.readTree(json).get("columns");
+
+    // array<string> is unsupported: skipped entirely (one column profiled).
+    Assertions.assertEquals(1, columns.size(), "array<string> column must be skipped");
+    JsonNode cDouble = findColumn(columns, "c_double");
+    Assertions.assertNotNull(cDouble, "scalar column must still be profiled");
+
+    // Scalar profile is unchanged: numeric dataType, no embedding key, standard numeric fields.
+    Assertions.assertEquals("Fractional", cDouble.get("dataType").asText());
+    Assertions.assertNull(cDouble.get("embedding"), "scalar column must not carry an embedding block");
+    Assertions.assertEquals(2.0, cDouble.get("mean").asDouble(), 1e-9);
+    Assertions.assertEquals(1.0, cDouble.get("minimum").asDouble(), 1e-9);
+    Assertions.assertEquals(3.0, cDouble.get("maximum").asDouble(), 1e-9);
+  }
+
+  // -------------------------------------------------------------------------
+  // array<float> element type is supported too
+  // -------------------------------------------------------------------------
+
+  @Test
+  void arrayFloatIsSupported() throws Exception {
+    StructType schema = new StructType(new StructField[]{
+        DataTypes.createStructField("emb",
+            DataTypes.createArrayType(DataTypes.FloatType, true), true),
+    });
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(Arrays.asList(3.0f, 4.0f)));
+    rows.add(RowFactory.create(Arrays.asList(6.0f, 8.0f)));
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, true, true);
+    JsonNode embedding = findColumn(MAPPER.readTree(json).get("columns"), "emb").get("embedding");
+
+    Assertions.assertEquals(2, embedding.get("dimension").asInt());
+    Assertions.assertEquals(2, embedding.get("count").asLong());
+    // centroid = mean([3,6])=4.5 ; mean([4,8])=6.0
+    Assertions.assertEquals(4.5, embedding.get("centroid").get(0).asDouble(), 1e-6);
+    Assertions.assertEquals(6.0, embedding.get("centroid").get(1).asDouble(), 1e-6);
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Builds a single-column {@code array<double>} fixture exercising every validity case:
+   * valid vectors, a null row, an empty row, a null-element row, and a ragged-length row.
+   */
+  private Dataset<Row> buildEmbeddingDataset() {
+    StructType schema = new StructType(new StructField[]{
+        DataTypes.createStructField("emb",
+            DataTypes.createArrayType(DataTypes.DoubleType, true), true),
+    });
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(Arrays.asList(3.0, 4.0)));            // norm 5,  valid
+    rows.add(RowFactory.create(Arrays.asList(0.0, 5.0)));            // norm 5,  valid
+    rows.add(RowFactory.create(Arrays.asList(6.0, 8.0)));            // norm 10, valid
+    rows.add(RowFactory.create((Object) null));                     // null row
+    rows.add(RowFactory.create((Object) new ArrayList<Double>()));  // empty row
+    rows.add(RowFactory.create(Arrays.asList(1.0, null)));          // null element
+    rows.add(RowFactory.create(Arrays.asList(1.0, 2.0, 3.0)));      // ragged (len 3)
+    return SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+  }
+
+  private JsonNode findColumn(JsonNode columns, String name) {
+    for (JsonNode col : columns) {
+      if (name.equals(col.get("column").asText())) {
+        return col;
+      }
+    }
+    return null;
+  }
+}

--- a/python/hopsworks_common/core/opensearch.py
+++ b/python/hopsworks_common/core/opensearch.py
@@ -60,18 +60,42 @@ def _handle_opensearch_exception(func):
                 client_wrapper._refresh_opensearch_connection()
             return func(*args, **kw)
         except RequestError as e:
-            caused_by = e.info.get("error") and e.info["error"].get("caused_by")
-            if caused_by and caused_by["type"] == "illegal_argument_exception":
+            error = e.info.get("error") if isinstance(e.info, dict) else None
+            caused_by = error.get("caused_by") if isinstance(error, dict) else None
+            # The illegal_argument_exception that carries the vector-database validation
+            # reason (e.g. "[knn] requires k to be in the range (0, N]") can arrive either
+            # nested under caused_by (OpenSearch wraps it in a search_phase_execution_exception)
+            # or as the top-level error (other backends report it directly). Handle both so
+            # find_neighbors' max-k probe can parse the limit instead of re-raising.
+            illegal_argument = None
+            if (
+                isinstance(caused_by, dict)
+                and caused_by.get("type") == "illegal_argument_exception"
+            ):
+                illegal_argument = caused_by
+            elif (
+                isinstance(error, dict)
+                and error.get("type") == "illegal_argument_exception"
+            ):
+                illegal_argument = error
+            if illegal_argument:
+                reason = illegal_argument.get("reason", "")
                 client_wrapper = args[0] if args else None
                 if client_wrapper and isinstance(
                     client_wrapper, ProjectOpenSearchClient
                 ):
-                    raise client_wrapper._create_vector_database_exception(
-                        caused_by["reason"]
-                    ) from e
+                    vector_db_exception = (
+                        client_wrapper._create_vector_database_exception(reason)
+                    )
+                    # Only keep the classified exception for recognized validation
+                    # messages (k / result-window too large). For any other
+                    # illegal_argument, fall through so the original response payload
+                    # (e.info) is preserved for diagnosing malformed queries.
+                    if vector_db_exception.reason != VectorDatabaseException.OTHERS:
+                        raise vector_db_exception from e
                 raise VectorDatabaseException(
                     VectorDatabaseException.OTHERS,
-                    f"Error in Opensearch request: {caused_by['reason']}",
+                    f"Error in Opensearch request: {reason or e}",
                     e.info,
                 ) from e
             raise VectorDatabaseException(

--- a/python/hsfs/core/distribution_engine.py
+++ b/python/hsfs/core/distribution_engine.py
@@ -42,13 +42,15 @@ class DistributionEngine:
     """Resolves bin edges and builds probability distributions from feature statistics.
 
     One instance is created per monitoring run. The cache keyed by
-    (fds_id, window_id) avoids re-parsing extended_statistics for the same
-    FeatureDescriptiveStatistics object within a single run.
+    (fds_id, feature_name, window_id) avoids re-parsing extended_statistics for
+    the same FeatureDescriptiveStatistics object within a single run.
+    feature_name is part of the key because synthetic merged-reference FDS have
+    id=None and would otherwise all collide on (None, window_id).
     """
 
     def __init__(self):
-        # (fds_id, window_id) -> parsed extended_statistics dict
-        self._cache: dict[tuple[int | None, int], dict] = {}
+        # (fds_id, feature_name, window_id) -> parsed extended_statistics dict
+        self._cache: dict[tuple[int | None, str | None, int], dict] = {}
 
     def _clear_cache(self):
         """Clear the per-run cache. Call at the start of each monitoring run."""
@@ -165,6 +167,11 @@ class DistributionEngine:
         if not reference_fds_list:
             return None
 
+        if reference_fds_list[0]._is_embedding():
+            return self._resolve_merged_embedding_reference(
+                reference_fds_list, histogram_bins
+            )
+
         total = len(reference_fds_list)
 
         # Validate that every FDS carries a native KLL sidecar.
@@ -226,6 +233,99 @@ class DistributionEngine:
             extended_statistics=extended,
         )
 
+    def _resolve_merged_embedding_reference(
+        self,
+        reference_fds_list: list[FeatureDescriptiveStatistics],
+        histogram_bins: int,
+    ) -> FeatureDescriptiveStatistics | None:
+        """Merge per-batch embedding norm KLL sidecars into a synthetic reference FDS.
+
+        The norm sketches are merged the same way as scalar columns, and the
+        centroid is recomputed as the count-weighted mean across batches so both
+        norm drift and CENTROID_DISTANCE work over a rolling reference window.
+
+        Returns None when the merge is not viable, so the caller falls back to the
+        full-window re-profile path.
+        """
+        from hsfs.core.feature_descriptive_statistics import (
+            FeatureDescriptiveStatistics,
+        )
+
+        total = len(reference_fds_list)
+
+        # Validate that every batch carries a native norm KLL sidecar.
+        base64_sketches = []
+        for fds in reference_fds_list:
+            embedding = fds._get_embedding_statistics() or {}
+            norm = embedding.get("norm") if isinstance(embedding, dict) else None
+            kll_entry = norm.get("kll") if isinstance(norm, dict) else None
+            if (
+                isinstance(kll_entry, dict)
+                and kll_entry.get("kllFormat") == "datasketches-native-v1"
+                and "bytes" in kll_entry
+            ):
+                base64_sketches.append(kll_entry["bytes"])
+
+        if len(base64_sketches) < total:
+            missing = total - len(base64_sketches)
+            logger.info(
+                "%d of %d constituent batches lack native embedding norm KLL sidecars; "
+                "falling back to full-window re-profile for feature '%s'",
+                missing,
+                total,
+                reference_fds_list[0].feature_name,
+            )
+            return None
+
+        merged_json = self._call_kll_merger(base64_sketches, histogram_bins)
+        if merged_json is None:
+            return None
+
+        parsed = json.loads(merged_json)
+        if not parsed.get("percentiles"):
+            return None
+
+        norm_block = {"histogram": parsed["histogram"]}
+        if "kll" in parsed and "kllFormat" in parsed:
+            norm_block["kll"] = {
+                "kllFormat": parsed["kllFormat"],
+                "bytes": parsed["kll"],
+            }
+
+        merged_centroid = _merge_centroids(reference_fds_list)
+
+        first_fds = reference_fds_list[0]
+        merged_count = parsed.get("n")
+        # Match the profiler embedding-block shape, which always emits count and
+        # dimension alongside norm and centroid.
+        # count mirrors the merged FDS count (the norm KLL n).
+        # dimension is the centroid length when a centroid is present, otherwise it
+        # falls back to a constituent batch's embedding dimension if one is recorded.
+        embedding_block: dict = {"norm": norm_block, "count": merged_count}
+        if merged_centroid is not None:
+            embedding_block["centroid"] = merged_centroid
+            embedding_block["dimension"] = len(merged_centroid)
+        else:
+            constituent_dimension = _first_embedding_dimension(reference_fds_list)
+            if constituent_dimension is not None:
+                embedding_block["dimension"] = constituent_dimension
+
+        # Mirror the scalar merged path: surface the merged norm percentiles/min/max
+        # at the top level too. _resolve_equi_frequency_edges reads
+        # reference_fds.percentiles and _resolve_equi_width_edges falls back to
+        # reference_fds.min/max, so without these the embedding EQUI_FREQUENCY
+        # binning over a merged reference falls back to EQUI_WIDTH (or raises when
+        # the norm histogram is absent), diverging from the non-merge path.
+        return FeatureDescriptiveStatistics(
+            feature_name=first_fds.feature_name,
+            feature_type=first_fds.feature_type,
+            percentiles=parsed["percentiles"],
+            min=parsed.get("min"),
+            max=parsed.get("max"),
+            count=merged_count,
+            extended_statistics={"embedding": embedding_block},
+        )
+
     # ------------------------------------------------------------------
     # Edge resolution helpers
     # ------------------------------------------------------------------
@@ -249,10 +349,14 @@ class DistributionEngine:
         detection_fds: FeatureDescriptiveStatistics,
     ) -> list[str]:
         ref_ext = (
-            reference_fds.extended_statistics if reference_fds is not None else None
+            _extended_statistics_for(reference_fds)
+            if reference_fds is not None
+            else None
         )
         det_ext = (
-            detection_fds.extended_statistics if detection_fds is not None else None
+            _extended_statistics_for(detection_fds)
+            if detection_fds is not None
+            else None
         )
 
         ref_hist = ref_ext.get("histogram", []) if ref_ext else []
@@ -326,8 +430,9 @@ class DistributionEngine:
     ) -> list[float]:
         # Try to read edges from the Deequ equi-width histogram first.
         histogram = None
-        if reference_fds.extended_statistics:
-            histogram = reference_fds.extended_statistics.get("histogram")
+        ext_stats = _extended_statistics_for(reference_fds)
+        if ext_stats:
+            histogram = ext_stats.get("histogram")
 
         if histogram is not None:
             edges = _parse_numeric_histogram_edges(histogram)
@@ -406,9 +511,9 @@ class DistributionEngine:
         fds: FeatureDescriptiveStatistics,
         window_id: int,
     ) -> dict | None:
-        cache_key = (fds.id, window_id)
+        cache_key = (fds.id, fds.feature_name, window_id)
         if cache_key not in self._cache:
-            self._cache[cache_key] = fds.extended_statistics or {}
+            self._cache[cache_key] = _extended_statistics_for(fds)
         return self._cache[cache_key]
 
     def _build_categorical_distribution(
@@ -470,6 +575,74 @@ class DistributionEngine:
 # ------------------------------------------------------------------
 # Module-level pure helpers (no state)
 # ------------------------------------------------------------------
+
+
+def _merge_centroids(
+    reference_fds_list: list[FeatureDescriptiveStatistics],
+) -> list[float] | None:
+    """Compute the count-weighted mean centroid across batches.
+
+    Each batch contributes its embedding count as the weight. Batches without a
+    usable centroid (empty vector or zero count) are skipped. Returns None when
+    no batch carries a usable centroid or when the dimensions are inconsistent.
+    """
+    accumulator: list[float] | None = None
+    total_count = 0
+    for fds in reference_fds_list:
+        embedding = fds._get_embedding_statistics() or {}
+        centroid = embedding.get("centroid") if isinstance(embedding, dict) else None
+        count = embedding.get("count") if isinstance(embedding, dict) else None
+        if not isinstance(centroid, list) or not centroid or not count:
+            continue
+        if accumulator is None:
+            accumulator = [0.0] * len(centroid)
+        elif len(centroid) != len(accumulator):
+            return None
+        for i, value in enumerate(centroid):
+            accumulator[i] += float(value) * count
+        total_count += count
+
+    if accumulator is None or total_count == 0:
+        return None
+    return [value / total_count for value in accumulator]
+
+
+def _first_embedding_dimension(
+    reference_fds_list: list[FeatureDescriptiveStatistics],
+) -> int | None:
+    """Return the first recorded embedding dimension across the batches.
+
+    Used as a fallback for the merged block's dimension when no centroid is
+    available. Prefers an explicit ``dimension`` field and falls back to a
+    non-empty centroid length. Returns None when no batch records either.
+    """
+    for fds in reference_fds_list:
+        embedding = fds._get_embedding_statistics() or {}
+        if not isinstance(embedding, dict):
+            continue
+        dimension = embedding.get("dimension")
+        if isinstance(dimension, int) and dimension > 0:
+            return dimension
+        centroid = embedding.get("centroid")
+        if isinstance(centroid, list) and centroid:
+            return len(centroid)
+    return None
+
+
+def _extended_statistics_for(fds: FeatureDescriptiveStatistics) -> dict:
+    """Return the extended-statistics dict to bin over for the given window.
+
+    For embedding features the distribution is built from the per-row L2 norm,
+    so the norm block (histogram and KLL) is returned in place of the top-level
+    extended statistics. All other feature types use their extended statistics
+    unchanged.
+    """
+    if fds._is_embedding():
+        norm_stats = fds._get_embedding_norm_extended_statistics()
+        if norm_stats is not None:
+            return norm_stats
+        return {}
+    return fds.extended_statistics or {}
 
 
 def _parse_bin_value(value_str: str) -> tuple[float | None, float | None]:

--- a/python/hsfs/core/feature_descriptive_statistics.py
+++ b/python/hsfs/core/feature_descriptive_statistics.py
@@ -27,6 +27,10 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 
+# Feature type emitted by the Spark profiler for numeric-array (embedding) columns.
+EMBEDDING_FEATURE_TYPE = "Embedding"
+
+
 @public
 class FeatureDescriptiveStatistics:
     # TODO: Add docstring
@@ -180,6 +184,8 @@ class FeatureDescriptiveStatistics:
             extended_statistics["histogram"] = json_dict["histogram"]
         if "kll" in json_dict:
             extended_statistics["kll"] = json_dict["kll"]
+        if "embedding" in json_dict:
+            extended_statistics["embedding"] = json_dict["embedding"]
         stats_dict["extended_statistics"] = (
             extended_statistics if extended_statistics else None
         )
@@ -229,7 +235,10 @@ class FeatureDescriptiveStatistics:
     @public
     @property
     def feature_type(self) -> str:
-        """Data type of the feature. It can be one of Boolean, Fractional, Integral, or String."""
+        """Data type of the feature.
+
+        It can be one of Boolean, Fractional, Integral, String, or Embedding.
+        """
         return self._feature_type
 
     @public
@@ -361,3 +370,45 @@ class FeatureDescriptiveStatistics:
     def extended_statistics(self) -> dict | None:
         """Additional statistics computed on the feature values such as histograms and correlations."""
         return self._extended_statistics
+
+    def _is_embedding(self) -> bool:
+        """Return whether these statistics describe an embedding (numeric-array) feature."""
+        return self._feature_type == EMBEDDING_FEATURE_TYPE
+
+    def _get_embedding_statistics(self) -> dict | None:
+        """Return the embedding statistics block, or None when not an embedding feature."""
+        if not isinstance(self._extended_statistics, dict):
+            return None
+        embedding = self._extended_statistics.get("embedding")
+        return embedding if isinstance(embedding, dict) else None
+
+    def _get_embedding_centroid(self) -> list[float] | None:
+        """Return the element-wise mean vector of the embedding, or None when unavailable.
+
+        The centroid is empty when every row in the window was invalid.
+        """
+        embedding = self._get_embedding_statistics()
+        if embedding is None:
+            return None
+        centroid = embedding.get("centroid")
+        return centroid if isinstance(centroid, list) else None
+
+    def _get_embedding_norm_extended_statistics(self) -> dict | None:
+        """Return an extended-statistics view sourced from the embedding norm block.
+
+        The returned dict mirrors a scalar numeric column's ``histogram``/``kll``
+        layout so the unchanged distribution machinery can consume it directly.
+        Returns None when no embedding norm statistics are present.
+        """
+        embedding = self._get_embedding_statistics()
+        if embedding is None:
+            return None
+        norm = embedding.get("norm")
+        if not isinstance(norm, dict):
+            return None
+        norm_stats = {}
+        if "histogram" in norm:
+            norm_stats["histogram"] = norm["histogram"]
+        if "kll" in norm:
+            norm_stats["kll"] = norm["kll"]
+        return norm_stats if norm_stats else None

--- a/python/hsfs/core/feature_monitoring_config.py
+++ b/python/hsfs/core/feature_monitoring_config.py
@@ -134,6 +134,9 @@ class FeatureMonitoringConfig:
         feature_view_version: int | None = None,
         model_name: str | None = None,
         model_version: int | None = None,
+        retrain_model_after_num_shifts: int | None = None,
+        model_retraining_job_name: str | None = None,
+        model_retraining_job_execution_args: str | None = None,
         valid_feature_names: list[str] | None = None,
         valid_features: dict[str, str] | None = None,
         href: str | None = None,
@@ -161,6 +164,12 @@ class FeatureMonitoringConfig:
         # model_name AND model_version. Persisted via to_dict/from_response_json.
         self._model_name = model_name
         self._model_version = model_version
+        # FSTORE-2053: automated re-training on drift. The job is stored by name (the
+        # backend resolves the name to a jobs row). All three are nullable; they are only
+        # meaningful when model_version is set.
+        self._retrain_model_after_num_shifts = retrain_model_after_num_shifts
+        self._model_retraining_job_name = model_retraining_job_name
+        self._model_retraining_job_execution_args = model_retraining_job_execution_args
         # In-memory only (not serialized): set by FeatureView.create_model_monitoring so
         # with_reference_training_dataset can default to / validate against the model's TD.
         self._associated_model_td_version: int | None = None
@@ -270,6 +279,18 @@ class FeatureMonitoringConfig:
             the_dict["modelName"] = self._model_name
         if self._model_version is not None:
             the_dict["modelVersion"] = self._model_version
+
+        # FSTORE-2053: re-training fields — emit only when set.
+        if self._retrain_model_after_num_shifts is not None:
+            the_dict["retrainModelAfterNumShifts"] = (
+                self._retrain_model_after_num_shifts
+            )
+        if self._model_retraining_job_name is not None:
+            the_dict["modelRetrainingJobName"] = self._model_retraining_job_name
+        if self._model_retraining_job_execution_args is not None:
+            the_dict["modelRetrainingJobExecutionArgs"] = (
+                self._model_retraining_job_execution_args
+            )
 
         # Backend-assigned entity IDs — emit only when set (populated from server responses).
         if self._training_dataset_id is not None:
@@ -553,10 +574,23 @@ class FeatureMonitoringConfig:
                     metric, feature_type
                 ):
                     from hsfs.core.feature_monitoring_config_engine import (
+                        EMBEDDING_ONLY_SCALAR_METRICS,
                         NUMERIC_ONLY_SCALAR_METRICS,
+                        _is_embedding_type,
                     )
 
                     metric_lower = metric.lower()
+                    if metric_lower in EMBEDDING_ONLY_SCALAR_METRICS:
+                        raise ValueError(
+                            f"Metric '{metric}' requires an embedding feature; "
+                            f"'{feature_name}' has type '{feature_type}'."
+                        )
+                    if _is_embedding_type((feature_type or "").lower()):
+                        raise ValueError(
+                            f"Metric '{metric}' is not supported for embedding feature "
+                            f"'{feature_name}'. Use a distribution metric for norm drift "
+                            f"or CENTROID_DISTANCE for centroid drift."
+                        )
                     if metric_lower in NUMERIC_ONLY_SCALAR_METRICS:
                         raise ValueError(
                             f"Metric '{metric}' requires a numeric feature; "
@@ -700,11 +734,15 @@ class FeatureMonitoringConfig:
                     ftype_lower = ftype.lower() if ftype else ""
                     from hsfs.core.feature_monitoring_config_engine import (
                         NUMERIC_HIVE_TYPES,
+                        _is_embedding_type,
                     )
 
+                    # Embeddings bin over their numeric norm histogram, so they use
+                    # the numeric strategy rather than CATEGORICAL.
                     is_numeric = (
                         ftype_lower in NUMERIC_HIVE_TYPES
                         or ftype_lower.startswith("decimal")
+                        or _is_embedding_type(ftype_lower)
                     )
                     resolved_binning_strategy = (
                         "EQUI_FREQUENCY" if is_numeric else "CATEGORICAL"
@@ -1065,6 +1103,39 @@ class FeatureMonitoringConfig:
     def model_version(self) -> int | None:
         """Version of the model whose inference logs are filtered by this configuration."""
         return self._model_version
+
+    @public
+    @property
+    def retrain_model_after_num_shifts(self) -> int | None:
+        """Number of consecutive drift-detected runs that trigger automated re-training.
+
+        When set, the backend counts leading consecutive runs where drift was detected
+        (after the last re-training trigger) and fires a re-training job once the count
+        reaches this threshold. Only valid on model monitoring configs (model FK present).
+        Added in version ~=3.8.1.
+        """
+        return self._retrain_model_after_num_shifts
+
+    @public
+    @property
+    def model_retraining_job_name(self) -> str | None:
+        """Name of the Hopsworks job to run when automated re-training is triggered.
+
+        When None and re-training is enabled, the backend resolves the job from the
+        model version's originating job (if recorded) or mints a default PYTHON job
+        pointing at the model's program file.
+        Added in version ~=3.8.1.
+        """
+        return self._model_retraining_job_name
+
+    @public
+    @property
+    def model_retraining_job_execution_args(self) -> str | None:
+        """Execution arguments passed to the re-training job at trigger time.
+
+        Added in version ~=3.8.1.
+        """
+        return self._model_retraining_job_execution_args
 
     @public
     @property

--- a/python/hsfs/core/feature_monitoring_config_engine.py
+++ b/python/hsfs/core/feature_monitoring_config_engine.py
@@ -542,6 +542,12 @@ class FeatureMonitoringConfigEngine:
 
         assert config is not None, "Feature monitoring config not found."
         feature_names = config.get_feature_names()
+        if not feature_names:
+            # All-features mode: the config has no feature_statistics_configs children,
+            # so resolve the monitored features from the entity schema.
+            # Empty/unmaterialized windows fabricate count=0 FDS from this list, and the
+            # backend rejects results whose featureStatisticsResults list is empty.
+            feature_names = [feature.name for feature in entity.features]
 
         if config.trigger_type == fmc.TriggerType.INGESTION:
             # Ingestion-triggered configs: read flags from the FG's statistics_config

--- a/python/hsfs/core/feature_monitoring_config_engine.py
+++ b/python/hsfs/core/feature_monitoring_config_engine.py
@@ -68,6 +68,11 @@ NUMERIC_ONLY_SCALAR_METRICS = set(VALID_FRACTIONAL_METRICS) - set(
     VALID_CATEGORICAL_METRICS
 )
 
+# Scalar metrics that apply only to embedding features. CENTROID_DISTANCE is the
+# L2 distance between the detection and reference centroids, scored against the
+# threshold through the existing scalar specific-value path.
+EMBEDDING_ONLY_SCALAR_METRICS = {"centroid_distance"}
+
 # Distribution metrics restricted to numeric features only
 NUMERIC_ONLY_DISTRIBUTION_METRICS = {"WASSERSTEIN", "KOLMOGOROV_SMIRNOV"}
 
@@ -86,6 +91,17 @@ NUMERIC_HIVE_TYPES = {"int", "bigint", "tinyint", "smallint", "float", "double"}
 
 # Phase-2 types: skip silently in fan-out but reject explicitly if named
 PHASE2_TYPES = {"timestamp", "date", "binary"}
+
+
+def _is_embedding_type(feature_type: str) -> bool:
+    """Return whether the lowercased Hive type denotes a numeric-array embedding.
+
+    Embeddings are profiled from ``array<T>`` columns whose element type is numeric.
+    """
+    if not feature_type.startswith("array<") or not feature_type.endswith(">"):
+        return False
+    element_type = feature_type[len("array<") : -1].strip()
+    return element_type in NUMERIC_HIVE_TYPES or element_type.startswith("decimal")
 
 
 if TYPE_CHECKING:
@@ -270,10 +286,13 @@ class FeatureMonitoringConfigEngine:
         if (
             metric_lower not in VALID_CATEGORICAL_METRICS
             and metric_lower not in VALID_FRACTIONAL_METRICS
+            and metric_lower not in EMBEDDING_ONLY_SCALAR_METRICS
         ):
             raise ValueError(
                 f"Invalid metric {metric_lower}. Supported metrics are {{}}.".format(
-                    set(VALID_FRACTIONAL_METRICS).union(set(VALID_CATEGORICAL_METRICS))
+                    set(VALID_FRACTIONAL_METRICS)
+                    .union(set(VALID_CATEGORICAL_METRICS))
+                    .union(set(EMBEDDING_ONLY_SCALAR_METRICS))
                 )
             )
 
@@ -562,6 +581,18 @@ class FeatureMonitoringConfigEngine:
                 else None
             )
 
+        # Features whose comparison config unambiguously targets an embedding metric,
+        # i.e. the CENTROID_DISTANCE scalar metric.
+        # Distribution metrics are deliberately excluded here because they are valid on
+        # both numeric and embedding features, so they cannot be attributed to an
+        # embedding from the config alone.
+        # Reused registered statistics for these features must carry the embedding block;
+        # otherwise the window is reprofiled (see
+        # MonitoringWindowConfigEngine._run_single_window_monitoring).
+        # A distribution-metric embedding is still caught downstream via the reused FDS
+        # self-identifying as feature_type == "Embedding".
+        embedding_feature_names = self._get_embedding_targeted_feature_names(config)
+
         # FSTORE-2050: model monitoring — when both fields are set, the detection window
         # is the FV's logging FG and we must filter to inference rows produced by this
         # exact (model_name, model_version). The same filter applies to the reference
@@ -672,6 +703,7 @@ class FeatureMonitoringConfigEngine:
                         profile_flags=profile_flags,
                         end_commit_time_override=end_commit_time,
                         model_filter=model_filter,
+                        embedding_feature_names=embedding_feature_names,
                     )
                 )
             except RestAPIError as e:
@@ -726,6 +758,7 @@ class FeatureMonitoringConfigEngine:
                         profile_flags=profile_flags,
                         end_commit_time_override=ref_commit_time_override,
                         model_filter=ref_model_filter,
+                        embedding_feature_names=embedding_feature_names,
                     )
                 )
             except RestAPIError as e:
@@ -752,6 +785,46 @@ class FeatureMonitoringConfigEngine:
             detection_window_commit_time=detection_window_commit_time,
         )
 
+    def _get_embedding_targeted_feature_names(
+        self, config: fmc.FeatureMonitoringConfig
+    ) -> set[str]:
+        """Return the names of features whose comparison config unambiguously targets embedding.
+
+        A feature unambiguously targets an embedding metric when any of its comparison
+        children uses an embedding-only scalar metric (CENTROID_DISTANCE).
+        These features require the ``extended_statistics.embedding`` block, so reused
+        registered statistics that lack it must not be reused for them (the window is
+        reprofiled instead, see
+        [`MonitoringWindowConfigEngine._run_single_window_monitoring`][hsfs.core.monitoring_window_config_engine.MonitoringWindowConfigEngine._run_single_window_monitoring]).
+
+        Limitation: distribution metrics (PSI, KL, etc.) are deliberately excluded.
+        A distribution metric is valid on both numeric and embedding features, so at this
+        point we cannot tell whether a distribution-targeted feature is an embedding whose
+        reused statistics are stale or a numeric feature that legitimately has no embedding
+        block.
+        Forcing a recompute on every distribution-targeted feature would needlessly
+        reprofile numeric features.
+        A stale embedding feature behind a distribution metric still self-identifies via
+        its reused statistics' feature type, which the window engine's guard also honours.
+
+        Parameters:
+            config: The feature monitoring configuration to inspect.
+
+        Returns:
+            The names of features whose comparison config uses CENTROID_DISTANCE.
+        """
+        embedding_metrics = {m.upper() for m in EMBEDDING_ONLY_SCALAR_METRICS}
+        targeted = set()
+        for fs_config in config.feature_statistics_configs or []:
+            for sc_config in fs_config.statistics_comparison_configs or []:
+                if (
+                    sc_config.metric is not None
+                    and sc_config.metric.upper() in embedding_metrics
+                ):
+                    targeted.add(fs_config.feature_name)
+                    break
+        return targeted
+
     # feature-type compatibility helpers
 
     def _is_type_compatible(self, metric: str, feature_type: str) -> bool:
@@ -764,7 +837,11 @@ class FeatureMonitoringConfigEngine:
         For distribution metrics, WASSERSTEIN and KOLMOGOROV_SMIRNOV require numeric types.
         PSI, KL_DIVERGENCE, JS_DIVERGENCE, and HELLINGER are compatible with any primitive.
 
-        Complex types (MAP, ARRAY, STRUCT, UNIONTYPE) are never compatible.
+        Embedding (numeric-array) features are compatible with every distribution metric
+        (norm drift over the embedding norm histogram is numeric) and with the
+        CENTROID_DISTANCE scalar metric, and incompatible with ordinary scalar metrics.
+
+        Other complex types (MAP, STRUCT, UNIONTYPE) are never compatible.
         Phase-2 types (timestamp, date, binary) are out of scope and not compatible.
 
         Parameters:
@@ -778,7 +855,21 @@ class FeatureMonitoringConfigEngine:
 
         type_lower = feature_type.lower() if feature_type else ""
 
-        # Complex types have no distribution/stats support.
+        metric_upper = metric.upper()
+        metric_lower = metric.lower()
+
+        # Embedding (numeric array) features: norm drift via any distribution metric
+        # plus the CENTROID_DISTANCE scalar metric.
+        if _is_embedding_type(type_lower):
+            if metric_upper in ALL_DISTRIBUTION_METRICS:
+                return True
+            return metric_lower in EMBEDDING_ONLY_SCALAR_METRICS
+
+        # CENTROID_DISTANCE only applies to embedding features.
+        if metric_lower in EMBEDDING_ONLY_SCALAR_METRICS:
+            return False
+
+        # Other complex types have no distribution/stats support.
         for complex_prefix in Feature.COMPLEX_TYPES:
             if type_lower.startswith(complex_prefix.lower()):
                 return False
@@ -791,8 +882,6 @@ class FeatureMonitoringConfigEngine:
             "decimal"
         )
 
-        metric_upper = metric.upper()
-
         if metric_upper in ALL_DISTRIBUTION_METRICS:
             if metric_upper in NUMERIC_ONLY_DISTRIBUTION_METRICS:
                 return is_numeric
@@ -800,7 +889,6 @@ class FeatureMonitoringConfigEngine:
             return True
 
         # Scalar metric path
-        metric_lower = metric.lower()
         if metric_lower in NUMERIC_ONLY_SCALAR_METRICS:
             return is_numeric
         # Type-agnostic scalar metrics (VALID_CATEGORICAL_METRICS)
@@ -828,7 +916,9 @@ class FeatureMonitoringConfigEngine:
         if not compatible:
             from hsfs.feature import Feature
 
-            if metric.upper() in ALL_DISTRIBUTION_METRICS:
+            if metric.lower() in EMBEDDING_ONLY_SCALAR_METRICS:
+                compatible_types = "numeric arrays (e.g. array<float>, array<double>)"
+            elif metric.upper() in ALL_DISTRIBUTION_METRICS:
                 if metric.upper() in NUMERIC_ONLY_DISTRIBUTION_METRICS:
                     compatible_types = list(NUMERIC_HIVE_TYPES) + ["decimal"]
                 else:

--- a/python/hsfs/core/feature_monitoring_result_engine.py
+++ b/python/hsfs/core/feature_monitoring_result_engine.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
@@ -38,6 +39,9 @@ from hsfs.core.statistics_comparison_result import StatisticsComparisonResult
 if TYPE_CHECKING:
     from hsfs.core.feature_statistics_config import FeatureStatisticsConfig
     from hsfs.core.statistics_comparison_config import StatisticsComparisonConfig
+
+
+logger = logging.getLogger(__name__)
 
 
 class FeatureMonitoringResultEngine:
@@ -425,6 +429,11 @@ class FeatureMonitoringResultEngine:
                 detection_statistics=detection_statistics,
                 reference_statistics=reference_statistics,
             )
+        elif sc_config.metric == "CENTROID_DISTANCE":
+            difference = self._compute_centroid_distance(
+                detection_statistics=detection_statistics,
+                reference_statistics=reference_statistics,
+            )
         else:
             difference = self._compute_difference_between_stats(
                 detection_statistics=detection_statistics,
@@ -506,6 +515,44 @@ class FeatureMonitoringResultEngine:
             metric=sc_config.distribution_metric,
             bin_centres=bin_centres,
         )
+
+    def _compute_centroid_distance(
+        self,
+        detection_statistics: FeatureDescriptiveStatistics,
+        reference_statistics: FeatureDescriptiveStatistics | None,
+    ) -> float | None:
+        """Compute the L2 distance between the detection and reference centroids.
+
+        This is the MVP centroid drift score and always uses the plain Euclidean distance.
+        Threading a configurable similarity function is a deferred follow-up.
+        Returns None when either centroid is missing, when either window is empty, or when the centroid lengths do not match.
+        """
+        import numpy as np
+
+        if reference_statistics is None:
+            return None
+        if self._is_monitoring_window_empty(detection_statistics):
+            return None
+        if self._is_monitoring_window_empty(reference_statistics):
+            return None
+
+        detection_centroid = detection_statistics._get_embedding_centroid()
+        reference_centroid = reference_statistics._get_embedding_centroid()
+        if not detection_centroid or not reference_centroid:
+            return None
+        if len(detection_centroid) != len(reference_centroid):
+            logger.warning(
+                "Centroid length mismatch for feature '%s' (detection=%d, reference=%d); "
+                "skipping CENTROID_DISTANCE.",
+                detection_statistics.feature_name,
+                len(detection_centroid),
+                len(reference_centroid),
+            )
+            return None
+
+        det = np.asarray(detection_centroid, dtype=np.float64)
+        ref = np.asarray(reference_centroid, dtype=np.float64)
+        return float(np.linalg.norm(det - ref))
 
     def _compute_difference_between_stats(
         self,
@@ -743,9 +790,12 @@ class FeatureMonitoringResultEngine:
 def _default_binning_strategy(fds: FeatureDescriptiveStatistics) -> str:
     """Return the default binning strategy for the given feature statistics.
 
-    Uses CATEGORICAL for non-numeric features (string, boolean, etc.)
-    and EQUI_FREQUENCY for numeric ones.
+    Uses CATEGORICAL for non-numeric features (string, boolean, etc.) and EQUI_FREQUENCY for numeric ones.
+    Embeddings bin over their numeric norm histogram, so they use EQUI_FREQUENCY too.
     """
+    if fds._is_embedding():
+        return "EQUI_FREQUENCY"
+
     feature_type = (fds.feature_type or "").lower()
     numeric_types = {
         "integral",

--- a/python/hsfs/core/feature_monitoring_result_engine.py
+++ b/python/hsfs/core/feature_monitoring_result_engine.py
@@ -262,14 +262,18 @@ class FeatureMonitoringResultEngine:
         )
 
         # create fds dicts
-        detection_stats_dict, empty_detection_window = {}, False
+        # An empty FDS list means nothing was profiled for the window, so the per-FDS
+        # loop below cannot flip the empty flag — initialize it from the list itself.
+        detection_stats_dict = {}
+        empty_detection_window = len(detection_statistics) == 0
         reference_stats_dict, empty_reference_window = None, None
         for det_fds in detection_statistics:
             detection_stats_dict[det_fds.feature_name] = det_fds
             if self._is_monitoring_window_empty(det_fds):
                 empty_detection_window = True
         if reference_statistics is not None:
-            reference_stats_dict, empty_reference_window = {}, False
+            reference_stats_dict = {}
+            empty_reference_window = len(reference_statistics) == 0
             for ref_fds in reference_statistics:
                 reference_stats_dict[ref_fds.feature_name] = ref_fds
                 if self._is_monitoring_window_empty(ref_fds):

--- a/python/hsfs/core/monitoring_window_config_engine.py
+++ b/python/hsfs/core/monitoring_window_config_engine.py
@@ -295,6 +295,7 @@ class MonitoringWindowConfigEngine:
         profile_flags: dict | None = None,
         end_commit_time_override: int | None = None,
         model_filter: tuple[str, int] | None = None,
+        embedding_feature_names: set[str] | None = None,
     ) -> list[FeatureDescriptiveStatistics]:
         """Fetch the entity data based on monitoring window configuration and compute statistics.
 
@@ -311,6 +312,16 @@ class MonitoringWindowConfigEngine:
                 read path filters rows by ``model_name = X AND model_version = str(Y)``
                 and the precomputed-stats lookup is skipped (registered stats are
                 aggregated over the whole entity and are not model-aware).
+            embedding_feature_names: optional names of features whose monitoring config
+                unambiguously targets an embedding metric, i.e. CENTROID_DISTANCE.
+                Distribution metrics are excluded because they apply to both numeric and
+                embedding features, so a distribution-metric embedding is caught instead
+                via its reused statistics self-identifying as ``feature_type ==
+                "Embedding"``.
+                When registered statistics are reused for the window, any such feature
+                whose reused statistics predate embedding support (no
+                ``extended_statistics.embedding`` block) forces a recompute of the whole
+                window so the embedding statistics are present.
 
         Returns:
             List of Descriptive statistics.
@@ -393,6 +404,21 @@ class MonitoringWindowConfigEngine:
                 feature_names=feature_names,
                 row_percentage=monitoring_window_config.row_percentage,
             )
+
+        # Stale-stats guard: registered statistics may predate embedding support and so
+        # lack the ``extended_statistics.embedding`` block.
+        # Reusing them for an embedding feature would silently drop the configured
+        # embedding metric or trip the detection/reference subset assertion downstream.
+        # Drop the reused stats in that case so the recompute path below reprofiles the
+        # window with embedding support.
+        if registered_stats is not None and self._reused_stats_lack_embedding(
+            registered_stats, embedding_feature_names
+        ):
+            logger.info(
+                "Reusing registered statistics that lack embedding statistics for an "
+                "embedding-targeted feature; reprofiling the window instead."
+            )
+            registered_stats = None
 
         if registered_stats is None:  # if statistics don't exist
             # TODO: What happens if window is TRAINING_DATASET and the TD statistics were not computed???
@@ -619,6 +645,49 @@ class MonitoringWindowConfigEngine:
             datetime: Rounded and converted event time.
         """
         return util._convert_event_time_to_timestamp(event_time)
+
+    def _reused_stats_lack_embedding(
+        self,
+        registered_stats,
+        embedding_feature_names: set[str] | None,
+    ) -> bool:
+        """Return True when reused statistics miss the embedding block where it is required.
+
+        Reused (registered) statistics computed before embedding support do not carry the
+        ``extended_statistics.embedding`` block.
+        The block is required when any of the following holds:
+
+        - a reused feature self-identifies as embedding (``feature_type == "Embedding"``)
+          yet lacks the block, which catches a stale embedding feature behind an ambiguous
+          distribution metric;
+        - a CENTROID_DISTANCE-targeted feature (``embedding_feature_names``) is present in
+          the reused statistics but lacks the block;
+        - a CENTROID_DISTANCE-targeted feature is absent from the reused statistics
+          altogether, the common case when the feature was skipped by the profiler before
+          embedding support and would otherwise let stale stats silently bypass the
+          CENTROID_DISTANCE comparison.
+
+        Parameters:
+            registered_stats: The reused statistics object holding feature descriptive statistics.
+            embedding_feature_names: Names of features whose config targets CENTROID_DISTANCE.
+
+        Returns:
+            True if any reused feature requires the embedding block but lacks it.
+        """
+        fds_list = registered_stats.feature_descriptive_statistics or []
+        targeted = embedding_feature_names or set()
+        present_names = {fds.feature_name for fds in fds_list}
+        # A targeted feature missing entirely from the reused stats predates embedding
+        # support; force a reprofile so its CENTROID_DISTANCE comparison is not skipped.
+        # This also covers an entirely empty stats list (the profiler skipped every
+        # column), which would otherwise let stale empty stats bypass the comparison.
+        if targeted - present_names:
+            return True
+        for fds in fds_list:
+            requires_embedding = fds.feature_name in targeted or fds._is_embedding()
+            if requires_embedding and fds._get_embedding_statistics() is None:
+                return True
+        return False
 
     def _should_use_merge_path(
         self,

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -4158,6 +4158,9 @@ class FeatureView:
         start_date_time: int | str | datetime | date | pd.Timestamp | None = None,
         end_date_time: int | str | datetime | date | pd.Timestamp | None = None,
         cron_expression: str | None = "0 0 12 ? * * *",
+        retrain_model_after_num_shifts: int | None = None,
+        model_retraining_job: Job | None = None,
+        model_retraining_job_execution_args: str | None = None,
     ) -> fmc.FeatureMonitoringConfig:
         """Enable feature monitoring on the inference logs of a specific deployed model.
 
@@ -4181,6 +4184,7 @@ class FeatureView:
                 model_name="iris_classifier",
                 model_version=3,
                 cron_expression="0 0 12 ? * * *",
+                retrain_model_after_num_shifts=3,
             ).with_detection_window(
                 # served by this model in the last day
                 time_offset="1d",
@@ -4205,11 +4209,22 @@ class FeatureView:
             cron_expression: Cron expression to use to schedule the job. The cron
                 expression must be in UTC and follow the Quartz specification. The
                 default value means "every day at 12pm UTC".
+            retrain_model_after_num_shifts: Number of consecutive drift-detected runs
+                that trigger automated re-training. Must be a positive integer.
+                Added in version ~=3.8.1.
+            model_retraining_job: Hopsworks job to run when re-training is triggered.
+                When None and re-training is enabled, the backend resolves the job from
+                the model version's originating job or mints a default PYTHON job.
+                Added in version ~=3.8.1.
+            model_retraining_job_execution_args: Execution arguments passed to the
+                re-training job at trigger time.
+                Added in version ~=3.8.1.
 
         Raises:
             hopsworks.client.exceptions.FeatureStoreException: If feature logging is not
                 enabled, the feature view is not registered, the named model is not
-                found, or the model has no recorded training dataset version.
+                found, the model has no recorded training dataset version, or
+                ``retrain_model_after_num_shifts`` is not a positive integer.
 
         Returns:
             Configuration with minimal information about the feature monitoring.
@@ -4219,6 +4234,16 @@ class FeatureView:
             raise FeatureStoreException(
                 "Feature logging is not enabled for this feature view. "
                 "Call self.enable_logging() first."
+            )
+
+        # FSTORE-2053: validate retrain_model_after_num_shifts — must be a positive int.
+        if retrain_model_after_num_shifts is not None and (
+            not isinstance(retrain_model_after_num_shifts, int)
+            or retrain_model_after_num_shifts <= 0
+        ):
+            raise FeatureStoreException(
+                "retrain_model_after_num_shifts must be a positive integer, "
+                f"got {retrain_model_after_num_shifts!r}."
             )
 
         # Idea A — warn when a sub-hourly cron is used for model monitoring.
@@ -4277,6 +4302,14 @@ class FeatureView:
         config._model_name = model_name
         config._model_version = model_version
         config._associated_model_td_version = training_dataset_version
+        # FSTORE-2053: stamp re-training fields.
+        config._retrain_model_after_num_shifts = retrain_model_after_num_shifts
+        config._model_retraining_job_name = (
+            model_retraining_job.name if model_retraining_job is not None else None
+        )
+        config._model_retraining_job_execution_args = (
+            model_retraining_job_execution_args
+        )
         return config
 
     @public

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -28,6 +28,7 @@ from hsml.engine import serving_engine
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from hopsworks_common.job import Job
     from hsfs.core.feature_monitoring_config import FeatureMonitoringConfig
     from hsml.client.istio.utils.infer_type import InferInput
     from hsml.deployment_tracing_config import DeploymentTracingConfig
@@ -319,6 +320,9 @@ class Deployment:
         start_date_time: int | str | None = None,
         end_date_time: int | str | None = None,
         cron_expression: str | None = "0 0 12 ? * * *",
+        retrain_model_after_num_shifts: int | None = None,
+        model_retraining_job: Job | None = None,
+        model_retraining_job_execution_args: str | None = None,
     ) -> FeatureMonitoringConfig:
         """Create a model monitoring config bound to this deployment's model.
 
@@ -337,6 +341,7 @@ class Deployment:
             my_deployment = ms.get_deployment(name="my_deployment")
             my_deployment.create_model_monitoring(
                 name="psi_drift",
+                retrain_model_after_num_shifts=3,
             ).with_detection_window(
                 time_offset="1d", window_length="1d",
             ).with_reference_training_dataset(  # defaults to model's TD version
@@ -351,10 +356,22 @@ class Deployment:
             start_date_time: Start date and time from which to start computing statistics.
             end_date_time: End date and time at which to stop computing statistics.
             cron_expression: Cron expression scheduling the FM job (UTC, Quartz).
+            retrain_model_after_num_shifts: Number of consecutive drift-detected runs
+                that trigger automated re-training. Must be a positive integer.
+                Added in version ~=3.8.1.
+            model_retraining_job: Hopsworks job to run when re-training is triggered.
+                When None and re-training is enabled, the backend resolves the job from
+                the model version's originating job or mints a default PYTHON job.
+                Added in version ~=3.8.1.
+            model_retraining_job_execution_args: Execution arguments passed to the
+                re-training job at trigger time.
+                Added in version ~=3.8.1.
 
         Raises:
             hopsworks.client.exceptions.ModelServingException: If the deployment's
                 model has no parent feature view recorded in its provenance.
+            hopsworks.client.exceptions.FeatureStoreException: If
+                ``retrain_model_after_num_shifts`` is not a positive integer.
 
         Returns:
             A ``FeatureMonitoringConfig`` builder. Call ``with_detection_window``,
@@ -377,6 +394,9 @@ class Deployment:
             start_date_time=start_date_time,
             end_date_time=end_date_time,
             cron_expression=cron_expression,
+            retrain_model_after_num_shifts=retrain_model_after_num_shifts,
+            model_retraining_job=model_retraining_job,
+            model_retraining_job_execution_args=model_retraining_job_execution_args,
         )
 
     @public

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -36,6 +36,7 @@ from hsml.schema import Schema
 
 
 if TYPE_CHECKING:
+    from hopsworks_common.job import Job
     from hsfs import feature_view
     from hsfs.core.feature_monitoring_config import FeatureMonitoringConfig
     from hsml import deployment, tag
@@ -76,6 +77,7 @@ class Model:
         href=None,
         feature_view=None,
         training_dataset_version=None,
+        training_job_name=None,
         **kwargs,
     ):
         self._id = id
@@ -97,6 +99,9 @@ class Model:
         self._input_example = input_example
         self._framework = framework
         self._model_schema = model_schema
+        # FSTORE-2053: name of the Hopsworks job that produced this model version.
+        # Set by the backend when the model was exported via a job (read-only from SDK).
+        self._training_job_name = training_job_name
 
         # This is needed for update_from_response_json function to not overwrite name of the shared registry this model originates from
         if not hasattr(self, "_shared_registry_project_name"):
@@ -651,6 +656,9 @@ class Model:
         start_date_time: int | str | None = None,
         end_date_time: int | str | None = None,
         cron_expression: str | None = "0 0 12 ? * * *",
+        retrain_model_after_num_shifts: int | None = None,
+        model_retraining_job: Job | None = None,
+        model_retraining_job_execution_args: str | None = None,
     ) -> FeatureMonitoringConfig:
         """Create a model monitoring config for this model.
 
@@ -670,6 +678,7 @@ class Model:
 
             my_model.create_model_monitoring(
                 name="psi_drift",
+                retrain_model_after_num_shifts=3,
             ).with_detection_window(
                 time_offset="1d", window_length="1d",
             ).with_reference_training_dataset(  # defaults to model's TD version
@@ -684,11 +693,22 @@ class Model:
             start_date_time: Start date and time from which to start computing statistics.
             end_date_time: End date and time at which to stop computing statistics.
             cron_expression: Cron expression scheduling the FM job (UTC, Quartz).
+            retrain_model_after_num_shifts: Number of consecutive drift-detected runs
+                that trigger automated re-training. Must be a positive integer.
+                Added in version ~=3.8.1.
+            model_retraining_job: Hopsworks job to run when re-training is triggered.
+                When None and re-training is enabled, the backend resolves the job from
+                the model version's originating job or mints a default PYTHON job.
+                Added in version ~=3.8.1.
+            model_retraining_job_execution_args: Execution arguments passed to the
+                re-training job at trigger time.
+                Added in version ~=3.8.1.
 
         Raises:
             hopsworks.client.exceptions.FeatureStoreException: If this model has no
                 parent feature view recorded in its provenance, or if downstream
-                FV validation fails (no logging enabled, no recorded TD version, ...).
+                FV validation fails (no logging enabled, no recorded TD version, or
+                ``retrain_model_after_num_shifts`` is not a positive integer).
 
         Returns:
             A ``FeatureMonitoringConfig`` builder. Call ``with_detection_window``,
@@ -711,6 +731,9 @@ class Model:
             start_date_time=start_date_time,
             end_date_time=end_date_time,
             cron_expression=cron_expression,
+            retrain_model_after_num_shifts=retrain_model_after_num_shifts,
+            model_retraining_job=model_retraining_job,
+            model_retraining_job_execution_args=model_retraining_job_execution_args,
         )
 
     def _get_default_serving_name(self):
@@ -736,7 +759,7 @@ class Model:
         return json.dumps(self, cls=util.Encoder)
 
     def to_dict(self):
-        return {
+        d = {
             "id": self._name + "_" + str(self._version),
             "projectName": self._project_name,
             "name": self._name,
@@ -751,6 +774,10 @@ class Model:
             "featureView": util._feature_view_to_json(self._feature_view),
             "trainingDatasetVersion": self._training_dataset_version,
         }
+        # FSTORE-2053: emit only when set (backend-assigned, read-only from SDK).
+        if self._training_job_name is not None:
+            d["trainingJobName"] = self._training_job_name
+        return d
 
     @public
     @property
@@ -849,6 +876,17 @@ class Model:
     @program.setter
     def program(self, program):
         self._program = program
+
+    @public
+    @property
+    def training_job_name(self) -> str | None:
+        """Name of the Hopsworks job that produced this model version.
+
+        Set by the backend when the model was exported via a job. None when the model
+        was saved from a notebook or an external SDK client.
+        Added in version ~=3.8.1.
+        """
+        return self._training_job_name
 
     @public
     @property

--- a/python/tests/core/test_distribution_engine.py
+++ b/python/tests/core/test_distribution_engine.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 import json
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -576,6 +577,46 @@ class TestCache:
         engine._clear_cache()
         assert len(engine._cache) == 0
 
+    def test_synthetic_fds_with_none_id_do_not_collide(self):
+        # Regression: synthetic merged-reference FDS have id=None. Two distinct
+        # features previously collided on (None, window_id) and reused each
+        # other's parsed extended_statistics. The feature_name in the cache key
+        # must keep them separate.
+        hist_a = _make_histogram([(0.0, 1.0, 100), (1.0, 2.0, 0)])
+        hist_b = _make_histogram([(0.0, 1.0, 0), (1.0, 2.0, 100)])
+        fds_a = _make_fds(None, feature_name="feat_a", histogram=hist_a)
+        fds_b = _make_fds(None, feature_name="feat_b", histogram=hist_b)
+        engine = DistributionEngine()
+
+        stats_a = engine._get_extended_stats(fds_a, _WINDOW_REFERENCE)
+        stats_b = engine._get_extended_stats(fds_b, _WINDOW_REFERENCE)
+
+        # Distinct features must not share a cache entry.
+        assert stats_a == {"histogram": hist_a}
+        assert stats_b == {"histogram": hist_b}
+        assert stats_a is not stats_b
+        assert len(engine._cache) == 2
+
+        # The full distribution path must reflect each feature's own histogram.
+        edges = [0.0, 1.0, 2.0]
+        probs_a = engine._build_distribution(
+            fds=fds_a,
+            binning_strategy="EQUI_WIDTH",
+            bin_edges=edges,
+            epsilon=1e-6,
+            window_id=_WINDOW_REFERENCE,
+        )
+        probs_b = engine._build_distribution(
+            fds=fds_b,
+            binning_strategy="EQUI_WIDTH",
+            bin_edges=edges,
+            epsilon=1e-6,
+            window_id=_WINDOW_REFERENCE,
+        )
+        # feat_a's mass is in the first bin, feat_b's in the second.
+        assert probs_a[0] > probs_a[1]
+        assert probs_b[1] > probs_b[0]
+
 
 # ---------------------------------------------------------------------------
 # _resolve_merged_reference
@@ -702,3 +743,170 @@ class TestResolveMergedReference:
         result = engine._resolve_merged_reference(fds_list, histogram_bins=20)
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Embedding features
+# ---------------------------------------------------------------------------
+
+
+def _make_embedding_fds(
+    fid: int,
+    feature_name: str = "user_vector",
+    histogram: list[dict] | None = None,
+    kll_bytes: str | None = None,
+    centroid: list[float] | None = None,
+    count: int = 100,
+    embedding_count: int = 100,
+) -> FeatureDescriptiveStatistics:
+    """Build an embedding FDS with a norm block and optional centroid."""
+    norm: dict = {}
+    if histogram is not None:
+        norm["histogram"] = histogram
+    if kll_bytes is not None:
+        norm["kll"] = {"kllFormat": "datasketches-native-v1", "bytes": kll_bytes}
+    embedding: dict = {"dimension": 2, "count": embedding_count}
+    if norm:
+        embedding["norm"] = norm
+    if centroid is not None:
+        embedding["centroid"] = centroid
+    return FeatureDescriptiveStatistics(
+        feature_name=feature_name,
+        feature_type="Embedding",
+        id=fid,
+        count=count,
+        extended_statistics={"embedding": embedding},
+    )
+
+
+class TestEmbeddingDistributionSourcing:
+    def test_build_distribution_uses_norm_histogram(self):
+        histogram = _make_histogram([(5.0, 5.5, 80), (5.5, 6.0, 20)])
+        fds = _make_embedding_fds(1, histogram=histogram)
+        engine = DistributionEngine()
+
+        bin_edges = engine._resolve_bin_edges(
+            reference_fds=fds,
+            detection_fds=fds,
+            binning_strategy="EQUI_WIDTH",
+            bin_count=2,
+            custom_edges=None,
+        )
+        probs = engine._build_distribution(
+            fds=fds,
+            binning_strategy="EQUI_WIDTH",
+            bin_edges=bin_edges,
+            epsilon=1e-6,
+            window_id=_WINDOW_REFERENCE,
+        )
+
+        # Two bins sourced from the norm histogram; sums to 1 and skewed to the first bin.
+        assert len(probs) == 2
+        assert abs(probs.sum() - 1.0) < 1e-9
+        assert probs[0] > probs[1]
+
+    def test_build_distribution_no_norm_returns_uniform_epsilon(self):
+        # All-invalid embedding: no norm block, so counts are all zero.
+        fds = _make_embedding_fds(2, histogram=None, embedding_count=0)
+        engine = DistributionEngine()
+        probs = engine._build_distribution(
+            fds=fds,
+            binning_strategy="EQUI_WIDTH",
+            bin_edges=[0.0, 1.0, 2.0],
+            epsilon=1e-6,
+            window_id=_WINDOW_DETECTION,
+        )
+        # No histogram: zero counts smoothed to a uniform distribution.
+        assert abs(probs.sum() - 1.0) < 1e-9
+        assert abs(probs[0] - probs[1]) < 1e-12
+
+
+class TestResolveMergedEmbeddingReference:
+    def _engine_with_mock(self, jvm_merge_return):
+        engine = DistributionEngine()
+        engine._call_kll_merger = MagicMock(return_value=jvm_merge_return)
+        return engine
+
+    def test_happy_path_merges_norm_and_centroid(self):
+        fds_list = [
+            _make_embedding_fds(
+                1, kll_bytes="Ynl0ZXMx", centroid=[1.0, 2.0], embedding_count=10
+            ),
+            _make_embedding_fds(
+                2, kll_bytes="Ynl0ZXMy", centroid=[3.0, 4.0], embedding_count=30
+            ),
+        ]
+        engine = self._engine_with_mock(_MERGED_JSON)
+
+        result = engine._resolve_merged_reference(fds_list, histogram_bins=20)
+
+        assert result is not None
+        assert result._is_embedding() is True
+        norm_stats = result._get_embedding_norm_extended_statistics()
+        assert len(norm_stats["histogram"]) == 2
+        assert norm_stats["kll"]["kllFormat"] == "datasketches-native-v1"
+        # Count-weighted centroid: (10*[1,2] + 30*[3,4]) / 40 = [2.5, 3.5].
+        assert result._get_embedding_centroid() == [2.5, 3.5]
+        engine._call_kll_merger.assert_called_once_with(["Ynl0ZXMx", "Ynl0ZXMy"], 20)
+
+    def test_falls_back_when_norm_kll_missing(self):
+        fds_list = [
+            _make_embedding_fds(1, kll_bytes="Ynl0ZXMx"),
+            _make_embedding_fds(2, kll_bytes=None, histogram=[]),
+        ]
+        engine = DistributionEngine()
+
+        result = engine._resolve_merged_reference(fds_list, histogram_bins=20)
+
+        assert result is None
+
+    def test_merged_reference_carries_percentiles_min_max(self):
+        """The synthetic embedding FDS surfaces the merged norm percentiles/min/max.
+
+        The scalar merged path sets these top-level fields and the embedding path
+        must mirror it, otherwise EQUI_FREQUENCY binning over the merged reference
+        reads None percentiles and falls back to EQUI_WIDTH.
+        """
+        fds_list = [
+            _make_embedding_fds(1, kll_bytes="Ynl0ZXMx", embedding_count=10),
+            _make_embedding_fds(2, kll_bytes="Ynl0ZXMy", embedding_count=30),
+        ]
+        engine = self._engine_with_mock(_MERGED_JSON)
+
+        result = engine._resolve_merged_reference(fds_list, histogram_bins=20)
+
+        assert result is not None
+        assert result.percentiles is not None
+        assert len(result.percentiles) == 99
+        assert result.min == 0.0
+        assert result.max == 10.0
+
+    def test_merged_reference_equi_frequency_does_not_fall_back(self, caplog):
+        """EQUI_FREQUENCY over a merged embedding reference resolves from percentiles.
+
+        With the top-level percentiles populated, _resolve_equi_frequency_edges
+        produces percentile-derived edges and never logs the EQUI_WIDTH fallback
+        warning (which fires when percentiles are None).
+        """
+        fds_list = [
+            _make_embedding_fds(1, kll_bytes="Ynl0ZXMx", embedding_count=10),
+            _make_embedding_fds(2, kll_bytes="Ynl0ZXMy", embedding_count=30),
+        ]
+        engine = self._engine_with_mock(_MERGED_JSON)
+
+        result = engine._resolve_merged_reference(fds_list, histogram_bins=20)
+        assert result is not None
+
+        with caplog.at_level(logging.WARNING):
+            edges = engine._resolve_bin_edges(
+                reference_fds=result,
+                detection_fds=result,
+                binning_strategy="EQUI_FREQUENCY",
+                bin_count=10,
+                custom_edges=None,
+            )
+
+        # 10 bins -> 11 strictly increasing edges, derived from the 99 percentiles.
+        assert len(edges) == 11
+        assert edges == sorted(edges)
+        assert "Falling back to EQUI_WIDTH" not in caplog.text

--- a/python/tests/core/test_feature_descriptive_statistics.py
+++ b/python/tests/core/test_feature_descriptive_statistics.py
@@ -383,3 +383,79 @@ class TestFeatureDescriptiveStatistics:
         assert kll.get("kllFormat") == "datasketches-native-v1"
         assert kll.get("bytes") == "AgEAAIAAAAAAAAAAAAAAAA=="
         assert "buckets" in kll
+
+    def test_from_deequ_json_embedding(self):
+        # Embedding (numeric-array) column: dataType "Embedding" plus a top-level
+        # "embedding" block carrying dimension, count, norm histogram/kll, centroid.
+        json_dict = {
+            "column": "user_vector",
+            "dataType": "Embedding",
+            "numRecordsNull": 0,
+            "numRecordsNonNull": 3,
+            "embedding": {
+                "dimension": 2,
+                "count": 3,
+                "norm": {
+                    "histogram": [
+                        {"value": "5.00 to 5.25", "count": 2, "ratio": 0.6667},
+                        {"value": "5.25 to 5.50", "count": 1, "ratio": 0.3333},
+                    ],
+                    "kll": {
+                        "kllFormat": "datasketches-native-v1",
+                        "bytes": "AgEAAIAAAAAAAAAAAAAAAA==",
+                        "buckets": [
+                            {
+                                "low_value": 5.0,
+                                "high_value": 5.5,
+                                "count": 3,
+                                "ratio": 1.0,
+                            }
+                        ],
+                    },
+                },
+                "centroid": [1.5, 2.5],
+            },
+        }
+
+        result = FeatureDescriptiveStatistics._from_deequ_json(json_dict)
+
+        assert result._feature_type == "Embedding"
+        assert result._is_embedding() is True
+        assert result._count == 3
+        embedding = result._get_embedding_statistics()
+        assert embedding["dimension"] == 2
+        assert result._get_embedding_centroid() == [1.5, 2.5]
+        # Norm view mirrors a scalar numeric column's histogram/kll layout.
+        norm_stats = result._get_embedding_norm_extended_statistics()
+        assert len(norm_stats["histogram"]) == 2
+        assert norm_stats["kll"]["kllFormat"] == "datasketches-native-v1"
+
+    def test_from_deequ_json_embedding_all_invalid(self):
+        # All rows invalid: embedding count 0, empty centroid, no norm block.
+        json_dict = {
+            "column": "user_vector",
+            "dataType": "Embedding",
+            "numRecordsNull": 0,
+            "numRecordsNonNull": 4,
+            "embedding": {"dimension": 2, "count": 0, "centroid": []},
+        }
+
+        result = FeatureDescriptiveStatistics._from_deequ_json(json_dict)
+
+        assert result._is_embedding() is True
+        assert result._get_embedding_centroid() == []
+        # No norm block: nothing to bin over.
+        assert result._get_embedding_norm_extended_statistics() is None
+
+    def test_get_embedding_accessors_non_embedding(self):
+        # Scalar features expose no embedding statistics.
+        fds = FeatureDescriptiveStatistics(
+            feature_name="amount",
+            feature_type="Fractional",
+            extended_statistics={"histogram": []},
+        )
+
+        assert fds._is_embedding() is False
+        assert fds._get_embedding_statistics() is None
+        assert fds._get_embedding_centroid() is None
+        assert fds._get_embedding_norm_extended_statistics() is None

--- a/python/tests/core/test_feature_monitoring_config.py
+++ b/python/tests/core/test_feature_monitoring_config.py
@@ -16,6 +16,7 @@
 
 from datetime import datetime, timezone
 
+import pytest
 from hsfs.core import feature_monitoring_config as fmc
 from hsfs.core.feature_monitoring_config import FeatureMonitoringType
 from hsfs.core.job_schedule import JobSchedule
@@ -747,6 +748,69 @@ class TestFeatureMonitoringConfigDistribution:
         assert len(scalar_children) >= 1
         assert len(dist_children) >= 1
 
+    # Embedding features
+
+    def _all_sc_configs(self, cfg):
+        return [
+            sc
+            for fs_config in cfg._feature_statistics_configs
+            for sc in (fs_config.statistics_comparison_configs or [])
+        ]
+
+    def test_compare_on_distribution_accepts_embedding(self):
+        valid_features = {"user_vector": "array<float>"}
+        cfg = self._build_config(valid_features=valid_features)
+
+        cfg.compare_on_distribution(
+            metric="PSI", threshold=0.2, feature_name="user_vector"
+        )
+
+        dist_children = [
+            sc for sc in self._all_sc_configs(cfg) if sc.distribution_metric is not None
+        ]
+        assert len(dist_children) == 1
+        # Embeddings default to the numeric EQUI_FREQUENCY strategy, not CATEGORICAL.
+        assert dist_children[0].binning_strategy == "EQUI_FREQUENCY"
+
+    def test_compare_on_accepts_embedding_centroid_distance(self):
+        valid_features = {"user_vector": "array<double>"}
+        cfg = self._build_config(valid_features=valid_features)
+
+        cfg.compare_on(
+            metric="CENTROID_DISTANCE", threshold=1.0, feature_name="user_vector"
+        )
+
+        scalar_children = [
+            sc for sc in self._all_sc_configs(cfg) if sc.metric is not None
+        ]
+        assert len(scalar_children) == 1
+        assert scalar_children[0].metric == "CENTROID_DISTANCE"
+
+    def test_compare_on_rejects_scalar_mean_on_embedding(self):
+        valid_features = {"user_vector": "array<float>"}
+        cfg = self._build_config(valid_features=valid_features)
+
+        with pytest.raises(ValueError, match="not supported for embedding feature"):
+            cfg.compare_on(metric="mean", threshold=1.0, feature_name="user_vector")
+
+    def test_compare_on_rejects_categorical_metric_on_embedding(self):
+        valid_features = {"user_vector": "array<float>"}
+        cfg = self._build_config(valid_features=valid_features)
+
+        with pytest.raises(ValueError, match="not supported for embedding feature"):
+            cfg.compare_on(
+                metric="completeness", threshold=1.0, feature_name="user_vector"
+            )
+
+    def test_compare_on_rejects_centroid_distance_on_scalar(self):
+        valid_features = {"amount": "double"}
+        cfg = self._build_config(valid_features=valid_features)
+
+        with pytest.raises(ValueError, match="requires an embedding feature"):
+            cfg.compare_on(
+                metric="CENTROID_DISTANCE", threshold=1.0, feature_name="amount"
+            )
+
     def test_type_promoted_to_pdf_after_compare_on_distribution(self):
         valid_features = {"amount": "double"}
         cfg = self._build_config(valid_features=valid_features)
@@ -1203,3 +1267,241 @@ class TestFeatureViewCreateModelMonitoring:
         assert "trainingDatasetId" not in d
         assert "featureViewId" not in d
         assert "enabled" not in d
+
+
+# ---------------------------------------------------------------------------
+# FSTORE-2053 — Automated re-training fields on FeatureMonitoringConfig
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureMonitoringConfigRetrainingFields:
+    """Round-trip and serialization of re-training fields on FeatureMonitoringConfig."""
+
+    def _build(self, **overrides):
+        kwargs = {
+            "feature_store_id": 67,
+            "feature_group_id": 42,
+            "feature_monitoring_type": FeatureMonitoringType.STATISTICS_COMPARISON,
+            "name": "retrain_monitoring",
+            "feature_statistics_configs": [],
+        }
+        kwargs.update(overrides)
+        return fmc.FeatureMonitoringConfig(**kwargs)
+
+    def test_default_retraining_fields_are_none(self):
+        cfg = self._build()
+        assert cfg.retrain_model_after_num_shifts is None
+        assert cfg.model_retraining_job_name is None
+        assert cfg.model_retraining_job_execution_args is None
+
+    def test_constructor_accepts_retraining_fields(self):
+        cfg = self._build(
+            retrain_model_after_num_shifts=3,
+            model_retraining_job_name="retrain_iris",
+            model_retraining_job_execution_args="--epochs 10",
+        )
+        assert cfg.retrain_model_after_num_shifts == 3
+        assert cfg.model_retraining_job_name == "retrain_iris"
+        assert cfg.model_retraining_job_execution_args == "--epochs 10"
+
+    def test_to_dict_emits_retraining_fields_when_set(self):
+        from hsfs.core.monitoring_window_config import MonitoringWindowConfig
+
+        cfg = self._build(
+            retrain_model_after_num_shifts=3,
+            model_retraining_job_name="retrain_iris",
+            model_retraining_job_execution_args="--epochs 10",
+        )
+        cfg._detection_window_config = MonitoringWindowConfig(
+            window_config_type=WindowConfigType.ALL_TIME, row_percentage=1.0
+        )
+        d = cfg.to_dict()
+        assert d["retrainModelAfterNumShifts"] == 3
+        assert d["modelRetrainingJobName"] == "retrain_iris"
+        assert d["modelRetrainingJobExecutionArgs"] == "--epochs 10"
+
+    def test_to_dict_omits_retraining_fields_when_unset(self):
+        from hsfs.core.monitoring_window_config import MonitoringWindowConfig
+
+        cfg = self._build()
+        cfg._detection_window_config = MonitoringWindowConfig(
+            window_config_type=WindowConfigType.ALL_TIME, row_percentage=1.0
+        )
+        d = cfg.to_dict()
+        assert "retrainModelAfterNumShifts" not in d
+        assert "modelRetrainingJobName" not in d
+        assert "modelRetrainingJobExecutionArgs" not in d
+
+    def test_from_response_json_round_trips_retraining_fields(self):
+
+        raw = {
+            "featureStoreId": 67,
+            "featureGroupId": 42,
+            "featureMonitoringType": "STATISTICS_COMPARISON",
+            "name": "retrain_monitoring",
+            "featureStatisticsConfigs": [],
+            "retrainModelAfterNumShifts": 5,
+            "modelRetrainingJobName": "my_retrain_job",
+            "modelRetrainingJobExecutionArgs": "--lr 0.001",
+            "detectionWindowConfig": {
+                "windowConfigType": "ALL_TIME",
+            },
+            "jobSchedule": {
+                "id": 1,
+                "startDateTime": 1676457000000,
+                "cronExpression": "0 0 * ? * * *",
+                "enabled": True,
+            },
+            "triggerType": "CRON",
+        }
+        cfg = fmc.FeatureMonitoringConfig.from_response_json(raw)
+        assert cfg.retrain_model_after_num_shifts == 5
+        assert cfg.model_retraining_job_name == "my_retrain_job"
+        assert cfg.model_retraining_job_execution_args == "--lr 0.001"
+
+
+# ---------------------------------------------------------------------------
+# FSTORE-2053 — create_model_monitoring re-training kwargs delegation + validation
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureViewCreateModelMonitoringRetraining:
+    """FSTORE-2053: create_model_monitoring stamps re-training fields and validates input."""
+
+    def _setup_happy_path(self, mocker):
+        """Return a mocked FeatureView ready for create_model_monitoring."""
+        from unittest.mock import MagicMock, PropertyMock
+
+        from hsfs.feature_view import FeatureView
+
+        fv = MagicMock(spec=FeatureView)
+        fv.logging_enabled = True
+
+        mocker.patch(
+            "hopsworks_common.client._get_instance",
+            return_value=MagicMock(_project_id=119),
+        )
+        model_meta = MagicMock()
+        model_meta.training_dataset_version = 9
+        mock_model_api = MagicMock()
+        mock_model_api._get.return_value = model_meta
+        mocker.patch("hsml.core.model_api.ModelApi", return_value=mock_model_api)
+
+        inner_config = fmc.FeatureMonitoringConfig(
+            feature_store_id=67,
+            feature_group_id=42,
+            feature_monitoring_type=FeatureMonitoringType.STATISTICS_COMPARISON,
+            name="cfg",
+            feature_statistics_configs=[],
+        )
+        mock_fg = MagicMock()
+        mock_fg.create_feature_monitoring.return_value = inner_config
+        mock_logging = MagicMock()
+        mock_logging.get_feature_group.return_value = mock_fg
+        type(fv).feature_logging = PropertyMock(return_value=mock_logging)
+
+        return fv, inner_config
+
+    def test_happy_path_stamps_retraining_fields_job_object(self, mocker):
+        from unittest.mock import MagicMock
+
+        from hsfs.feature_view import FeatureView
+
+        fv, inner_config = self._setup_happy_path(mocker)
+
+        mock_job = MagicMock()
+        mock_job.name = "retrain_iris"
+
+        result = FeatureView.create_model_monitoring(
+            fv,
+            name="cfg",
+            model_name="iris",
+            model_version=3,
+            retrain_model_after_num_shifts=4,
+            model_retraining_job=mock_job,
+            model_retraining_job_execution_args="--epochs 5",
+        )
+
+        assert result._retrain_model_after_num_shifts == 4
+        assert result._model_retraining_job_name == "retrain_iris"
+        assert result._model_retraining_job_execution_args == "--epochs 5"
+
+    def test_happy_path_no_retraining_job_leaves_name_none(self, mocker):
+        from hsfs.feature_view import FeatureView
+
+        fv, inner_config = self._setup_happy_path(mocker)
+
+        result = FeatureView.create_model_monitoring(
+            fv,
+            name="cfg",
+            model_name="iris",
+            model_version=3,
+            retrain_model_after_num_shifts=2,
+        )
+
+        assert result._retrain_model_after_num_shifts == 2
+        assert result._model_retraining_job_name is None
+        assert result._model_retraining_job_execution_args is None
+
+    def test_validation_rejects_zero_num_shifts(self, mocker):
+        import pytest
+        from hopsworks_common.client.exceptions import FeatureStoreException
+        from hsfs.feature_view import FeatureView
+
+        fv, _ = self._setup_happy_path(mocker)
+
+        with pytest.raises(FeatureStoreException, match="positive integer"):
+            FeatureView.create_model_monitoring(
+                fv,
+                name="cfg",
+                model_name="iris",
+                model_version=3,
+                retrain_model_after_num_shifts=0,
+            )
+
+    def test_validation_rejects_negative_num_shifts(self, mocker):
+        import pytest
+        from hopsworks_common.client.exceptions import FeatureStoreException
+        from hsfs.feature_view import FeatureView
+
+        fv, _ = self._setup_happy_path(mocker)
+
+        with pytest.raises(FeatureStoreException, match="positive integer"):
+            FeatureView.create_model_monitoring(
+                fv,
+                name="cfg",
+                model_name="iris",
+                model_version=3,
+                retrain_model_after_num_shifts=-1,
+            )
+
+    def test_validation_rejects_non_int_num_shifts(self, mocker):
+        import pytest
+        from hopsworks_common.client.exceptions import FeatureStoreException
+        from hsfs.feature_view import FeatureView
+
+        fv, _ = self._setup_happy_path(mocker)
+
+        with pytest.raises(FeatureStoreException, match="positive integer"):
+            FeatureView.create_model_monitoring(
+                fv,
+                name="cfg",
+                model_name="iris",
+                model_version=3,
+                retrain_model_after_num_shifts=1.5,
+            )
+
+    def test_validation_accepts_none_num_shifts(self, mocker):
+        """None is allowed: it simply disables re-training (opt-in feature)."""
+        from hsfs.feature_view import FeatureView
+
+        fv, inner_config = self._setup_happy_path(mocker)
+
+        result = FeatureView.create_model_monitoring(
+            fv,
+            name="cfg",
+            model_name="iris",
+            model_version=3,
+            retrain_model_after_num_shifts=None,
+        )
+        assert result._retrain_model_after_num_shifts is None

--- a/python/tests/core/test_feature_monitoring_config_engine.py
+++ b/python/tests/core/test_feature_monitoring_config_engine.py
@@ -584,6 +584,72 @@ class TestFeatureMonitoringConfigEngine:
         assert result.empty_detection_window is False
         assert result.shift_detected is False
 
+    def test_run_feature_monitoring_all_features_mode_uses_schema_feature_names(
+        self, mocker
+    ):
+        """All-features configs must resolve feature names from the entity schema.
+
+        A config without feature_statistics_configs children returns [] from
+        get_feature_names().
+        Passing [] downstream fabricates zero count=0 FDS on empty windows, which the
+        backend rejects with 'Feature statistics results not provided' (270287).
+        """
+        # Arrange
+        config_engine = feature_monitoring_config_engine.FeatureMonitoringConfigEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+
+        mock_config = MagicMock()
+        mock_config.id = 42
+        mock_config.get_feature_names.return_value = []
+        mock_config.feature_statistics_configs = None
+        mock_config.detection_window_config = MagicMock()
+        mock_config.reference_window_config = None
+        mock_config.model_name = None
+        mock_config.model_version = None
+        mocker.patch.object(
+            config_engine._feature_monitoring_config_api,
+            "_get_by_name",
+            return_value=mock_config,
+        )
+
+        run_window_mock = mocker.patch.object(
+            config_engine._monitoring_window_config_engine,
+            "_run_single_window_monitoring",
+            return_value=[
+                FeatureDescriptiveStatistics(feature_name="amount", count=0),
+                FeatureDescriptiveStatistics(feature_name="embedding", count=0),
+            ],
+        )
+        save_mock = mocker.patch.object(
+            config_engine._result_engine,
+            "_run_and_save_statistics_comparison",
+            return_value=MagicMock(),
+        )
+
+        entity = MagicMock()
+        feat_amount, feat_embedding = MagicMock(), MagicMock()
+        feat_amount.name = "amount"
+        feat_embedding.name = "embedding"
+        entity.features = [feat_amount, feat_embedding]
+
+        # Act
+        config_engine._run_feature_monitoring(
+            entity=entity,
+            config_name="all_features_config",
+        )
+
+        # Assert: the window read received the schema-derived names, not []
+        assert run_window_mock.call_args.kwargs["feature_names"] == [
+            "amount",
+            "embedding",
+        ]
+        assert (
+            save_mock.call_args.kwargs["detection_statistics"]
+            is run_window_mock.return_value
+        )
+
     # ------------------------------------------------------------------
     # H4 — profile_flags gate & XOR validator
     # ------------------------------------------------------------------

--- a/python/tests/core/test_feature_monitoring_config_engine.py
+++ b/python/tests/core/test_feature_monitoring_config_engine.py
@@ -710,6 +710,98 @@ class TestFeatureMonitoringConfigEngine:
                 "profile_flags must be None for scalar-only config"
             )
 
+    def _build_mock_fm_config_with_centroid_child(self, feature_names):
+        """Build a mock FeatureMonitoringConfig with one CENTROID_DISTANCE child."""
+        sc_centroid = StatisticsComparisonConfig(
+            metric="CENTROID_DISTANCE",
+            threshold=0.2,
+            strict=False,
+        )
+        fs_configs = [
+            MagicMock(
+                feature_name=f,
+                statistics_comparison_configs=[sc_centroid],
+            )
+            for f in feature_names
+        ]
+        config = MagicMock()
+        config.id = 42
+        config.get_feature_names.return_value = feature_names
+        config.feature_statistics_configs = fs_configs
+        config.detection_window_config = MagicMock()
+        config.reference_window_config = MagicMock()
+        return config
+
+    def test_get_embedding_targeted_feature_names_includes_centroid_distance(self):
+        """CENTROID_DISTANCE features are returned; distribution-only features are not."""
+        config_engine = feature_monitoring_config_engine.FeatureMonitoringConfigEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        centroid = StatisticsComparisonConfig(
+            metric="CENTROID_DISTANCE", threshold=0.2, strict=False
+        )
+        distribution = StatisticsComparisonConfig(
+            distribution_metric="PSI",
+            threshold=0.2,
+            strict=False,
+            binning_strategy="EQUI_WIDTH",
+            bin_count=10,
+            smoothing_epsilon=1e-6,
+        )
+        config = MagicMock()
+        config.feature_statistics_configs = [
+            MagicMock(feature_name="emb", statistics_comparison_configs=[centroid]),
+            MagicMock(
+                feature_name="amount", statistics_comparison_configs=[distribution]
+            ),
+        ]
+
+        targeted = config_engine._get_embedding_targeted_feature_names(config)
+
+        assert targeted == {"emb"}
+
+    def test_run_feature_monitoring_passes_embedding_feature_names(self, mocker):
+        """A CENTROID_DISTANCE config forwards the embedding-targeted feature set downstream."""
+        feature_names = ["emb"]
+        non_empty_fds = [FeatureDescriptiveStatistics(feature_name="emb", count=100)]
+
+        config_engine = feature_monitoring_config_engine.FeatureMonitoringConfigEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+
+        mock_config = self._build_mock_fm_config_with_centroid_child(feature_names)
+        mocker.patch.object(
+            config_engine._feature_monitoring_config_api,
+            "_get_by_name",
+            return_value=mock_config,
+        )
+
+        run_single_mock = mocker.patch.object(
+            config_engine._monitoring_window_config_engine,
+            "_run_single_window_monitoring",
+            return_value=non_empty_fds,
+        )
+
+        saved_result = MagicMock()
+        saved_result.empty_reference_window = False
+        saved_result.empty_detection_window = False
+        saved_result.shift_detected = False
+        mocker.patch.object(
+            config_engine._result_engine,
+            "_run_and_save_statistics_comparison",
+            return_value=saved_result,
+        )
+
+        entity = MagicMock()
+        config_engine._run_feature_monitoring(
+            entity=entity, config_name="centroid_config"
+        )
+
+        for call in run_single_mock.call_args_list:
+            assert call.kwargs.get("embedding_feature_names") == {"emb"}
+
     def test_distribution_child_rejects_specific_value(self):
         """validate_statistics_comparison_config raises when distribution child has specific_value."""
         config_engine = feature_monitoring_config_engine.FeatureMonitoringConfigEngine(
@@ -726,3 +818,57 @@ class TestFeatureMonitoringConfigEngine:
             ValueError, match="specific_value is not allowed for distribution"
         ):
             config_engine._validate_statistics_comparison_config(mock_sc)
+
+
+class TestEmbeddingTypeCompatibility:
+    def _engine(self):
+        return feature_monitoring_config_engine.FeatureMonitoringConfigEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+
+    def test_is_embedding_type(self):
+        assert feature_monitoring_config_engine._is_embedding_type("array<float>")
+        assert feature_monitoring_config_engine._is_embedding_type("array<double>")
+        assert feature_monitoring_config_engine._is_embedding_type("array<int>")
+        assert feature_monitoring_config_engine._is_embedding_type(
+            "array<decimal(10,2)>"
+        )
+        # Non-numeric arrays and primitives are not embeddings.
+        assert not feature_monitoring_config_engine._is_embedding_type("array<string>")
+        assert not feature_monitoring_config_engine._is_embedding_type("double")
+        assert not feature_monitoring_config_engine._is_embedding_type(
+            "map<string,int>"
+        )
+
+    def test_embedding_valid_for_distribution_metric(self):
+        engine = self._engine()
+        # Norm drift via any distribution metric is allowed for embeddings.
+        assert engine._is_type_compatible("PSI", "array<float>") is True
+        assert engine._is_type_compatible("WASSERSTEIN", "array<double>") is True
+        assert engine._is_type_compatible("KOLMOGOROV_SMIRNOV", "array<float>") is True
+
+    def test_embedding_valid_for_centroid_distance(self):
+        engine = self._engine()
+        assert engine._is_type_compatible("CENTROID_DISTANCE", "array<float>") is True
+
+    def test_embedding_invalid_for_scalar_metrics(self):
+        engine = self._engine()
+        for metric in ("mean", "std_dev", "min", "max", "sum", "completeness"):
+            assert engine._is_type_compatible(metric, "array<float>") is False
+
+    def test_centroid_distance_invalid_for_non_embedding(self):
+        engine = self._engine()
+        assert engine._is_type_compatible("CENTROID_DISTANCE", "double") is False
+        assert engine._is_type_compatible("CENTROID_DISTANCE", "string") is False
+
+    def test_validate_statistics_metric_accepts_centroid_distance(self):
+        engine = self._engine()
+        # Does not raise.
+        engine._validate_statistics_metric("CENTROID_DISTANCE")
+        engine._validate_statistics_metric("centroid_distance")
+
+    def test_validate_statistics_metric_rejects_unknown(self):
+        engine = self._engine()
+        with pytest.raises(ValueError, match="Invalid metric"):
+            engine._validate_statistics_metric("not_a_metric")

--- a/python/tests/core/test_feature_monitoring_result_engine.py
+++ b/python/tests/core/test_feature_monitoring_result_engine.py
@@ -15,6 +15,7 @@
 #
 
 from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock
 
 import dateutil
 import pytest
@@ -153,6 +154,42 @@ class TestFeatureMonitoringResultEngine:
         assert result._feature_statistics_results is None
         assert result._raised_exception is True
         assert after_time >= result._monitoring_time >= before_time
+
+    def test_run_and_save_statistics_comparison_empty_detection_statistics(
+        self, mocker
+    ):
+        """Zero detection FDS must still flag the detection window as empty.
+
+        An all-features config combined with an empty window can yield an empty FDS
+        list; the per-FDS loop cannot flip the empty flags in that case.
+        """
+        # Arrange
+        mocker.patch(HSFS_CLIENT_GET_INSTANCE)
+        mocker.patch(LAST_EXECUTION_API)
+        mocker.patch(GET_JOB_API)
+        result_engine_save_mock = mocker.patch(
+            "hsfs.core.feature_monitoring_result_engine.FeatureMonitoringResultEngine._save",
+        )
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        fm_config = MagicMock()
+        fm_config.id = DEFAULT_CONFIG_ID
+        fm_config.feature_statistics_configs = None
+
+        # Act
+        result_engine._run_and_save_statistics_comparison(
+            fm_config=fm_config,
+            detection_statistics=[],
+            reference_statistics=[],
+        )
+
+        # Assert
+        result = result_engine_save_mock.call_args[0][0]
+        assert result._empty_detection_window is True
+        assert result._empty_reference_window is True
+        assert result._feature_statistics_results == []
 
     # Build result
 

--- a/python/tests/core/test_feature_monitoring_result_engine.py
+++ b/python/tests/core/test_feature_monitoring_result_engine.py
@@ -326,6 +326,111 @@ class TestFeatureMonitoringResultEngine:
         assert diff_with_shift == 5.0
         assert with_shift is True
 
+    def test_default_binning_strategy_embedding(self):
+        # Embeddings bin over their numeric norm histogram, so EQUI_FREQUENCY.
+        fds = FeatureDescriptiveStatistics(
+            feature_name="user_vector", feature_type="Embedding", count=10
+        )
+        assert (
+            feature_monitoring_result_engine._default_binning_strategy(fds)
+            == "EQUI_FREQUENCY"
+        )
+
+    def test_default_binning_strategy_non_numeric(self):
+        fds = FeatureDescriptiveStatistics(
+            feature_name="city", feature_type="String", count=10
+        )
+        assert (
+            feature_monitoring_result_engine._default_binning_strategy(fds)
+            == "CATEGORICAL"
+        )
+
+    def _embedding_fds(self, centroid, count=10):
+        return FeatureDescriptiveStatistics(
+            feature_name="user_vector",
+            feature_type="Embedding",
+            count=count,
+            extended_statistics={"embedding": {"dimension": 2, "centroid": centroid}},
+        )
+
+    def test_compute_centroid_distance_l2(self):
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        det = self._embedding_fds([0.0, 0.0])
+        ref = self._embedding_fds([3.0, 4.0])
+
+        distance = result_engine._compute_centroid_distance(
+            detection_statistics=det, reference_statistics=ref
+        )
+
+        assert distance == 5.0
+
+    def test_compute_centroid_distance_via_dispatch(self):
+        from hsfs.core.statistics_comparison_config import StatisticsComparisonConfig
+
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        det = self._embedding_fds([0.0, 0.0])
+        ref = self._embedding_fds([3.0, 4.0])
+        sc_config = StatisticsComparisonConfig(
+            metric="CENTROID_DISTANCE", threshold=4.0, strict=False, id=1
+        )
+
+        difference, shift = result_engine._compute_difference_and_shift(
+            sc_config=sc_config,
+            detection_statistics=det,
+            reference_statistics=ref,
+        )
+
+        assert difference == 5.0
+        assert shift is True
+
+    def test_compute_centroid_distance_length_mismatch(self):
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        det = self._embedding_fds([1.0, 2.0, 3.0])
+        ref = self._embedding_fds([3.0, 4.0])
+
+        distance = result_engine._compute_centroid_distance(
+            detection_statistics=det, reference_statistics=ref
+        )
+
+        assert distance is None
+
+    def test_compute_centroid_distance_missing_centroid(self):
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        det = self._embedding_fds([])  # all-invalid window
+        ref = self._embedding_fds([3.0, 4.0])
+
+        distance = result_engine._compute_centroid_distance(
+            detection_statistics=det, reference_statistics=ref
+        )
+
+        assert distance is None
+
+    def test_compute_centroid_distance_empty_window(self):
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        det = self._embedding_fds([1.0, 2.0], count=0)
+        ref = self._embedding_fds([3.0, 4.0])
+
+        distance = result_engine._compute_centroid_distance(
+            detection_statistics=det, reference_statistics=ref
+        )
+
+        assert distance is None
+
     # Helper methods
 
     def test_build_query_params_time_none(self):

--- a/python/tests/core/test_monitoring_window_config_engine.py
+++ b/python/tests/core/test_monitoring_window_config_engine.py
@@ -928,3 +928,284 @@ class TestMergeDispatch:
         assert not resolve_mock.called, (
             "cap reached — must fall back before even invoking the merger"
         )
+
+
+# ---------------------------------------------------------------------------
+# Stale-stats embedding guard tests
+# ---------------------------------------------------------------------------
+
+
+def _make_scalar_fg():
+    """Create a minimal non-time-travel FeatureGroup mock that skips the merge path."""
+    fg = MagicMock(spec=feature_group.FeatureGroup)
+    fg._feature_store_id = 1
+    fg.ENTITY_TYPE = "featuregroups"
+    fg.time_travel_format = None
+    return fg
+
+
+def _embedding_fds(feature_name: str, with_block: bool):
+    """Build an embedding FDS with or without the extended_statistics.embedding block."""
+    extended = (
+        {"embedding": {"dimension": 2, "centroid": [1.0, 2.0]}} if with_block else {}
+    )
+    return FeatureDescriptiveStatistics(
+        feature_name=feature_name,
+        feature_type="Embedding",
+        count=10,
+        extended_statistics=extended,
+    )
+
+
+class TestStaleStatsEmbeddingGuard:
+    """Tests for _reused_stats_lack_embedding and its effect in _run_single_window_monitoring."""
+
+    def test_lacks_embedding_when_targeted_feature_missing_block(self):
+        """A CENTROID_DISTANCE-targeted feature without the embedding block requires recompute."""
+        engine = mwce.MonitoringWindowConfigEngine()
+        registered = MagicMock()
+        registered.feature_descriptive_statistics = [
+            _embedding_fds("emb", with_block=False)
+        ]
+
+        assert engine._reused_stats_lack_embedding(registered, {"emb"}) is True
+
+    def test_has_embedding_when_targeted_feature_has_block(self):
+        """A targeted feature that already carries the embedding block can be reused."""
+        engine = mwce.MonitoringWindowConfigEngine()
+        registered = MagicMock()
+        registered.feature_descriptive_statistics = [
+            _embedding_fds("emb", with_block=True)
+        ]
+
+        assert engine._reused_stats_lack_embedding(registered, {"emb"}) is False
+
+    def test_self_identified_embedding_without_block_requires_recompute(self):
+        """A reused FDS that is an embedding type but lacks the block requires recompute.
+
+        This covers a stale embedding feature behind an ambiguous distribution metric,
+        which is not in the explicitly targeted set.
+        """
+        engine = mwce.MonitoringWindowConfigEngine()
+        registered = MagicMock()
+        registered.feature_descriptive_statistics = [
+            _embedding_fds("emb", with_block=False)
+        ]
+
+        # No targeted names: detection still fires via the FDS feature type.
+        assert engine._reused_stats_lack_embedding(registered, None) is True
+
+    def test_scalar_feature_never_requires_embedding(self):
+        """A present scalar FDS is not forced to recompute when nothing targets embedding.
+
+        With no CENTROID_DISTANCE target and a non-embedding feature type, neither the
+        absent-target branch nor the missing-block branch fires.
+        """
+        engine = mwce.MonitoringWindowConfigEngine()
+        registered = MagicMock()
+        registered.feature_descriptive_statistics = [
+            FeatureDescriptiveStatistics(
+                feature_name="amount", feature_type="Fractional"
+            )
+        ]
+
+        assert engine._reused_stats_lack_embedding(registered, None) is False
+
+    def test_lacks_embedding_when_targeted_feature_absent(self):
+        """A CENTROID_DISTANCE-targeted feature missing entirely requires recompute.
+
+        Reused stats produced before embedding support omit the feature altogether
+        rather than carrying an embedding-less FDS for it, so the absence itself must
+        force a reprofile instead of silently bypassing the comparison.
+        """
+        engine = mwce.MonitoringWindowConfigEngine()
+        registered = MagicMock()
+        registered.feature_descriptive_statistics = [
+            FeatureDescriptiveStatistics(
+                feature_name="amount", feature_type="Fractional"
+            )
+        ]
+
+        assert engine._reused_stats_lack_embedding(registered, {"emb"}) is True
+
+    def test_lacks_embedding_when_all_stats_missing_and_targeted(self):
+        """An empty reused stats list with a CENTROID_DISTANCE target requires recompute.
+
+        Stats produced before embedding support may have skipped every column, leaving
+        the list empty. The targeted feature is then absent like any other missing
+        feature, so the absence must force a reprofile rather than be treated as
+        nothing-to-do.
+        """
+        engine = mwce.MonitoringWindowConfigEngine()
+        registered = MagicMock()
+        registered.feature_descriptive_statistics = []
+
+        assert engine._reused_stats_lack_embedding(registered, {"emb"}) is True
+
+    def test_empty_stats_without_target_does_not_recompute(self):
+        """An empty reused stats list with no CENTROID_DISTANCE target needs no recompute.
+
+        With nothing targeted and no FDS to self-identify as embedding, neither branch
+        fires.
+        """
+        engine = mwce.MonitoringWindowConfigEngine()
+        registered = MagicMock()
+        registered.feature_descriptive_statistics = []
+
+        assert engine._reused_stats_lack_embedding(registered, None) is False
+
+    def test_reused_stale_embedding_forces_recompute(self, mocker):
+        """End-to-end: reused stats lacking the embedding block trigger a window reprofile."""
+        engine = mwce.MonitoringWindowConfigEngine()
+        fg = _make_scalar_fg()
+        window_config = mwc.MonitoringWindowConfig(
+            window_config_type=mwc.WindowConfigType.ALL_TIME,
+            row_percentage=1.0,
+        )
+
+        mocker.patch.object(engine, "_init_statistics_engine")
+        mocker.patch.object(
+            engine, "_get_window_start_end_times", return_value=(None, 123)
+        )
+        stats_engine_mock = MagicMock()
+        engine._statistics_engine = stats_engine_mock
+
+        # Reused (stale) stats: embedding feature missing the block.
+        stale = MagicMock()
+        stale.feature_descriptive_statistics = [_embedding_fds("emb", with_block=False)]
+        stats_engine_mock._get_by_time_window.return_value = stale
+
+        # The recompute path returns fresh stats carrying the embedding block.
+        fresh = MagicMock()
+        fresh.feature_descriptive_statistics = [_embedding_fds("emb", with_block=True)]
+        stats_engine_mock._compute_and_save_monitoring_statistics.return_value = fresh
+        mocker.patch.object(
+            engine, "_fetch_entity_data_in_monitoring_window", return_value=MagicMock()
+        )
+
+        result = engine._run_single_window_monitoring(
+            entity=fg,
+            monitoring_window_config=window_config,
+            feature_names=["emb"],
+            embedding_feature_names={"emb"},
+        )
+
+        stats_engine_mock._compute_and_save_monitoring_statistics.assert_called_once()
+        assert result == fresh.feature_descriptive_statistics
+
+    def test_reused_fresh_embedding_is_not_recomputed(self, mocker):
+        """End-to-end: reused stats that already carry the embedding block are reused as-is."""
+        engine = mwce.MonitoringWindowConfigEngine()
+        fg = _make_scalar_fg()
+        window_config = mwc.MonitoringWindowConfig(
+            window_config_type=mwc.WindowConfigType.ALL_TIME,
+            row_percentage=1.0,
+        )
+
+        mocker.patch.object(engine, "_init_statistics_engine")
+        mocker.patch.object(
+            engine, "_get_window_start_end_times", return_value=(None, 123)
+        )
+        stats_engine_mock = MagicMock()
+        engine._statistics_engine = stats_engine_mock
+
+        reusable = MagicMock()
+        reusable.feature_descriptive_statistics = [
+            _embedding_fds("emb", with_block=True)
+        ]
+        stats_engine_mock._get_by_time_window.return_value = reusable
+        fetch_mock = mocker.patch.object(
+            engine, "_fetch_entity_data_in_monitoring_window"
+        )
+
+        result = engine._run_single_window_monitoring(
+            entity=fg,
+            monitoring_window_config=window_config,
+            feature_names=["emb"],
+            embedding_feature_names={"emb"},
+        )
+
+        stats_engine_mock._compute_and_save_monitoring_statistics.assert_not_called()
+        fetch_mock.assert_not_called()
+        assert result == reusable.feature_descriptive_statistics
+
+    def test_reused_stats_omitting_targeted_feature_forces_recompute(self, mocker):
+        """End-to-end: reused stats missing a targeted feature trigger a reprofile."""
+        engine = mwce.MonitoringWindowConfigEngine()
+        fg = _make_scalar_fg()
+        window_config = mwc.MonitoringWindowConfig(
+            window_config_type=mwc.WindowConfigType.ALL_TIME,
+            row_percentage=1.0,
+        )
+
+        mocker.patch.object(engine, "_init_statistics_engine")
+        mocker.patch.object(
+            engine, "_get_window_start_end_times", return_value=(None, 123)
+        )
+        stats_engine_mock = MagicMock()
+        engine._statistics_engine = stats_engine_mock
+
+        # Reused (stale) stats predate embedding support: the targeted feature is
+        # absent entirely, not present with an embedding-less FDS.
+        stale = MagicMock()
+        stale.feature_descriptive_statistics = [
+            FeatureDescriptiveStatistics(
+                feature_name="amount", feature_type="Fractional"
+            )
+        ]
+        stats_engine_mock._get_by_time_window.return_value = stale
+
+        fresh = MagicMock()
+        fresh.feature_descriptive_statistics = [_embedding_fds("emb", with_block=True)]
+        stats_engine_mock._compute_and_save_monitoring_statistics.return_value = fresh
+        mocker.patch.object(
+            engine, "_fetch_entity_data_in_monitoring_window", return_value=MagicMock()
+        )
+
+        result = engine._run_single_window_monitoring(
+            entity=fg,
+            monitoring_window_config=window_config,
+            feature_names=["emb"],
+            embedding_feature_names={"emb"},
+        )
+
+        stats_engine_mock._compute_and_save_monitoring_statistics.assert_called_once()
+        assert result == fresh.feature_descriptive_statistics
+
+    def test_scalar_path_unchanged_when_no_embedding_target(self, mocker):
+        """Non-embedding config reuses scalar stats without recompute (path unchanged)."""
+        engine = mwce.MonitoringWindowConfigEngine()
+        fg = _make_scalar_fg()
+        window_config = mwc.MonitoringWindowConfig(
+            window_config_type=mwc.WindowConfigType.ALL_TIME,
+            row_percentage=1.0,
+        )
+
+        mocker.patch.object(engine, "_init_statistics_engine")
+        mocker.patch.object(
+            engine, "_get_window_start_end_times", return_value=(None, 123)
+        )
+        stats_engine_mock = MagicMock()
+        engine._statistics_engine = stats_engine_mock
+
+        reusable = MagicMock()
+        reusable.feature_descriptive_statistics = [
+            FeatureDescriptiveStatistics(
+                feature_name="amount", feature_type="Fractional"
+            )
+        ]
+        stats_engine_mock._get_by_time_window.return_value = reusable
+        fetch_mock = mocker.patch.object(
+            engine, "_fetch_entity_data_in_monitoring_window"
+        )
+
+        result = engine._run_single_window_monitoring(
+            entity=fg,
+            monitoring_window_config=window_config,
+            feature_names=["amount"],
+            embedding_feature_names=None,
+        )
+
+        stats_engine_mock._compute_and_save_monitoring_statistics.assert_not_called()
+        fetch_mock.assert_not_called()
+        assert result == reusable.feature_descriptive_statistics

--- a/python/tests/core/test_opensearch.py
+++ b/python/tests/core/test_opensearch.py
@@ -16,7 +16,10 @@
 from unittest.mock import MagicMock
 
 import pytest
-from hopsworks_common.core.opensearch import ProjectOpenSearchClient
+from hopsworks_common.core.opensearch import (
+    ProjectOpenSearchClient,
+    _handle_opensearch_exception,
+)
 from hsfs.client.exceptions import VectorDatabaseException
 from hsfs.core.opensearch import OpenSearchClientSingleton, OpensearchRequestOption
 
@@ -82,6 +85,72 @@ class TestOpenSearchClientSingleton:
         assert isinstance(exception, VectorDatabaseException)
         assert exception.reason == expected_reason
         assert exception.info == expected_info
+
+    @pytest.mark.parametrize(
+        "error_body",
+        [
+            # k-too-large reported as a top-level illegal_argument_exception (no caused_by),
+            # as this backend does.
+            {
+                "error": {
+                    "type": "illegal_argument_exception",
+                    "reason": "[knn] requires k to be in the range (0, 10000]",
+                }
+            },
+            # k-too-large nested under caused_by, as OpenSearch wraps it.
+            {
+                "error": {
+                    "type": "search_phase_execution_exception",
+                    "reason": "all shards failed",
+                    "caused_by": {
+                        "type": "illegal_argument_exception",
+                        "reason": "[knn] requires k to be in the range (0, 10000]",
+                    },
+                }
+            },
+        ],
+    )
+    def test_handle_opensearch_exception_routes_k_too_large(self, error_body):
+        # The max-k probe in find_neighbors relies on a k-too-large RequestError being
+        # classified as REQUESTED_K_TOO_LARGE regardless of whether the vector database
+        # reports it at the top level or nested under caused_by.
+        from opensearchpy.exceptions import RequestError
+
+        target = ProjectOpenSearchClient(opensearch_client=None)
+
+        @_handle_opensearch_exception
+        def _raise(_self):
+            raise RequestError(400, "illegal_argument_exception", error_body)
+
+        with pytest.raises(VectorDatabaseException) as excinfo:
+            _raise(target)
+        assert excinfo.value.reason == VectorDatabaseException.REQUESTED_K_TOO_LARGE
+        assert (
+            excinfo.value.info[VectorDatabaseException.REQUESTED_K_TOO_LARGE_INFO_K]
+            == 10000
+        )
+
+    def test_handle_opensearch_exception_preserves_info_for_generic_error(self):
+        # A top-level illegal_argument that is not a known validation message must stay
+        # OTHERS and keep the original response payload so malformed queries stay diagnosable.
+        from opensearchpy.exceptions import RequestError
+
+        target = ProjectOpenSearchClient(opensearch_client=None)
+        error_body = {
+            "error": {
+                "type": "illegal_argument_exception",
+                "reason": "Unknown field [bogus] in knn query",
+            }
+        }
+
+        @_handle_opensearch_exception
+        def _raise(_self):
+            raise RequestError(400, "illegal_argument_exception", error_body)
+
+        with pytest.raises(VectorDatabaseException) as excinfo:
+            _raise(target)
+        assert excinfo.value.reason == VectorDatabaseException.OTHERS
+        assert excinfo.value.info == error_body
 
     @pytest.fixture(autouse=True)
     def reset_singleton(self):


### PR DESCRIPTION
## Summary
Extends Feature Monitoring V2 to features of type **embedding** (vectors), which were previously skipped by statistics computation. Spark/JVM engine only; Python-engine profiling parity, per-dimension stats, and model re-training automation are out of scope (the latter tracked separately).

- **Spark/JVM profiler**: numeric `array<T>` columns are profiled as `Embedding`. Per-row L2 norm runs through the existing histogram + KLL path, and the element-wise mean (centroid) is computed, both emitted under a new `embedding` block in the profile JSON. Row validity rules: null / empty / null-NaN-or-infinite element / ragged length / all-invalid.
- **Python SDK**: parses the embedding block; accepts embedding features at config time for distribution metrics and the new `CENTROID_DISTANCE` scalar metric (rejecting scalar metrics on them); sources norm histogram/KLL from the embedding block; merges per-batch norm KLL and a count-weighted centroid for rolling reference windows; scores `CENTROID_DISTANCE` as plain L2 distance; defaults embeddings to equi-frequency binning; reprofiles stale windows missing the embedding block.
- **Java SDK**: preserves the `embedding` block in the profiler-JSON parser.

Spec: https://hopsworks.atlassian.net/wiki/spaces/~597211656/pages/1533771777

## Test plan
- [x] `java/spark` profile tests incl. new `ColumnProfilerEmbeddingTest` (norm, centroid, edge cases, infinity)
- [x] Python `core/` tests: FDS parsing, config validation, distribution sourcing, rolling-reference merge, centroid L2, binning default, stale-stats reprofile guard
- [x] Java SDK FDS round-trip test preserves embedding
- [ ] Cluster integration: full Spark profile → HopsFS extended-statistics round-trip → drift result on a real embedding FG (deferred; no cluster yet)

## Notes for reviewers
- `CENTROID_DISTANCE` is plain L2 for the MVP; similarity-function-aware (cosine/dot) distance is a deferred follow-up.
- Companion PRs: hopsworks-ee (backend enum + validation), hopsworks-front (timeline rendering).