### PR TITLE
[HWORKS-1840] Upgrade KServe to v0.19.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,10 +50,10 @@ dependencies = [
     "fsspec<2025.12.0",
     "retrying",
     "hopsworks_aiomysql[sa]==0.2.2",
-    "opensearch-py>=1.1.0,<=2.8.0",
+    "opensearch-py>=2.8.0,<3.0.0",   # >=2.8.0 for urllib3>=2 (KServe 0.19); <3.0.0 stays on the 2.x line
     "tqdm",
     "grpcio>=1.49.1,<2.0.0",         # ^1.49.1
-    "protobuf>=4.25.4,<5.0.0",       # ^4.25.4
+    "protobuf>=4.25.4,<7.0.0",       # widened to <7 so KServe 0.19 (protobuf>=6.33.5,<7) can coexist
     "packaging",                     # ^21.0
     "hopsworks-apigen>=1.0.4,<2.0.0",
     "click>=8.1",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "fsspec<2025.12.0",
     "retrying",
     "hopsworks_aiomysql[sa]==0.2.2",
-    "opensearch-py>=2.8.0,<3.0.0",   # >=2.8.0 for urllib3>=2 (KServe 0.19); <3.0.0 stays on the 2.x line
+    "opensearch-py>=1.1.0,<=2.8.0",
     "tqdm",
     "grpcio>=1.49.1,<2.0.0",         # ^1.49.1
     "protobuf>=4.25.4,<7.0.0",       # widened to <7 so KServe 0.19 (protobuf>=6.33.5,<7) can coexist


### PR DESCRIPTION
Part of the cross-repo KServe 0.19 upgrade (HWORKS-1840).
https://hopsworks.atlassian.net/browse/HWORKS-1840

Relax two dependency bounds so the KServe 0.19 Python client installs alongside hopsworks in the serving inference pipelines:

- `opensearch-py >=1.1.0,<=2.8.0` -> `>=2.8.0,<3.0.0`. opensearch-py 1.x caps urllib3<2, conflicting with KServe 0.19 (urllib3>=2.6). 2.8.0 allows urllib3>=2; the client code is already version-aware for 2.x.
- `protobuf >=4.25.4,<5.0.0` -> `>=4.25.4,<7.0.0`. KServe 0.19 requires protobuf>=6.33.5,<7. `uv lock` resolves to protobuf 6.33.6 with no conflict (uv.lock is gitignored here; pyproject.toml is the tracked source).

Companion PRs: hopsworks-helm #2035, docker-images #582, kserve #40 (merged).
