### PR TITLE
[FSTORE-2051] `get_tag` function for feature_groups, feature_views and training_datasets throws a `TypeError`

### DIFF
--- a/python/hopsworks_common/core/dataset_api.py
+++ b/python/hopsworks_common/core/dataset_api.py
@@ -1152,8 +1152,7 @@ class DatasetApi:
 
         path_params.append(path)
 
-        # Tag.from_response_json already deserializes each value from its JSON
-        # string, so the value is used directly without a second json.loads.
+        # from_response_json already returns deserialized values.
         return {
             tag._name: tag._value
             for tag in tag.Tag.from_response_json(

--- a/python/hopsworks_common/core/dataset_api.py
+++ b/python/hopsworks_common/core/dataset_api.py
@@ -1152,8 +1152,10 @@ class DatasetApi:
 
         path_params.append(path)
 
+        # Tag.from_response_json already deserializes each value from its JSON
+        # string, so the value is used directly without a second json.loads.
         return {
-            tag._name: json.loads(tag._value)
+            tag._name: tag._value
             for tag in tag.Tag.from_response_json(
                 _client._send_request("GET", path_params)
             )

--- a/python/hopsworks_common/core/tags_api.py
+++ b/python/hopsworks_common/core/tags_api.py
@@ -116,8 +116,7 @@ class TagsApi:
         if name is not None:
             path_params.append(name)
 
-        # Tag.from_response_json already deserializes each value from its JSON
-        # string, so the value is used directly without a second json.loads.
+        # from_response_json already returns deserialized values.
         return {
             tag._name: tag._value
             for tag in tag.Tag.from_response_json(

--- a/python/hopsworks_common/core/tags_api.py
+++ b/python/hopsworks_common/core/tags_api.py
@@ -116,8 +116,10 @@ class TagsApi:
         if name is not None:
             path_params.append(name)
 
+        # Tag.from_response_json already deserializes each value from its JSON
+        # string, so the value is used directly without a second json.loads.
         return {
-            tag._name: json.loads(tag._value)
+            tag._name: tag._value
             for tag in tag.Tag.from_response_json(
                 _client._send_request("GET", path_params)
             )

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -232,8 +232,7 @@ class ModelApi:
             model_instance.id,
             "tags",
         ]
-        # Tag.from_response_json already deserializes each value from its JSON
-        # string, so the value is used directly without a second json.loads.
+        # from_response_json already returns deserialized values.
         return {
             tag._name: tag._value
             for tag in tag.Tag.from_response_json(
@@ -266,8 +265,7 @@ class ModelApi:
             name,
         ]
 
-        # from_response_json returns a list of Tag objects, so build the
-        # name->value mapping and look the requested tag up by name.
+        # from_response_json returns a list of tags; look the value up by name.
         tags = {
             tag._name: tag._value
             for tag in tag.Tag.from_response_json(

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from hsml import client, decorators, model, tag
 from hsml.core import explicit_provenance
@@ -241,7 +242,7 @@ class ModelApi:
         }
 
     @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return=None)
-    def _get_tag(self, model_instance: model.Model, name: str) -> dict | None:
+    def _get_tag(self, model_instance: model.Model, name: str) -> Any:
         """Get the tag.
 
         Gets the tag for a specific name
@@ -251,7 +252,7 @@ class ModelApi:
             name: tag name
 
         Returns:
-            dict of tag name/value
+            The value of the tag with the specified name, or `None` if it does not exist.
         """
         _client = client._get_instance()
         path_params = [

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -231,8 +231,10 @@ class ModelApi:
             model_instance.id,
             "tags",
         ]
+        # Tag.from_response_json already deserializes each value from its JSON
+        # string, so the value is used directly without a second json.loads.
         return {
-            tag._name: json.loads(tag._value)
+            tag._name: tag._value
             for tag in tag.Tag.from_response_json(
                 _client._send_request("GET", path_params)
             )
@@ -263,9 +265,15 @@ class ModelApi:
             name,
         ]
 
-        return tag.Tag.from_response_json(_client._send_request("GET", path_params))[
-            name
-        ]
+        # from_response_json returns a list of Tag objects, so build the
+        # name->value mapping and look the requested tag up by name.
+        tags = {
+            tag._name: tag._value
+            for tag in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+        return tags.get(name)
 
     def _get_feature_view_provenance(
         self, model_instance

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -242,7 +242,7 @@ class ModelApi:
         }
 
     @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return=None)
-    def _get_tag(self, model_instance: model.Model, name: str) -> Any:
+    def _get_tag(self, model_instance: model.Model, name: str) -> Any | None:
         """Get the tag.
 
         Gets the tag for a specific name

--- a/python/tests/core/test_dataset_api.py
+++ b/python/tests/core/test_dataset_api.py
@@ -105,10 +105,6 @@ class TestDatasetApiUploadChunk:
 
 
 class TestDatasetApiTags:
-    # DatasetApi.get_tags builds its name->value dict the same way as
-    # TagsApi/ModelApi; Tag.from_response_json already deserializes the value,
-    # so get_tags must not decode it a second time.
-
     def _patch_client(self, mocker, send_request_return) -> MagicMock:
         client_instance = MagicMock()
         client_instance._project_id = 1

--- a/python/tests/core/test_dataset_api.py
+++ b/python/tests/core/test_dataset_api.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -101,3 +102,35 @@ class TestDatasetApiUploadChunk:
         # Sanity-check the constant value matches the backend enum:
         # DatasetErrorCode range=110000, UPLOAD_DISK_SPACE_ERROR code=55
         assert DatasetApi.DATASET_ERROR_CODE_UPLOAD_DISK_SPACE == 110055
+
+
+class TestDatasetApiTags:
+    # DatasetApi.get_tags builds its name->value dict the same way as
+    # TagsApi/ModelApi; Tag.from_response_json already deserializes the value,
+    # so get_tags must not decode it a second time.
+
+    def _patch_client(self, mocker, send_request_return) -> MagicMock:
+        client_instance = MagicMock()
+        client_instance._project_id = 1
+        client_instance._send_request.return_value = send_request_return
+        mocker.patch(
+            "hopsworks_common.core.dataset_api.client._get_instance",
+            return_value=client_instance,
+        )
+        return client_instance
+
+    @pytest.mark.parametrize("value", [{"a": 1}, 7, ["x"], True, "plain string"])
+    def test_get_tags_does_not_double_decode(self, mocker, value):
+        # Arrange
+        api = DatasetApi()
+        response = {
+            "count": 1,
+            "items": [{"name": "meta", "value": json.dumps(value)}],
+        }
+        self._patch_client(mocker, response)
+
+        # Act
+        result = api.get_tags("/Projects/p/Resources/file")
+
+        # Assert
+        assert result == {"meta": value}

--- a/python/tests/core/test_model_api.py
+++ b/python/tests/core/test_model_api.py
@@ -23,7 +23,6 @@ from hsml.core.model_api import ModelApi
 
 
 def _tags_response(items: list[tuple[str, str]]) -> dict:
-    # Each item value is the JSON-encoded string the backend stores for the tag.
     return {
         "count": len(items),
         "items": [{"name": name, "value": value} for name, value in items],
@@ -46,10 +45,6 @@ def _model() -> SimpleNamespace:
 
 
 class TestModelApi:
-    # ModelApi._get_tags/_get_tag mirror the feature-store tag path; the value
-    # is already deserialized by Tag.from_response_json and must not be decoded
-    # a second time.
-
     def test_get_tags_decodes_values_without_double_decode(self, mocker):
         # Arrange
         api = ModelApi()
@@ -66,8 +61,6 @@ class TestModelApi:
         assert result == {"meta": value, "count": 9}
 
     def test_get_tag_returns_value_for_name(self, mocker):
-        # _get_tag previously indexed the list returned by from_response_json by
-        # string name, which is always a TypeError.
         # Arrange
         api = ModelApi()
         value = {"owner": "team-a"}
@@ -91,8 +84,6 @@ class TestModelApi:
         assert result == 7
 
     def test_get_tag_absent_name_returns_none(self, mocker):
-        # The public Model.get_tag contract is "value or None if it does not
-        # exist"; an empty response yields None rather than raising.
         # Arrange
         api = ModelApi()
         _patch_client(mocker, {"count": 0, "items": []})

--- a/python/tests/core/test_model_api.py
+++ b/python/tests/core/test_model_api.py
@@ -90,6 +90,19 @@ class TestModelApi:
         # Assert
         assert result == 7
 
+    def test_get_tag_absent_name_returns_none(self, mocker):
+        # The public Model.get_tag contract is "value or None if it does not
+        # exist"; an empty response yields None rather than raising.
+        # Arrange
+        api = ModelApi()
+        _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        result = api._get_tag(_model(), "missing")
+
+        # Assert
+        assert result is None
+
     @pytest.mark.parametrize("bad_value", [{"a": 1}, 7, ["x"], True])
     def test_get_tags_does_not_double_decode(self, mocker, bad_value):
         # Arrange

--- a/python/tests/core/test_model_api.py
+++ b/python/tests/core/test_model_api.py
@@ -1,0 +1,103 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from hsml.core.model_api import ModelApi
+
+
+def _tags_response(items: list[tuple[str, str]]) -> dict:
+    # Each item value is the JSON-encoded string the backend stores for the tag.
+    return {
+        "count": len(items),
+        "items": [{"name": name, "value": value} for name, value in items],
+    }
+
+
+def _patch_client(mocker, send_request_return) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 1
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hsml.core.model_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+def _model() -> SimpleNamespace:
+    return SimpleNamespace(model_registry_id=1, id=12)
+
+
+class TestModelApi:
+    # ModelApi._get_tags/_get_tag mirror the feature-store tag path; the value
+    # is already deserialized by Tag.from_response_json and must not be decoded
+    # a second time.
+
+    def test_get_tags_decodes_values_without_double_decode(self, mocker):
+        # Arrange
+        api = ModelApi()
+        value = {"owner": "team-a", "score": 3}
+        _patch_client(
+            mocker,
+            _tags_response([("meta", json.dumps(value)), ("count", json.dumps(9))]),
+        )
+
+        # Act
+        result = api._get_tags(_model())
+
+        # Assert
+        assert result == {"meta": value, "count": 9}
+
+    def test_get_tag_returns_value_for_name(self, mocker):
+        # _get_tag previously indexed the list returned by from_response_json by
+        # string name, which is always a TypeError.
+        # Arrange
+        api = ModelApi()
+        value = {"owner": "team-a"}
+        _patch_client(mocker, _tags_response([("meta", json.dumps(value))]))
+
+        # Act
+        result = api._get_tag(_model(), "meta")
+
+        # Assert
+        assert result == value
+
+    def test_get_tag_numeric_value(self, mocker):
+        # Arrange
+        api = ModelApi()
+        _patch_client(mocker, _tags_response([("version", json.dumps(7))]))
+
+        # Act
+        result = api._get_tag(_model(), "version")
+
+        # Assert
+        assert result == 7
+
+    @pytest.mark.parametrize("bad_value", [{"a": 1}, 7, ["x"], True])
+    def test_get_tags_does_not_double_decode(self, mocker, bad_value):
+        # Arrange
+        api = ModelApi()
+        _patch_client(mocker, _tags_response([("t", json.dumps(bad_value))]))
+
+        # Act
+        result = api._get_tags(_model())
+
+        # Assert
+        assert result == {"t": bad_value}

--- a/python/tests/core/test_tags_api.py
+++ b/python/tests/core/test_tags_api.py
@@ -1,0 +1,151 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.core.tags_api import TagsApi
+
+
+def _tags_response(name: str, value: str) -> dict:
+    # value is the JSON-encoded string the backend stores for the tag.
+    return {
+        "count": 1,
+        "items": [{"name": name, "value": value, "schema": "test_schema"}],
+    }
+
+
+def _patch_client(mocker, send_request_return) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 1
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hopsworks_common.core.tags_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+# A feature-group-like metadata object: has an id and no `training_data`
+# attribute, so TagsApi._get_path takes the featuregroups/trainingdatasets branch.
+def _fg_metadata() -> SimpleNamespace:
+    return SimpleNamespace(id=14)
+
+
+class TestTagsApi:
+    # TagsApi._get backs get_tag/get_tags for feature groups, feature views,
+    # and training datasets. Tag.from_response_json already deserializes the
+    # value, so _get must not deserialize it a second time.
+
+    def test_get_decodes_json_object_value(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        value = {"owner": "team-a", "pii": True, "cols": [1, 2]}
+        _patch_client(mocker, _tags_response("meta", json.dumps(value)))
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {"meta": value}
+
+    def test_get_decodes_numeric_value(self, mocker):
+        # A non-string decoded value is what triggered the TypeError from the
+        # redundant second json.loads (json.loads(5) is a TypeError).
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, _tags_response("version", json.dumps(7)))
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {"version": 7}
+
+    def test_get_preserves_plain_string_value(self, mocker):
+        # A tag value that is not valid JSON stays a string; the old double
+        # decode raised JSONDecodeError on it.
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, _tags_response("note", "just a plain string"))
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {"note": "just a plain string"}
+
+    def test_get_by_name_appends_name_to_path(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(
+            mocker, _tags_response("meta", json.dumps({"k": "v"}))
+        )
+
+        # Act
+        result = api._get(_fg_metadata(), name="meta")
+
+        # Assert
+        assert result == {"meta": {"k": "v"}}
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params[-1] == "meta"
+
+    def test_get_empty_returns_empty_dict(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {}
+
+    def test_get_feature_view_uses_featureview_path(self, mocker):
+        # A feature-view-like object has a `training_data` attribute, so
+        # _get_path takes the featureview branch; decoding is identical.
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        fv_metadata = SimpleNamespace(
+            name="my_fv", version=1, training_data=lambda: None
+        )
+        client_instance = _patch_client(
+            mocker, _tags_response("meta", json.dumps({"k": "v"}))
+        )
+
+        # Act
+        result = api._get(fv_metadata)
+
+        # Assert
+        assert result == {"meta": {"k": "v"}}
+        path_params = client_instance._send_request.call_args.args[1]
+        assert "featureview" in path_params
+
+    @pytest.mark.parametrize("bad_value", [{"a": 1}, 7, ["x"], True])
+    def test_get_does_not_double_decode(self, mocker, bad_value):
+        # Regression guard: every non-string value must round-trip without the
+        # second json.loads that previously raised TypeError.
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, _tags_response("t", json.dumps(bad_value)))
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {"t": bad_value}

--- a/python/tests/core/test_tags_api.py
+++ b/python/tests/core/test_tags_api.py
@@ -23,7 +23,6 @@ from hopsworks_common.core.tags_api import TagsApi
 
 
 def _tags_response(name: str, value: str) -> dict:
-    # value is the JSON-encoded string the backend stores for the tag.
     return {
         "count": 1,
         "items": [{"name": name, "value": value, "schema": "test_schema"}],
@@ -41,17 +40,13 @@ def _patch_client(mocker, send_request_return) -> MagicMock:
     return client_instance
 
 
-# A feature-group-like metadata object: has an id and no `training_data`
-# attribute, so TagsApi._get_path takes the featuregroups/trainingdatasets branch.
+# A feature-group-like metadata object: an id and no `training_data` attribute,
+# so TagsApi._get_path takes the featuregroups/trainingdatasets branch.
 def _fg_metadata() -> SimpleNamespace:
     return SimpleNamespace(id=14)
 
 
 class TestTagsApi:
-    # TagsApi._get backs get_tag/get_tags for feature groups, feature views,
-    # and training datasets. Tag.from_response_json already deserializes the
-    # value, so _get must not deserialize it a second time.
-
     def test_get_decodes_json_object_value(self, mocker):
         # Arrange
         api = TagsApi(feature_store_id=99, entity_type="featuregroups")
@@ -65,8 +60,6 @@ class TestTagsApi:
         assert result == {"meta": value}
 
     def test_get_decodes_numeric_value(self, mocker):
-        # A non-string decoded value is what triggered the TypeError from the
-        # redundant second json.loads (json.loads(5) is a TypeError).
         # Arrange
         api = TagsApi(feature_store_id=99, entity_type="featuregroups")
         _patch_client(mocker, _tags_response("version", json.dumps(7)))
@@ -78,8 +71,6 @@ class TestTagsApi:
         assert result == {"version": 7}
 
     def test_get_preserves_plain_string_value(self, mocker):
-        # A tag value that is not valid JSON stays a string; the old double
-        # decode raised JSONDecodeError on it.
         # Arrange
         api = TagsApi(feature_store_id=99, entity_type="featuregroups")
         _patch_client(mocker, _tags_response("note", "just a plain string"))
@@ -117,8 +108,7 @@ class TestTagsApi:
         assert result == {}
 
     def test_get_feature_view_uses_featureview_path(self, mocker):
-        # A feature-view-like object has a `training_data` attribute, so
-        # _get_path takes the featureview branch; decoding is identical.
+        # A feature-view-like object has a `training_data` attribute (featureview path).
         # Arrange
         api = TagsApi(feature_store_id=99, entity_type="featuregroups")
         fv_metadata = SimpleNamespace(
@@ -138,8 +128,6 @@ class TestTagsApi:
 
     @pytest.mark.parametrize("bad_value", [{"a": 1}, 7, ["x"], True])
     def test_get_does_not_double_decode(self, mocker, bad_value):
-        # Regression guard: every non-string value must round-trip without the
-        # second json.loads that previously raised TypeError.
         # Arrange
         api = TagsApi(feature_store_id=99, entity_type="featuregroups")
         _patch_client(mocker, _tags_response("t", json.dumps(bad_value)))

--- a/python/tests/test_tag.py
+++ b/python/tests/test_tag.py
@@ -50,9 +50,6 @@ class TestTag:
         assert len(t_list) == 0
 
     def test_from_response_json_decodes_json_value(self):
-        # The backend stores values as JSON strings; from_response_json is the
-        # single point that deserializes them, so a non-string value must come
-        # back as the decoded object (not the JSON string).
         # Arrange
         value = {"owner": "team-a", "cols": [1, 2]}
         response = {
@@ -74,7 +71,6 @@ class TestTag:
             (json_module.dumps(True), True),
             (json_module.dumps(["a", "b"]), ["a", "b"]),
             (json_module.dumps("quoted"), "quoted"),
-            # A plain non-JSON string is left untouched (decode is suppressed).
             ("plain text", "plain text"),
         ],
     )

--- a/python/tests/test_tag.py
+++ b/python/tests/test_tag.py
@@ -14,6 +14,8 @@
 #   limitations under the License.
 #
 
+import json as json_module
+
 import humps
 import pytest
 from hsml import tag
@@ -46,6 +48,24 @@ class TestTag:
 
         # Assert
         assert len(t_list) == 0
+
+    def test_from_response_json_decodes_json_value(self):
+        # The backend stores values as JSON strings; from_response_json is the
+        # single point that deserializes them, so a non-string value must come
+        # back as the decoded object (not the JSON string).
+        # Arrange
+        value = {"owner": "team-a", "cols": [1, 2]}
+        response = {
+            "count": 1,
+            "items": [{"name": "meta", "value": json_module.dumps(value)}],
+        }
+
+        # Act
+        t_list = tag.Tag.from_response_json(humps.camelize(response))
+
+        # Assert
+        assert len(t_list) == 1
+        assert t_list[0].value == value
 
     # constructor
 

--- a/python/tests/test_tag.py
+++ b/python/tests/test_tag.py
@@ -67,6 +67,27 @@ class TestTag:
         assert len(t_list) == 1
         assert t_list[0].value == value
 
+    @pytest.mark.parametrize(
+        "stored_value, expected",
+        [
+            (json_module.dumps(7), 7),
+            (json_module.dumps(True), True),
+            (json_module.dumps(["a", "b"]), ["a", "b"]),
+            (json_module.dumps("quoted"), "quoted"),
+            # A plain non-JSON string is left untouched (decode is suppressed).
+            ("plain text", "plain text"),
+        ],
+    )
+    def test_from_response_json_value_decoding(self, stored_value, expected):
+        # Arrange
+        response = {"count": 1, "items": [{"name": "t", "value": stored_value}]}
+
+        # Act
+        t_list = tag.Tag.from_response_json(humps.camelize(response))
+
+        # Assert
+        assert t_list[0].value == expected
+
     # constructor
 
     def test_constructor(self, backend_fixtures):


### PR DESCRIPTION
## Summary
- `get_tag`/`get_tags` raised `TypeError` (and `JSONDecodeError` for plain strings) whenever a tag value was not a plain string. Root cause: HWORKS-2233 (#810) moved JSON value-decoding into `Tag.from_response_json`, but `TagsApi._get`, `ModelApi._get_tags`, and `DatasetApi.get_tags` still ran a second `json.loads` on the already-decoded value.
- Treat `Tag.from_response_json` as the single decode point: use the decoded `tag._value` directly in those three methods.
- Fix `ModelApi._get_tag`, which indexed the list returned by `from_response_json` by a string name (always a `TypeError`); it now builds the name→value mapping and returns `.get(name)`.

## Test plan
- New `python/tests/core/test_tags_api.py` and `python/tests/core/test_model_api.py` drive the API methods with object / array / numeric / boolean / plain-string tag values; decode coverage added to `python/tests/test_tag.py`; double-decode guard added to `python/tests/core/test_dataset_api.py`. Verified these fail against the unfixed source.
- `ruff check`, `ruff format`, and `docsig` clean.
- End-to-end: a `loadtest` workflow test (`tests/workflows/feature_store/python_driver/test_tag_round_trip.py`, separate PR) round-trips tags of every JSON value type through feature group, feature view, and training dataset `get_tag`/`get_tags` — passing on a live cluster.