### PR TITLE
[HWORKS-2871] Support git backed agent deployments and cost configuration for agent deployments

### DIFF
--- a/python/hsml/deployment_tracing_config.py
+++ b/python/hsml/deployment_tracing_config.py
@@ -30,6 +30,10 @@ class DeploymentTracingConfig:
         enabled: Whether tracing is enabled.
         otel_tracing_storage: Where traces are stored. Allowed values are
             ``online``, ``offline`` and ``both``. Defaults to ``online``.
+        otel_input_token_price_per_million: Optional input token price used to
+            compute trace cost metrics.
+        otel_output_token_price_per_million: Optional output token price used to
+            compute trace cost metrics.
     """
 
     STORAGE_ONLINE = "online"
@@ -41,11 +45,19 @@ class DeploymentTracingConfig:
         self,
         enabled: bool | None = None,
         otel_tracing_storage: str | None = STORAGE_ONLINE,
+        otel_input_token_price_per_million: float | None = None,
+        otel_output_token_price_per_million: float | None = None,
         **kwargs,
     ):
         self._enabled = enabled
         self._otel_tracing_storage = self._validate_otel_tracing_storage(
             otel_tracing_storage
+        )
+        self._otel_input_token_price_per_million = (
+            otel_input_token_price_per_million
+        )
+        self._otel_output_token_price_per_million = (
+            otel_output_token_price_per_million
         )
 
     @public
@@ -89,6 +101,12 @@ class DeploymentTracingConfig:
         kwargs["otel_tracing_storage"] = util._extract_field_from_json(
             config, "otel_tracing_storage"
         )
+        kwargs["otel_input_token_price_per_million"] = util._extract_field_from_json(
+            config, "otel_input_token_price_per_million"
+        )
+        kwargs["otel_output_token_price_per_million"] = util._extract_field_from_json(
+            config, "otel_output_token_price_per_million"
+        )
         return kwargs
 
     def update_from_response_json(self, json_dict):
@@ -103,6 +121,14 @@ class DeploymentTracingConfig:
         json = {"otelTracingStorage": self._otel_tracing_storage}
         if self._enabled is not None:
             json["enabled"] = self._enabled
+        if self._otel_input_token_price_per_million is not None:
+            json["otelInputTokenPricePerMillion"] = (
+                self._otel_input_token_price_per_million
+            )
+        if self._otel_output_token_price_per_million is not None:
+            json["otelOutputTokenPricePerMillion"] = (
+                self._otel_output_token_price_per_million
+            )
         return json
 
     @public
@@ -127,9 +153,41 @@ class DeploymentTracingConfig:
             otel_tracing_storage
         )
 
+    @public
+    @property
+    def otel_input_token_price_per_million(self):
+        """Optional input token price used to compute trace cost metrics."""
+        return self._otel_input_token_price_per_million
+
+    @otel_input_token_price_per_million.setter
+    def otel_input_token_price_per_million(
+        self, otel_input_token_price_per_million: float | None
+    ):
+        self._otel_input_token_price_per_million = (
+            otel_input_token_price_per_million
+        )
+
+    @public
+    @property
+    def otel_output_token_price_per_million(self):
+        """Optional output token price used to compute trace cost metrics."""
+        return self._otel_output_token_price_per_million
+
+    @otel_output_token_price_per_million.setter
+    def otel_output_token_price_per_million(
+        self, otel_output_token_price_per_million: float | None
+    ):
+        self._otel_output_token_price_per_million = (
+            otel_output_token_price_per_million
+        )
+
     def __repr__(self):
         return (
             "DeploymentTracingConfig("
             f"enabled: {self._enabled!r}, "
-            f"otel_tracing_storage: {self._otel_tracing_storage!r})"
+            f"otel_tracing_storage: {self._otel_tracing_storage!r}, "
+            f"otel_input_token_price_per_million: "
+            f"{self._otel_input_token_price_per_million!r}, "
+            f"otel_output_token_price_per_million: "
+            f"{self._otel_output_token_price_per_million!r})"
         )

--- a/python/hsml/deployment_tracing_config.py
+++ b/python/hsml/deployment_tracing_config.py
@@ -30,9 +30,9 @@ class DeploymentTracingConfig:
         enabled: Whether tracing is enabled.
         otel_tracing_storage: Where traces are stored. Allowed values are
             ``online``, ``offline`` and ``both``. Defaults to ``online``.
-        otel_input_token_price_per_million: Optional input token price used to
+        input_token_price_per_million_tokens: Optional input token price used to
             compute trace cost metrics.
-        otel_output_token_price_per_million: Optional output token price used to
+        output_token_price_per_million_tokens: Optional output token price used to
             compute trace cost metrics.
     """
 
@@ -45,19 +45,19 @@ class DeploymentTracingConfig:
         self,
         enabled: bool | None = None,
         otel_tracing_storage: str | None = STORAGE_ONLINE,
-        otel_input_token_price_per_million: float | None = None,
-        otel_output_token_price_per_million: float | None = None,
-        **kwargs,
+        input_token_price_per_million_tokens: float | None = None,
+        output_token_price_per_million_tokens: float | None = None,
     ):
         self._enabled = enabled
         self._otel_tracing_storage = self._validate_otel_tracing_storage(
             otel_tracing_storage
         )
-        self._otel_input_token_price_per_million = (
-            otel_input_token_price_per_million
+
+        self._input_token_price_per_million_tokens = (
+            input_token_price_per_million_tokens
         )
-        self._otel_output_token_price_per_million = (
-            otel_output_token_price_per_million
+        self._output_token_price_per_million_tokens = (
+            output_token_price_per_million_tokens
         )
 
     @public
@@ -101,12 +101,23 @@ class DeploymentTracingConfig:
         kwargs["otel_tracing_storage"] = util._extract_field_from_json(
             config, "otel_tracing_storage"
         )
-        kwargs["otel_input_token_price_per_million"] = util._extract_field_from_json(
-            config, "otel_input_token_price_per_million"
+        input_price = util._extract_field_from_json(
+            config, "input_token_price_per_million_tokens"
         )
-        kwargs["otel_output_token_price_per_million"] = util._extract_field_from_json(
-            config, "otel_output_token_price_per_million"
+        if input_price is None:
+            input_price = util._extract_field_from_json(
+                config, "otel_input_token_price_per_million"
+            )
+        kwargs["input_token_price_per_million_tokens"] = input_price
+
+        output_price = util._extract_field_from_json(
+            config, "output_token_price_per_million_tokens"
         )
+        if output_price is None:
+            output_price = util._extract_field_from_json(
+                config, "otel_output_token_price_per_million"
+            )
+        kwargs["output_token_price_per_million_tokens"] = output_price
         return kwargs
 
     def update_from_response_json(self, json_dict):
@@ -121,13 +132,13 @@ class DeploymentTracingConfig:
         json = {"otelTracingStorage": self._otel_tracing_storage}
         if self._enabled is not None:
             json["enabled"] = self._enabled
-        if self._otel_input_token_price_per_million is not None:
+        if self._input_token_price_per_million_tokens is not None:
             json["otelInputTokenPricePerMillion"] = (
-                self._otel_input_token_price_per_million
+                self._input_token_price_per_million_tokens
             )
-        if self._otel_output_token_price_per_million is not None:
+        if self._output_token_price_per_million_tokens is not None:
             json["otelOutputTokenPricePerMillion"] = (
-                self._otel_output_token_price_per_million
+                self._output_token_price_per_million_tokens
             )
         return json
 
@@ -155,30 +166,30 @@ class DeploymentTracingConfig:
 
     @public
     @property
-    def otel_input_token_price_per_million(self):
+    def input_token_price_per_million_tokens(self):
         """Optional input token price used to compute trace cost metrics."""
-        return self._otel_input_token_price_per_million
+        return self._input_token_price_per_million_tokens
 
-    @otel_input_token_price_per_million.setter
-    def otel_input_token_price_per_million(
-        self, otel_input_token_price_per_million: float | None
+    @input_token_price_per_million_tokens.setter
+    def input_token_price_per_million_tokens(
+        self, input_token_price_per_million_tokens: float | None
     ):
-        self._otel_input_token_price_per_million = (
-            otel_input_token_price_per_million
+        self._input_token_price_per_million_tokens = (
+            input_token_price_per_million_tokens
         )
 
     @public
     @property
-    def otel_output_token_price_per_million(self):
+    def output_token_price_per_million_tokens(self):
         """Optional output token price used to compute trace cost metrics."""
-        return self._otel_output_token_price_per_million
+        return self._output_token_price_per_million_tokens
 
-    @otel_output_token_price_per_million.setter
-    def otel_output_token_price_per_million(
-        self, otel_output_token_price_per_million: float | None
+    @output_token_price_per_million_tokens.setter
+    def output_token_price_per_million_tokens(
+        self, output_token_price_per_million_tokens: float | None
     ):
-        self._otel_output_token_price_per_million = (
-            otel_output_token_price_per_million
+        self._output_token_price_per_million_tokens = (
+            output_token_price_per_million_tokens
         )
 
     def __repr__(self):
@@ -186,8 +197,8 @@ class DeploymentTracingConfig:
             "DeploymentTracingConfig("
             f"enabled: {self._enabled!r}, "
             f"otel_tracing_storage: {self._otel_tracing_storage!r}, "
-            f"otel_input_token_price_per_million: "
-            f"{self._otel_input_token_price_per_million!r}, "
-            f"otel_output_token_price_per_million: "
-            f"{self._otel_output_token_price_per_million!r})"
+            f"input_token_price_per_million_tokens: "
+            f"{self._input_token_price_per_million_tokens!r}, "
+            f"output_token_price_per_million_tokens: "
+            f"{self._output_token_price_per_million_tokens!r})"
         )

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -42,6 +42,13 @@ except ImportError:
 
 
 _AGENT_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_GIT_PROVIDER_ALIASES = {
+    "github": "GitHub",
+    "gitlab": "GitLab",
+    "bitbucket": "BitBucket",
+}
+_SAFE_GIT_RELATIVE_PATH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+_SAFE_GIT_BRANCH_NAME_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
 
 
 if TYPE_CHECKING:
@@ -371,6 +378,9 @@ class ModelServing:
         scaling_configuration: PredictorScalingConfig | dict | None = None,
         env_vars: dict | None = None,
         tracing: DeploymentTracingConfig | dict | None = None,
+        git_url: str | None = None,
+        git_provider: str | None = None,
+        git_branch: str | None = None,
     ) -> Predictor:
         """Create an Entrypoint metadata object.
 
@@ -402,10 +412,20 @@ class ModelServing:
             scaling_configuration: Scaling configuration for the predictor.
             env_vars: Environment variables to set on the predictor.
             tracing: Tracing configuration for the endpoint.
+            git_url: Optional Git repository URL for a git-backed endpoint.
+            git_provider: Git provider for git-backed endpoints.
+            git_branch: Optional branch to clone for git-backed endpoints.
 
         Returns:
             The predictor metadata object.
         """
+        git_url = _trim_to_none(git_url)
+        git_provider = _normalize_git_provider(git_provider)
+        git_branch = _trim_to_none(git_branch)
+
+        if git_url is not None:
+            _validate_git_agent_source(script_file, git_url, git_provider, git_branch)
+
         return Predictor.for_server(
             name=name,
             script_file=script_file,
@@ -418,6 +438,9 @@ class ModelServing:
             scaling_configuration=scaling_configuration,
             env_vars=env_vars,
             tracing=tracing,
+            git_url=git_url,
+            git_provider=git_provider,
+            git_branch=git_branch,
         )
 
     @public
@@ -436,6 +459,9 @@ class ModelServing:
         api_protocol: str | None = IE.API_PROTOCOL_REST,
         scaling_configuration: PredictorScalingConfig | dict | None = None,
         tracing: DeploymentTracingConfig | dict | None = None,
+        git_url: str | None = None,
+        git_provider: str | None = None,
+        git_branch: str | None = None,
     ) -> Deployment:
         """Deploy a Python script or package as an agent.
 
@@ -447,6 +473,7 @@ class ModelServing:
         Pass either a `.py` script or a directory containing a `pyproject.toml`.
         For a script, the file is uploaded and run directly.
         For a package, a wheel is built locally with the project's PEP 517 backend, uploaded, and installed; a small runner module invokes the package via `runpy.run_module`.
+        When `git_url` is set, `entry` must be a safe relative `.py` path inside the repository and is used as-is.
 
         ```python
         ms = project.get_model_serving()
@@ -478,6 +505,10 @@ class ModelServing:
             api_protocol: API protocol to be enabled in the deployment (i.e., 'REST' or 'GRPC').
             scaling_configuration: Scaling configuration for the predictor.
             tracing: Tracing configuration for the deployment.
+            git_url: Optional Git repository URL. When set, `entry` is treated as
+                a relative path inside the repository and is not uploaded.
+            git_provider: Git provider for git-backed agent deployments.
+            git_branch: Optional branch to clone for git-backed agent deployments.
 
         Returns:
             The deployment metadata object.
@@ -486,18 +517,39 @@ class ModelServing:
             ValueError: If `entry` is neither a `.py` file nor a directory with `pyproject.toml`, or if `name`/`environment` contain characters outside `[A-Za-z0-9_-]`.
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
-        entry_abs = os.path.abspath(entry)
-        is_script = os.path.isfile(entry_abs) and entry_abs.endswith(".py")
-        is_package = os.path.isdir(entry_abs) and os.path.isfile(
-            os.path.join(entry_abs, "pyproject.toml")
-        )
-        if not (is_script or is_package):
-            raise ValueError(
-                f"entry must be a .py file or a directory containing pyproject.toml: {entry}"
+        entry = _trim_to_none(entry)
+        if entry is None:
+            raise ValueError("entry must not be empty")
+        requirements = _trim_to_none(requirements)
+
+        git_url = _trim_to_none(git_url)
+        git_provider = _normalize_git_provider(git_provider)
+        git_branch = _trim_to_none(git_branch)
+        git_backed = git_url is not None
+
+        if git_backed:
+            _validate_git_agent_source(entry, git_url, git_provider, git_branch)
+            is_script = True
+            is_package = False
+            script_file = entry
+        else:
+            entry_abs = os.path.abspath(entry)
+            is_script = os.path.isfile(entry_abs) and entry_abs.endswith(".py")
+            is_package = os.path.isdir(entry_abs) and os.path.isfile(
+                os.path.join(entry_abs, "pyproject.toml")
             )
+            if not (is_script or is_package):
+                raise ValueError(
+                    f"entry must be a .py file or a directory containing pyproject.toml: {entry}"
+                )
+
+            script_file = None
 
         if name is None:
-            name = os.path.basename(entry_abs)
+            default_name_source = entry
+            if not git_backed:
+                default_name_source = os.path.basename(entry_abs)
+            name = os.path.basename(default_name_source)
             if is_script:
                 name = os.path.splitext(name)[0]
         _validate_agent_identifier(name, "name")
@@ -511,19 +563,7 @@ class ModelServing:
         ds_api = _dataset_api.DatasetApi()
         env_api = _environment_api.EnvironmentApi()
 
-        _ensure_dataset_dir(ds_api, agent_dir)
-
-        env = env_api.get_environment(env_name) or env_api.create_environment(
-            env_name, base_environment_name="python-agent-pipeline"
-        )
-
-        if is_script:
-            script_file = ds_api.upload(entry_abs, agent_dir, overwrite=True)
-        else:
-            script_file = _build_and_install_package(ds_api, env, entry_abs, agent_dir)
-        # The serving backend expects the script path under /Projects/<proj>/...
-        script_file = util._convert_to_abs(script_file, self._project_name)
-
+        requirements_abs = None
         if requirements is not None:
             requirements_abs = os.path.abspath(requirements)
             if not os.path.isfile(requirements_abs):
@@ -531,6 +571,25 @@ class ModelServing:
                     "requirements must be a path to an existing file: "
                     + requirements_abs
                 )
+
+        if not git_backed or requirements_abs is not None:
+            _ensure_dataset_dir(ds_api, agent_dir)
+
+        env = env_api.get_environment(env_name) or env_api.create_environment(
+            env_name, base_environment_name="python-agent-pipeline"
+        )
+
+        if not git_backed:
+            if is_script:
+                script_file = ds_api.upload(entry_abs, agent_dir, overwrite=True)
+            else:
+                script_file = _build_and_install_package(
+                    ds_api, env, entry_abs, agent_dir
+                )
+            # The serving backend expects the script path under /Projects/<proj>/...
+            script_file = util._convert_to_abs(script_file, self._project_name)
+
+        if requirements_abs is not None:
             req_remote = ds_api.upload(requirements_abs, agent_dir, overwrite=True)
             env.install_requirements(req_remote)
 
@@ -545,6 +604,9 @@ class ModelServing:
             environment=env_name,
             scaling_configuration=scaling_configuration,
             tracing=tracing,
+            git_url=git_url if git_backed else None,
+            git_provider=git_provider if git_backed else None,
+            git_branch=git_branch if git_backed else None,
         )
 
         existing = self.get_deployment(name)
@@ -787,3 +849,68 @@ def _read_package_name(package_dir: str) -> str:
             f"Cannot read [project].name as a static string from {package_dir}/pyproject.toml"
         )
     return pkg_name
+
+
+def _trim_to_none(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _normalize_git_provider(git_provider: str | None) -> str | None:
+    if hasattr(git_provider, "git_provider"):
+        git_provider = git_provider.git_provider
+    provider = _trim_to_none(git_provider)
+    if not provider:
+        return None
+    normalized = _GIT_PROVIDER_ALIASES.get(provider.lower())
+    return normalized or provider
+
+
+def _is_valid_https_url(value: str | None) -> bool:
+    if not value:
+        return False
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return False
+    return parsed.scheme.lower() == "https" and bool(parsed.netloc)
+
+
+def _is_safe_relative_path(value: str) -> bool:
+    return (
+        not value.startswith("/")
+        and ".." not in value
+        and bool(_SAFE_GIT_RELATIVE_PATH_RE.fullmatch(value))
+    )
+
+
+def _is_safe_branch_name(value: str) -> bool:
+    return (
+        not value.startswith("-")
+        and ".." not in value
+        and bool(_SAFE_GIT_BRANCH_NAME_RE.fullmatch(value))
+    )
+
+
+def _validate_git_agent_source(
+    entry: str,
+    git_url: str | None,
+    git_provider: str | None,
+    git_branch: str | None,
+) -> None:
+    if not _is_valid_https_url(git_url):
+        raise ValueError("Git URL must be a valid https URL.")
+    if not git_provider:
+        raise ValueError("Git provider is required for Git-backed agent deployments.")
+    if not _is_safe_relative_path(entry):
+        raise ValueError("Predictor script must be a safe relative path.")
+    if not entry.endswith(".py"):
+        raise ValueError("Predictor script must be a .py file.")
+    if git_branch is not None and not _is_safe_branch_name(git_branch):
+        raise ValueError("Git branch must be a safe branch name.")

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -907,7 +907,7 @@ def _validate_git_agent_source(
     if not _is_valid_https_url(git_url):
         raise ValueError("Git URL must be a valid https URL.")
     if not git_provider:
-        raise ValueError("Git provider is required for Git-backed agent deployments.")
+        raise ValueError("Git provider is required for Git-backed deployments.")
     if not _is_safe_relative_path(entry):
         raise ValueError("Predictor script must be a safe relative path.")
     if not entry.endswith(".py"):

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -82,6 +82,9 @@ class Predictor(DeployableComponent):
         vllm_variant: str | None = None,
         vllm_image_tag: str | None = None,
         tracing: DeploymentTracingConfig | dict | Default | None = None,
+        git_url: str | None = None,
+        git_provider: str | None = None,
+        git_branch: str | None = None,
         **kwargs,
     ):
         serving_tool = (
@@ -131,6 +134,9 @@ class Predictor(DeployableComponent):
         self._project_name = None
         self._env_vars = env_vars
         self._tracing = util._get_obj_from_json(tracing, DeploymentTracingConfig)
+        self._git_url = git_url
+        self._git_provider = git_provider
+        self._git_branch = git_branch
         self._vllm_variant = vllm_variant
         self._vllm_image_tag = vllm_image_tag
 
@@ -328,6 +334,13 @@ class Predictor(DeployableComponent):
             ["tracing", "tracing_config"],
             as_instance_of=DeploymentTracingConfig,
         )
+        kwargs["git_url"] = util._extract_field_from_json(json_decamelized, "git_url")
+        kwargs["git_provider"] = util._extract_field_from_json(
+            json_decamelized, "git_provider"
+        )
+        kwargs["git_branch"] = util._extract_field_from_json(
+            json_decamelized, "git_branch"
+        )
         kwargs["id"] = json_decamelized.pop("id")
         kwargs["created_at"] = json_decamelized.pop("created")
         kwargs["creator"] = json_decamelized.pop("creator")
@@ -407,6 +420,12 @@ class Predictor(DeployableComponent):
             json = {**json, **self._transformer.to_dict()}
         if self._tracing is not None:
             json = {**json, "tracing": self._tracing.to_dict()}
+        if self._git_url is not None:
+            json = {**json, "gitUrl": self._git_url}
+        if self._git_provider is not None:
+            json = {**json, "gitProvider": self._git_provider}
+        if self._git_branch is not None:
+            json = {**json, "gitBranch": self._git_branch}
         if self._scaling_configuration is not None:
             json = {**json, **self._scaling_configuration.to_dict()}
         return json
@@ -588,6 +607,36 @@ class Predictor(DeployableComponent):
     @tracing.setter
     def tracing(self, tracing: DeploymentTracingConfig | dict | Default | None):
         self._tracing = util._get_obj_from_json(tracing, DeploymentTracingConfig)
+
+    @public
+    @property
+    def git_url(self):
+        """Configured Git repository URL for this deployment."""
+        return self._git_url
+
+    @git_url.setter
+    def git_url(self, git_url: str | None):
+        self._git_url = git_url
+
+    @public
+    @property
+    def git_provider(self):
+        """Configured Git provider for this deployment."""
+        return self._git_provider
+
+    @git_provider.setter
+    def git_provider(self, git_provider: str | None):
+        self._git_provider = git_provider
+
+    @public
+    @property
+    def git_branch(self):
+        """Configured Git branch for this deployment."""
+        return self._git_branch
+
+    @git_branch.setter
+    def git_branch(self, git_branch: str | None):
+        self._git_branch = git_branch
 
     @public
     @property
@@ -785,4 +834,11 @@ class Predictor(DeployableComponent):
             if self._description is not None
             else ""
         )
-        return f"Predictor(name: {self._name!r}" + desc + ")"
+        git = ""
+        if self._git_url is not None:
+            git += f", git_url: {self._git_url!r}"
+        if self._git_provider is not None:
+            git += f", git_provider: {self._git_provider!r}"
+        if self._git_branch is not None:
+            git += f", git_branch: {self._git_branch!r}"
+        return f"Predictor(name: {self._name!r}" + desc + git + ")"

--- a/python/tests/test_deployment_tracing_config.py
+++ b/python/tests/test_deployment_tracing_config.py
@@ -41,16 +41,16 @@ class TestDeploymentTracingConfig:
         config = DeploymentTracingConfig(
             enabled=True,
             otel_tracing_storage=DeploymentTracingConfig.STORAGE_OFFLINE,
-            otel_input_token_price_per_million=1.25,
-            otel_output_token_price_per_million=2.5,
+            input_token_price_per_million_tokens=1.25,
+            output_token_price_per_million_tokens=2.5,
         )
 
         restored = DeploymentTracingConfig.from_response_json(config.to_dict())
 
         assert restored.enabled is True
         assert restored.otel_tracing_storage == DeploymentTracingConfig.STORAGE_OFFLINE
-        assert restored.otel_input_token_price_per_million == 1.25
-        assert restored.otel_output_token_price_per_million == 2.5
+        assert restored.input_token_price_per_million_tokens == 1.25
+        assert restored.output_token_price_per_million_tokens == 2.5
 
     def test_rejects_invalid_storage(self):
         with pytest.raises(ValueError, match="Possible values"):

--- a/python/tests/test_deployment_tracing_config.py
+++ b/python/tests/test_deployment_tracing_config.py
@@ -37,6 +37,21 @@ class TestDeploymentTracingConfig:
         assert restored.enabled is True
         assert restored.otel_tracing_storage == DeploymentTracingConfig.STORAGE_BOTH
 
+    def test_round_trip_with_cost_prices(self):
+        config = DeploymentTracingConfig(
+            enabled=True,
+            otel_tracing_storage=DeploymentTracingConfig.STORAGE_OFFLINE,
+            otel_input_token_price_per_million=1.25,
+            otel_output_token_price_per_million=2.5,
+        )
+
+        restored = DeploymentTracingConfig.from_response_json(config.to_dict())
+
+        assert restored.enabled is True
+        assert restored.otel_tracing_storage == DeploymentTracingConfig.STORAGE_OFFLINE
+        assert restored.otel_input_token_price_per_million == 1.25
+        assert restored.otel_output_token_price_per_million == 2.5
+
     def test_rejects_invalid_storage(self):
         with pytest.raises(ValueError, match="Possible values"):
             DeploymentTracingConfig(otel_tracing_storage="invalid")

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -347,9 +347,7 @@ class TestDeployAgentScript:
         ds_api.upload.assert_called_once()
         assert mock_for_server.call_args.kwargs["tracing"] is tracing
 
-    def test_git_source_uses_relative_entry_without_upload(
-        self, ms, mocker, stub_apis
-    ):
+    def test_git_source_uses_relative_entry_without_upload(self, ms, mocker, stub_apis):
         # Arrange
         ds_api, env_api, _ = stub_apis
         mocker.patch.object(ms, "get_deployment", return_value=None)

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -104,6 +104,26 @@ class TestTracingForwarding:
         # Assert
         assert mock_for_server.call_args.kwargs["tracing"] is tracing
 
+    def test_create_endpoint_forwards_git_source(self, ms, mocker):
+        # Arrange
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.create_endpoint(
+            name="endpoint",
+            script_file="src/endpoint.py",
+            git_url="https://github.com/example/repo.git",
+            git_provider="github",
+            git_branch="main",
+        )
+
+        # Assert
+        kwargs = mock_for_server.call_args.kwargs
+        assert kwargs["script_file"] == "src/endpoint.py"
+        assert kwargs["git_url"] == "https://github.com/example/repo.git"
+        assert kwargs["git_provider"] == "GitHub"
+        assert kwargs["git_branch"] == "main"
+
 
 class TestDeployAgentIdentifierValidation:
     @pytest.fixture
@@ -326,6 +346,36 @@ class TestDeployAgentScript:
         # Assert
         ds_api.upload.assert_called_once()
         assert mock_for_server.call_args.kwargs["tracing"] is tracing
+
+    def test_git_source_uses_relative_entry_without_upload(
+        self, ms, mocker, stub_apis
+    ):
+        # Arrange
+        ds_api, env_api, _ = stub_apis
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+        deployed = mocker.MagicMock(name="deployment")
+        mock_for_server.return_value.deploy.return_value = deployed
+
+        # Act
+        result = ms.deploy_agent(
+            entry="src/agents/my_agent.py",
+            git_url="https://github.com/example/repo.git",
+            git_provider="github",
+            git_branch="main",
+        )
+
+        # Assert
+        assert result is deployed
+        ds_api.upload.assert_not_called()
+        ds_api.exists.assert_not_called()
+        env_api.get_environment.assert_called_once_with("my_agent")
+        kwargs = mock_for_server.call_args.kwargs
+        assert kwargs["name"] == "my_agent"
+        assert kwargs["script_file"] == "src/agents/my_agent.py"
+        assert kwargs["git_url"] == "https://github.com/example/repo.git"
+        assert kwargs["git_provider"] == "GitHub"
+        assert kwargs["git_branch"] == "main"
 
 
 class TestDeployAgentPackage:

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1212,6 +1212,38 @@ class TestPredictor:
         assert restored.tracing.enabled is True
         assert restored.tracing.otel_tracing_storage == "offline"
 
+    def test_git_wire_round_trip(self, mocker):
+        # Git metadata should survive serialisation for git-backed agent deployments.
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        mocker.patch(
+            "hsml.predictor.Predictor._validate_serving_tool",
+            return_value=PREDICTOR.SERVING_TOOL_KSERVE,
+        )
+        mocker.patch(
+            "hsml.predictor.Predictor._validate_resources",
+            return_value=resources.PredictorResources(0),
+        )
+
+        p = predictor.Predictor(
+            name="my_agent",
+            model_server=PREDICTOR.MODEL_SERVER_PYTHON,
+            script_file="src/agent.py",
+            model_framework=MODEL.FRAMEWORK_PYTHON,
+            git_url="https://github.com/org/repo.git",
+            git_provider="GitHub",
+            git_branch="main",
+        )
+
+        serialized = p.to_dict()
+        restored = predictor.Predictor.from_response_json(serialized)
+
+        assert serialized["gitUrl"] == "https://github.com/org/repo.git"
+        assert serialized["gitProvider"] == "GitHub"
+        assert serialized["gitBranch"] == "main"
+        assert restored.git_url == "https://github.com/org/repo.git"
+        assert restored.git_provider == "GitHub"
+        assert restored.git_branch == "main"
+
     # vLLM variant round-trip
 
     def test_vllm_variant_vllm_round_trip(self, mocker, backend_fixtures):

--- a/skills/hops/hops-agent-deployment/SKILL.md
+++ b/skills/hops/hops-agent-deployment/SKILL.md
@@ -5,12 +5,12 @@ description: Use when writing and deploying an interactive agent (e.g. a LlamaIn
 
 # Hopsworks Agent Deployments
 
-An agent deployment is a **server-only KServe deployment with no model attached** — you ship an entry script (or a package) that handles requests. Use it for interactive agents and LLM workflows (LlamaIndex, custom LLM orchestration). The agent *is* the **inference pipeline** of the AI system: it usually skips the training pipeline and calls a foundation LLM, and if it needs RAG it reads context from the feature store (write the RAG features in a separate **feature pipeline** — see hops-features). For a scheduled, non-interactive coding agent, use **hops-agent-job** instead; for a model-backed predictor, use **hops-online-inference**.
+An agent deployment is a **server-only KServe deployment with no model attached** — you ship an entry script (or a package) that handles requests. Use it for interactive agents and LLM workflows (LlamaIndex, custom LLM orchestration). The agent *is* the **inference pipeline** of the AI system: it usually skips the training pipeline and calls a foundation LLM, and if it needs RAG it reads context from the feature store (write the RAG features in a separate **feature pipeline** — see hops-features). Agents can be created from HopsFS or from GitHub/Git repositories, just like apps. For a scheduled, non-interactive coding agent, use **hops-agent-job** instead; for a model-backed predictor, use **hops-online-inference**.
 
 Start with a deterministic **LLM workflow** (a fixed sequence of steps) and only graduate to an autonomous agent when the task is open-ended enough to require runtime planning over tools. Workflows are cheaper, lower-latency, and easier to make reliable.
 
 ## Contract
-- **Input:** an entry script (a `.py` file, or a directory containing a `pyproject.toml`).
+- **Input:** an entry script (a `.py` file, or a directory containing a `pyproject.toml`), either from HopsFS or from a Git repository.
 - **Output:** a served agent deployment (server-only KServe deployment, queryable endpoint).
 - **Pre-condition:** auth + serving reachable; the agent name and environment are valid (`[A-Za-z0-9_-]+`).
 
@@ -40,6 +40,10 @@ class Predict:
 
 ## Deploy — CLI (preferred)
 
+Use the CLI for local HopsFS sources. Git-backed agents are supported too, but
+they are created through the SDK example below with `git_url`,
+`git_provider`, and `git_branch`.
+
 ```bash
 hops agent create my_agent.py --name my_agent \
   --requirements requirements.txt --environment my_agent
@@ -53,7 +57,10 @@ hops agent delete my_agent --yes
 
 **Confirm before deleting.** `hops agent delete` tears down the served agent irreversibly; confirm the exact name with the user, and never tear down an agent you created as a side effect (temp or test ones included) unless they asked.
 
-`create` re-run uploads the latest code and rewrites the predictor; a running agent is left untouched (use `start`, or `restart` via the SDK, to roll onto new code).
+`create` re-run uploads the latest code and rewrites the predictor; a running
+agent is left untouched (use `start`, or `restart` via the SDK, to roll onto
+new code). For Git-backed agents, use the SDK example below so the repository
+is cloned on each start.
 
 ## Deploy — SDK
 
@@ -73,6 +80,24 @@ deployment = ms.deploy_agent(
 deployment.start(await_running=600)
 print(deployment.predict(inputs={"prompt": "hello"}))
 # After editing the code: re-create, then deployment.restart()
+```
+
+### Git-backed Agents
+
+When the agent source lives in Git, provide the repository fields instead of a HopsFS path. Git-backed agents are cloned again on each start, so a restart or redeploy picks up new commits.
+
+- Supported Git providers: `GitHub`, `GitLab`, and `BitBucket`.
+- Use the repository root or a repo-relative path for the entry script.
+
+```python
+deployment = ms.deploy_agent(
+    entry="agent.py",
+    name="my_agent",
+    git_url="https://github.com/gibchikafa/my-agent-repo.git",
+    git_provider="GitHub",
+    git_branch="main",
+    environment="my_agent",
+)
 ```
 
 ## Next Steps

--- a/skills/hops/hops-app/SKILL.md
+++ b/skills/hops/hops-app/SKILL.md
@@ -24,6 +24,15 @@ A Streamlit app is a **UI / consumer of the FTI pipelines**, not a pipeline itse
 
 Custom apps are general-purpose web services such as FastAPI, Flask, Gradio, or plain WSGI/ASGI apps. They should bind to `0.0.0.0` and the injected `APP_PORT`, and should not hardcode `APP_BASE_URL_PATH` in new code. Legacy apps can stay on Compatibility prefix while they are migrated, but new apps should not depend on it.
 
+## Proxy Behavior
+
+Hopsworks places Python apps behind `/hopsworks-api/pythonapp/{projectName}/{appName}/`, but the proxy is not a general-purpose client-side URL rewriter.
+
+- It can forward the browser mount, rewrite some HTML/CSS links, and preserve redirects.
+- It does not reliably rewrite arbitrary JavaScript string literals or client-side `fetch("/api/...")` calls.
+- If a framework needs a public base path, the app must derive it itself via framework support, `X-Forwarded-Prefix`, or explicit relative URLs.
+- For Next.js, prefer a mount-aware `basePath` / `assetPrefix` / API-path helper when the app must run under the Hopsworks subpath.
+
 ## Contract
 
 - **Input:** a Streamlit or custom app + environment + memory.
@@ -51,9 +60,10 @@ Full CLI surface is in **Manage Apps from the CLI** below.
 ## Routing and Readiness
 
 - The browser URL is always the proxy mount point: `/hopsworks-api/pythonapp/{projectName}/{appName}/`.
-- New apps should be written as root-based apps and should not depend on `APP_BASE_URL_PATH`.
+- New apps should be mount-aware and should not depend on `APP_BASE_URL_PATH`.
 - Legacy prefix mode exists only for existing apps that are still being migrated.
 - Hopsworks forwards `X-Forwarded-Prefix` for frameworks that need to generate absolute links.
+- Do not expect the proxy to repair client-side JavaScript paths such as `fetch("/api/...")`.
 - Readiness is separate from browser routing:
   - Streamlit defaults to `/_stcore/health`
   - custom apps default to `/`
@@ -71,7 +81,8 @@ variable, switch it to `Root routing`.
 Migration checklist:
 
 1. Update the app code so route decorators use `/` or the app's own subpath
-   directly instead of `APP_BASE_URL_PATH`.
+   directly instead of `APP_BASE_URL_PATH`. For browser code, build API and
+   asset URLs from the app mount instead of assuming the site root.
 2. In the app settings dialog, open **App routing and readiness** and change
    `Proxy routing mode` to `Root routing`.
 3. Set `App base path` to the public mount point you want, for example `/` or


### PR DESCRIPTION
- add input and output token price fields to DeploymentTracingConfig serialization
- preserve gitUrl, gitProvider, and gitBranch through Predictor and ModelServing
- add deploy-agent and endpoint tests for git source round-trips and tracing cost pricing

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
