### PR TITLE
[HWORKS-2931] Bump HopsFS to 3.4.3.2-EE-RC0

### DIFF
--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -161,7 +161,7 @@
                 <dependency>
                     <groupId>io.hops</groupId>
                     <artifactId>hadoop-client</artifactId>
-                    <version>3.4.3.1-EE-RC0</version>
+                    <version>3.4.3.2-EE-RC0</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -8,7 +8,7 @@
     <version>5.1.0-SNAPSHOT</version>
 
     <properties>
-        <hops.version>3.4.3.1-EE-RC0</hops.version>
+        <hops.version>3.4.3.2-EE-RC0</hops.version>
         <hsfs.version>${project.version}</hsfs.version>
         <slf4j.version>2.0.17</slf4j.version>
         <hudi.version>1.0.2.1</hudi.version>


### PR DESCRIPTION
Bump HopsFS to `3.4.3.2-EE-RC0`.

- hadoop / hopsfs version → `3.4.3.2-EE-RC0` in `java/spark/pom.xml` and `utils/java/pom.xml`

The HopsFS maven artifacts remain Java-8 bytecode, so the JDK 8 build and CI are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
