### PR TITLE
[FSTORE-2065] Add support to search for deployment and model tags

### DIFF
--- a/python/hopsworks_common/core/search_api.py
+++ b/python/hopsworks_common/core/search_api.py
@@ -23,10 +23,13 @@ from urllib.parse import quote
 from hopsworks_apigen import public
 from hopsworks_common import client
 from hopsworks_common.search_results import (
+    DeploymentSearchResult,
     FeatureGroupSearchResult,
     FeatureSearchResult,
     FeaturestoreSearchResult,
     FeatureViewSearchResult,
+    ModelRegistrySearchResult,
+    ModelSearchResult,
     TrainingDatasetSearchResult,
 )
 from hopsworks_common.util import Encoder
@@ -35,6 +38,8 @@ from hopsworks_common.util import Encoder
 DOC_TYPE_ARG = Literal[
     "FEATUREGROUP", "FEATUREVIEW", "TRAININGDATASET", "FEATURE", "ALL"
 ]
+
+MODEL_REGISTRY_DOC_TYPE_ARG = Literal["MODEL", "DEPLOYMENT", "ALL"]
 
 
 @public("hopsworks.core.search_api.TagSearchFilter")
@@ -493,6 +498,178 @@ class SearchApi:
         )
         return result.features
 
+    @public
+    def model_registry(
+        self,
+        search_term: str | None = None,
+        tag_filter: dict[str, str]
+        | list[dict[str, str] | TagSearchFilter]
+        | None = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> ModelRegistrySearchResult:
+        """Search for models and deployments.
+
+        The search is scoped to the model registries accessible from the current project.
+        Global (cross-project) search is not supported for the model registry.
+
+        Parameters:
+            search_term: The term to search for.
+            tag_filter:
+                Filter results by tags.
+                Can be a single dictionary, an array of dictionaries, or an array of TagSearchFilter objects.
+                Each tag filter requires: `"name"` (the tag schema name as defined by Hopsworks Admin), `"key"` (the property within that tag schema), and `"value"` (the value to match).
+            offset: The number of results to skip.
+            limit: The number of search results to return.
+
+        Returns:
+            The search results containing lists of metadata objects for models and deployments.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            search_api = project.get_search_api()
+
+            # Simple search
+            result = search_api.model_registry("search-term")
+
+            # Access results
+            for model_meta in result.models:
+                print(f"Model: {model_meta.name} v{model_meta.version}")
+
+                # Get the same Model object as returned by model_registry.get_model
+                model = model_meta.get()
+
+            # Search with a tag filter
+            result = search_api.model_registry(
+                "search-term",
+                tag_filter={"name": "tag1", "key": "environment", "value": "production"},
+            )
+            ```
+        """
+        return self._search_model_registry(
+            doc_type="ALL",
+            search_term=search_term,
+            tag_filter=tag_filter,
+            offset=offset,
+            limit=limit,
+        )
+
+    @public
+    def models(
+        self,
+        search_term: str | None = None,
+        tag_filter: dict[str, str]
+        | list[dict[str, str] | TagSearchFilter]
+        | None = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[ModelSearchResult]:
+        """Search for models only.
+
+        The search is scoped to the model registries accessible from the current project.
+
+        Parameters:
+            search_term: The term to search for.
+            tag_filter:
+                Filter results by tags.
+                Can be a single dictionary, an array of dictionaries, or an array of TagSearchFilter objects.
+                Each tag filter requires: `"name"` (the tag schema name as defined by Hopsworks Admin), `"key"` (the property within that tag schema), and `"value"` (the value to match).
+            offset: The number of results to skip.
+            limit: The number of search results to return.
+
+        Returns:
+            A list of metadata objects for models matching the search criteria.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            search_api = project.get_search_api()
+
+            # Search for models
+            model_metas = search_api.models("fraud")
+
+            for model_meta in model_metas:
+                print(f"Model: {model_meta.name} v{model_meta.version}")
+
+                # Get the same Model object as returned by model_registry.get_model
+                model = model_meta.get()
+            ```
+        """
+        result = self._search_model_registry(
+            doc_type="MODEL",
+            search_term=search_term,
+            tag_filter=tag_filter,
+            offset=offset,
+            limit=limit,
+        )
+        return result.models
+
+    @public
+    def deployments(
+        self,
+        search_term: str | None = None,
+        tag_filter: dict[str, str]
+        | list[dict[str, str] | TagSearchFilter]
+        | None = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[DeploymentSearchResult]:
+        """Search for deployments only.
+
+        The search is scoped to the model registries accessible from the current project.
+
+        Parameters:
+            search_term: The term to search for.
+            tag_filter:
+                Filter results by tags.
+                Can be a single dictionary, an array of dictionaries, or an array of TagSearchFilter objects.
+                Each tag filter requires: `"name"` (the tag schema name as defined by Hopsworks Admin), `"key"` (the property within that tag schema), and `"value"` (the value to match).
+            offset: The number of results to skip.
+            limit: The number of search results to return.
+
+        Returns:
+            A list of metadata objects for deployments matching the search criteria.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            search_api = project.get_search_api()
+
+            # Search for deployments
+            deployment_metas = search_api.deployments("fraud")
+
+            for deployment_meta in deployment_metas:
+                print(f"Deployment: {deployment_meta.name}")
+
+                # Get the same Deployment object as returned by model_serving.get_deployment
+                deployment = deployment_meta.get()
+            ```
+        """
+        result = self._search_model_registry(
+            doc_type="DEPLOYMENT",
+            search_term=search_term,
+            tag_filter=tag_filter,
+            offset=offset,
+            limit=limit,
+        )
+        return result.deployments
+
     def _parse_keyword_filter(
         self, keyword_filter: str | list[str] | None
     ) -> list[KeywordSearchFilter] | None:
@@ -622,3 +799,51 @@ class SearchApi:
         )
 
         return FeaturestoreSearchResult(result)
+
+    def _search_model_registry(
+        self,
+        doc_type: MODEL_REGISTRY_DOC_TYPE_ARG,
+        search_term: str | None = None,
+        tag_filter: dict[str, str]
+        | list[dict[str, str] | TagSearchFilter]
+        | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> ModelRegistrySearchResult:
+        if doc_type not in get_args(MODEL_REGISTRY_DOC_TYPE_ARG):
+            raise ValueError(
+                f"doc_type must be one of the following {get_args(MODEL_REGISTRY_DOC_TYPE_ARG)}."
+            )
+
+        # Parse tag_filter to list of TagSearchFilter objects
+        parsed_tags = self._parse_tag_filter(tag_filter)
+
+        if search_term is None and not parsed_tags:
+            raise ValueError(
+                "At least one of search_term or tag_filter must be provided."
+            )
+
+        _client = client._get_instance()
+        path_params = ["project", _client._project_id, "elastic", "modelregistry"]
+
+        headers = {"content-type": "application/json"}
+        query_params = {
+            "docType": doc_type,
+            "from": offset,
+            "size": limit,
+        }
+
+        if search_term is not None:
+            query_params["searchTerm"] = search_term
+
+        if parsed_tags:
+            # Convert list of TagSearchFilter objects to list of dictionaries
+            tags_dict = [tag.to_dict() for tag in parsed_tags]
+            # Serialize to JSON string and URL-encode all characters (safe="") since JSON contains special chars
+            query_params["tags"] = quote(json.dumps(tags_dict), safe="")
+
+        result = _client._send_request(
+            "GET", path_params, query_params=query_params, headers=headers
+        )
+
+        return ModelRegistrySearchResult(result)

--- a/python/hopsworks_common/search_results.py
+++ b/python/hopsworks_common/search_results.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from hsfs.feature_group import FeatureGroup
     from hsfs.feature_view import FeatureView
     from hsfs.training_dataset import TrainingDataset
+    from hsml.deployment import Deployment
+    from hsml.model import Model
 
 
 @public("hopsworks.core.search_api.Project")
@@ -336,6 +338,63 @@ class FeatureSearchResult(SearchResultItem):
     """Search result for a Feature."""
 
 
+@public("hopsworks.core.search_api.ModelSearchResult")
+class ModelSearchResult(SearchResultItem):
+    """Search result for a Model."""
+
+    @public
+    @property
+    def tags(self) -> list:
+        """Tags attached to the model as a list of `{"key", "value"}` dictionaries."""
+        return self._raw_data.get("tags", [])
+
+    @public
+    def get(self) -> Model | None:
+        """Retrieve the full Model object.
+
+        This uses the project associated with this search result to obtain a
+        connection to the model registry and then fetches the Model with the
+        given name and version.
+
+        Returns:
+            The full Model object corresponding to this search result.
+
+        Raises:
+            Exception: If the connection to the model registry fails or the
+                Model cannot be retrieved.
+        """
+        mr = client._get_connection()._get_model_registry(self.project.name)
+        return mr.get_model(self.name, version=self.version)
+
+
+@public("hopsworks.core.search_api.DeploymentSearchResult")
+class DeploymentSearchResult(SearchResultItem):
+    """Search result for a Deployment."""
+
+    @public
+    @property
+    def tags(self) -> list:
+        """Tags attached to the deployment as a list of `{"key", "value"}` dictionaries."""
+        return self._raw_data.get("tags", [])
+
+    @public
+    def get(self) -> Deployment | None:
+        """Retrieve the full Deployment object.
+
+        This obtains a connection to model serving and then fetches the
+        Deployment with the given name.
+
+        Returns:
+            The full Deployment object corresponding to this search result.
+
+        Raises:
+            Exception: If the connection to model serving fails or the
+                Deployment cannot be retrieved.
+        """
+        ms = client._get_connection()._get_model_serving()
+        return ms.get_deployment(self.name)
+
+
 @public("hopsworks.core.search_api.FeaturestoreSearchResult")
 class FeaturestoreSearchResult:
     """Container for all featurestore search results."""
@@ -467,4 +526,80 @@ class FeaturestoreSearchResult:
             f"feature_views={len(self._feature_views)}/{self._feature_views_total}, "
             f"training_datasets={len(self._training_datasets)}/{self._training_datasets_total}, "
             f"features={len(self._features)}/{self._features_total})"
+        )
+
+
+@public("hopsworks.core.search_api.ModelRegistrySearchResult")
+class ModelRegistrySearchResult:
+    """Container for all model registry search results."""
+
+    def __init__(self, response_data: dict):
+        self._log = logging.getLogger(__name__)
+        self._models = [ModelSearchResult(m) for m in response_data.get("models", [])]
+        self._deployments = [
+            DeploymentSearchResult(d) for d in response_data.get("deployments", [])
+        ]
+
+        # Store metadata about result counts
+        self._models_offset = response_data.get("modelsFrom", 0)
+        self._models_total = response_data.get("modelsTotal", 0)
+        self._deployments_offset = response_data.get("deploymentsFrom", 0)
+        self._deployments_total = response_data.get("deploymentsTotal", 0)
+
+    @public
+    @property
+    def models(self) -> list[ModelSearchResult]:
+        """List of Model search results."""
+        return self._models
+
+    @public
+    @property
+    def deployments(self) -> list[DeploymentSearchResult]:
+        """List of Deployment search results."""
+        return self._deployments
+
+    @public
+    @property
+    def models_offset(self) -> int:
+        """Total offset for the returned list of models within the whole result."""
+        return self._models_offset
+
+    @public
+    @property
+    def deployments_offset(self) -> int:
+        """Total offset for the returned list of deployments within the whole result."""
+        return self._deployments_offset
+
+    @public
+    @property
+    def models_total(self) -> int:
+        """Total number of Models matching the search."""
+        return self._models_total
+
+    @public
+    @property
+    def deployments_total(self) -> int:
+        """Total number of Deployments matching the search."""
+        return self._deployments_total
+
+    def json(self) -> dict:
+        """Convert to JSON-serializable dictionary.
+
+        Returns:
+            JSONDictionary representation of the object.
+        """
+        return {
+            "models": [m.json() for m in self._models],
+            "modelsFrom": self._models_offset,
+            "modelsTotal": self._models_total,
+            "deployments": [d.json() for d in self._deployments],
+            "deploymentsFrom": self._deployments_offset,
+            "deploymentsTotal": self._deployments_total,
+        }
+
+    def __repr__(self):
+        return (
+            f"ModelRegistrySearchResult("
+            f"models={len(self._models)}/{self._models_total}, "
+            f"deployments={len(self._deployments)}/{self._deployments_total})"
         )

--- a/python/tests/core/test_search_api.py
+++ b/python/tests/core/test_search_api.py
@@ -1,0 +1,122 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from urllib.parse import quote
+
+import pytest
+from hopsworks_common.core.search_api import SearchApi
+from hopsworks_common.search_results import (
+    DeploymentSearchResult,
+    ModelRegistrySearchResult,
+    ModelSearchResult,
+)
+
+
+_RESPONSE = {
+    "models": [
+        {
+            "name": "test_model",
+            "version": 1,
+            "parentProjectId": 1,
+            "parentProjectName": "proj",
+            "tags": [],
+            "highlights": {},
+        }
+    ],
+    "deployments": [
+        {
+            "name": "test_deployment",
+            "version": 1,
+            "parentProjectId": 1,
+            "parentProjectName": "proj",
+            "tags": [],
+            "highlights": {},
+        }
+    ],
+    "modelsFrom": 0,
+    "modelsTotal": 1,
+    "deploymentsFrom": 0,
+    "deploymentsTotal": 1,
+}
+
+
+class TestSearchApiModelRegistry:
+    def _patch_client(self, mocker):
+        instance = mocker.MagicMock()
+        instance._project_id = 119
+        instance._send_request.return_value = _RESPONSE
+        mocker.patch("hopsworks_common.client._get_instance", return_value=instance)
+        return instance
+
+    def test_model_registry_builds_project_scoped_request(self, mocker):
+        instance = self._patch_client(mocker)
+
+        result = SearchApi().model_registry("fraud", offset=5, limit=20)
+
+        assert isinstance(result, ModelRegistrySearchResult)
+        assert len(result.models) == 1
+        assert len(result.deployments) == 1
+        instance._send_request.assert_called_once()
+        args, kwargs = instance._send_request.call_args
+        assert args[0] == "GET"
+        assert args[1] == ["project", 119, "elastic", "modelregistry"]
+        query_params = kwargs["query_params"]
+        assert query_params["docType"] == "ALL"
+        assert query_params["searchTerm"] == "fraud"
+        assert query_params["from"] == 5
+        assert query_params["size"] == 20
+        assert "keywords" not in query_params
+
+    def test_models_sets_doc_type_and_returns_list(self, mocker):
+        instance = self._patch_client(mocker)
+
+        models = SearchApi().models("fraud")
+
+        assert all(isinstance(m, ModelSearchResult) for m in models)
+        assert models[0].name == "test_model"
+        _, kwargs = instance._send_request.call_args
+        assert kwargs["query_params"]["docType"] == "MODEL"
+
+    def test_deployments_sets_doc_type_and_returns_list(self, mocker):
+        instance = self._patch_client(mocker)
+
+        deployments = SearchApi().deployments("fraud")
+
+        assert all(isinstance(d, DeploymentSearchResult) for d in deployments)
+        assert deployments[0].name == "test_deployment"
+        _, kwargs = instance._send_request.call_args
+        assert kwargs["query_params"]["docType"] == "DEPLOYMENT"
+
+    def test_tag_filter_is_json_encoded(self, mocker):
+        instance = self._patch_client(mocker)
+
+        SearchApi().models(
+            tag_filter={"name": "t", "key": "environment", "value": "production"}
+        )
+
+        _, kwargs = instance._send_request.call_args
+        expected = quote(
+            json.dumps([{"name": "t", "key": "environment", "value": "production"}]),
+            safe="",
+        )
+        assert kwargs["query_params"]["tags"] == expected
+
+    def test_requires_search_term_or_tag_filter(self, mocker):
+        self._patch_client(mocker)
+
+        with pytest.raises(ValueError, match="search_term or tag_filter"):
+            SearchApi().models()

--- a/python/tests/core/test_search_results.py
+++ b/python/tests/core/test_search_results.py
@@ -191,3 +191,58 @@ class TestSearchResults:
         fg = result.feature_groups[0]
         assert fg.project.id == 123
         assert fg.project.name == "my_project"
+
+    def test_model_registry_search_result_from_response_json(self):
+        json_dict = {
+            "models": [
+                {
+                    "name": "test_model",
+                    "version": 2,
+                    "description": "test description",
+                    "parentProjectId": 1,
+                    "parentProjectName": "test_project",
+                    "tags": [{"key": "environment", "value": "production"}],
+                    "highlights": {
+                        "description": "<em>fraud</em> detection",
+                        "tags": [],
+                    },
+                },
+            ],
+            "deployments": [
+                {
+                    "name": "test_deployment",
+                    "version": 1,
+                    "description": "serving deployment",
+                    "parentProjectId": 1,
+                    "parentProjectName": "test_project",
+                    "tags": [],
+                    "highlights": {},
+                },
+            ],
+            "modelsFrom": 0,
+            "modelsTotal": 1,
+            "deploymentsFrom": 0,
+            "deploymentsTotal": 1,
+        }
+
+        result = search_results.ModelRegistrySearchResult(json_dict)
+
+        assert len(result.models) == 1
+        assert len(result.deployments) == 1
+        assert result.models[0].name == "test_model"
+        assert result.models[0].version == 2
+        assert result.models[0].tags == [{"key": "environment", "value": "production"}]
+        assert result.deployments[0].name == "test_deployment"
+        assert result.deployments[0].tags == []
+        assert result.models_total == 1
+        assert result.deployments_total == 1
+
+    def test_model_registry_search_result_with_empty_response(self):
+        result = search_results.ModelRegistrySearchResult({})
+
+        assert len(result.models) == 0
+        assert len(result.deployments) == 0
+        assert result.models_total == 0
+        assert result.deployments_total == 0
+        assert result.models_offset == 0
+        assert result.deployments_offset == 0

--- a/python/tests/test_search_results.py
+++ b/python/tests/test_search_results.py
@@ -16,8 +16,10 @@
 
 from hopsworks_common.connection import Connection
 from hopsworks_common.search_results import (
+    DeploymentSearchResult,
     FeatureGroupSearchResult,
     FeatureViewSearchResult,
+    ModelSearchResult,
     TrainingDatasetSearchResult,
 )
 
@@ -74,3 +76,29 @@ class TestSearchResults:
         assert result == "TD"
         conn._get_feature_store.assert_called_once_with("proj")
         fs.get_training_dataset.assert_called_once_with("entity", version=1)
+
+    def test_model_search_result_get(self, mocker):
+        conn = mocker.MagicMock(spec=Connection)
+        mr = mocker.MagicMock()
+        conn._get_model_registry.return_value = mr
+        mr.get_model.return_value = "MODEL"
+        mocker.patch("hopsworks_common.client._get_connection", return_value=conn)
+
+        result = ModelSearchResult(_DATA).get()
+
+        assert result == "MODEL"
+        conn._get_model_registry.assert_called_once_with("proj")
+        mr.get_model.assert_called_once_with("entity", version=1)
+
+    def test_deployment_search_result_get(self, mocker):
+        conn = mocker.MagicMock(spec=Connection)
+        ms = mocker.MagicMock()
+        conn._get_model_serving.return_value = ms
+        ms.get_deployment.return_value = "DEPLOYMENT"
+        mocker.patch("hopsworks_common.client._get_connection", return_value=conn)
+
+        result = DeploymentSearchResult(_DATA).get()
+
+        assert result == "DEPLOYMENT"
+        conn._get_model_serving.assert_called_once_with()
+        ms.get_deployment.assert_called_once_with("entity")


### PR DESCRIPTION
## What
Exposes tag/metadata search for models and deployments in the Python client, mirroring the feature-store search. JIRA: https://hopsworks.atlassian.net/browse/FSTORE-2065

## Change
`SearchApi` gains `model_registry`, `models`, and `deployments` methods that query the new `modelregistry` endpoint by tag and search term, reusing the existing tag-filter machinery. New `ModelSearchResult`, `DeploymentSearchResult`, and `ModelRegistrySearchResult` types parse the response and resolve the underlying `Model` / `Deployment`. Keyword and global-search params are omitted (the backend endpoint does not support them).

## Companion PRs
- hopsworks-ee: the `modelregistry` search endpoint this calls.
- hopsworks-helm: the index template.

## Testing
16 unit tests pass; ruff check/format clean.

## Needs sign-off
New `@public` symbols (mirroring the feature-store search analogs): `SearchApi.model_registry/models/deployments`, `ModelSearchResult`, `DeploymentSearchResult`, `ModelRegistrySearchResult` (+ properties). Please confirm the public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)