### PR TITLE
[FSTORE-2049] Add support for Mandatory Tags in Models and Deployments

### DIFF
--- a/python/hopsworks_common/util.py
+++ b/python/hopsworks_common/util.py
@@ -894,6 +894,25 @@ def _generate_fully_qualified_feature_name(
     return f"{feature_group._get_project_name()}_{feature_group.name}_{feature_group.version}_{feature_name}"
 
 
+def _check_missing_mandatory_tags(
+    missing_mandatory_tags: list[dict[str, Any]] | None,
+    message: str = "Missing mandatory tags",
+) -> None:
+    """Warn about mandatory tags that a fetched entity has not set.
+
+    Shared across feature store, model registry, and model serving so every
+    artifact type surfaces missing mandatory tags the same way on retrieval.
+    No-op when the list is empty, so callers can invoke it unconditionally.
+
+    Parameters:
+        missing_mandatory_tags: Backend-reported tags that are mandatory for the entity but not set.
+        message: Prefix for the emitted warning.
+    """
+    if missing_mandatory_tags:
+        tag_names = [tag.get("name", str(tag)) for tag in missing_mandatory_tags]
+        warnings.warn(f"{message}: {tag_names}", stacklevel=2)
+
+
 class AsyncTask:
     """Generic class to represent an async task."""
 

--- a/python/hsfs/core/feature_group_api.py
+++ b/python/hsfs/core/feature_group_api.py
@@ -57,7 +57,12 @@ class FeatureGroupApi:
             "featuregroups",
         ]
         query_params = {
-            "expand": ["features", "expectationsuite", "transformationfunctions", "mandatorytags"]
+            "expand": [
+                "features",
+                "expectationsuite",
+                "transformationfunctions",
+                "mandatorytags",
+            ]
         }
         headers = {"content-type": "application/json"}
         return feature_group_instance.update_from_response_json(
@@ -84,7 +89,12 @@ class FeatureGroupApi:
             name,
         ]
         query_params = {
-            "expand": ["features", "expectationsuite", "transformationfunctions", "mandatorytags"]
+            "expand": [
+                "features",
+                "expectationsuite",
+                "transformationfunctions",
+                "mandatorytags",
+            ]
         }
         return _client._send_request("GET", path_params, query_params)
 
@@ -104,7 +114,12 @@ class FeatureGroupApi:
             name,
         ]
         query_params = {
-            "expand": ["features", "expectationsuite", "transformationfunctions", "mandatorytags"],
+            "expand": [
+                "features",
+                "expectationsuite",
+                "transformationfunctions",
+                "mandatorytags",
+            ],
             "version": version,
         }
         return _client._send_request("GET", path_params, query_params)
@@ -199,7 +214,12 @@ class FeatureGroupApi:
             feature_group_id,
         ]
         query_params = {
-            "expand": ["features", "expectationsuite", "transformationfunctions", "mandatorytags"]
+            "expand": [
+                "features",
+                "expectationsuite",
+                "transformationfunctions",
+                "mandatorytags",
+            ]
         }
         fg_json = _client._send_request("GET", path_params, query_params)
         if (

--- a/python/hsfs/core/feature_group_api.py
+++ b/python/hsfs/core/feature_group_api.py
@@ -57,7 +57,7 @@ class FeatureGroupApi:
             "featuregroups",
         ]
         query_params = {
-            "expand": ["features", "expectationsuite", "transformationfunctions"]
+            "expand": ["features", "expectationsuite", "transformationfunctions", "mandatorytags"]
         }
         headers = {"content-type": "application/json"}
         return feature_group_instance.update_from_response_json(
@@ -84,7 +84,7 @@ class FeatureGroupApi:
             name,
         ]
         query_params = {
-            "expand": ["features", "expectationsuite", "transformationfunctions"]
+            "expand": ["features", "expectationsuite", "transformationfunctions", "mandatorytags"]
         }
         return _client._send_request("GET", path_params, query_params)
 
@@ -104,7 +104,7 @@ class FeatureGroupApi:
             name,
         ]
         query_params = {
-            "expand": ["features", "expectationsuite", "transformationfunctions"],
+            "expand": ["features", "expectationsuite", "transformationfunctions", "mandatorytags"],
             "version": version,
         }
         return _client._send_request("GET", path_params, query_params)
@@ -199,7 +199,7 @@ class FeatureGroupApi:
             feature_group_id,
         ]
         query_params = {
-            "expand": ["features", "expectationsuite", "transformationfunctions"]
+            "expand": ["features", "expectationsuite", "transformationfunctions", "mandatorytags"]
         }
         fg_json = _client._send_request("GET", path_params, query_params)
         if (

--- a/python/hsfs/core/feature_view_api.py
+++ b/python/hsfs/core/feature_view_api.py
@@ -109,7 +109,7 @@ class FeatureViewApi:
                 for fv in self._client._send_request(
                     self._GET,
                     path,
-                    {"expand": ["query", "features", "transformationfunctions"]},
+                    {"expand": ["query", "features", "transformationfunctions", "mandatorytags"]},
                 )["items"]
             ]
         except RestAPIError as e:
@@ -142,7 +142,7 @@ class FeatureViewApi:
                 self._client._send_request(
                     self._GET,
                     path,
-                    {"expand": ["query", "features", "transformationfunctions"]},
+                    {"expand": ["query", "features", "transformationfunctions", "mandatorytags"]},
                 )
             )
         except RestAPIError as e:

--- a/python/hsfs/core/feature_view_api.py
+++ b/python/hsfs/core/feature_view_api.py
@@ -109,7 +109,14 @@ class FeatureViewApi:
                 for fv in self._client._send_request(
                     self._GET,
                     path,
-                    {"expand": ["query", "features", "transformationfunctions", "mandatorytags"]},
+                    {
+                        "expand": [
+                            "query",
+                            "features",
+                            "transformationfunctions",
+                            "mandatorytags",
+                        ]
+                    },
                 )["items"]
             ]
         except RestAPIError as e:
@@ -142,7 +149,14 @@ class FeatureViewApi:
                 self._client._send_request(
                     self._GET,
                     path,
-                    {"expand": ["query", "features", "transformationfunctions", "mandatorytags"]},
+                    {
+                        "expand": [
+                            "query",
+                            "features",
+                            "transformationfunctions",
+                            "mandatorytags",
+                        ]
+                    },
                 )
             )
         except RestAPIError as e:

--- a/python/hsfs/core/training_dataset_api.py
+++ b/python/hsfs/core/training_dataset_api.py
@@ -59,8 +59,9 @@ class TrainingDatasetApi:
             "trainingdatasets",
             name,
         ]
+        query_params = {"expand": ["mandatorytags"]}
         return training_dataset.TrainingDataset.from_response_json(
-            _client._send_request("GET", path_params),
+            _client._send_request("GET", path_params, query_params),
         )
 
     @decorators._catch_not_found(
@@ -76,7 +77,7 @@ class TrainingDatasetApi:
             "trainingdatasets",
             name,
         ]
-        query_params = {"version": version}
+        query_params = {"version": version, "expand": ["mandatorytags"]}
         return training_dataset.TrainingDataset.from_response_json(
             _client._send_request("GET", path_params, query_params),
         )

--- a/python/hsfs/core/training_dataset_engine.py
+++ b/python/hsfs/core/training_dataset_engine.py
@@ -165,3 +165,13 @@ class TrainingDatasetEngine:
         self._training_dataset_api._update_metadata(
             training_dataset, training_dataset, "updateStatsConfig"
         )
+
+    def _update_metadata(self, training_dataset):
+        """Update the metadata (e.g. description) of a training dataset.
+
+        Parameters:
+            training_dataset: The training dataset whose metadata to update.
+        """
+        self._training_dataset_api._update_metadata(
+            training_dataset, training_dataset, "updateMetadata"
+        )

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -1043,6 +1043,7 @@ class FeatureStore:
         online_disk: bool | None = None,
         sink_enabled: bool | None = False,
         sink_job_conf: dict[str, Any] | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         partitioned_by: list[str] | None = None,
         online_partition_columns: bool = False,
     ) -> (
@@ -1183,6 +1184,13 @@ class FeatureStore:
                 Enable copying data from the configured data source to the feature group.
             sink_job_conf:
                 Optional configuration describing the sink job to create when `sink_enabled` is True.
+            tags:
+                Optionally, define tags for the feature group. Tags can be provided as:
+                - A single Tag object
+                - A dictionary with 'name' and 'value' keys (e.g., {"name": "tag1", "value": "value1"})
+                - A list of Tag objects
+                - A list of dictionaries with 'name' and 'value' keys
+                Tags will be attached to the feature group after it is saved.
             partitioned_by:
                 A list of time grains derived from `event_time` to partition the offline data by, e.g. `["year", "month", "day"]`.
                 Supported grains are `year`, `month`, `week`, `day`, and `hour`.
@@ -1197,6 +1205,7 @@ class FeatureStore:
         """
         feature_group_object = self._feature_group_api._get(self.id, name, version)
         if not feature_group_object:
+            normalized_tags = self._normalize_tags(tags)
             if not data_source:
                 data_source = ds.DataSource(
                     storage_connector=storage_connector, path=path
@@ -1243,6 +1252,7 @@ class FeatureStore:
                 online_disk=online_disk,
                 sink_enabled=sink_enabled,
                 sink_job_conf=sink_job_conf,
+                tags=normalized_tags,
                 partitioned_by=partitioned_by,
                 online_partition_columns=online_partition_columns,
             )
@@ -2196,6 +2206,7 @@ class FeatureStore:
         transformation_functions: dict[str, TransformationFunction] | None = None,
         logging_enabled: bool | None = False,
         extra_log_columns: list[feature.Feature] | list[dict[str, str]] | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
     ) -> feature_view.FeatureView:
         """Get feature view metadata object or create a new one if it doesn't exist.
 
@@ -2250,6 +2261,13 @@ class FeatureStore:
                 It can be a list of Feature objects or list a dictionaries that contains the the name and type of the columns as keys.
                 Defaults to `None`, no extra log columns.
                 Setting this argument implicitly enables feature logging.
+            tags:
+                Optionally, define tags for the feature view. Tags can be provided as:
+                - A single Tag object
+                - A dictionary with 'name' and 'value' keys (e.g., {"name": "tag1", "value": "value1"})
+                - A list of Tag objects
+                - A list of dictionaries with 'name' and 'value' keys
+                Tags will be attached to the feature view after it is saved.
 
         Returns:
             The feature view metadata object.
@@ -2267,6 +2285,7 @@ class FeatureStore:
                 transformation_functions=transformation_functions or [],
                 logging_enabled=logging_enabled,
                 extra_log_columns=extra_log_columns,
+                tags=tags,
             )
         return fv_object
 

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -2624,6 +2624,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         n_processes: int | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -2734,10 +2735,13 @@ class FeatureView:
                 Independent transformations run concurrently; a chained sequence runs in order.
                 Defaults to `1` (sequential execution); a value above the DAG's maximum parallelism is capped, with a warning.
                 Ignored by the Spark engine, which pushes transformations down to Spark.
+            tags: Tags to attach to the training dataset for better discoverability.
 
         Returns:
             (X, y): Tuple of dataframe of features and labels. If there are no labels, y returns `None`.
         """
+        normalized_tags = tag.Tag._normalize(tags)
+
         td = training_dataset.TrainingDataset(
             name=self.name,
             version=None,
@@ -2752,6 +2756,7 @@ class FeatureView:
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
             lookback=Lookback.from_user_input(lookback),
+            tags=normalized_tags,
         )
         td, df = self._feature_view_engine._get_training_data(
             self,
@@ -2794,6 +2799,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         n_processes: int | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -2916,6 +2922,7 @@ class FeatureView:
                 Independent transformations run concurrently; a chained sequence runs in order.
                 Defaults to `1` (sequential execution); a value above the DAG's maximum parallelism is capped, with a warning.
                 Ignored by the Spark engine, which pushes transformations down to Spark.
+            tags: Tags to attach to the training dataset for better discoverability.
 
         Returns:
             (X_train, X_test, y_train, y_test):
@@ -2924,6 +2931,8 @@ class FeatureView:
         self._validate_train_test_split(
             test_size=test_size, train_end=train_end, test_start=test_start
         )
+        normalized_tags = tag.Tag._normalize(tags)
+
         td = training_dataset.TrainingDataset(
             name=self.name,
             version=None,
@@ -2942,6 +2951,7 @@ class FeatureView:
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
             lookback=Lookback.from_user_input(lookback),
+            tags=normalized_tags,
         )
         td, df = self._feature_view_engine._get_training_data(
             self,
@@ -3001,6 +3011,7 @@ class FeatureView:
         transformation_context: dict[str, Any] = None,
         lookback: FeatureGroupLookback | Lookback | dict[str, Any] | None = None,
         n_processes: int | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         **kwargs,
     ) -> tuple[
         TrainingDatasetDataFrameTypes,
@@ -3138,6 +3149,7 @@ class FeatureView:
                 Independent transformations run concurrently; a chained sequence runs in order.
                 Defaults to `1` (sequential execution); a value above the DAG's maximum parallelism is capped, with a warning.
                 Ignored by the Spark engine, which pushes transformations down to Spark.
+            tags: Tags to attach to the training dataset for better discoverability.
 
         Returns:
             (X_train, X_val, X_test, y_train, y_val, y_test):
@@ -3151,6 +3163,8 @@ class FeatureView:
             validation_end=validation_end,
             test_start=test_start,
         )
+        normalized_tags = tag.Tag._normalize(tags)
+
         td = training_dataset.TrainingDataset(
             name=self.name,
             version=None,
@@ -3172,6 +3186,7 @@ class FeatureView:
             training_dataset_type=training_dataset.TrainingDataset.IN_MEMORY,
             extra_filter=extra_filter,
             lookback=Lookback.from_user_input(lookback),
+            tags=normalized_tags,
         )
         td, df = self._feature_view_engine._get_training_data(
             self,

--- a/python/hsfs/training_dataset.py
+++ b/python/hsfs/training_dataset.py
@@ -887,6 +887,15 @@ class TrainingDataset(TrainingDatasetBase):
         self._training_dataset_engine._update_statistics_config(self)
         return self
 
+    def _update_metadata(self) -> TrainingDataset:
+        """Persist a metadata (description) update of the training dataset.
+
+        Private helper that exercises the ``updateMetadata`` REST path, which the
+        public SDK does not otherwise expose for training datasets.
+        """
+        self._training_dataset_engine._update_metadata(self)
+        return self
+
     @public
     def delete(self):
         """Delete training dataset and all associated metadata.

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import TYPE_CHECKING, Any
 
 from hopsworks_common.util import (
@@ -32,6 +31,7 @@ from hopsworks_common.util import (
     VersionWarning,
     _append_feature_store_suffix,
     _autofix_feature_name,
+    _check_missing_mandatory_tags,
     _check_timestamp_format_from_date_string,
     _contains_uppercase,
     _contains_whitespace,
@@ -101,15 +101,6 @@ def _is_sub_hour_cron(cron_expression: str | None) -> bool:
         return True
     # Range with step "0-59/15", or single value (fires once per hour at most).
     return "/" in minute_field
-
-
-def _check_missing_mandatory_tags(
-    missing_mandatory_tags: list[dict[str, Any]] | None,
-    message: str = "Missing mandatory tags",
-) -> None:
-    if missing_mandatory_tags:
-        tag_names = [tag.get("name", str(tag)) for tag in missing_mandatory_tags]
-        warnings.warn(f"{message}: {tag_names}", stacklevel=2)
 
 
 def _validate_feature(
@@ -278,6 +269,7 @@ __all__ = [
     "_loading_animation",
     "_append_feature_store_suffix",
     "_autofix_feature_name",
+    "_check_missing_mandatory_tags",
     "_check_timestamp_format_from_date_string",
     "_contains_uppercase",
     "_contains_whitespace",

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -160,9 +160,7 @@ class ModelApi:
         ]
         _client._send_request("DELETE", path_params)
 
-    def _set_tag(
-        self, model_instance: model.Model, name: str, value: str | dict
-    ) -> None:
+    def _set_tag(self, model_instance: model.Model, name: str, value: Any) -> None:
         """Attach a name/value tag to a model.
 
         A tag consists of a name/value pair. Tag names are unique identifiers.
@@ -211,7 +209,7 @@ class ModelApi:
         _client._send_request("DELETE", path_params)
 
     @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
-    def _get_tags(self, model_instance: model.Model) -> dict:
+    def _get_tags(self, model_instance: model.Model) -> dict[str, Any]:
         """Get the tags.
 
         Gets all tags if no tag name is specified.

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -57,6 +57,35 @@ class ModelApi:
             )
         )
 
+    def _patch(self, model_instance: model.Model, body: dict) -> model.Model:
+        """Update mutable fields (currently framework) of a model version.
+
+        Parameters:
+            model_instance: metadata object of the model to update
+            body: mutable fields to update, e.g. ``{"framework": ...}``
+
+        Returns:
+            updated metadata object of the model
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "modelregistries",
+            str(model_instance.model_registry_id),
+            "models",
+            model_instance.name + "_" + str(model_instance.version),
+        ]
+        headers = {"content-type": "application/json"}
+        return model_instance.update_from_response_json(
+            _client._send_request(
+                "PATCH",
+                path_params,
+                headers=headers,
+                data=json.dumps(body),
+            )
+        )
+
     @decorators._catch_not_found("hsml.model.Model", fallback_return=None)
     def _get(
         self,

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from hsml import client, decorators, model, tag
+from hopsworks_common import tag
+from hsml import client, decorators, model
 from hsml.core import explicit_provenance
 
 

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -85,7 +85,7 @@ class ModelApi:
             "models",
             name + "_" + str(version),
         ]
-        query_params = {"expand": "trainingdatasets"}
+        query_params = {"expand": ["trainingdatasets", "mandatorytags"]}
 
         model_json = _client._send_request("GET", path_params, query_params)
         model_meta = model.Model.from_response_json(model_json)

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -56,8 +56,9 @@ class ServingApi:
             "serving",
             str(id),
         ]
+        query_params = {"expand": ["mandatorytags"]}
 
-        deployment_json = _client._send_request("GET", path_params)
+        deployment_json = _client._send_request("GET", path_params, query_params=query_params)
         deployment_instance = deployment.Deployment.from_response_json(deployment_json)
         deployment_instance.model_registry_id = _client._project_id
         deployment_instance.project_name = _client._project_name
@@ -75,7 +76,7 @@ class ServingApi:
         """
         _client = client._get_instance()
         path_params = ["project", _client._project_id, "serving"]
-        query_params = {"name": name}
+        query_params = {"name": name, "expand": ["mandatorytags"]}
 
         deployment_json = _client._send_request(
             "GET", path_params, query_params=query_params

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -180,8 +180,9 @@ class ServingApi:
             str(deployment_instance.id),
             "tags",
         ]
+        # from_response_json already returns deserialized values.
         return {
-            t._name: json.loads(t._value)
+            t._name: t._value
             for t in tag.Tag.from_response_json(
                 _client._send_request("GET", path_params)
             )
@@ -209,9 +210,14 @@ class ServingApi:
             "tags",
             name,
         ]
-        return tag.Tag.from_response_json(_client._send_request("GET", path_params))[
-            name
-        ]
+        # from_response_json returns a list of tags; look the value up by name.
+        tags = {
+            t._name: t._value
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+        return tags.get(name)
 
     def _get_inference_endpoints(self) -> list[inference_endpoint.InferenceEndpoint]:
         """Get inference endpoints.

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -58,7 +58,9 @@ class ServingApi:
         ]
         query_params = {"expand": ["mandatorytags"]}
 
-        deployment_json = _client._send_request("GET", path_params, query_params=query_params)
+        deployment_json = _client._send_request(
+            "GET", path_params, query_params=query_params
+        )
         deployment_instance = deployment.Deployment.from_response_json(deployment_json)
         deployment_instance.model_registry_id = _client._project_id
         deployment_instance.project_name = _client._project_name

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -24,6 +24,7 @@ from hsml import (
     deployment,
     inference_endpoint,
     predictor_state,
+    tag,
 )
 from hsml.client.istio.utils.infer_type import (
     InferInput,
@@ -111,6 +112,106 @@ class ServingApi:
             deployment_instance.model_registry_id = _client._project_id
             deployment_instance.project_name = _client._project_name
         return deployment_instances
+
+    def _set_tag(
+        self, deployment_instance: deployment.Deployment, name: str, value: str | dict
+    ) -> None:
+        """Attach a name/value tag to a deployment.
+
+        A tag consists of a name/value pair.
+        Tag names are unique identifiers.
+        The value of a tag can be any valid json - primitives, arrays or json objects.
+
+        Parameters:
+            deployment_instance: deployment instance to attach the tag to
+            name: name of the tag to be added
+            value: value of the tag to be added
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "serving",
+            str(deployment_instance.id),
+            "tags",
+            name,
+        ]
+        headers = {"content-type": "application/json"}
+        json_value = json.dumps(value)
+        _client._send_request("PUT", path_params, headers=headers, data=json_value)
+
+    def _delete_tag(
+        self, deployment_instance: deployment.Deployment, name: str
+    ) -> None:
+        """Delete a tag attached to a deployment.
+
+        Tag names are unique identifiers.
+
+        Parameters:
+            deployment_instance: deployment instance to delete the tag from
+            name: name of the tag to be removed
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "serving",
+            str(deployment_instance.id),
+            "tags",
+            name,
+        ]
+        _client._send_request("DELETE", path_params)
+
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_tags(self, deployment_instance: deployment.Deployment) -> dict:
+        """Get all tags attached to a deployment.
+
+        Parameters:
+            deployment_instance: deployment instance to get the tags from
+
+        Returns:
+            dict of tag name/values
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "serving",
+            str(deployment_instance.id),
+            "tags",
+        ]
+        return {
+            t._name: json.loads(t._value)
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return=None)
+    def _get_tag(
+        self, deployment_instance: deployment.Deployment, name: str
+    ) -> dict | None:
+        """Get the tag with a specific name attached to a deployment.
+
+        Parameters:
+            deployment_instance: deployment instance to get the tag from
+            name: tag name
+
+        Returns:
+            the tag value, or `None` if it does not exist
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "serving",
+            str(deployment_instance.id),
+            "tags",
+            name,
+        ]
+        return tag.Tag.from_response_json(_client._send_request("GET", path_params))[
+            name
+        ]
 
     def _get_inference_endpoints(self) -> list[inference_endpoint.InferenceEndpoint]:
         """Get inference endpoints.

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from hsml import (
     client,
@@ -114,7 +115,7 @@ class ServingApi:
         return deployment_instances
 
     def _set_tag(
-        self, deployment_instance: deployment.Deployment, name: str, value: str | dict
+        self, deployment_instance: deployment.Deployment, name: str, value: Any
     ) -> None:
         """Attach a name/value tag to a deployment.
 
@@ -163,7 +164,7 @@ class ServingApi:
         _client._send_request("DELETE", path_params)
 
     @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
-    def _get_tags(self, deployment_instance: deployment.Deployment) -> dict:
+    def _get_tags(self, deployment_instance: deployment.Deployment) -> dict[str, Any]:
         """Get all tags attached to a deployment.
 
         Parameters:
@@ -191,7 +192,7 @@ class ServingApi:
     @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return=None)
     def _get_tag(
         self, deployment_instance: deployment.Deployment, name: str
-    ) -> dict | None:
+    ) -> Any | None:
         """Get the tag with a specific name attached to a deployment.
 
         Parameters:

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -184,7 +184,6 @@ class ServingApi:
             str(deployment_instance.id),
             "tags",
         ]
-        # from_response_json already returns deserialized values.
         return {
             t._name: t._value
             for t in tag.Tag.from_response_json(
@@ -214,7 +213,6 @@ class ServingApi:
             "tags",
             name,
         ]
-        # from_response_json returns a list of tags; look the value up by name.
         tags = {
             t._name: t._value
             for t in tag.Tag.from_response_json(

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from hopsworks_common import tag
 from hsml import (
     client,
     decorators,
@@ -25,7 +26,6 @@ from hsml import (
     deployment,
     inference_endpoint,
     predictor_state,
-    tag,
 )
 from hsml.client.istio.utils.infer_type import (
     InferInput,

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -50,11 +50,13 @@ class Deployment:
         name: str | None = None,
         description: str | None = None,
         project_namespace: str = None,
+        missing_mandatory_tags=None,
         **kwargs,
     ):
         self._predictor = predictor
         self._description = description
         self._project_namespace = project_namespace
+        self._missing_mandatory_tags = missing_mandatory_tags or []
 
         if self._predictor is None:
             raise ModelServingException("A predictor is required")
@@ -219,6 +221,15 @@ class Deployment:
             hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tags.
         """
         return self._serving_engine._get_tags(self)
+
+    @property
+    def missing_mandatory_tags(self) -> list:
+        """Mandatory tags configured for deployments that this deployment is missing.
+
+        Populated from the backend response.
+        Empty when all mandatory deployment tags are set.
+        """
+        return self._missing_mandatory_tags
 
     @public
     def get_state(self) -> PredictorState:
@@ -686,6 +697,9 @@ class Deployment:
             predictor=predictor_instance,
             name=predictor_instance._name,
             description=predictor_instance._description,
+            missing_mandatory_tags=getattr(
+                predictor_instance, "_missing_mandatory_tags", []
+            ),
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
 from hopsworks_common import client, usage, util
@@ -50,7 +50,7 @@ class Deployment:
         name: str | None = None,
         description: str | None = None,
         project_namespace: str = None,
-        missing_mandatory_tags=None,
+        missing_mandatory_tags: list[dict[str, Any]] | None = None,
         **kwargs,
     ):
         self._predictor = predictor
@@ -166,7 +166,7 @@ class Deployment:
 
     @public
     @usage._method_logger
-    def add_tag(self, name: str, value: str | dict):
+    def add_tag(self, name: str, value: Any):
         """Attach a tag to a deployment.
 
         A tag consists of a <name,value> pair.
@@ -196,7 +196,7 @@ class Deployment:
         self._serving_engine._delete_tag(self, name)
 
     @public
-    def get_tag(self, name: str) -> str | None:
+    def get_tag(self, name: str) -> Any | None:
         """Get the value of a tag attached to a deployment.
 
         Parameters:
@@ -211,7 +211,7 @@ class Deployment:
         return self._serving_engine._get_tag(self, name)
 
     @public
-    def get_tags(self) -> dict:
+    def get_tags(self) -> dict[str, Any]:
         """Retrieve all tags attached to a deployment.
 
         Returns:
@@ -222,8 +222,9 @@ class Deployment:
         """
         return self._serving_engine._get_tags(self)
 
+    @public
     @property
-    def missing_mandatory_tags(self) -> list:
+    def missing_mandatory_tags(self) -> list[dict[str, Any]]:
         """Mandatory tags configured for deployments that this deployment is missing.
 
         Populated from the backend response.

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -163,6 +163,64 @@ class Deployment:
         self._serving_engine._delete(self, force)
 
     @public
+    @usage._method_logger
+    def add_tag(self, name: str, value: str | dict):
+        """Attach a tag to a deployment.
+
+        A tag consists of a <name,value> pair.
+        Tag names are unique identifiers across the whole cluster.
+        The value of a tag can be any valid json - primitives, arrays or json objects.
+
+        Parameters:
+            name: Name of the tag to be added.
+            value: Value of the tag to be added.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to add the tag.
+        """
+        self._serving_engine._set_tag(self, name, value)
+
+    @public
+    @usage._method_logger
+    def delete_tag(self, name: str):
+        """Delete a tag attached to a deployment.
+
+        Parameters:
+            name: Name of the tag to be removed.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to delete the tag.
+        """
+        self._serving_engine._delete_tag(self, name)
+
+    @public
+    def get_tag(self, name: str) -> str | None:
+        """Get the value of a tag attached to a deployment.
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            tag value, or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tag.
+        """
+        return self._serving_engine._get_tag(self, name)
+
+    @public
+    def get_tags(self) -> dict:
+        """Retrieve all tags attached to a deployment.
+
+        Returns:
+            Dictionary of tag name/values.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tags.
+        """
+        return self._serving_engine._get_tags(self)
+
+    @public
     def get_state(self) -> PredictorState:
         """Get the current state of the deployment.
 

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -50,13 +50,11 @@ class Deployment:
         name: str | None = None,
         description: str | None = None,
         project_namespace: str = None,
-        missing_mandatory_tags: list[dict[str, Any]] | None = None,
         **kwargs,
     ):
         self._predictor = predictor
         self._description = description
         self._project_namespace = project_namespace
-        self._missing_mandatory_tags = missing_mandatory_tags or []
 
         if self._predictor is None:
             raise ModelServingException("A predictor is required")
@@ -230,7 +228,7 @@ class Deployment:
         Populated from the backend response.
         Empty when all mandatory deployment tags are set.
         """
-        return self._missing_mandatory_tags
+        return self._predictor._missing_mandatory_tags
 
     @public
     def get_state(self) -> PredictorState:
@@ -698,9 +696,6 @@ class Deployment:
             predictor=predictor_instance,
             name=predictor_instance._name,
             description=predictor_instance._description,
-            missing_mandatory_tags=getattr(
-                predictor_instance, "_missing_mandatory_tags", []
-            ),
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/engine/model_engine.py
+++ b/python/hsml/engine/model_engine.py
@@ -904,6 +904,15 @@ class ModelEngine:
     def _delete(self, model_instance):
         self._engine._delete(model_instance)
 
+    def _update_framework(self, model_instance, framework):
+        """Update the framework of a model version via the model registry API.
+
+        Parameters:
+            model_instance: the model whose framework to update
+            framework: the new framework value
+        """
+        return self._model_api._patch(model_instance, {"framework": framework})
+
     def _set_tag(self, model_instance, name, value):
         """Attach a name/value tag to a model.
 

--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -71,6 +71,18 @@ class ServingEngine:
 
         self._engine = local_engine.LocalEngine()
 
+    def _set_tag(self, deployment_instance, name: str, value):
+        self._serving_api._set_tag(deployment_instance, name, value)
+
+    def _delete_tag(self, deployment_instance, name: str):
+        self._serving_api._delete_tag(deployment_instance, name)
+
+    def _get_tag(self, deployment_instance, name: str):
+        return self._serving_api._get_tag(deployment_instance, name)
+
+    def _get_tags(self, deployment_instance):
+        return self._serving_api._get_tags(deployment_instance)
+
     def _poll_deployment_status(
         self, deployment_instance, status: str, await_status: int, update_progress=None
     ):

--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -72,15 +72,39 @@ class ServingEngine:
         self._engine = local_engine.LocalEngine()
 
     def _set_tag(self, deployment_instance, name: str, value):
+        """Attach a name/value tag to a deployment.
+
+        Parameters:
+            deployment_instance: the deployment to tag
+            name: tag name
+            value: tag value
+        """
         self._serving_api._set_tag(deployment_instance, name, value)
 
     def _delete_tag(self, deployment_instance, name: str):
+        """Remove a tag from a deployment.
+
+        Parameters:
+            deployment_instance: the deployment to remove the tag from
+            name: tag name to remove
+        """
         self._serving_api._delete_tag(deployment_instance, name)
 
     def _get_tag(self, deployment_instance, name: str):
+        """Get tag with a certain name.
+
+        Parameters:
+            deployment_instance: the deployment to get the tag from
+            name: tag name
+        """
         return self._serving_api._get_tag(deployment_instance, name)
 
     def _get_tags(self, deployment_instance):
+        """Get all tags for a deployment.
+
+        Parameters:
+            deployment_instance: the deployment to get tags from
+        """
         return self._serving_api._get_tags(deployment_instance)
 
     def _poll_deployment_status(

--- a/python/hsml/llm/model.py
+++ b/python/hsml/llm/model.py
@@ -43,6 +43,7 @@ class Model(Model):
         href=None,
         feature_view=None,
         training_dataset_version=None,
+        missing_mandatory_tags=None,
         **kwargs,
     ):
         super().__init__(
@@ -64,6 +65,7 @@ class Model(Model):
             model_registry_id=model_registry_id,
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
+            missing_mandatory_tags=missing_mandatory_tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/llm/model.py
+++ b/python/hsml/llm/model.py
@@ -74,5 +74,7 @@ class Model(Model):
         json_decamelized.pop("framework")
         if "type" in json_decamelized:  # backwards compatibility
             _ = json_decamelized.pop("type")
+        if "tags" in json_decamelized:
+            _ = json_decamelized.pop("tags")
         self.__init__(**json_decamelized)
         return self

--- a/python/hsml/llm/model.py
+++ b/python/hsml/llm/model.py
@@ -66,6 +66,7 @@ class Model(Model):
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
             missing_mandatory_tags=missing_mandatory_tags,
+            tags=tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/llm/signature.py
+++ b/python/hsml/llm/signature.py
@@ -25,6 +25,7 @@ from hsml.llm.model import Model
 if TYPE_CHECKING:
     import numpy
     import pandas
+    from hopsworks_common import tag
     from hsfs.feature_view import FeatureView
     from hsml.model_schema import ModelSchema
 
@@ -47,7 +48,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
-    tags: dict[str, Any] | None = None,
+    tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
 ) -> Model:
     """Create an LLM model metadata object.
 
@@ -68,8 +69,9 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
-        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
-            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
+        tags: Optionally the tags to attach to the model when it is saved, in the same shapes accepted by feature groups.
+            A single [`Tag`][hopsworks.tag.Tag], a `{"name": "owner", "value": "team-a"}` dict, or a list of either, for example `[{"name": "owner", "value": "team-a"}]`.
+            The tags ride the create request, so any mandatory model tags missing from them cause the backend to reject the save.
 
     Returns:
         The model metadata object.

--- a/python/hsml/llm/signature.py
+++ b/python/hsml/llm/signature.py
@@ -15,7 +15,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
 from hopsworks_common import usage
@@ -47,6 +47,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
+    tags: dict[str, Any] | None = None,
 ) -> Model:
     """Create an LLM model metadata object.
 
@@ -67,6 +68,8 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
+        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
+            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
 
     Returns:
         The model metadata object.
@@ -81,6 +84,7 @@ def create_model(
         model_schema=model_schema,
         feature_view=feature_view,
         training_dataset_version=training_dataset_version,
+        tags=tags,
     )
     model._shared_registry_project_name = _mr.shared_registry_project_name
     model._model_registry_id = _mr.model_registry_id

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -503,8 +503,7 @@ class Model:
         self._model_engine._delete_tag(model_instance=self, name=name)
 
     def _update_framework(self, framework: str) -> Model:
-        """Update the model's framework.
-        """
+        """Update the model's framework."""
         self._model_engine._update_framework(self, framework)
         return self
 

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -76,11 +76,13 @@ class Model:
         href=None,
         feature_view=None,
         training_dataset_version=None,
+        missing_mandatory_tags=None,
         **kwargs,
     ):
         self._id = id
         self._name = name
         self._version = version
+        self._missing_mandatory_tags = missing_mandatory_tags or []
 
         if description is None:
             self._description = "A collection of models for " + name
@@ -521,6 +523,15 @@ class Model:
             hopsworks.client.exceptions.RestAPIError: In case of a server error.
         """
         return self._model_engine._get_tags(model_instance=self)
+
+    @property
+    def missing_mandatory_tags(self) -> list:
+        """Mandatory tags configured for models that this model is missing.
+
+        Populated from the backend response.
+        Empty when all mandatory model tags are set.
+        """
+        return self._missing_mandatory_tags
 
     @public
     def get_url(self):

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -82,10 +82,6 @@ class Model:
         self._name = name
         self._version = version
         self._missing_mandatory_tags = missing_mandatory_tags or []
-        # Tags provided at creation ride the create request as a list of Tag
-        # objects, serialized identically to feature groups. Response-derived
-        # tags are stripped upstream (_set_model_class, update_from_response_json)
-        # so they never leak back into the create body on a round-trip.
         self._tags = tag.Tag._normalize(tags)
 
         if description is None:
@@ -751,8 +747,6 @@ class Model:
         if "type" in json_decamelized:  # backwards compatibility
             _ = json_decamelized.pop("type")
         if "tags" in json_decamelized:
-            # Tags are always retrieved from the backend separately; dropping the
-            # response tags keeps them out of the create body on a re-save.
             _ = json_decamelized.pop("tags")
         self.__init__(**json_decamelized)
         return self

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -76,7 +76,7 @@ class Model:
         href=None,
         feature_view=None,
         training_dataset_version=None,
-        missing_mandatory_tags=None,
+        missing_mandatory_tags: list[dict[str, Any]] | None = None,
         **kwargs,
     ):
         self._id = id
@@ -524,8 +524,9 @@ class Model:
         """
         return self._model_engine._get_tags(model_instance=self)
 
+    @public
     @property
-    def missing_mandatory_tags(self) -> list:
+    def missing_mandatory_tags(self) -> list[dict[str, Any]]:
         """Mandatory tags configured for models that this model is missing.
 
         Populated from the backend response.

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -38,7 +38,7 @@ from hsml.schema import Schema
 if TYPE_CHECKING:
     from hsfs import feature_view
     from hsfs.core.feature_monitoring_config import FeatureMonitoringConfig
-    from hsml import deployment, tag
+    from hsml import deployment
     from hsml.inference_batcher import InferenceBatcher
     from hsml.inference_logger import InferenceLogger
     from hsml.resources import PredictorResources
@@ -453,7 +453,7 @@ class Model:
 
     @public
     @usage._method_logger
-    def add_tag(self, name: str, value: str | dict):
+    def add_tag(self, name: str, value: Any):
         """Attach a tag to a model.
 
         A tag consists of a <name,value> pair. Tag names are unique identifiers across the whole cluster.
@@ -470,7 +470,7 @@ class Model:
 
     @public
     @usage._method_logger
-    def set_tag(self, name: str, value: str | dict):
+    def set_tag(self, name: str, value: Any):
         """Deprecated: Use add_tag instead.
 
         Parameters:
@@ -498,14 +498,14 @@ class Model:
         self._model_engine._delete_tag(model_instance=self, name=name)
 
     @public
-    def get_tag(self, name: str) -> str | None:
-        """Get the tags of a model.
+    def get_tag(self, name: str) -> Any | None:
+        """Get the value of a tag attached to a model.
 
         Parameters:
             name: Name of the tag to get.
 
         Returns:
-            tag value or `None` if it does not exist.
+            tag value, or `None` if it does not exist.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tag.
@@ -513,11 +513,11 @@ class Model:
         return self._model_engine._get_tag(model_instance=self, name=name)
 
     @public
-    def get_tags(self) -> dict[str, tag.Tag]:
-        """Retrieves all tags attached to a model.
+    def get_tags(self) -> dict[str, Any]:
+        """Retrieve all tags attached to a model.
 
         Returns:
-            Dictionary of tags.
+            Dictionary of tag name/values.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: In case of a server error.

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -71,8 +71,7 @@ class Model:
         input_example=None,
         framework=None,
         model_registry_id=None,
-        # unused, but needed since they come in the backend response
-        tags=None,
+        tags: dict[str, Any] | None = None,
         href=None,
         feature_view=None,
         training_dataset_version=None,
@@ -83,6 +82,10 @@ class Model:
         self._name = name
         self._version = version
         self._missing_mandatory_tags = missing_mandatory_tags or []
+        # Tags provided at creation ride the create request; the backend
+        # returns tags as a list (attached tags), which is falsy-normalized to
+        # {} here so it never leaks into the create body on a round-trip.
+        self._tags = tags if isinstance(tags, dict) else {}
 
         if description is None:
             self._description = "A collection of models for " + name
@@ -382,6 +385,7 @@ class Model:
         env_vars: dict | None = None,
         vllm_variant: str | None = None,
         vllm_image_tag: str | None = None,
+        tags: dict[str, Any] | None = None,
     ) -> deployment.Deployment:
         """Deploy the model.
 
@@ -420,6 +424,8 @@ class Model:
             env_vars: Environment variables to set on the predictor.
             vllm_variant: vLLM image variant for vLLM deployments. One of `'VLLM'` or `'VLLM_OMNI'`. Ignored for non-vLLM model servers.
             vllm_image_tag: vLLM image tag override. `None` uses the cluster default; if set, it should match one of the tags made available by a cluster administrator. Ignored for non-vLLM model servers.
+            tags: Optionally a dictionary of tag name/value pairs to attach to the deployment when it is created.
+                The tags ride the create request, so any mandatory deployment tags missing from this dictionary cause the backend to reject the creation.
 
         Returns:
             The deployment metadata object of a new or existing deployment.
@@ -447,6 +453,7 @@ class Model:
             env_vars=env_vars,
             vllm_variant=vllm_variant,
             vllm_image_tag=vllm_image_tag,
+            tags=tags,
         )
 
         return predictor.deploy()
@@ -748,7 +755,7 @@ class Model:
         return json.dumps(self, cls=util.Encoder)
 
     def to_dict(self):
-        return {
+        model_dict = {
             "id": self._name + "_" + str(self._version),
             "projectName": self._project_name,
             "name": self._name,
@@ -763,6 +770,14 @@ class Model:
             "featureView": util._feature_view_to_json(self._feature_view),
             "trainingDatasetVersion": self._training_dataset_version,
         }
+        if self._tags:
+            model_dict["tags"] = {
+                "items": [
+                    {"name": name, "value": json.dumps(value)}
+                    for name, value in self._tags.items()
+                ]
+            }
+        return model_dict
 
     @public
     @property

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -502,6 +502,12 @@ class Model:
         """
         self._model_engine._delete_tag(model_instance=self, name=name)
 
+    def _update_framework(self, framework: str) -> Model:
+        """Update the model's framework.
+        """
+        self._model_engine._update_framework(self, framework)
+        return self
+
     @public
     def get_tag(self, name: str) -> Any | None:
         """Get the value of a tag attached to a model.

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 import humps
 from hopsworks_apigen import public
-from hopsworks_common import client, usage, util
+from hopsworks_common import client, tag, usage, util
 from hopsworks_common.constants import INFERENCE_ENDPOINTS as IE
 from hopsworks_common.constants import MODEL_REGISTRY
 from hsml.core import explicit_provenance
@@ -71,7 +71,7 @@ class Model:
         input_example=None,
         framework=None,
         model_registry_id=None,
-        tags: dict[str, Any] | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         href=None,
         feature_view=None,
         training_dataset_version=None,
@@ -82,10 +82,11 @@ class Model:
         self._name = name
         self._version = version
         self._missing_mandatory_tags = missing_mandatory_tags or []
-        # Tags provided at creation ride the create request; the backend
-        # returns tags as a list (attached tags), which is falsy-normalized to
-        # {} here so it never leaks into the create body on a round-trip.
-        self._tags = tags if isinstance(tags, dict) else {}
+        # Tags provided at creation ride the create request as a list of Tag
+        # objects, serialized identically to feature groups. Response-derived
+        # tags are stripped upstream (_set_model_class, update_from_response_json)
+        # so they never leak back into the create body on a round-trip.
+        self._tags = tag.Tag._normalize(tags)
 
         if description is None:
             self._description = "A collection of models for " + name
@@ -385,7 +386,7 @@ class Model:
         env_vars: dict | None = None,
         vllm_variant: str | None = None,
         vllm_image_tag: str | None = None,
-        tags: dict[str, Any] | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
     ) -> deployment.Deployment:
         """Deploy the model.
 
@@ -424,8 +425,9 @@ class Model:
             env_vars: Environment variables to set on the predictor.
             vllm_variant: vLLM image variant for vLLM deployments. One of `'VLLM'` or `'VLLM_OMNI'`. Ignored for non-vLLM model servers.
             vllm_image_tag: vLLM image tag override. `None` uses the cluster default; if set, it should match one of the tags made available by a cluster administrator. Ignored for non-vLLM model servers.
-            tags: Optionally a dictionary of tag name/value pairs to attach to the deployment when it is created.
-                The tags ride the create request, so any mandatory deployment tags missing from this dictionary cause the backend to reject the creation.
+            tags: Optionally the tags to attach to the deployment when it is created, in the same shapes accepted by feature groups.
+                A single [`Tag`][hopsworks.tag.Tag], a `{"name": "owner", "value": "team-a"}` dict, or a list of either, for example `[{"name": "owner", "value": "team-a"}]`.
+                The tags ride the create request, so any mandatory deployment tags missing from them cause the backend to reject the creation.
 
         Returns:
             The deployment metadata object of a new or existing deployment.
@@ -748,6 +750,10 @@ class Model:
         json_decamelized = humps.decamelize(json_dict)
         if "type" in json_decamelized:  # backwards compatibility
             _ = json_decamelized.pop("type")
+        if "tags" in json_decamelized:
+            # Tags are always retrieved from the backend separately; dropping the
+            # response tags keeps them out of the create body on a re-save.
+            _ = json_decamelized.pop("tags")
         self.__init__(**json_decamelized)
         return self
 
@@ -770,13 +776,9 @@ class Model:
             "featureView": util._feature_view_to_json(self._feature_view),
             "trainingDatasetVersion": self._training_dataset_version,
         }
-        if self._tags:
-            model_dict["tags"] = {
-                "items": [
-                    {"name": name, "value": json.dumps(value)}
-                    for name, value in self._tags.items()
-                ]
-            }
+        tags_dict = tag.Tag._tags_to_dict(self._tags)
+        if tags_dict:
+            model_dict["tags"] = tags_dict
         return model_dict
 
     @public

--- a/python/hsml/model_registry.py
+++ b/python/hsml/model_registry.py
@@ -104,12 +104,15 @@ class ModelRegistry:
             )
             version = self.DEFAULT_VERSION
 
-        return self._model_api._get(
+        model_instance = self._model_api._get(
             name,
             version,
             self.model_registry_id,
             shared_registry_project_name=self.shared_registry_project_name,
         )
+        if model_instance is not None:
+            util._check_missing_mandatory_tags(model_instance.missing_mandatory_tags)
+        return model_instance
 
     @public
     @usage._method_logger

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -23,7 +23,7 @@ import zipfile
 from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
-from hopsworks_common import usage, util
+from hopsworks_common import tag, usage, util
 from hopsworks_common.client.exceptions import RestAPIError
 from hopsworks_common.constants import INFERENCE_ENDPOINTS as IE
 from hopsworks_common.constants import PREDICTOR_STATE
@@ -220,7 +220,7 @@ class ModelServing:
         vllm_variant: str | None = None,
         vllm_image_tag: str | None = None,
         tracing: DeploymentTracingConfig | dict | None = None,
-        tags: dict[str, Any] | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
     ) -> Predictor:
         """Create a Predictor metadata object.
 
@@ -266,8 +266,9 @@ class ModelServing:
             vllm_variant: vLLM image variant for vLLM deployments. One of `'VLLM'` or `'VLLM_OMNI'`. Ignored for non-vLLM model servers.
             vllm_image_tag: vLLM image tag override. `None` uses the cluster default; if set, it should match one of the tags made available by a cluster administrator. Ignored for non-vLLM model servers.
             tracing: Tracing configuration for the predictor.
-            tags: Optionally a dictionary of tag name/value pairs to attach to the deployment when it is created.
-                The tags ride the create request, so any mandatory deployment tags missing from this dictionary cause the backend to reject the creation.
+            tags: Optionally the tags to attach to the deployment when it is created, in the same shapes accepted by feature groups.
+                A single [`Tag`][hopsworks.tag.Tag], a `{"name": "owner", "value": "team-a"}` dict, or a list of either, for example `[{"name": "owner", "value": "team-a"}]`.
+                The tags ride the create request, so any mandatory deployment tags missing from them cause the backend to reject the creation.
 
         Returns:
             The predictor metadata object.
@@ -636,7 +637,7 @@ class ModelServing:
         predictor: Predictor,
         name: str | None = None,
         environment: str | None = None,
-        tags: dict[str, Any] | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
     ) -> Deployment:
         """Create a Deployment metadata object.
 
@@ -701,14 +702,15 @@ class ModelServing:
             predictor: predictor to be used in the deployment
             name: name of the deployment
             environment: (**Deprecated**) The project Python environment to use. This argument will be ignored, use the argument `environment` in the `create_predictor()` or `create_endpoint()` methods instead.
-            tags: Optionally a dictionary of tag name/value pairs to attach to the deployment when it is created.
-                The tags ride the create request, so any mandatory deployment tags missing from this dictionary cause the backend to reject the creation.
+            tags: Optionally the tags to attach to the deployment when it is created, in the same shapes accepted by feature groups.
+                A single [`Tag`][hopsworks.tag.Tag], a `{"name": "owner", "value": "team-a"}` dict, or a list of either, for example `[{"name": "owner", "value": "team-a"}]`.
+                The tags ride the create request, so any mandatory deployment tags missing from them cause the backend to reject the creation.
 
         Returns:
             The deployment metadata object.
         """
         if tags:
-            predictor._tags = tags
+            predictor._tags = tag.Tag._normalize(tags)
         return Deployment(predictor=predictor, name=name)
 
     @public

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -20,7 +20,7 @@ import posixpath
 import re
 import tempfile
 import zipfile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
 from hopsworks_common import usage, util
@@ -129,7 +129,12 @@ class ModelServing:
         """
         if name is None and ("DEPLOYMENT_NAME" in os.environ):
             name = os.environ["DEPLOYMENT_NAME"]
-        return self._serving_api._get(name)
+        deployment_instance = self._serving_api._get(name)
+        if deployment_instance is not None:
+            util._check_missing_mandatory_tags(
+                deployment_instance.missing_mandatory_tags
+            )
+        return deployment_instance
 
     @public
     @usage._method_logger
@@ -215,6 +220,7 @@ class ModelServing:
         vllm_variant: str | None = None,
         vllm_image_tag: str | None = None,
         tracing: DeploymentTracingConfig | dict | None = None,
+        tags: dict[str, Any] | None = None,
     ) -> Predictor:
         """Create a Predictor metadata object.
 
@@ -260,6 +266,8 @@ class ModelServing:
             vllm_variant: vLLM image variant for vLLM deployments. One of `'VLLM'` or `'VLLM_OMNI'`. Ignored for non-vLLM model servers.
             vllm_image_tag: vLLM image tag override. `None` uses the cluster default; if set, it should match one of the tags made available by a cluster administrator. Ignored for non-vLLM model servers.
             tracing: Tracing configuration for the predictor.
+            tags: Optionally a dictionary of tag name/value pairs to attach to the deployment when it is created.
+                The tags ride the create request, so any mandatory deployment tags missing from this dictionary cause the backend to reject the creation.
 
         Returns:
             The predictor metadata object.
@@ -284,6 +292,7 @@ class ModelServing:
             vllm_variant=vllm_variant,
             vllm_image_tag=vllm_image_tag,
             tracing=tracing,
+            tags=tags,
         )
 
     @public
@@ -627,6 +636,7 @@ class ModelServing:
         predictor: Predictor,
         name: str | None = None,
         environment: str | None = None,
+        tags: dict[str, Any] | None = None,
     ) -> Deployment:
         """Create a Deployment metadata object.
 
@@ -691,10 +701,14 @@ class ModelServing:
             predictor: predictor to be used in the deployment
             name: name of the deployment
             environment: (**Deprecated**) The project Python environment to use. This argument will be ignored, use the argument `environment` in the `create_predictor()` or `create_endpoint()` methods instead.
+            tags: Optionally a dictionary of tag name/value pairs to attach to the deployment when it is created.
+                The tags ride the create request, so any mandatory deployment tags missing from this dictionary cause the backend to reject the creation.
 
         Returns:
             The deployment metadata object.
         """
+        if tags:
+            predictor._tags = tags
         return Deployment(predictor=predictor, name=name)
 
     @public

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -91,10 +91,6 @@ class Predictor(DeployableComponent):
         **kwargs,
     ):
         self._missing_mandatory_tags = missing_mandatory_tags or []
-        # Tags provided at creation ride the serving-create request as a list of
-        # Tag objects, serialized identically to feature groups. The serving GET
-        # response never carries tags (they surface via missing_mandatory_tags),
-        # so nothing response-derived reaches this list on a round-trip.
         self._tags = tag.Tag._normalize(tags)
         serving_tool = (
             self._validate_serving_tool(serving_tool)

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import humps
 from hopsworks_apigen import public
-from hopsworks_common import client, util
+from hopsworks_common import client, tag, util
 from hopsworks_common.constants import (
     INFERENCE_ENDPOINTS,
     MODEL,
@@ -87,14 +87,15 @@ class Predictor(DeployableComponent):
         git_provider: str | None = None,
         git_branch: str | None = None,
         missing_mandatory_tags: list[dict[str, Any]] | None = None,
-        tags: dict[str, Any] | None = None,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         **kwargs,
     ):
         self._missing_mandatory_tags = missing_mandatory_tags or []
-        # Tags provided at creation ride the serving-create request; the backend
-        # returns attached tags separately, so this stays isolated from the
-        # missing_mandatory_tags surfaced on retrieval.
-        self._tags = tags if isinstance(tags, dict) else {}
+        # Tags provided at creation ride the serving-create request as a list of
+        # Tag objects, serialized identically to feature groups. The serving GET
+        # response never carries tags (they surface via missing_mandatory_tags),
+        # so nothing response-derived reaches this list on a round-trip.
+        self._tags = tag.Tag._normalize(tags)
         serving_tool = (
             self._validate_serving_tool(serving_tool)
             or self._get_default_serving_tool()
@@ -439,16 +440,9 @@ class Predictor(DeployableComponent):
             json = {**json, "gitBranch": self._git_branch}
         if self._scaling_configuration is not None:
             json = {**json, **self._scaling_configuration.to_dict()}
-        if self._tags:
-            json = {
-                **json,
-                "tags": {
-                    "items": [
-                        {"name": name, "value": _json.dumps(value)}
-                        for name, value in self._tags.items()
-                    ]
-                },
-            }
+        tags_dict = tag.Tag._tags_to_dict(self._tags)
+        if tags_dict:
+            json = {**json, "tags": tags_dict}
         return json
 
     @public

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 from __future__ import annotations
 
-import json
+import json as _json
 from typing import Any
 
 import humps
@@ -87,9 +87,14 @@ class Predictor(DeployableComponent):
         git_provider: str | None = None,
         git_branch: str | None = None,
         missing_mandatory_tags: list[dict[str, Any]] | None = None,
+        tags: dict[str, Any] | None = None,
         **kwargs,
     ):
         self._missing_mandatory_tags = missing_mandatory_tags or []
+        # Tags provided at creation ride the serving-create request; the backend
+        # returns attached tags separately, so this stays isolated from the
+        # missing_mandatory_tags surfaced on retrieval.
+        self._tags = tags if isinstance(tags, dict) else {}
         serving_tool = (
             self._validate_serving_tool(serving_tool)
             or self._get_default_serving_tool()
@@ -378,7 +383,7 @@ class Predictor(DeployableComponent):
         return self
 
     def json(self):
-        return json.dumps(self, cls=util.Encoder)
+        return _json.dumps(self, cls=util.Encoder)
 
     def to_dict(self):
         json = {
@@ -434,6 +439,16 @@ class Predictor(DeployableComponent):
             json = {**json, "gitBranch": self._git_branch}
         if self._scaling_configuration is not None:
             json = {**json, **self._scaling_configuration.to_dict()}
+        if self._tags:
+            json = {
+                **json,
+                "tags": {
+                    "items": [
+                        {"name": name, "value": _json.dumps(value)}
+                        for name, value in self._tags.items()
+                    ]
+                },
+            }
         return json
 
     @public

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -85,8 +85,10 @@ class Predictor(DeployableComponent):
         git_url: str | None = None,
         git_provider: str | None = None,
         git_branch: str | None = None,
+        missing_mandatory_tags=None,
         **kwargs,
     ):
+        self._missing_mandatory_tags = missing_mandatory_tags or []
         serving_tool = (
             self._validate_serving_tool(serving_tool)
             or self._get_default_serving_tool()
@@ -362,6 +364,9 @@ class Predictor(DeployableComponent):
         )
         kwargs["vllm_image_tag"] = util._extract_field_from_json(
             json_decamelized, "vllm_image_tag"
+        )
+        kwargs["missing_mandatory_tags"] = util._extract_field_from_json(
+            json_decamelized, "missing_mandatory_tags"
         )
         return kwargs
 

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 from __future__ import annotations
 
-import json as _json
+import json
 from typing import Any
 
 import humps
@@ -380,10 +380,10 @@ class Predictor(DeployableComponent):
         return self
 
     def json(self):
-        return _json.dumps(self, cls=util.Encoder)
+        return json.dumps(self, cls=util.Encoder)
 
     def to_dict(self):
-        json = {
+        predictor_dict = {
             "id": self._id,
             "name": self._name,
             "description": self._description,
@@ -398,48 +398,51 @@ class Predictor(DeployableComponent):
             "projectNamespace": self._project_namespace,
         }
         if self._model_server == PREDICTOR.MODEL_SERVER_VLLM:
-            json = {
-                **json,
+            predictor_dict = {
+                **predictor_dict,
                 "vllmVariant": self._vllm_variant,
                 "vllmImageTag": self._vllm_image_tag,
             }
         if self.model_name is not None:
-            json = {**json, "modelName": self._model_name}
+            predictor_dict = {**predictor_dict, "modelName": self._model_name}
         if self.model_path is not None:
-            json = {**json, "modelPath": self._model_path}
+            predictor_dict = {**predictor_dict, "modelPath": self._model_path}
         if self.model_version is not None:
-            json = {**json, "modelVersion": self._model_version}
+            predictor_dict = {**predictor_dict, "modelVersion": self._model_version}
         if self.model_framework is not None:
-            json = {**json, "modelFramework": self._model_framework}
+            predictor_dict = {**predictor_dict, "modelFramework": self._model_framework}
         if self._env_vars:
-            json = {
-                **json,
+            predictor_dict = {
+                **predictor_dict,
                 "predictorEnvVars": [f"{k}={v}" for k, v in self._env_vars.items()],
             }
         if self.environment is not None:
-            json = {**json, "environmentDTO": {"name": self._environment}}
+            predictor_dict = {
+                **predictor_dict,
+                "environmentDTO": {"name": self._environment},
+            }
         if self._resources is not None:
-            json = {**json, **self._resources.to_dict()}
+            predictor_dict = {**predictor_dict, **self._resources.to_dict()}
         if self._inference_logger is not None:
-            json = {**json, **self._inference_logger.to_dict()}
+            predictor_dict = {**predictor_dict, **self._inference_logger.to_dict()}
         if self._inference_batcher is not None:
-            json = {**json, **self._inference_batcher.to_dict()}
+            predictor_dict = {**predictor_dict, **self._inference_batcher.to_dict()}
         if self._transformer is not None:
-            json = {**json, **self._transformer.to_dict()}
+            predictor_dict = {**predictor_dict, **self._transformer.to_dict()}
         if self._tracing is not None:
-            json = {**json, "tracing": self._tracing.to_dict()}
+            predictor_dict = {**predictor_dict, "tracing": self._tracing.to_dict()}
         if self._git_url is not None:
-            json = {**json, "gitUrl": self._git_url}
+            predictor_dict = {**predictor_dict, "gitUrl": self._git_url}
         if self._git_provider is not None:
-            json = {**json, "gitProvider": self._git_provider}
+            predictor_dict = {**predictor_dict, "gitProvider": self._git_provider}
         if self._git_branch is not None:
-            json = {**json, "gitBranch": self._git_branch}
+            predictor_dict = {**predictor_dict, "gitBranch": self._git_branch}
         if self._scaling_configuration is not None:
-            json = {**json, **self._scaling_configuration.to_dict()}
+            predictor_dict = {**predictor_dict, **self._scaling_configuration.to_dict()}
         tags_dict = tag.Tag._tags_to_dict(self._tags)
         if tags_dict:
-            json = {**json, "tags": tags_dict}
-        return json
+            predictor_dict = {**predictor_dict, "tags": tags_dict}
+        return predictor_dict
 
     @public
     @property

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import humps
 from hopsworks_apigen import public
@@ -85,7 +86,7 @@ class Predictor(DeployableComponent):
         git_url: str | None = None,
         git_provider: str | None = None,
         git_branch: str | None = None,
-        missing_mandatory_tags=None,
+        missing_mandatory_tags: list[dict[str, Any]] | None = None,
         **kwargs,
     ):
         self._missing_mandatory_tags = missing_mandatory_tags or []

--- a/python/hsml/python/model.py
+++ b/python/hsml/python/model.py
@@ -43,6 +43,7 @@ class Model(Model):
         href=None,
         feature_view=None,
         training_dataset_version=None,
+        missing_mandatory_tags=None,
         **kwargs,
     ):
         super().__init__(
@@ -64,6 +65,7 @@ class Model(Model):
             model_registry_id=model_registry_id,
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
+            missing_mandatory_tags=missing_mandatory_tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/python/model.py
+++ b/python/hsml/python/model.py
@@ -74,5 +74,7 @@ class Model(Model):
         json_decamelized.pop("framework")
         if "type" in json_decamelized:  # backwards compatibility
             _ = json_decamelized.pop("type")
+        if "tags" in json_decamelized:
+            _ = json_decamelized.pop("tags")
         self.__init__(**json_decamelized)
         return self

--- a/python/hsml/python/model.py
+++ b/python/hsml/python/model.py
@@ -66,6 +66,7 @@ class Model(Model):
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
             missing_mandatory_tags=missing_mandatory_tags,
+            tags=tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/python/signature.py
+++ b/python/hsml/python/signature.py
@@ -15,7 +15,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
 from hopsworks_common import usage
@@ -47,6 +47,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
+    tags: dict[str, Any] | None = None,
 ) -> Model:
     """Create a generic Python model metadata object.
 
@@ -67,6 +68,8 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
+        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
+            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
 
     Returns:
         The model metadata object.
@@ -81,6 +84,7 @@ def create_model(
         model_schema=model_schema,
         feature_view=feature_view,
         training_dataset_version=training_dataset_version,
+        tags=tags,
     )
     model._shared_registry_project_name = _mr.shared_registry_project_name
     model._model_registry_id = _mr.model_registry_id

--- a/python/hsml/python/signature.py
+++ b/python/hsml/python/signature.py
@@ -25,6 +25,7 @@ from hsml.python.model import Model
 if TYPE_CHECKING:
     import numpy
     import pandas
+    from hopsworks_common import tag
     from hsfs.feature_view import FeatureView
     from hsml.model_schema import ModelSchema
 
@@ -47,7 +48,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
-    tags: dict[str, Any] | None = None,
+    tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
 ) -> Model:
     """Create a generic Python model metadata object.
 
@@ -68,8 +69,9 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
-        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
-            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
+        tags: Optionally the tags to attach to the model when it is saved, in the same shapes accepted by feature groups.
+            A single [`Tag`][hopsworks.tag.Tag], a `{"name": "owner", "value": "team-a"}` dict, or a list of either, for example `[{"name": "owner", "value": "team-a"}]`.
+            The tags ride the create request, so any mandatory model tags missing from them cause the backend to reject the save.
 
     Returns:
         The model metadata object.

--- a/python/hsml/sklearn/model.py
+++ b/python/hsml/sklearn/model.py
@@ -43,6 +43,7 @@ class Model(Model):
         href=None,
         feature_view=None,
         training_dataset_version=None,
+        missing_mandatory_tags=None,
         **kwargs,
     ):
         super().__init__(
@@ -64,6 +65,7 @@ class Model(Model):
             model_registry_id=model_registry_id,
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
+            missing_mandatory_tags=missing_mandatory_tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/sklearn/model.py
+++ b/python/hsml/sklearn/model.py
@@ -74,5 +74,7 @@ class Model(Model):
         json_decamelized.pop("framework")
         if "type" in json_decamelized:  # backwards compatibility
             _ = json_decamelized.pop("type")
+        if "tags" in json_decamelized:
+            _ = json_decamelized.pop("tags")
         self.__init__(**json_decamelized)
         return self

--- a/python/hsml/sklearn/model.py
+++ b/python/hsml/sklearn/model.py
@@ -66,6 +66,7 @@ class Model(Model):
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
             missing_mandatory_tags=missing_mandatory_tags,
+            tags=tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/sklearn/signature.py
+++ b/python/hsml/sklearn/signature.py
@@ -25,6 +25,7 @@ from hsml.sklearn.model import Model
 if TYPE_CHECKING:
     import numpy
     import pandas
+    from hopsworks_common import tag
     from hsfs.feature_view import FeatureView
     from hsml.model_schema import ModelSchema
 
@@ -47,7 +48,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
-    tags: dict[str, Any] | None = None,
+    tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
 ) -> Model:
     """Create an SkLearn model metadata object.
 
@@ -68,8 +69,9 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
-        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
-            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
+        tags: Optionally the tags to attach to the model when it is saved, in the same shapes accepted by feature groups.
+            A single [`Tag`][hopsworks.tag.Tag], a `{"name": "owner", "value": "team-a"}` dict, or a list of either, for example `[{"name": "owner", "value": "team-a"}]`.
+            The tags ride the create request, so any mandatory model tags missing from them cause the backend to reject the save.
 
     Returns:
         The model metadata object.

--- a/python/hsml/sklearn/signature.py
+++ b/python/hsml/sklearn/signature.py
@@ -15,7 +15,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
 from hopsworks_common import usage
@@ -47,6 +47,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
+    tags: dict[str, Any] | None = None,
 ) -> Model:
     """Create an SkLearn model metadata object.
 
@@ -67,6 +68,8 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
+        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
+            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
 
     Returns:
         The model metadata object.
@@ -81,6 +84,7 @@ def create_model(
         model_schema=model_schema,
         feature_view=feature_view,
         training_dataset_version=training_dataset_version,
+        tags=tags,
     )
     model._shared_registry_project_name = _mr.shared_registry_project_name
     model._model_registry_id = _mr.model_registry_id

--- a/python/hsml/tensorflow/model.py
+++ b/python/hsml/tensorflow/model.py
@@ -43,6 +43,7 @@ class Model(Model):
         href=None,
         feature_view=None,
         training_dataset_version=None,
+        missing_mandatory_tags=None,
         **kwargs,
     ):
         super().__init__(
@@ -64,6 +65,7 @@ class Model(Model):
             model_registry_id=model_registry_id,
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
+            missing_mandatory_tags=missing_mandatory_tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/tensorflow/model.py
+++ b/python/hsml/tensorflow/model.py
@@ -74,5 +74,7 @@ class Model(Model):
         json_decamelized.pop("framework")
         if "type" in json_decamelized:  # backwards compatibility
             _ = json_decamelized.pop("type")
+        if "tags" in json_decamelized:
+            _ = json_decamelized.pop("tags")
         self.__init__(**json_decamelized)
         return self

--- a/python/hsml/tensorflow/model.py
+++ b/python/hsml/tensorflow/model.py
@@ -66,6 +66,7 @@ class Model(Model):
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
             missing_mandatory_tags=missing_mandatory_tags,
+            tags=tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/tensorflow/signature.py
+++ b/python/hsml/tensorflow/signature.py
@@ -25,6 +25,7 @@ from hsml.tensorflow.model import Model
 if TYPE_CHECKING:
     import numpy
     import pandas
+    from hopsworks_common import tag
     from hsfs.feature_view import FeatureView
     from hsml.model_schema import ModelSchema
 
@@ -47,7 +48,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
-    tags: dict[str, Any] | None = None,
+    tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
 ) -> Model:
     """Create a TensorFlow model metadata object.
 
@@ -68,8 +69,9 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
-        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
-            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
+        tags: Optionally the tags to attach to the model when it is saved, in the same shapes accepted by feature groups.
+            A single [`Tag`][hopsworks.tag.Tag], a `{"name": "owner", "value": "team-a"}` dict, or a list of either, for example `[{"name": "owner", "value": "team-a"}]`.
+            The tags ride the create request, so any mandatory model tags missing from them cause the backend to reject the save.
 
     Returns:
         The model metadata object.

--- a/python/hsml/tensorflow/signature.py
+++ b/python/hsml/tensorflow/signature.py
@@ -15,7 +15,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
 from hopsworks_common import usage
@@ -47,6 +47,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
+    tags: dict[str, Any] | None = None,
 ) -> Model:
     """Create a TensorFlow model metadata object.
 
@@ -67,6 +68,8 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
+        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
+            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
 
     Returns:
         The model metadata object.
@@ -81,6 +84,7 @@ def create_model(
         model_schema=model_schema,
         feature_view=feature_view,
         training_dataset_version=training_dataset_version,
+        tags=tags,
     )
     model._shared_registry_project_name = _mr.shared_registry_project_name
     model._model_registry_id = _mr.model_registry_id

--- a/python/hsml/torch/model.py
+++ b/python/hsml/torch/model.py
@@ -43,6 +43,7 @@ class Model(Model):
         href=None,
         feature_view=None,
         training_dataset_version=None,
+        missing_mandatory_tags=None,
         **kwargs,
     ):
         super().__init__(
@@ -64,6 +65,7 @@ class Model(Model):
             model_registry_id=model_registry_id,
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
+            missing_mandatory_tags=missing_mandatory_tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/torch/model.py
+++ b/python/hsml/torch/model.py
@@ -74,5 +74,7 @@ class Model(Model):
         json_decamelized.pop("framework")
         if "type" in json_decamelized:  # backwards compatibility
             _ = json_decamelized.pop("type")
+        if "tags" in json_decamelized:
+            _ = json_decamelized.pop("tags")
         self.__init__(**json_decamelized)
         return self

--- a/python/hsml/torch/model.py
+++ b/python/hsml/torch/model.py
@@ -66,6 +66,7 @@ class Model(Model):
             feature_view=feature_view,
             training_dataset_version=training_dataset_version,
             missing_mandatory_tags=missing_mandatory_tags,
+            tags=tags,
         )
 
     def update_from_response_json(self, json_dict):

--- a/python/hsml/torch/signature.py
+++ b/python/hsml/torch/signature.py
@@ -25,6 +25,7 @@ from hsml.torch.model import Model
 if TYPE_CHECKING:
     import numpy
     import pandas
+    from hopsworks_common import tag
     from hsfs.feature_view import FeatureView
     from hsml.model_schema import ModelSchema
 
@@ -47,7 +48,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
-    tags: dict[str, Any] | None = None,
+    tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
 ) -> Model:
     """Create a Torch model metadata object.
 
@@ -68,8 +69,9 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
-        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
-            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
+        tags: Optionally the tags to attach to the model when it is saved, in the same shapes accepted by feature groups.
+            A single [`Tag`][hopsworks.tag.Tag], a `{"name": "owner", "value": "team-a"}` dict, or a list of either, for example `[{"name": "owner", "value": "team-a"}]`.
+            The tags ride the create request, so any mandatory model tags missing from them cause the backend to reject the save.
 
     Returns:
         The model metadata object.

--- a/python/hsml/torch/signature.py
+++ b/python/hsml/torch/signature.py
@@ -15,7 +15,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
 from hopsworks_common import usage
@@ -47,6 +47,7 @@ def create_model(
     model_schema: ModelSchema | None = None,
     feature_view: FeatureView | None = None,
     training_dataset_version: int | None = None,
+    tags: dict[str, Any] | None = None,
 ) -> Model:
     """Create a Torch model metadata object.
 
@@ -67,6 +68,8 @@ def create_model(
         model_schema: Optionally a model schema for the model inputs and/or outputs.
         feature_view: Optionally a feature view object returned by querying the feature store. If the feature view is not provided, the model will not have access to provenance.
         training_dataset_version: Optionally a training dataset version. If training dataset version is not provided, but the feature view is provided, the training dataset version used will be the last accessed training dataset of the feature view, within the code/notebook that reads the feature view and training dataset and then creates the model.
+        tags: Optionally a dictionary of tag name/value pairs to attach to the model when it is saved.
+            The tags ride the create request, so any mandatory model tags missing from this dictionary cause the backend to reject the save.
 
     Returns:
         The model metadata object.
@@ -81,6 +84,7 @@ def create_model(
         model_schema=model_schema,
         feature_view=feature_view,
         training_dataset_version=training_dataset_version,
+        tags=tags,
     )
     model._shared_registry_project_name = _mr.shared_registry_project_name
     model._model_registry_id = _mr.model_registry_id

--- a/python/tests/core/test_serving_api.py
+++ b/python/tests/core/test_serving_api.py
@@ -1,0 +1,107 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from hsml.core.serving_api import ServingApi
+
+
+def _tags_response(items: list[tuple[str, str]]) -> dict:
+    return {
+        "count": len(items),
+        "items": [{"name": name, "value": value} for name, value in items],
+    }
+
+
+def _patch_client(mocker, send_request_return) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 1
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hsml.core.serving_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+def _deployment() -> SimpleNamespace:
+    return SimpleNamespace(id=12)
+
+
+class TestServingApi:
+    def test_get_tags_decodes_values_without_double_decode(self, mocker):
+        # Arrange
+        api = ServingApi()
+        value = {"owner": "team-a", "score": 3}
+        _patch_client(
+            mocker,
+            _tags_response([("meta", json.dumps(value)), ("count", json.dumps(9))]),
+        )
+
+        # Act
+        result = api._get_tags(_deployment())
+
+        # Assert
+        assert result == {"meta": value, "count": 9}
+
+    def test_get_tag_returns_value_for_name(self, mocker):
+        # Arrange
+        api = ServingApi()
+        value = {"owner": "team-a"}
+        _patch_client(mocker, _tags_response([("meta", json.dumps(value))]))
+
+        # Act
+        result = api._get_tag(_deployment(), "meta")
+
+        # Assert
+        assert result == value
+
+    def test_get_tag_numeric_value(self, mocker):
+        # Arrange
+        api = ServingApi()
+        _patch_client(mocker, _tags_response([("version", json.dumps(7))]))
+
+        # Act
+        result = api._get_tag(_deployment(), "version")
+
+        # Assert
+        assert result == 7
+
+    def test_get_tag_absent_name_returns_none(self, mocker):
+        # Arrange
+        api = ServingApi()
+        _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        result = api._get_tag(_deployment(), "missing")
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.parametrize("bad_value", [{"a": 1}, 7, ["x"], True])
+    def test_get_tags_does_not_double_decode(self, mocker, bad_value):
+        # Arrange
+        api = ServingApi()
+        _patch_client(mocker, _tags_response([("t", json.dumps(bad_value))]))
+
+        # Act
+        result = api._get_tags(_deployment())
+
+        # Assert
+        assert result == {"t": bad_value}

--- a/python/tests/core/test_serving_api.py
+++ b/python/tests/core/test_serving_api.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from hopsworks_common.client.exceptions import RestAPIError
 from hsml.core.serving_api import ServingApi
 
 
@@ -32,7 +33,10 @@ def _tags_response(items: list[tuple[str, str]]) -> dict:
 def _patch_client(mocker, send_request_return) -> MagicMock:
     client_instance = MagicMock()
     client_instance._project_id = 1
-    client_instance._send_request.return_value = send_request_return
+    if isinstance(send_request_return, Exception):
+        client_instance._send_request.side_effect = send_request_return
+    else:
+        client_instance._send_request.return_value = send_request_return
     mocker.patch(
         "hsml.core.serving_api.client._get_instance",
         return_value=client_instance,
@@ -45,21 +49,6 @@ def _deployment() -> SimpleNamespace:
 
 
 class TestServingApi:
-    def test_get_tags_decodes_values_without_double_decode(self, mocker):
-        # Arrange
-        api = ServingApi()
-        value = {"owner": "team-a", "score": 3}
-        _patch_client(
-            mocker,
-            _tags_response([("meta", json.dumps(value)), ("count", json.dumps(9))]),
-        )
-
-        # Act
-        result = api._get_tags(_deployment())
-
-        # Assert
-        assert result == {"meta": value, "count": 9}
-
     def test_get_tag_returns_value_for_name(self, mocker):
         # Arrange
         api = ServingApi()
@@ -87,6 +76,27 @@ class TestServingApi:
         # Arrange
         api = ServingApi()
         _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        result = api._get_tag(_deployment(), "missing")
+
+        # Assert
+        assert result is None
+
+    def test_get_tag_not_found_error_returns_none(self, mocker):
+        # Arrange
+        api = ServingApi()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {
+            "errorCode": 370002,
+            "errorMsg": "not found",
+            "usrMsg": "not found",
+        }
+        _patch_client(
+            mocker,
+            RestAPIError("/project/1/serving/12/tags/missing", mock_response),
+        )
 
         # Act
         result = api._get_tag(_deployment(), "missing")

--- a/python/tests/fixtures/model_fixtures.json
+++ b/python/tests/fixtures/model_fixtures.json
@@ -72,6 +72,7 @@
           "model_registry_id": 1,
           "tags": [],
           "framework": "SKLEARN",
+          "missing_mandatory_tags": [{ "name": "owner" }],
           "href": "test_href"
         }
       ]
@@ -98,6 +99,7 @@
           "model_registry_id": 1,
           "tags": [],
           "framework": "TENSORFLOW",
+          "missing_mandatory_tags": [{ "name": "owner" }],
           "href": "test_href"
         }
       ]
@@ -124,6 +126,7 @@
           "model_registry_id": 1,
           "tags": [],
           "framework": "TORCH",
+          "missing_mandatory_tags": [{ "name": "owner" }],
           "href": "test_href"
         }
       ]
@@ -150,6 +153,7 @@
           "model_registry_id": 1,
           "tags": [],
           "framework": "LLM",
+          "missing_mandatory_tags": [{ "name": "owner" }],
           "href": "test_href"
         }
       ]

--- a/python/tests/fixtures/model_fixtures.json
+++ b/python/tests/fixtures/model_fixtures.json
@@ -45,6 +45,7 @@
           "model_registry_id": 1,
           "tags": [],
           "framework": "PYTHON",
+          "missing_mandatory_tags": [{ "name": "owner" }],
           "href": "test_href"
         }
       ]

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -215,6 +215,7 @@ class TestDeployment:
         class MockPredictor:
             _name = "name"
             _description = "description"
+            _missing_mandatory_tags = []
 
         p = MockPredictor()
         mock_deployment_init = mocker.patch(
@@ -226,7 +227,10 @@ class TestDeployment:
 
         # Assert
         mock_deployment_init.assert_called_once_with(
-            predictor=p, name=p._name, description=p._description
+            predictor=p,
+            name=p._name,
+            description=p._description,
+            missing_mandatory_tags=p._missing_mandatory_tags,
         )
 
     # save

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -180,6 +180,33 @@ class TestDeployment:
         # Assert
         assert "not an instance of the Predictor class" in str(e_info.value)
 
+    # tags at creation
+
+    def test_to_dict_omits_tags_when_absent(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+
+        # Assert
+        assert "tags" not in d.to_dict()
+
+    def test_to_dict_serializes_tags_at_creation(self, mocker, backend_fixtures):
+        # The serving-create body is Predictor.to_dict(); tags must land as the
+        # top-level TagsDTO shape with json-encoded values so mandatory-tag
+        # enforcement applies at deployment creation (FSTORE-2049).
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        p._tags = {"owner": "team-a", "cost_center": 42}
+        d = deployment.Deployment(predictor=p)
+
+        # Assert
+        assert d.to_dict()["tags"] == {
+            "items": [
+                {"name": "owner", "value": '"team-a"'},
+                {"name": "cost_center", "value": "42"},
+            ]
+        }
+
     # tags
 
     def test_add_tag(self, mocker, backend_fixtures):

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -191,21 +191,79 @@ class TestDeployment:
         assert "tags" not in d.to_dict()
 
     def test_to_dict_serializes_tags_at_creation(self, mocker, backend_fixtures):
-        # The serving-create body is Predictor.to_dict(); tags must land as the
-        # top-level TagsDTO shape with json-encoded values so mandatory-tag
-        # enforcement applies at deployment creation (FSTORE-2049).
+        # The serving-create body is Predictor.to_dict(); tags flow through the
+        # shared Tag normalizer and land as the same TagsDTO shape as feature
+        # groups: count plus items with string values raw and dict values
+        # json-encoded, so mandatory-tag enforcement applies at deployment
+        # creation (FSTORE-2049).
         # Arrange
+        from hopsworks_common.tag import Tag
+
         p = self._get_dummy_predictor(mocker, backend_fixtures)
-        p._tags = {"owner": "team-a", "cost_center": 42}
+        p._tags = Tag._normalize(
+            [
+                {"name": "owner", "value": "team-a"},
+                {"name": "cost_center", "value": {"id": 42}},
+            ]
+        )
         d = deployment.Deployment(predictor=p)
 
         # Assert
         assert d.to_dict()["tags"] == {
+            "count": 2,
             "items": [
-                {"name": "owner", "value": '"team-a"'},
-                {"name": "cost_center", "value": "42"},
-            ]
+                {"name": "owner", "value": "team-a"},
+                {"name": "cost_center", "value": '{"id": 42}'},
+            ],
         }
+
+    def test_to_dict_serializes_tags_from_list_and_tag_forms(
+        self, mocker, backend_fixtures
+    ):
+        # tags accepts the feature-group shapes: a single name/value dict, a list
+        # of such dicts, and a Tag object. Each serializes to the identical item.
+        # Arrange
+        from hopsworks_common.tag import Tag
+
+        expected = {"count": 1, "items": [{"name": "a", "value": "1"}]}
+
+        # Act / Assert
+        for tags in (
+            [{"name": "a", "value": "1"}],
+            {"name": "a", "value": "1"},
+            Tag(name="a", value="1"),
+        ):
+            p = self._get_dummy_predictor(mocker, backend_fixtures)
+            p._tags = Tag._normalize(tags)
+            d = deployment.Deployment(predictor=p)
+            assert d.to_dict()["tags"] == expected
+
+    def test_to_dict_omits_response_tags_on_round_trip(self, mocker, backend_fixtures):
+        # The serving GET response never carries create-time tags; a predictor
+        # rebuilt from a response must therefore emit no tags key on re-save.
+        # Arrange
+        mocker.patch(
+            "hopsworks_common.client._get_serving_num_instances_limits",
+            return_value=[-1],
+        )
+        mocker.patch(
+            "hopsworks_common.client._is_scale_to_zero_required", return_value=False
+        )
+        mocker.patch("hopsworks_common.client._is_saas_connection", return_value=False)
+        mocker.patch("hopsworks_common.client._is_kserve_installed", return_value=True)
+        serving_json = humps.camelize(
+            copy.deepcopy(
+                backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+                    "items"
+                ][0]
+            )
+        )
+
+        # Act
+        d = deployment.Deployment.from_response_json(serving_json)
+
+        # Assert
+        assert "tags" not in d.to_dict()
 
     # tags
 

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -110,6 +110,64 @@ class TestDeployment:
         # Assert
         assert "not an instance of the Predictor class" in str(e_info.value)
 
+    # tags
+
+    def test_add_tag(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_set_tag = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine._set_tag"
+        )
+
+        # Act
+        d.add_tag("tag_name", "tag_value")
+
+        # Assert
+        mock_serving_engine_set_tag.assert_called_once_with(d, "tag_name", "tag_value")
+
+    def test_delete_tag(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_delete_tag = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine._delete_tag"
+        )
+
+        # Act
+        d.delete_tag("tag_name")
+
+        # Assert
+        mock_serving_engine_delete_tag.assert_called_once_with(d, "tag_name")
+
+    def test_get_tag(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_get_tag = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine._get_tag"
+        )
+
+        # Act
+        d.get_tag("tag_name")
+
+        # Assert
+        mock_serving_engine_get_tag.assert_called_once_with(d, "tag_name")
+
+    def test_get_tags(self, mocker, backend_fixtures):
+        # Arrange
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        d = deployment.Deployment(predictor=p)
+        mock_serving_engine_get_tags = mocker.patch(
+            "hsml.engine.serving_engine.ServingEngine._get_tags"
+        )
+
+        # Act
+        d.get_tags()
+
+        # Assert
+        mock_serving_engine_get_tags.assert_called_once_with(d)
+
     def test_tracing_property_delegates_to_predictor(self, mocker):
         # Arrange
         mocker.patch(

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -14,6 +14,9 @@
 #   limitations under the License.
 #
 
+import copy
+
+import humps
 import pytest
 from hsml import deployment, deployment_tracing_config, predictor, resources
 from hsml.client.exceptions import ModelServingException
@@ -63,6 +66,73 @@ class TestDeployment:
         assert depl == pred
         mock_pred_from_response_json.assert_called_once_with(pred)
         mock_from_predictor.assert_called_once_with(pred)
+
+    def test_from_response_json_surfaces_missing_mandatory_tags(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        mocker.patch(
+            "hopsworks_common.client._get_serving_num_instances_limits",
+            return_value=[-1],
+        )
+        mocker.patch(
+            "hopsworks_common.client._is_scale_to_zero_required", return_value=False
+        )
+        mocker.patch("hopsworks_common.client._is_saas_connection", return_value=False)
+        mocker.patch("hopsworks_common.client._is_kserve_installed", return_value=True)
+        serving_json = humps.camelize(
+            copy.deepcopy(
+                backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+                    "items"
+                ][0]
+            )
+        )
+        serving_json["missingMandatoryTags"] = [
+            {"name": "owner", "deploymentSpecific": True}
+        ]
+
+        # Act
+        d = deployment.Deployment.from_response_json(serving_json)
+
+        # Assert
+        assert isinstance(d, deployment.Deployment)
+        assert d.missing_mandatory_tags == [
+            {"name": "owner", "deployment_specific": True}
+        ]
+
+    def test_update_from_response_json_refreshes_missing_mandatory_tags(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        mocker.patch(
+            "hopsworks_common.client._get_serving_num_instances_limits",
+            return_value=[-1],
+        )
+        mocker.patch(
+            "hopsworks_common.client._is_scale_to_zero_required", return_value=False
+        )
+        mocker.patch("hopsworks_common.client._is_saas_connection", return_value=False)
+        mocker.patch("hopsworks_common.client._is_kserve_installed", return_value=True)
+        p_json = copy.deepcopy(
+            backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+                "items"
+            ][0]
+        )
+        d = deployment.Deployment.from_response_json(humps.camelize(p_json))
+        assert d.missing_mandatory_tags == []
+
+        updated_serving_json = humps.camelize(p_json)
+        updated_serving_json["missingMandatoryTags"] = [
+            {"name": "owner", "deploymentSpecific": True}
+        ]
+
+        # Act
+        d.update_from_response_json(updated_serving_json)
+
+        # Assert
+        assert d.missing_mandatory_tags == [
+            {"name": "owner", "deployment_specific": True}
+        ]
 
     # constructor
 
@@ -215,7 +285,6 @@ class TestDeployment:
         class MockPredictor:
             _name = "name"
             _description = "description"
-            _missing_mandatory_tags = []
 
         p = MockPredictor()
         mock_deployment_init = mocker.patch(
@@ -230,7 +299,6 @@ class TestDeployment:
             predictor=p,
             name=p._name,
             description=p._description,
-            missing_mandatory_tags=p._missing_mandatory_tags,
         )
 
     # save

--- a/python/tests/test_feature_store.py
+++ b/python/tests/test_feature_store.py
@@ -163,6 +163,89 @@ class TestFeatureStore:
         assert fg_res.feature_store == fs
         assert fg_res._feature_store == fs
 
+    def test_create_feature_group_normalizes_tags(self, backend_fixtures, mocker):
+        # Arrange
+        from hopsworks_common.tag import Tag
+
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        mocker.patch(
+            "hsfs.feature_group.FeatureGroup._has_deltalake", return_value=True
+        )
+        json = backend_fixtures["feature_store"]["get"]["response"]
+        fs = feature_store_mod.FeatureStore.from_response_json(json)
+
+        # Act: a dict tag is accepted and normalized to a Tag object.
+        fg_res = fs.create_feature_group(
+            "test_feature_group_name",
+            version=1,
+            tags={"name": "team", "value": "fraud"},
+        )
+
+        # Assert
+        assert len(fg_res._tags) == 1
+        assert isinstance(fg_res._tags[0], Tag)
+        assert fg_res._tags[0].name == "team"
+        assert fg_res._tags[0].value == "fraud"
+
+    def test_get_or_create_feature_group_forwards_tags_when_missing(
+        self, backend_fixtures, mocker
+    ):
+        # Arrange
+        from hopsworks_common.tag import Tag
+
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        mocker.patch(
+            "hsfs.feature_group.FeatureGroup._has_deltalake", return_value=True
+        )
+        json = backend_fixtures["feature_store"]["get"]["response"]
+        fs = feature_store_mod.FeatureStore.from_response_json(json)
+        # The feature group does not exist yet, so it is constructed with tags.
+        mocker.patch.object(fs._feature_group_api, "_get", return_value=None)
+
+        # Act
+        fg_res = fs.get_or_create_feature_group(
+            "test_feature_group_name",
+            version=1,
+            tags=[Tag(name="team", value="fraud"), {"name": "tier", "value": "gold"}],
+        )
+
+        # Assert: mixed Tag/dict input is normalized onto the constructed group.
+        assert [(t.name, t.value) for t in fg_res._tags] == [
+            ("team", "fraud"),
+            ("tier", "gold"),
+        ]
+
+    def test_get_or_create_feature_view_forwards_tags_when_missing(
+        self, backend_fixtures, mocker
+    ):
+        # Arrange
+        from hopsworks_common.tag import Tag
+
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        json = backend_fixtures["feature_store"]["get"]["response"]
+        fs = feature_store_mod.FeatureStore.from_response_json(json)
+        # The feature view does not exist yet, so create_feature_view is invoked.
+        mocker.patch.object(fs._feature_view_engine, "_get", return_value=None)
+        create_feature_view = mocker.patch.object(
+            fs, "create_feature_view", return_value="created_fv"
+        )
+        tags = [Tag(name="team", value="fraud")]
+
+        # Act
+        fv_res = fs.get_or_create_feature_view(
+            name="test_feature_view_name",
+            query=mocker.Mock(),
+            version=1,
+            tags=tags,
+        )
+
+        # Assert: tags are forwarded verbatim to create_feature_view.
+        assert fv_res == "created_fv"
+        assert create_feature_view.call_args.kwargs["tags"] == tags
+
     def test_create_feature_group_time_travel_format_defaults_to_delta(
         self, backend_fixtures, mocker
     ):

--- a/python/tests/test_feature_view.py
+++ b/python/tests/test_feature_view.py
@@ -1056,6 +1056,91 @@ class TestFeatureView:
         assert call_args_list[0][0][2] is False  # (name, version, force)
         assert call_args_list[1][0][2] is True
 
+    def test_training_data_passes_normalized_tags(self, mocker):
+        # Arrange
+        from hopsworks_common.tag import Tag
+
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        fv = feature_view.FeatureView(
+            name="test_fv", featurestore_id=99, query=fg1.select_all(), version=1
+        )
+        get_training_data = mocker.patch.object(
+            fv._feature_view_engine,
+            "_get_training_data",
+            side_effect=lambda self, read_options, training_dataset_obj, **kwargs: (
+                training_dataset_obj,
+                "df",
+            ),
+        )
+        mocker.patch.object(fv, "update_last_accessed_training_dataset")
+
+        # Act: a dict tag is normalized before reaching the training dataset.
+        fv.training_data(tags={"name": "team", "value": "fraud"})
+
+        # Assert
+        td = get_training_data.call_args.kwargs["training_dataset_obj"]
+        assert len(td._tags) == 1
+        assert isinstance(td._tags[0], Tag)
+        assert (td._tags[0].name, td._tags[0].value) == ("team", "fraud")
+
+    def test_train_test_split_passes_normalized_tags(self, mocker):
+        # Arrange
+        from hopsworks_common.tag import Tag
+
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        fv = feature_view.FeatureView(
+            name="test_fv", featurestore_id=99, query=fg1.select_all(), version=1
+        )
+        get_training_data = mocker.patch.object(
+            fv._feature_view_engine,
+            "_get_training_data",
+            side_effect=lambda self, read_options, training_dataset_obj, **kwargs: (
+                training_dataset_obj,
+                "df",
+            ),
+        )
+        mocker.patch.object(fv, "update_last_accessed_training_dataset")
+
+        # Act
+        fv.train_test_split(test_size=0.2, tags=[Tag(name="team", value="fraud")])
+
+        # Assert
+        td = get_training_data.call_args.kwargs["training_dataset_obj"]
+        assert [(t.name, t.value) for t in td._tags] == [("team", "fraud")]
+
+    def test_train_validation_test_split_passes_normalized_tags(self, mocker):
+        # Arrange
+        from hopsworks_common.tag import Tag
+
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        fv = feature_view.FeatureView(
+            name="test_fv", featurestore_id=99, query=fg1.select_all(), version=1
+        )
+        get_training_data = mocker.patch.object(
+            fv._feature_view_engine,
+            "_get_training_data",
+            side_effect=lambda self, read_options, training_dataset_obj, **kwargs: (
+                training_dataset_obj,
+                "df",
+            ),
+        )
+        mocker.patch.object(fv, "update_last_accessed_training_dataset")
+
+        # Act
+        fv.train_validation_test_split(
+            validation_size=0.2,
+            test_size=0.2,
+            tags=[{"name": "team", "value": "fraud"}],
+        )
+
+        # Assert
+        td = get_training_data.call_args.kwargs["training_dataset_obj"]
+        assert isinstance(td._tags[0], Tag)
+        assert [(t.name, t.value) for t in td._tags] == [("team", "fraud")]
+
 
 class TestFeatureViewExecuteOdts:
     def test_execute_odts_with_transformations(self, mocker):

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -362,9 +362,10 @@ class TestModel:
         assert "tags" not in m.to_dict()
 
     def test_to_dict_serializes_tags_at_creation(self, mocker):
-        # create_model builds the model with a tags dict; to_dict must emit the
-        # TagsDTO shape with json-encoded values so the tags ride the create PUT
-        # (FSTORE-2049 mandatory-tag enforcement at creation).
+        # create_model builds the model with tags via the shared Tag normalizer;
+        # to_dict must emit the same TagsDTO shape as feature groups: count plus
+        # items with string values raw and dict values json-encoded, so the tags
+        # ride the create PUT (FSTORE-2049 mandatory-tag enforcement at creation).
         # Arrange
         mocker.patch("hsml.model_registry.ModelRegistry.from_response_json")
         mr = mocker.MagicMock()
@@ -378,17 +379,62 @@ class TestModel:
         m = signature.create_model(
             name="my_model",
             version=1,
-            tags={"owner": "team-a", "cost_center": 42},
+            tags=[
+                {"name": "owner", "value": "team-a"},
+                {"name": "cost_center", "value": {"id": 42}},
+            ],
         )
         model_dict = m.to_dict()
 
         # Assert
         assert model_dict["tags"] == {
+            "count": 2,
             "items": [
-                {"name": "owner", "value": '"team-a"'},
-                {"name": "cost_center", "value": "42"},
-            ]
+                {"name": "owner", "value": "team-a"},
+                {"name": "cost_center", "value": '{"id": 42}'},
+            ],
         }
+
+    def test_to_dict_serializes_tags_from_list_and_tag_forms(self, mocker):
+        # The tags argument accepts the same shapes as feature groups: a single
+        # name/value dict, a list of such dicts, and a Tag object. Each must
+        # serialize to the identical TagsDTO item.
+        # Arrange
+        from hopsworks_common.tag import Tag
+        from hsml.python import signature
+
+        mocker.patch("hsml.model_registry.ModelRegistry.from_response_json")
+        mr = mocker.MagicMock()
+        mr.shared_registry_project_name = None
+        mr.model_registry_id = 1
+        signature._mr = mr
+        expected = {"count": 1, "items": [{"name": "a", "value": "1"}]}
+
+        # Act / Assert
+        for tags in (
+            [{"name": "a", "value": "1"}],
+            {"name": "a", "value": "1"},
+            Tag(name="a", value="1"),
+        ):
+            m = signature.create_model(name="my_model", version=1, tags=tags)
+            assert m.to_dict()["tags"] == expected
+
+    def test_to_dict_omits_response_tags_on_round_trip(self, mocker, backend_fixtures):
+        # A model built from a GET response carries a backend-populated tags
+        # field; re-saving must not resend them, so to_dict emits no tags key.
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        m_json = {
+            **m_json,
+            "tags": {"count": 1, "items": [{"name": "x", "value": "y"}]},
+        }
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.update_from_response_json(m_json)
+
+        # Assert
+        assert "tags" not in m.to_dict()
 
     # delete
 

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -271,6 +271,7 @@ class TestModel:
             env_vars=None,
             vllm_variant=None,
             vllm_image_tag=None,
+            tags=None,
         )
         mock_predictor.deploy.assert_called_once()
 
@@ -290,6 +291,104 @@ class TestModel:
         # Assert
         assert mock_predictor_for_model.call_args.kwargs["env_vars"] == env_vars
         mock_predictor.deploy.assert_called_once()
+
+    def test_deploy_forwards_tags(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_predictor = mocker.Mock()
+        mock_predictor_for_model = mocker.patch(
+            "hsml.predictor.Predictor.for_model", return_value=mock_predictor
+        )
+        tags = {"owner": "team-a"}
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.deploy(name="test", tags=tags)
+
+        # Assert
+        assert mock_predictor_for_model.call_args.kwargs["tags"] == tags
+        mock_predictor.deploy.assert_called_once()
+
+    # get-time missing mandatory tag warning
+
+    def test_get_model_warns_on_missing_mandatory_tags(self, mocker, backend_fixtures):
+        # Arrange
+        from hsml import model_registry
+
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        m = model.Model.from_response_json(m_json)
+        m._missing_mandatory_tags = [{"name": "owner"}]
+        mocker.patch("hsml.core.model_api.ModelApi._get", return_value=m)
+        mr = model_registry.ModelRegistry(
+            project_name="p", project_id=1, model_registry_id=1
+        )
+
+        # Act / Assert
+        with pytest.warns(UserWarning, match="Missing mandatory tags"):
+            mr.get_model("my_model", version=1)
+
+    def test_get_model_no_warning_when_tags_present(self, mocker, backend_fixtures):
+        # Arrange
+        import warnings
+
+        from hsml import model_registry
+
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        m = model.Model.from_response_json(m_json)
+        m._missing_mandatory_tags = []
+        mocker.patch("hsml.core.model_api.ModelApi._get", return_value=m)
+        mr = model_registry.ModelRegistry(
+            project_name="p", project_id=1, model_registry_id=1
+        )
+
+        # Act
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mr.get_model("my_model", version=1)
+
+        # Assert
+        assert not [w for w in caught if "Missing mandatory tags" in str(w.message)]
+
+    # to_dict tags
+
+    def test_to_dict_omits_tags_when_absent(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+
+        # Assert
+        assert "tags" not in m.to_dict()
+
+    def test_to_dict_serializes_tags_at_creation(self, mocker):
+        # create_model builds the model with a tags dict; to_dict must emit the
+        # TagsDTO shape with json-encoded values so the tags ride the create PUT
+        # (FSTORE-2049 mandatory-tag enforcement at creation).
+        # Arrange
+        mocker.patch("hsml.model_registry.ModelRegistry.from_response_json")
+        mr = mocker.MagicMock()
+        mr.shared_registry_project_name = None
+        mr.model_registry_id = 1
+        from hsml.python import signature
+
+        signature._mr = mr
+
+        # Act
+        m = signature.create_model(
+            name="my_model",
+            version=1,
+            tags={"owner": "team-a", "cost_center": 42},
+        )
+        model_dict = m.to_dict()
+
+        # Assert
+        assert model_dict["tags"] == {
+            "items": [
+                {"name": "owner", "value": '"team-a"'},
+                {"name": "cost_center", "value": "42"},
+            ]
+        }
 
     # delete
 

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -400,6 +400,9 @@ class TestModel:
         assert m.training_metrics == m_json["metrics"]
         assert m._user_full_name == m_json["user_full_name"]
         assert m.model_registry_id == m_json["model_registry_id"]
+        # Framework subclasses must forward missing_mandatory_tags to the base
+        # constructor; a dropped kwarg silently reverts it to [] (FSTORE-2049).
+        assert m.missing_mandatory_tags == m_json.get("missing_mandatory_tags", [])
 
         if model_framework is None:
             assert m.framework is None

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -75,6 +75,34 @@ class TestModel:
             m_json = json["items"][i]
             self.assert_model(mocker, m, m_json, MODEL.FRAMEWORK_PYTHON)
 
+    @pytest.mark.parametrize(
+        "fixture_key, framework",
+        [
+            ("get_python", MODEL.FRAMEWORK_PYTHON),
+            ("get_sklearn", MODEL.FRAMEWORK_SKLEARN),
+            ("get_tensorflow", MODEL.FRAMEWORK_TENSORFLOW),
+            ("get_torch", MODEL.FRAMEWORK_TORCH),
+            ("get_llm", MODEL.FRAMEWORK_LLM),
+        ],
+    )
+    def test_from_response_json_framework_subclass(
+        self, mocker, backend_fixtures, fixture_key, framework
+    ):
+        # from_response_json dispatches to the framework subclass, so this
+        # catches a subclass dropping a base-Model kwarg such as
+        # missing_mandatory_tags (FSTORE-2049).
+        # Arrange
+        json = backend_fixtures["model"][fixture_key]["response"]
+        json_camelized = humps.camelize(json)  # as returned by the backend
+
+        # Act
+        m_lst = model.Model.from_response_json(copy.deepcopy(json_camelized))
+
+        # Assert
+        assert isinstance(m_lst, list)
+        assert len(m_lst) == 1
+        self.assert_model(mocker, m_lst[0], json["items"][0], framework)
+
     # constructor
 
     def test_constructor_base(self, mocker, backend_fixtures):

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -86,6 +86,58 @@ class TestTracingForwarding:
         # Assert
         assert mock_for_model.call_args.kwargs["tracing"] is tracing
 
+    def test_create_predictor_forwards_tags(self, ms, mocker):
+        # Arrange
+        model = mocker.Mock()
+        model._get_default_serving_name.return_value = "my_model"
+        mock_for_model = mocker.patch("hsml.model_serving.Predictor.for_model")
+        tags = {"owner": "team-a"}
+
+        # Act
+        ms.create_predictor(model, tags=tags)
+
+        # Assert
+        assert mock_for_model.call_args.kwargs["tags"] == tags
+
+    def test_create_deployment_sets_tags_on_predictor(self, ms, mocker):
+        # Arrange
+        predictor = mocker.Mock()
+        mock_deployment = mocker.patch("hsml.model_serving.Deployment")
+        tags = {"owner": "team-a"}
+
+        # Act
+        ms.create_deployment(predictor, tags=tags)
+
+        # Assert
+        assert predictor._tags == tags
+        mock_deployment.assert_called_once_with(predictor=predictor, name=None)
+
+    def test_get_deployment_warns_on_missing_mandatory_tags(self, ms, mocker):
+        # Arrange
+        d = mocker.Mock()
+        d.missing_mandatory_tags = [{"name": "owner"}]
+        mocker.patch.object(ms._serving_api, "_get", return_value=d)
+
+        # Act / Assert
+        with pytest.warns(UserWarning, match="Missing mandatory tags"):
+            ms.get_deployment("my_deployment")
+
+    def test_get_deployment_no_warning_when_tags_present(self, ms, mocker):
+        # Arrange
+        import warnings
+
+        d = mocker.Mock()
+        d.missing_mandatory_tags = []
+        mocker.patch.object(ms._serving_api, "_get", return_value=d)
+
+        # Act
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ms.get_deployment("my_deployment")
+
+        # Assert
+        assert not [w for w in caught if "Missing mandatory tags" in str(w.message)]
+
     def test_create_endpoint_forwards_tracing(self, ms, mocker):
         # Arrange
         tracing = deployment_tracing_config.DeploymentTracingConfig(

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -100,16 +100,24 @@ class TestTracingForwarding:
         assert mock_for_model.call_args.kwargs["tags"] == tags
 
     def test_create_deployment_sets_tags_on_predictor(self, ms, mocker):
+        # create_deployment normalizes the tags through the shared Tag helper and
+        # stashes the resulting list[Tag] on the predictor so Predictor.to_dict
+        # serializes them into the serving-create body (FSTORE-2049).
         # Arrange
+        from hopsworks_common.tag import Tag
+
         predictor = mocker.Mock()
         mock_deployment = mocker.patch("hsml.model_serving.Deployment")
-        tags = {"owner": "team-a"}
+        tags = {"name": "owner", "value": "team-a"}
 
         # Act
         ms.create_deployment(predictor, tags=tags)
 
         # Assert
-        assert predictor._tags == tags
+        assert Tag._tags_to_dict(predictor._tags) == {
+            "count": 1,
+            "items": [{"name": "owner", "value": "team-a"}],
+        }
         mock_deployment.assert_called_once_with(predictor=predictor, name=None)
 
     def test_get_deployment_warns_on_missing_mandatory_tags(self, ms, mocker):


### PR DESCRIPTION
## Summary
- Add `add_tag`/`get_tag`/`get_tags`/`delete_tag` to `Deployment`, delegating to the serving API at `/project/{id}/serving/{servingId}/tags`.
- Surface `missing_mandatory_tags` on `Model` and `Deployment`.
- Fix the framework `Model` subclasses (python/sklearn/tensorflow/torch/llm) to forward `missing_mandatory_tags` to the base constructor; without this the value was dropped on every real model GET (`from_response_json` returns a subclass).
- Fix the serving API deployment-tag read path: `_get_tags` no longer double-decodes already-deserialized values, and `_get_tag` no longer indexes a list by name.

## Test plan
- `pytest python/tests/test_model.py` (subclass round-trip regression), `python/tests/test_deployment.py`, `python/tests/core/test_serving_api.py` (tag decode/lookup regression) all pass; ruff clean.
- Integration-tested via loadtest `model_registry/test_tags.py` against a live cluster.

## Related PRs
- Backend: logicalclocks/hopsworks-ee#3136 · UI: logicalclocks/hopsworks-front · tests: logicalclocks/loadtest · docs: logicalclocks/logicalclocks.github.io