### PR TITLE
[FSTORE-2051][4.8] `get_tag` function for feature_groups, feature_views and training_datasets throws a `TypeError`

### DIFF
--- a/python/hopsworks_common/core/dataset_api.py
+++ b/python/hopsworks_common/core/dataset_api.py
@@ -1020,8 +1020,9 @@ class DatasetApi:
 
         path_params.append(path)
 
+        # from_response_json already returns deserialized values.
         return {
-            tag._name: json.loads(tag._value)
+            tag._name: tag._value
             for tag in tag.Tag.from_response_json(
                 _client._send_request("GET", path_params)
             )

--- a/python/hopsworks_common/core/tags_api.py
+++ b/python/hopsworks_common/core/tags_api.py
@@ -116,8 +116,9 @@ class TagsApi:
         if name is not None:
             path_params.append(name)
 
+        # from_response_json already returns deserialized values.
         return {
-            tag._name: json.loads(tag._value)
+            tag._name: tag._value
             for tag in tag.Tag.from_response_json(
                 _client._send_request("GET", path_params)
             )

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 
 from hsml import client, decorators, model, tag
 from hsml.core import explicit_provenance

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from hsml import client, decorators, model, tag
 from hsml.core import explicit_provenance
@@ -231,8 +232,9 @@ class ModelApi:
             model_instance.id,
             "tags",
         ]
+        # from_response_json already returns deserialized values.
         return {
-            tag._name: json.loads(tag._value)
+            tag._name: tag._value
             for tag in tag.Tag.from_response_json(
                 _client._send_request("GET", path_params)
             )
@@ -249,7 +251,7 @@ class ModelApi:
             name: tag name
 
         Returns:
-            dict of tag name/value
+            The value of the tag with the specified name, or `None` if it does not exist.
         """
         _client = client.get_instance()
         path_params = [
@@ -263,9 +265,14 @@ class ModelApi:
             name,
         ]
 
-        return tag.Tag.from_response_json(_client._send_request("GET", path_params))[
-            name
-        ]
+        # from_response_json returns a list of tags; look the value up by name.
+        tags = {
+            tag._name: tag._value
+            for tag in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+        return tags.get(name)
 
     def get_feature_view_provenance(
         self, model_instance

--- a/python/tests/core/test_dataset_api.py
+++ b/python/tests/core/test_dataset_api.py
@@ -27,7 +27,7 @@ class TestDatasetApiTags:
         client_instance._project_id = 1
         client_instance._send_request.return_value = send_request_return
         mocker.patch(
-            "hopsworks_common.core.dataset_api.client._get_instance",
+            "hopsworks_common.core.dataset_api.client.get_instance",
             return_value=client_instance,
         )
         return client_instance

--- a/python/tests/core/test_dataset_api.py
+++ b/python/tests/core/test_dataset_api.py
@@ -18,7 +18,6 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from hopsworks_common.client.exceptions import RestAPIError
 from hopsworks_common.core.dataset_api import DatasetApi
 
 

--- a/python/tests/core/test_dataset_api.py
+++ b/python/tests/core/test_dataset_api.py
@@ -1,0 +1,50 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.client.exceptions import RestAPIError
+from hopsworks_common.core.dataset_api import DatasetApi
+
+
+class TestDatasetApiTags:
+    def _patch_client(self, mocker, send_request_return) -> MagicMock:
+        client_instance = MagicMock()
+        client_instance._project_id = 1
+        client_instance._send_request.return_value = send_request_return
+        mocker.patch(
+            "hopsworks_common.core.dataset_api.client._get_instance",
+            return_value=client_instance,
+        )
+        return client_instance
+
+    @pytest.mark.parametrize("value", [{"a": 1}, 7, ["x"], True, "plain string"])
+    def test_get_tags_does_not_double_decode(self, mocker, value):
+        # Arrange
+        api = DatasetApi()
+        response = {
+            "count": 1,
+            "items": [{"name": "meta", "value": json.dumps(value)}],
+        }
+        self._patch_client(mocker, response)
+
+        # Act
+        result = api.get_tags("/Projects/p/Resources/file")
+
+        # Assert
+        assert result == {"meta": value}

--- a/python/tests/core/test_model_api.py
+++ b/python/tests/core/test_model_api.py
@@ -1,0 +1,107 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from hsml.core.model_api import ModelApi
+
+
+def _tags_response(items: list[tuple[str, str]]) -> dict:
+    return {
+        "count": len(items),
+        "items": [{"name": name, "value": value} for name, value in items],
+    }
+
+
+def _patch_client(mocker, send_request_return) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 1
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hsml.core.model_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+def _model() -> SimpleNamespace:
+    return SimpleNamespace(model_registry_id=1, id=12)
+
+
+class TestModelApi:
+    def test_get_tags_decodes_values_without_double_decode(self, mocker):
+        # Arrange
+        api = ModelApi()
+        value = {"owner": "team-a", "score": 3}
+        _patch_client(
+            mocker,
+            _tags_response([("meta", json.dumps(value)), ("count", json.dumps(9))]),
+        )
+
+        # Act
+        result = api._get_tags(_model())
+
+        # Assert
+        assert result == {"meta": value, "count": 9}
+
+    def test_get_tag_returns_value_for_name(self, mocker):
+        # Arrange
+        api = ModelApi()
+        value = {"owner": "team-a"}
+        _patch_client(mocker, _tags_response([("meta", json.dumps(value))]))
+
+        # Act
+        result = api._get_tag(_model(), "meta")
+
+        # Assert
+        assert result == value
+
+    def test_get_tag_numeric_value(self, mocker):
+        # Arrange
+        api = ModelApi()
+        _patch_client(mocker, _tags_response([("version", json.dumps(7))]))
+
+        # Act
+        result = api._get_tag(_model(), "version")
+
+        # Assert
+        assert result == 7
+
+    def test_get_tag_absent_name_returns_none(self, mocker):
+        # Arrange
+        api = ModelApi()
+        _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        result = api._get_tag(_model(), "missing")
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.parametrize("bad_value", [{"a": 1}, 7, ["x"], True])
+    def test_get_tags_does_not_double_decode(self, mocker, bad_value):
+        # Arrange
+        api = ModelApi()
+        _patch_client(mocker, _tags_response([("t", json.dumps(bad_value))]))
+
+        # Act
+        result = api._get_tags(_model())
+
+        # Assert
+        assert result == {"t": bad_value}

--- a/python/tests/core/test_model_api.py
+++ b/python/tests/core/test_model_api.py
@@ -34,7 +34,7 @@ def _patch_client(mocker, send_request_return) -> MagicMock:
     client_instance._project_id = 1
     client_instance._send_request.return_value = send_request_return
     mocker.patch(
-        "hsml.core.model_api.client._get_instance",
+        "hsml.core.model_api.client.get_instance",
         return_value=client_instance,
     )
     return client_instance

--- a/python/tests/core/test_model_api.py
+++ b/python/tests/core/test_model_api.py
@@ -45,7 +45,7 @@ def _model() -> SimpleNamespace:
 
 
 class TestModelApi:
-    def test_get_tags_decodes_values_without_double_decode(self, mocker):
+    def testget_tags_decodes_values_without_double_decode(self, mocker):
         # Arrange
         api = ModelApi()
         value = {"owner": "team-a", "score": 3}
@@ -55,7 +55,7 @@ class TestModelApi:
         )
 
         # Act
-        result = api._get_tags(_model())
+        result = api.get_tags(_model())
 
         # Assert
         assert result == {"meta": value, "count": 9}
@@ -67,7 +67,7 @@ class TestModelApi:
         _patch_client(mocker, _tags_response([("meta", json.dumps(value))]))
 
         # Act
-        result = api._get_tag(_model(), "meta")
+        result = api.get_tag(_model(), "meta")
 
         # Assert
         assert result == value
@@ -78,7 +78,7 @@ class TestModelApi:
         _patch_client(mocker, _tags_response([("version", json.dumps(7))]))
 
         # Act
-        result = api._get_tag(_model(), "version")
+        result = api.get_tag(_model(), "version")
 
         # Assert
         assert result == 7
@@ -89,19 +89,19 @@ class TestModelApi:
         _patch_client(mocker, {"count": 0, "items": []})
 
         # Act
-        result = api._get_tag(_model(), "missing")
+        result = api.get_tag(_model(), "missing")
 
         # Assert
         assert result is None
 
     @pytest.mark.parametrize("bad_value", [{"a": 1}, 7, ["x"], True])
-    def test_get_tags_does_not_double_decode(self, mocker, bad_value):
+    def testget_tags_does_not_double_decode(self, mocker, bad_value):
         # Arrange
         api = ModelApi()
         _patch_client(mocker, _tags_response([("t", json.dumps(bad_value))]))
 
         # Act
-        result = api._get_tags(_model())
+        result = api.get_tags(_model())
 
         # Assert
         assert result == {"t": bad_value}

--- a/python/tests/core/test_tags_api.py
+++ b/python/tests/core/test_tags_api.py
@@ -1,0 +1,139 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.core.tags_api import TagsApi
+
+
+def _tags_response(name: str, value: str) -> dict:
+    return {
+        "count": 1,
+        "items": [{"name": name, "value": value, "schema": "test_schema"}],
+    }
+
+
+def _patch_client(mocker, send_request_return) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 1
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hopsworks_common.core.tags_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+# A feature-group-like metadata object: an id and no `training_data` attribute,
+# so TagsApi._get_path takes the featuregroups/trainingdatasets branch.
+def _fg_metadata() -> SimpleNamespace:
+    return SimpleNamespace(id=14)
+
+
+class TestTagsApi:
+    def test_get_decodes_json_object_value(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        value = {"owner": "team-a", "pii": True, "cols": [1, 2]}
+        _patch_client(mocker, _tags_response("meta", json.dumps(value)))
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {"meta": value}
+
+    def test_get_decodes_numeric_value(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, _tags_response("version", json.dumps(7)))
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {"version": 7}
+
+    def test_get_preserves_plain_string_value(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, _tags_response("note", "just a plain string"))
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {"note": "just a plain string"}
+
+    def test_get_by_name_appends_name_to_path(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(
+            mocker, _tags_response("meta", json.dumps({"k": "v"}))
+        )
+
+        # Act
+        result = api._get(_fg_metadata(), name="meta")
+
+        # Assert
+        assert result == {"meta": {"k": "v"}}
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params[-1] == "meta"
+
+    def test_get_empty_returns_empty_dict(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {}
+
+    def test_get_feature_view_uses_featureview_path(self, mocker):
+        # A feature-view-like object has a `training_data` attribute (featureview path).
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        fv_metadata = SimpleNamespace(
+            name="my_fv", version=1, training_data=lambda: None
+        )
+        client_instance = _patch_client(
+            mocker, _tags_response("meta", json.dumps({"k": "v"}))
+        )
+
+        # Act
+        result = api._get(fv_metadata)
+
+        # Assert
+        assert result == {"meta": {"k": "v"}}
+        path_params = client_instance._send_request.call_args.args[1]
+        assert "featureview" in path_params
+
+    @pytest.mark.parametrize("bad_value", [{"a": 1}, 7, ["x"], True])
+    def test_get_does_not_double_decode(self, mocker, bad_value):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, _tags_response("t", json.dumps(bad_value)))
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == {"t": bad_value}

--- a/python/tests/core/test_tags_api.py
+++ b/python/tests/core/test_tags_api.py
@@ -54,7 +54,7 @@ class TestTagsApi:
         _patch_client(mocker, _tags_response("meta", json.dumps(value)))
 
         # Act
-        result = api._get(_fg_metadata())
+        result = api.get(_fg_metadata())
 
         # Assert
         assert result == {"meta": value}
@@ -65,7 +65,7 @@ class TestTagsApi:
         _patch_client(mocker, _tags_response("version", json.dumps(7)))
 
         # Act
-        result = api._get(_fg_metadata())
+        result = api.get(_fg_metadata())
 
         # Assert
         assert result == {"version": 7}
@@ -76,7 +76,7 @@ class TestTagsApi:
         _patch_client(mocker, _tags_response("note", "just a plain string"))
 
         # Act
-        result = api._get(_fg_metadata())
+        result = api.get(_fg_metadata())
 
         # Assert
         assert result == {"note": "just a plain string"}
@@ -89,7 +89,7 @@ class TestTagsApi:
         )
 
         # Act
-        result = api._get(_fg_metadata(), name="meta")
+        result = api.get(_fg_metadata(), name="meta")
 
         # Assert
         assert result == {"meta": {"k": "v"}}
@@ -102,7 +102,7 @@ class TestTagsApi:
         _patch_client(mocker, {"count": 0, "items": []})
 
         # Act
-        result = api._get(_fg_metadata())
+        result = api.get(_fg_metadata())
 
         # Assert
         assert result == {}
@@ -119,7 +119,7 @@ class TestTagsApi:
         )
 
         # Act
-        result = api._get(fv_metadata)
+        result = api.get(fv_metadata)
 
         # Assert
         assert result == {"meta": {"k": "v"}}
@@ -133,7 +133,7 @@ class TestTagsApi:
         _patch_client(mocker, _tags_response("t", json.dumps(bad_value)))
 
         # Act
-        result = api._get(_fg_metadata())
+        result = api.get(_fg_metadata())
 
         # Assert
         assert result == {"t": bad_value}

--- a/python/tests/core/test_tags_api.py
+++ b/python/tests/core/test_tags_api.py
@@ -34,7 +34,7 @@ def _patch_client(mocker, send_request_return) -> MagicMock:
     client_instance._project_id = 1
     client_instance._send_request.return_value = send_request_return
     mocker.patch(
-        "hopsworks_common.core.tags_api.client._get_instance",
+        "hopsworks_common.core.tags_api.client.get_instance",
         return_value=client_instance,
     )
     return client_instance

--- a/python/tests/test_tag.py
+++ b/python/tests/test_tag.py
@@ -14,6 +14,8 @@
 #   limitations under the License.
 #
 
+import json as json_module
+
 import humps
 import pytest
 from hsml import tag
@@ -46,6 +48,41 @@ class TestTag:
 
         # Assert
         assert len(t_list) == 0
+
+    def test_from_response_json_decodes_json_value(self):
+        # Arrange
+        value = {"owner": "team-a", "cols": [1, 2]}
+        response = {
+            "count": 1,
+            "items": [{"name": "meta", "value": json_module.dumps(value)}],
+        }
+
+        # Act
+        t_list = tag.Tag.from_response_json(humps.camelize(response))
+
+        # Assert
+        assert len(t_list) == 1
+        assert t_list[0].value == value
+
+    @pytest.mark.parametrize(
+        "stored_value, expected",
+        [
+            (json_module.dumps(7), 7),
+            (json_module.dumps(True), True),
+            (json_module.dumps(["a", "b"]), ["a", "b"]),
+            (json_module.dumps("quoted"), "quoted"),
+            ("plain text", "plain text"),
+        ],
+    )
+    def test_from_response_json_value_decoding(self, stored_value, expected):
+        # Arrange
+        response = {"count": 1, "items": [{"name": "t", "value": stored_value}]}
+
+        # Act
+        t_list = tag.Tag.from_response_json(humps.camelize(response))
+
+        # Assert
+        assert t_list[0].value == expected
 
     # constructor
 


### PR DESCRIPTION
Cherry picking changes done by https://github.com/logicalclocks/hopsworks-api/pull/1022
---------

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
