### PR TITLE
[HWORKS-2921] Honor training_dataset.seed in Python engine random split

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1444,7 +1444,11 @@ class Engine:
         for i, split in enumerate(splits):
             groups += [i] * int(df_size * split.percentage)
         groups += [len(splits) - 1] * (df_size - len(groups))
-        random.shuffle(groups)
+        # Honor the user-provided seed so random splits are reproducible across
+        # runs, mirroring the Spark engine (randomSplit(..., seed)). A private
+        # generator avoids touching the process-global random module; seed=None
+        # falls back to entropy seeding, preserving the previous behaviour.
+        random.Random(training_dataset_obj.seed).shuffle(groups)
         if HAS_POLARS and (
             isinstance(df, (pl.DataFrame, pl.dataframe.frame.DataFrame))
         ):

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -2469,6 +2469,56 @@ class TestPython:
         assert result is transformed_splits
         assert mock_fit_and_transform.call_args[0][2] is raw_splits
 
+    def test_random_split_is_reproducible_with_seed(self, mocker):
+        # A user-provided seed must make the random split reproducible across
+        # runs (the documented `seed` contract that the Spark engine honors).
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        python_engine = python.Engine()
+        df = pd.DataFrame({"col": range(1000)})
+        td = training_dataset.TrainingDataset(
+            name="test",
+            version=1,
+            data_format="CSV",
+            featurestore_id=99,
+            splits={"train": 0.8, "test": 0.2},
+            train_split="train",
+            seed=123,
+            id=10,
+        )
+
+        # Act
+        first = python_engine._random_split(df.copy(), td)
+        second = python_engine._random_split(df.copy(), td)
+
+        # Assert
+        for name in ("train", "test"):
+            assert first[name]["col"].tolist() == second[name]["col"].tolist()
+
+    def test_random_split_depends_on_seed(self, mocker):
+        # Different seeds must yield different splits, proving the seed is
+        # actually honored rather than ignored or hard-coded.
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        python_engine = python.Engine()
+        df = pd.DataFrame({"col": range(1000)})
+
+        def train_rows(seed):
+            td = training_dataset.TrainingDataset(
+                name="test",
+                version=1,
+                data_format="CSV",
+                featurestore_id=99,
+                splits={"train": 0.8, "test": 0.2},
+                train_split="train",
+                seed=seed,
+                id=10,
+            )
+            return python_engine._random_split(df.copy(), td)["train"]["col"].tolist()
+
+        # Act / Assert
+        assert train_rows(1) != train_rows(2)
+
     def test_split_labels(self):
         # Arrange
         python_engine = python.Engine()

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -3365,6 +3365,60 @@ class TestSpark:
             sum_rows += result[column].count()
         assert sum_rows == 6
 
+    def test_random_split_is_reproducible_with_seed(self, mocker):
+        # A user-provided seed must make the random split reproducible across
+        # runs; the Spark engine forwards it to DataFrame.randomSplit.
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        spark_engine = spark.Engine()
+
+        td = training_dataset.TrainingDataset(
+            name="test",
+            version=1,
+            data_format="CSV",
+            featurestore_id=99,
+            splits={"test_split1": 0.5, "test_split2": 0.5},
+            seed=1,
+        )
+
+        df = pd.DataFrame({"col_0": list(range(100))})
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        # Act
+        first = spark_engine._random_split(dataset=spark_df, training_dataset=td)
+        second = spark_engine._random_split(dataset=spark_df, training_dataset=td)
+
+        # Assert
+        for name in ("test_split1", "test_split2"):
+            first_rows = sorted(r["col_0"] for r in first[name].collect())
+            second_rows = sorted(r["col_0"] for r in second[name].collect())
+            assert first_rows == second_rows
+
+    def test_random_split_depends_on_seed(self, mocker):
+        # Different seeds must yield different splits, proving the seed is
+        # actually forwarded rather than ignored or hard-coded.
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        spark_engine = spark.Engine()
+
+        df = pd.DataFrame({"col_0": list(range(100))})
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+
+        def train_rows(seed):
+            td = training_dataset.TrainingDataset(
+                name="test",
+                version=1,
+                data_format="CSV",
+                featurestore_id=99,
+                splits={"test_split1": 0.5, "test_split2": 0.5},
+                seed=seed,
+            )
+            result = spark_engine._random_split(dataset=spark_df, training_dataset=td)
+            return sorted(r["col_0"] for r in result["test_split1"].collect())
+
+        # Act / Assert
+        assert train_rows(1) != train_rows(2)
+
     def test_time_series_split(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client._get_instance")


### PR DESCRIPTION
## What

The Python engine's `_random_split` (`hsfs/engine/python.py`) shuffled the split assignment with the process-global `random.shuffle` and **never read `training_dataset.seed`**:

```python
random.shuffle(groups)   # global RNG, seed ignored
```

So random train/test splits are **not reproducible on the Python engine** — even though `seed` is a documented, user-facing knob (`feature_view.train_test_split(..., seed=…)`, persisted to the backend) whose docstring promises *"reproducibility of the random split at a later date"*, and the **Spark engine honors it**:

```python
# hsfs/engine/spark.py
split_dataset = dataset.randomSplit(split_weights, training_dataset.seed)
```

The seed is plumbed end-to-end (constructor param → `to_dict` → backend round-trip) and consumed by Spark; the Python engine was the sole place it was dropped.

## Fix

Shuffle through a private generator seeded with the user's seed:

```python
random.Random(training_dataset_obj.seed).shuffle(groups)
```

- Reproducible across runs when a seed is set (matches the documented contract and the Spark engine).
- `seed=None` falls back to entropy seeding, preserving the previous default behaviour.
- Uses a private `random.Random` instance, so the process-global RNG is left untouched.

Note: this makes the *Python engine self-consistent and reproducible*; it does not produce bit-identical splits to Spark for the same seed, since pandas-side shuffle and Spark's `randomSplit` (per-row Bernoulli sampling) are different algorithms. Cross-engine bit-identity isn't achievable and was never promised.

## Tests

Added reproducibility + seed-dependence tests for **both** engines:

- `tests/engine/test_python.py`: `test_random_split_is_reproducible_with_seed`, `test_random_split_depends_on_seed`
- `tests/engine/test_spark.py`: `test_random_split_is_reproducible_with_seed`, `test_random_split_depends_on_seed`

All 4 pass; the Python reproducibility test was confirmed to **fail** against the old `random.shuffle` line, and the 23 surrounding split tests still pass.

## Related

Follow-up to HWORKS-2920 (which stopped the telemetry code from reseeding the global RNG). That change removed an accidental import-time `random.seed(42)` that had been giving the Python split a *misleading* partial-determinism; this PR fixes the actual root cause by honoring the real seed rather than relying on a global one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)