### PR TITLE
[FSTORE-2061] Millisecond timestamp for vector embeddings not handled correctly

### DIFF
--- a/python/hsfs/core/vector_db_client.py
+++ b/python/hsfs/core/vector_db_client.py
@@ -224,9 +224,9 @@ class VectorDbClient:
                     feature_value // 10**3, tz=timezone.utc
                 ).date()
             elif feature_type == "timestamp":
-                # convert timestamp in ms to datetime in s
+                # true division so sub-second precision survives, e.g. timestamp(3)
                 result[feature_name] = datetime.fromtimestamp(
-                    feature_value // 10**3, tz=timezone.utc
+                    feature_value / 10**3, tz=timezone.utc
                 ).replace(tzinfo=None)
             elif feature_type == "binary" or (
                 feature.is_complex() and feature not in self._embedding_features

--- a/python/hsfs/core/vector_db_client.py
+++ b/python/hsfs/core/vector_db_client.py
@@ -217,7 +217,7 @@ class VectorDbClient:
             feature_name = feature.name
             feature_type = feature.type.lower()
             feature_value = result.get(feature_name)
-            if not feature_value:  # Feature value can be null
+            if feature_value is None:
                 continue
             if feature_type == "date":
                 result[feature_name] = datetime.fromtimestamp(

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1719,8 +1719,12 @@ class VectorServer:
                 timestamp_value / 1000, tz=timezone.utc
             ).replace(tzinfo=None)
         if isinstance(timestamp_value, str):
-            # rest client returns timestamp as string
-            return datetime.strptime(timestamp_value, self.SQL_TIMESTAMP_STRING_FORMAT)
+            # rest client returns timestamp as string, with fractional seconds
+            # when the online type has sub-second precision, e.g. timestamp(3)
+            fmt = self.SQL_TIMESTAMP_STRING_FORMAT + (
+                ".%f" if "." in timestamp_value else ""
+            )
+            return datetime.strptime(timestamp_value, fmt)
         if isinstance(timestamp_value, datetime):
             # sql client returns already datetime object
             return timestamp_value

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1701,15 +1701,17 @@ class VectorServer:
                 )
 
     def _handle_timestamp_based_on_dtype(
-        self, timestamp_value: str | int
+        self, timestamp_value: str | int | datetime | None
     ) -> datetime | None:
         """Handle the timestamp based on the dtype which is returned.
 
-        Currently timestamp which are in the database are returned as string. Whereas
-        passed features which were given as datetime are returned as integer timestamp.
+        The rest client returns timestamps as strings.
+        Passed features given as datetime are returned as integer timestamps.
+        The sql client already returns datetime objects.
+        Missing values arrive as None and are passed through.
 
         Parameters:
-            timestamp_value: The timestamp value to be handled, either as int or str.
+            timestamp_value: The timestamp value to be handled.
         """
         if timestamp_value is None:
             return None

--- a/python/tests/core/test_vector_db_client.py
+++ b/python/tests/core/test_vector_db_client.py
@@ -528,3 +528,11 @@ class TestVectorDbClient:
         )
 
         assert result["f_ts"] == datetime(2024, 4, 18, 12, 0, 25, 789000)
+
+    def test_convert_to_pandas_type_epoch_zero_is_not_null(self):
+        # 0 epoch ms is a valid timestamp and must not be skipped as null
+        result = self.target._convert_to_pandas_type(
+            self.fg.columns, {"f1": 4, "f_ts": 0}
+        )
+
+        assert result["f_ts"] == datetime(1970, 1, 1)

--- a/python/tests/core/test_vector_db_client.py
+++ b/python/tests/core/test_vector_db_client.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from datetime import datetime
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -516,3 +517,14 @@ class TestVectorDbClient:
                 ]
             }
         }
+
+    def test_convert_to_pandas_type_timestamp_keeps_milliseconds(self):
+        # OpenSearch stores timestamps as epoch ms; sub-second precision must
+        # survive the conversion, e.g. for timestamp(3) online types (FSTORE-2061)
+        epoch_ms = _convert_event_time_to_timestamp("2024-04-18 12:00:25.789")
+
+        result = self.target._convert_to_pandas_type(
+            self.fg.columns, {"f1": 4, "f_ts": epoch_ms}
+        )
+
+        assert result["f_ts"] == datetime(2024, 4, 18, 12, 0, 25, 789000)

--- a/python/tests/core/test_vector_server.py
+++ b/python/tests/core/test_vector_server.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 
+from datetime import datetime
 from unittest.mock import PropertyMock
 
 import pytest
@@ -119,3 +120,24 @@ class TestVectorServer:
         server._setup_rest_client_and_engine(entity, reset_rest_client=True)
 
         singleton.assert_called_once_with(transport=None, optional_config=None)
+
+    @pytest.mark.parametrize(
+        "timestamp_value, expected",
+        [
+            ("2024-04-18 12:00:25", datetime(2024, 4, 18, 12, 0, 25)),
+            # fractional seconds appear when the online type has sub-second
+            # precision, e.g. timestamp(3) (FSTORE-2061)
+            ("2024-04-18 12:00:25.789", datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            ("2024-04-18 12:00:25.789000", datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            (1713441625789, datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            (
+                datetime(2024, 4, 18, 12, 0, 25, 789000),
+                datetime(2024, 4, 18, 12, 0, 25, 789000),
+            ),
+            (None, None),
+        ],
+    )
+    def test_handle_timestamp_based_on_dtype(self, timestamp_value, expected):
+        server = VectorServer.__new__(VectorServer)
+
+        assert server._handle_timestamp_based_on_dtype(timestamp_value) == expected


### PR DESCRIPTION
## Summary
- Parse fractional seconds in `VectorServer._handle_timestamp_based_on_dtype`: append `.%f` to the timestamp format when the string carries a fractional part. Fixes `ValueError: unconverted data remains: .123` in `get_feature_vector(s)` through the RonDB REST client for feature groups whose online store data type is `timestamp(p)` (allowed since FSTORE-1926 / hopsworks-ee#3017). The MySQL client already returns `datetime` objects and was unaffected.
- Preserve millisecond precision in `VectorDbClient._convert_to_pandas_type`: convert OpenSearch epoch-millisecond values with true division instead of floor division, so timestamps of feature groups with embeddings no longer lose their sub-second part.
- Unit tests for both paths in `tests/core/test_vector_server.py` and `tests/core/test_vector_db_client.py`.

## Test plan
- [x] `pytest tests/core/test_vector_server.py tests/core/test_vector_db_client.py` (54 passed) and ruff clean.
- [x] Cluster verification via logicalclocks/loadtest#948 `test_feature_vector_timestamp_precision`: feature group with `online_type="timestamp(3)"`, `get_feature_vector` and `get_feature_vectors` return millisecond-precision datetimes through both the SQL and REST online clients with this branch installed.
- [x] Reproduced the original failure on the same cluster with the unpatched SDK (Spark job environment): identical `ValueError` at `vector_server.py:1723`, REST client only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
