### PR TITLE
[HWORKS-2920] Don't reseed the global random module on import

### DIFF
--- a/python/hopsworks_common/usage.py
+++ b/python/hopsworks_common/usage.py
@@ -118,7 +118,9 @@ class EnvironmentAttribute:
 class MethodCounter:
     def __init__(self):
         self.method_counts = {}
-        random.seed(42)
+        # Use a private generator so telemetry sampling never touches the
+        # process-global random module (which belongs to the user's program).
+        self._rng = random.Random(42)
 
     def _add(self, m):
         s = self._get_method_name(m)
@@ -133,10 +135,10 @@ class MethodCounter:
         if cnt < 100:
             return True
         if cnt < 1000:
-            return random.random() < 0.1
+            return self._rng.random() < 0.1
         if cnt < 10000:
-            return random.random() < 0.01
-        return random.random() < 0.001
+            return self._rng.random() < 0.01
+        return self._rng.random() < 0.001
 
     def _get_method_name(self, m):
         return m.__module__ + m.__name__

--- a/python/tests/test_usage.py
+++ b/python/tests/test_usage.py
@@ -1,0 +1,42 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.parametrize("module", ["hopsworks", "hopsworks_common.usage"])
+def test_import_does_not_touch_global_random(module):
+    """Importing the SDK must not reseed the interpreter-global `random` module.
+
+    The telemetry sampler keeps its own private generator; if it ever reaches
+    for the global `random` module again it would silently override the user's
+    own randomness (data shuffling, train/test splits, etc.).
+    The import side effect only fires on first import, so run a fresh
+    interpreter and assert the global RNG state is byte-for-byte unchanged.
+    """
+    code = textwrap.dedent(f"""
+        import random
+        random.seed(12345)
+        before = random.getstate()
+        import {module}  # noqa: F401
+        after = random.getstate()
+        assert before == after, "{module} import mutated the global random state"
+    """)
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
## What

`MethodCounter.__init__` called `random.seed(42)` on the process-global `random` module. This runs at **import time** via the module-level singleton `_method_counter = MethodCounter()`, and `hopsworks_common.usage` is imported pervasively across the SDK (`connection.py`, `job.py`, `deployment.py`, …). So `import hopsworks` silently reseeded the interpreter's global RNG to a fixed value.

## Why it's a problem

A library must not touch the process-global `random` generator — it belongs to the user's program. Any user code relying on `random.shuffle` / `random.choice` / `random.random` after `import hopsworks` (data shuffling, train/test splits, sampling) would silently get a fixed, seed-42-derived sequence they never asked for. The effect is also import-order dependent ("whoever seeds last wins"), which is a miserable class of bug to debug.

The fixed seed was never needed: the telemetry down-sampling in `_should_sample` works fine with an unseeded generator, and the seed only ever produced this side effect.

## Fix

Give the telemetry sampler its own private `random.Random(42)` instance and route all `_should_sample` draws through it. Sampling behaviour is unchanged; the global RNG is left untouched.

## Test

New `python/tests/test_usage.py` spawns a fresh interpreter (the reseed only fires on first import, so an in-process test would miss it), seeds the global RNG, imports the SDK, and asserts `random.getstate()` is byte-for-byte unchanged. Parametrized over both `hopsworks` and `hopsworks_common.usage`.

Validated locally: `ruff check`/`format` clean; the test passes against the real `hopsworks_common.usage` module and correctly fails against the old `random.seed(42)` behaviour.

## Follow-up (out of scope)

Separately, the Python engine's `_random_split` (`hsfs/engine/python.py`) uses the global `random.shuffle` and ignores `training_dataset.seed`, whereas the Spark engine honours it. It was inheriting the telemetry seed-42 by accident (so its reproducibility was already illusory). Making Python-engine splits actually respect the user's `seed` deserves its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)