### PR TITLE
[HWORKS-494][append] hsml: skip serving-file resolution on deployment update

### DIFF
--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -522,8 +522,10 @@ class ServingEngine:
     def _save(self, deployment_instance, await_update: int):
         # Local paths on script_file / config_file are auto-uploaded under
         # /Projects/<p>/Deployments/<name>/resources/ and rewritten to
-        # HopsFS paths in-memory. The fields then hold HopsFS paths, so
-        # re-saving without reassigning the field is a no-op for uploads.
+        # HopsFS paths in-memory. On update of a deployment fetched from the
+        # backend, these fields hold backend-managed references (e.g. a bare
+        # basename), which are left untouched; only newly-assigned local
+        # paths are re-uploaded.
         self._upload_local_serving_files(deployment_instance)
 
         if deployment_instance.id is None:
@@ -536,10 +538,13 @@ class ServingEngine:
 
         Rewrites the in-memory fields to HopsFS paths. HopsFS / ``None`` are
         left untouched. Each role uploads to its own subdirectory to avoid
-        basename collisions.
+        basename collisions. On update of a persisted deployment, fields that
+        are not new local paths (e.g. backend-managed references returned by
+        ``get_deployment``) are passed through unchanged.
         """
         predictor = deployment_instance._predictor
         deployment_name = deployment_instance.name
+        is_update = deployment_instance.id is not None
 
         targets = [
             (predictor, "script_file", "predictor", "script_file"),
@@ -562,6 +567,7 @@ class ServingEngine:
                 getattr(obj, field),
                 field_name=field_label,
                 subdir=subdir,
+                is_update=is_update,
             )
             setattr(obj, field, resolved)
 

--- a/python/hsml/utils/local_paths.py
+++ b/python/hsml/utils/local_paths.py
@@ -46,6 +46,7 @@ def _resolve_serving_file(
     field_name: str,
     subdir: str,
     overwrite: bool = True,
+    is_update: bool = False,
 ) -> str | None:
     """Resolve a user-supplied serving file path to an absolute HopsFS path.
 
@@ -61,7 +62,12 @@ def _resolve_serving_file(
     4. ``DatasetApi.exists(path)`` is true → it's a HopsFS path (absolute,
        project-relative, or ``hdfs://``); rewrite to the absolute
        ``/Projects/<p>/...`` form and return.
-    5. Otherwise → raise ``ValueError``.
+    5. Otherwise, on create → raise ``ValueError``; on update
+       (``is_update``) → return unchanged. A deployment fetched from the
+       backend reports ``script_file`` / ``config_file`` as backend-managed
+       references (often a bare basename) that are neither local files nor
+       resolvable via ``DatasetApi.exists``; re-resolving them on every save
+       would spuriously fail, so they are passed through untouched.
 
     ``subdir`` is the per-role subfolder (``"predictor"``, ``"transformer"``,
     ``"config"``) under ``Deployments/<name>/resources/``; it prevents
@@ -98,6 +104,13 @@ def _resolve_serving_file(
         if path.startswith("/Projects/"):
             return path
         return f"/Projects/{project_name}/{path.lstrip('/')}"
+
+    if is_update:
+        # Persisted deployment: the backend returns script_file / config_file
+        # as backend-managed references (often a bare basename), not a
+        # resolvable local or HopsFS path. Only genuinely new local paths
+        # (handled above) get re-uploaded; leave everything else untouched.
+        return path
 
     raise ValueError(
         f"Could not find {field_name}: '{path}' in the local filesystem "

--- a/python/hsml/utils/local_paths.py
+++ b/python/hsml/utils/local_paths.py
@@ -62,12 +62,13 @@ def _resolve_serving_file(
     4. ``DatasetApi.exists(path)`` is true → it's a HopsFS path (absolute,
        project-relative, or ``hdfs://``); rewrite to the absolute
        ``/Projects/<p>/...`` form and return.
-    5. Otherwise, on create → raise ``ValueError``; on update
-       (``is_update``) → return unchanged. A deployment fetched from the
-       backend reports ``script_file`` / ``config_file`` as backend-managed
-       references (often a bare basename) that are neither local files nor
-       resolvable via ``DatasetApi.exists``; re-resolving them on every save
-       would spuriously fail, so they are passed through untouched.
+    5. Unresolved.
+       On update, a bare basename is a backend-managed reference (a
+       deployment fetched from the backend reports ``script_file`` /
+       ``config_file`` that way) and is returned unchanged.
+       A create, or an update with a path-like value (one containing a
+       separator) that resolved to nothing, is a genuine mistake and raises
+       ``ValueError`` instead of deferring to a later backend failure.
 
     ``subdir`` is the per-role subfolder (``"predictor"``, ``"transformer"``,
     ``"config"``) under ``Deployments/<name>/resources/``; it prevents
@@ -105,11 +106,13 @@ def _resolve_serving_file(
             return path
         return f"/Projects/{project_name}/{path.lstrip('/')}"
 
-    if is_update:
-        # Persisted deployment: the backend returns script_file / config_file
-        # as backend-managed references (often a bare basename), not a
-        # resolvable local or HopsFS path. Only genuinely new local paths
-        # (handled above) get re-uploaded; leave everything else untouched.
+    if is_update and os.path.basename(path) == path:
+        # Persisted deployment: the backend reports script_file / config_file
+        # as a bare basename (no separator), which is neither a local file nor
+        # resolvable via DatasetApi.exists. Pass it through untouched. A
+        # path-like value that resolved to nothing (e.g. "./missing.py" or a
+        # typoed "/Projects/..." path) is a genuine mistake, so fall through
+        # and raise rather than defer the error to a later backend failure.
         return path
 
     raise ValueError(

--- a/python/tests/test_local_paths.py
+++ b/python/tests/test_local_paths.py
@@ -253,6 +253,45 @@ class TestResolveServingFile:
             )
         local_engine._upload.assert_not_called()
 
+    def test_update_passes_unresolvable_reference_through(
+        self, project_name, local_engine
+    ):
+        # On update, a deployment fetched from the backend reports script_file
+        # as a backend-managed reference (a bare basename) that is neither a
+        # local file nor found via DatasetApi.exists. It must be returned
+        # unchanged instead of raising, and not uploaded.
+        out = _resolve_serving_file(
+            local_engine,
+            "my_dep",
+            "predictor.py",
+            "script_file",
+            subdir="predictor",
+            is_update=True,
+        )
+
+        assert out == "predictor.py"
+        local_engine._upload.assert_not_called()
+
+    def test_update_still_uploads_new_local_path(
+        self, tmp_path, project_name, local_engine
+    ):
+        # Reassigning script_file to a new local path on update must still
+        # upload — the passthrough only covers unresolvable references.
+        local = tmp_path / "new_predictor.py"
+        local.write_text("# noop\n")
+
+        out = _resolve_serving_file(
+            local_engine,
+            "my_dep",
+            str(local),
+            "script_file",
+            subdir="predictor",
+            is_update=True,
+        )
+
+        assert out.endswith("/Deployments/my_dep/resources/predictor/new_predictor.py")
+        local_engine._upload.assert_called_once()
+
     def test_local_uploads_to_role_subdir(self, tmp_path, project_name, local_engine):
         # Predictor and transformer with the same basename land in
         # different subdirs.

--- a/python/tests/test_local_paths.py
+++ b/python/tests/test_local_paths.py
@@ -292,6 +292,27 @@ class TestResolveServingFile:
         assert out.endswith("/Deployments/my_dep/resources/predictor/new_predictor.py")
         local_engine._upload.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "bad_path", ["./does_not_exist.py", "/Projects/p/typo.py", "subdir/x.py"]
+    )
+    def test_update_path_like_value_still_raises(
+        self, bad_path, project_name, local_engine
+    ):
+        # On update, the passthrough only covers bare basenames (backend-managed
+        # references). A path-like value (contains a separator) that resolved to
+        # nothing is a genuine mistake — a missing local path or a typoed HopsFS
+        # path — so it must still raise rather than defer to a backend failure.
+        with pytest.raises(ValueError, match="Could not find script_file"):
+            _resolve_serving_file(
+                local_engine,
+                "my_dep",
+                bad_path,
+                "script_file",
+                subdir="predictor",
+                is_update=True,
+            )
+        local_engine._upload.assert_not_called()
+
     def test_local_uploads_to_role_subdir(self, tmp_path, project_name, local_engine):
         # Predictor and transformer with the same basename land in
         # different subdirs.

--- a/python/tests/test_serving_engine.py
+++ b/python/tests/test_serving_engine.py
@@ -172,6 +172,25 @@ class TestUploadLocalServingFiles:
             assert call.args[0] is eng._engine  # the LocalEngine
             assert call.args[1] == "my_dep_123"  # deployment_name
 
+    def test_is_update_derived_from_deployment_id(self, mocker):
+        # A deployment with an id is an update: the resolver is told so, so it
+        # passes backend-managed references through instead of raising.
+        eng = self._engine(mocker)
+        mock_resolve = mocker.patch.object(
+            serving_engine,
+            "_resolve_serving_file",
+            side_effect=lambda engine, name, p, **kw: p,
+        )
+
+        predictor = _FakePredictor(script_file="predictor.py", config_file=None)
+
+        eng._upload_local_serving_files(_FakeDeployment(predictor, "d", id=None))
+        assert all(c.kwargs["is_update"] is False for c in mock_resolve.mock_calls)
+
+        mock_resolve.reset_mock()
+        eng._upload_local_serving_files(_FakeDeployment(predictor, "d", id=42))
+        assert all(c.kwargs["is_update"] is True for c in mock_resolve.mock_calls)
+
 
 class TestSave:
     """Tests for ServingEngine._save() method.


### PR DESCRIPTION
`ServingEngine._save` ran the local-file auto-upload pass on every save. On create this resolves and uploads `script_file` / `config_file`. On update of a deployment fetched via `get_deployment`, those fields hold backend-managed references (the backend returns `script_file` as a bare basename, e.g. `predictor.py`). `_resolve_serving_file` could not classify such a value: not a local file, not found via `DatasetApi.exists`, so it raised

    ValueError: Could not find script_file: 'predictor.py' in the local
    filesystem or in Hopsworks File System.

This broke every model-serving loadtest that re-fetches a deployment and then calls `.save()` (the `_update_deployment` step), e.g. test_deploy_and_predict_python_model_with_kserve.

Add an `is_update` flag, derived in `_upload_local_serving_files` from `deployment_instance.id is not None` (the same create/update discriminator `_save` already uses) and passed to
`_resolve_serving_file`. On update, an otherwise-unresolvable path is returned unchanged instead of raising; genuinely new local paths still upload. Behaviour on create is unchanged.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
