### PR TITLE
Read external Glue Iceberg FGs by catalog, not by path

### DIFF
--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -113,6 +113,7 @@ from hsfs import feature_group as fg_mod
 from hsfs.core import (
     dataset_api,
     delta_engine,
+    glue_catalog,
     hudi_engine,
     iceberg_engine,
     kafka_engine,
@@ -280,14 +281,22 @@ class Engine:
 
     def _register_external_temporary_table(self, external_fg, alias):
         if not isinstance(external_fg, fg_mod.SpineGroup):
-            external_dataset = external_fg.data_source.storage_connector.read(
-                external_fg.data_source.query,
-                external_fg.data_format,
-                external_fg.options,
-                external_fg.data_source.storage_connector._get_path(
-                    external_fg.data_source.path
-                ),  # cant rely on location since this method can be used before FG is saved
-            )
+            glue = glue_catalog.GlueCatalog._for_feature_group(external_fg)
+            if glue is not None and (external_fg.data_format or "").lower() == "iceberg":
+                # A Glue-managed Iceberg table keeps its current-metadata pointer
+                # in the catalog, not in the location's version-hint.text, so it
+                # must be read by catalog identifier rather than by S3 path (a
+                # path-based Iceberg read would fail looking for version-hint.text).
+                external_dataset = self._read_glue_iceberg_via_catalog(glue)
+            else:
+                external_dataset = external_fg.data_source.storage_connector.read(
+                    external_fg.data_source.query,
+                    external_fg.data_format,
+                    external_fg.options,
+                    external_fg.data_source.storage_connector._get_path(
+                        external_fg.data_source.path
+                    ),  # cant rely on location since this method can be used before FG is saved
+                )
             if (
                 external_fg.data_source.storage_connector.type
                 == StorageConnector.MONGODB
@@ -312,6 +321,24 @@ class Engine:
 
         external_dataset.createOrReplaceTempView(alias)
         return external_dataset
+
+    def _read_glue_iceberg_via_catalog(self, glue):
+        """Read a Glue Data Catalog Iceberg table by catalog identifier.
+
+        Configures the Glue catalog on the session and reads through
+        `.table(<catalog>.<database>.<table>)` instead of a path-based
+        `.load()`, mirroring the managed-Iceberg read path
+        ([`IcebergEngine._register_temporary_table_via_catalog`][hsfs.core.iceberg_engine.IcebergEngine._register_temporary_table_via_catalog]),
+        because the table's current-metadata pointer lives in the catalog.
+        """
+        glue._configure_spark_session(
+            self._spark_session,
+            self._spark_context,
+            iceberg_engine.IcebergEngine.ICEBERG_SPARK_CATALOG_IMPL,
+        )
+        return self._spark_session.read.format(
+            iceberg_engine.IcebergEngine.ICEBERG_SPARK_FORMAT
+        ).table(glue.qualified_name)
 
     def _register_hudi_temporary_table(
         self, hudi_fg_alias, feature_store_id, feature_store_name, read_options

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -618,6 +618,47 @@ class TestSpark:
         # Assert
         assert mock_sc_read.return_value.createOrReplaceTempView.call_count == 1
 
+    def test_register_external_temporary_table_glue_iceberg_uses_catalog(
+        self, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        mock_sc_read = mocker.patch("hsfs.storage_connector.GlueConnector.read")
+        mock_via_catalog = mocker.patch(
+            "hsfs.engine.spark.Engine._read_glue_iceberg_via_catalog"
+        )
+
+        spark_engine = spark.Engine()
+
+        glue_connector = storage_connector.GlueConnector(
+            id=1,
+            name="test_connector",
+            featurestore_id=1,
+            database="db",
+        )
+
+        external_fg = feature_group.ExternalFeatureGroup(
+            id=10,
+            location="s3://bucket/db.db/tbl",
+            data_format="ICEBERG",
+            data_source=ds.DataSource(
+                storage_connector=glue_connector, database="db", table="tbl"
+            ),
+        )
+
+        # Act
+        spark_engine._register_external_temporary_table(
+            external_fg=external_fg,
+            alias="tbl_1",
+        )
+
+        # Assert: Glue + Iceberg goes through the catalog, not the path-based read
+        mock_via_catalog.assert_called_once()
+        assert mock_sc_read.call_count == 0
+        assert (
+            mock_via_catalog.return_value.createOrReplaceTempView.call_count == 1
+        )
+
     def test_register_hudi_temporary_table(self, mocker):
         # Arrange
         mock_hudi_engine = mocker.patch("hsfs.core.hudi_engine.HudiEngine")


### PR DESCRIPTION
External feature groups backed by a Glue connector with iceberg format were read path-based (spark.read.format("iceberg").load(s3a://...)), which uses HadoopTables and requires metadata/version-hint.text. Glue- catalog-managed Iceberg tables keep the current-metadata pointer in the catalog and do not write version-hint.text, so the read fails.

Route Glue + Iceberg external FGs through the catalog (.table(cat.db.tbl)) reusing GlueCatalog._configure_spark_session, mirroring the managed Iceberg path in IcebergEngine._register_temporary_table_via_catalog.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
