### PR TITLE
[FSTORE-2066] Fixes for stats computation / feature monitoring

### DIFF
--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfile.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfile.java
@@ -34,11 +34,13 @@ class ColumnProfile {
   private final double completeness;
   private final long numRecordsNonNull;
   private final long numRecordsNull;
-  private final double distinctness;
-  private final double entropy;
-  private final double uniqueness;
+  // uniqueness-family stats are null when exactUniqueness is disabled, so the
+  // serializer omits their keys and consumers deserialize them as absent
+  private final Double distinctness;
+  private final Double entropy;
+  private final Double uniqueness;
   private final long approximateNumDistinctValues;
-  private final long exactNumDistinctValues;
+  private final Long exactNumDistinctValues;
 
   private final Double mean;
   private final Double maximum;
@@ -97,15 +99,15 @@ class ColumnProfile {
     return numRecordsNull;
   }
 
-  double getDistinctness() {
+  Double getDistinctness() {
     return distinctness;
   }
 
-  double getEntropy() {
+  Double getEntropy() {
     return entropy;
   }
 
-  double getUniqueness() {
+  Double getUniqueness() {
     return uniqueness;
   }
 
@@ -113,7 +115,7 @@ class ColumnProfile {
     return approximateNumDistinctValues;
   }
 
-  long getExactNumDistinctValues() {
+  Long getExactNumDistinctValues() {
     return exactNumDistinctValues;
   }
 
@@ -160,11 +162,11 @@ class ColumnProfile {
     private double completeness;
     private long numRecordsNonNull;
     private long numRecordsNull;
-    private double distinctness;
-    private double entropy;
-    private double uniqueness;
+    private Double distinctness;
+    private Double entropy;
+    private Double uniqueness;
     private long approximateNumDistinctValues;
-    private long exactNumDistinctValues;
+    private Long exactNumDistinctValues;
     private Double mean;
     private Double maximum;
     private Double minimum;
@@ -200,17 +202,17 @@ class ColumnProfile {
       return this;
     }
 
-    Builder distinctness(double value) {
+    Builder distinctness(Double value) {
       this.distinctness = value;
       return this;
     }
 
-    Builder entropy(double value) {
+    Builder entropy(Double value) {
       this.entropy = value;
       return this;
     }
 
-    Builder uniqueness(double value) {
+    Builder uniqueness(Double value) {
       this.uniqueness = value;
       return this;
     }
@@ -220,7 +222,7 @@ class ColumnProfile {
       return this;
     }
 
-    Builder exactNumDistinctValues(long value) {
+    Builder exactNumDistinctValues(Long value) {
       this.exactNumDistinctValues = value;
       return this;
     }

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -63,9 +63,11 @@ import java.util.Map;
  *
  * <h3>Uniqueness formula</h3>
  *
- * <p>{@code uniqueness = max(0, (2 * exactDistinct - nonNull) / nonNull)} — verified against
- * the Deequ baseline. This formula holds because Deequ defines uniqueness as the fraction of
- * values appearing exactly once, and with random integers most duplicates appear exactly twice.
+ * <p>{@code uniqueness = singletons / nonNull} — Deequ's exact definition (fraction of values
+ * appearing exactly once). The singleton count comes from the same per-value frequency pass
+ * as entropy, so no additional Spark job is paid for it. (An earlier shortcut,
+ * {@code (2 * exactDistinct - nonNull) / nonNull}, is only equivalent when no value occurs
+ * more than twice and undercounts otherwise.)
  *
  * <h3>stdDev</h3>
  *
@@ -116,10 +118,12 @@ public class ColumnProfiler {
       }
 
       Row aggRow = computeScalars(df, columns, exactUniqueness);
-      // entropy is derived from exact per-value frequencies; only pay for the
-      // per-column groupBy when exact uniqueness stats were requested
-      Map<String, Double> entropyMap = exactUniqueness
-          ? computeEntropy(df, columns) : new LinkedHashMap<String, Double>();
+      // entropy and the uniqueness singleton count are derived from exact per-value
+      // frequencies; only pay for the per-column groupBy when exact uniqueness
+      // stats were requested
+      Map<String, ValueFrequencyStats> frequencyStatsMap = exactUniqueness
+          ? computeValueFrequencyStats(df, columns)
+          : new LinkedHashMap<String, ValueFrequencyStats>();
 
       Map<String, Map<String, Double>> correlationMap =
           new LinkedHashMap<String, Map<String, Double>>();
@@ -129,7 +133,7 @@ public class ColumnProfiler {
 
       List<ColumnProfile> profiles = new ArrayList<ColumnProfile>(columns.size());
       for (ColumnInfo col : columns) {
-        ColumnProfile cp = buildProfile(df, col, aggRow, entropyMap, correlationMap,
+        ColumnProfile cp = buildProfile(df, col, aggRow, frequencyStatsMap, correlationMap,
             histogram, histogramBins, kll, exactUniqueness);
         profiles.add(cp);
       }
@@ -213,18 +217,31 @@ public class ColumnProfiler {
   }
 
   // ---------------------------------------------------------------------------
-  // Pass 2: entropy — one groupBy per column
+  // Pass 2: per-value frequencies (entropy + uniqueness singletons) — one groupBy per column
   // ---------------------------------------------------------------------------
 
-  private Map<String, Double> computeEntropy(Dataset<Row> df, List<ColumnInfo> columns) {
-    Map<String, Double> result = new LinkedHashMap<String, Double>();
+  /** Per-column stats derived from the exact per-value frequency distribution. */
+  private static final class ValueFrequencyStats {
+    private final double entropy;
+    private final long singletons;
+
+    private ValueFrequencyStats(double entropy, long singletons) {
+      this.entropy = entropy;
+      this.singletons = singletons;
+    }
+  }
+
+  private Map<String, ValueFrequencyStats> computeValueFrequencyStats(Dataset<Row> df,
+      List<ColumnInfo> columns) {
+    Map<String, ValueFrequencyStats> result = new LinkedHashMap<String, ValueFrequencyStats>();
     for (ColumnInfo col : columns) {
-      result.put(col.name, computeColumnEntropy(df, col.name));
+      result.put(col.name, computeColumnValueFrequencyStats(df, col.name));
     }
     return result;
   }
 
-  private double computeColumnEntropy(Dataset<Row> df, String columnName) {
+  private ValueFrequencyStats computeColumnValueFrequencyStats(Dataset<Row> df,
+      String columnName) {
     Column cc = functions.col(columnName);
     List<Row> rows = df.filter(cc.isNotNull())
         .groupBy(cc)
@@ -233,14 +250,19 @@ public class ColumnProfiler {
         .collectAsList();
 
     if (rows.isEmpty()) {
-      return 0.0;
+      return new ValueFrequencyStats(0.0, 0L);
     }
     long total = 0;
+    long singletons = 0;
     for (Row row : rows) {
-      total += row.getLong(0);
+      long count = row.getLong(0);
+      total += count;
+      if (count == 1) {
+        singletons++;
+      }
     }
     if (total == 0) {
-      return 0.0;
+      return new ValueFrequencyStats(0.0, 0L);
     }
     double entropy = 0.0;
     for (Row row : rows) {
@@ -250,7 +272,7 @@ public class ColumnProfiler {
         entropy -= pp * Math.log(pp);
       }
     }
-    return entropy;
+    return new ValueFrequencyStats(entropy, singletons);
   }
 
   // ---------------------------------------------------------------------------
@@ -285,7 +307,7 @@ public class ColumnProfiler {
   // ---------------------------------------------------------------------------
 
   private ColumnProfile buildProfile(Dataset<Row> df, ColumnInfo col, Row aggRow,
-      Map<String, Double> entropyMap,
+      Map<String, ValueFrequencyStats> frequencyStatsMap,
       Map<String, Map<String, Double>> correlationMap,
       boolean histogram, int histogramBins, boolean kll, boolean exactUniqueness) {
     String nn = col.name;
@@ -300,15 +322,16 @@ public class ColumnProfiler {
     // meaningful when exactUniqueness=true. When false they stay null and the serializer
     // omits their keys, so consumers deserialize them as absent instead of a bogus 0.
     Long exactDistinct = exactUniqueness ? (Long) aggRow.getAs(nn + "__exact_distinct") : null;
+    ValueFrequencyStats freqStats = frequencyStatsMap.get(nn);
 
     double completeness = total > 0 ? (double) nonNull / total : 0.0;
     Double distinctness = exactUniqueness
         ? (nonNull > 0 ? (double) exactDistinct / nonNull : 0.0) : null;
     Double uniqueness = exactUniqueness
-        ? (nonNull > 0 ? Math.max(0.0, (double) (2L * exactDistinct - nonNull) / nonNull) : 0.0)
+        ? (nonNull > 0 && freqStats != null ? (double) freqStats.singletons / nonNull : 0.0)
         : null;
     Double entropy = exactUniqueness
-        ? (entropyMap.containsKey(nn) ? entropyMap.get(nn) : 0.0) : null;
+        ? (freqStats != null ? freqStats.entropy : 0.0) : null;
 
     ColumnProfile.Builder builder = new ColumnProfile.Builder()
         .columnName(nn)

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -116,7 +116,10 @@ public class ColumnProfiler {
       }
 
       Row aggRow = computeScalars(df, columns, exactUniqueness);
-      Map<String, Double> entropyMap = computeEntropy(df, columns);
+      // entropy is derived from exact per-value frequencies; only pay for the
+      // per-column groupBy when exact uniqueness stats were requested
+      Map<String, Double> entropyMap = exactUniqueness
+          ? computeEntropy(df, columns) : new LinkedHashMap<String, Double>();
 
       Map<String, Map<String, Double>> correlationMap =
           new LinkedHashMap<String, Map<String, Double>>();
@@ -294,18 +297,18 @@ public class ColumnProfiler {
     long total = nonNull + nullCount;
     long approxDistinct = aggRow.getAs(nn + "__approx_distinct");
     // exactNumDistinctValues + derived stats (distinctness/uniqueness/entropy) are only
-    // meaningful when exactUniqueness=true. When false we leave them at 0; the serializer
-    // still emits the keys (matching Deequ's shape, which is always keys-present).
-    long exactDistinct = exactUniqueness ? (Long) aggRow.getAs(nn + "__exact_distinct") : 0L;
+    // meaningful when exactUniqueness=true. When false they stay null and the serializer
+    // omits their keys, so consumers deserialize them as absent instead of a bogus 0.
+    Long exactDistinct = exactUniqueness ? (Long) aggRow.getAs(nn + "__exact_distinct") : null;
 
     double completeness = total > 0 ? (double) nonNull / total : 0.0;
-    double distinctness = exactUniqueness && nonNull > 0
-        ? (double) exactDistinct / nonNull : 0.0;
-    double uniqueness = exactUniqueness && nonNull > 0
-        ? Math.max(0.0, (double) (2L * exactDistinct - nonNull) / nonNull)
-        : 0.0;
-    double entropy = exactUniqueness && entropyMap.containsKey(nn)
-        ? entropyMap.get(nn) : 0.0;
+    Double distinctness = exactUniqueness
+        ? (nonNull > 0 ? (double) exactDistinct / nonNull : 0.0) : null;
+    Double uniqueness = exactUniqueness
+        ? (nonNull > 0 ? Math.max(0.0, (double) (2L * exactDistinct - nonNull) / nonNull) : 0.0)
+        : null;
+    Double entropy = exactUniqueness
+        ? (entropyMap.containsKey(nn) ? entropyMap.get(nn) : 0.0) : null;
 
     ColumnProfile.Builder builder = new ColumnProfile.Builder()
         .columnName(nn)

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -50,29 +50,33 @@ import java.util.Map;
  * <h3>KLL gating divergence from Deequ</h3>
  *
  * <p>Deequ always emits {@code kll} for numeric columns regardless of {@code withKLLProfiling()};
- * the toggle is a no-op in 2.0.7-spark-3.5. This implementation emits {@code kll} only when
- * {@code kll=true}, aligning with the Phase-1 API contract. The {@code kll=false} path produces
- * smaller profiles. The golden-parity test (task #6) accounts for this known divergence.
+ * the toggle is a no-op in 2.0.7-spark-3.5.
+ * This implementation emits {@code kll} only when {@code kll=true}, aligning with the Phase-1
+ * API contract.
+ * The {@code kll=false} path produces smaller profiles.
+ * The golden-parity test (task #6) accounts for this known divergence.
  *
  * <h3>Entropy computation</h3>
  *
  * <p>Shannon entropy is derived from the exact per-value frequency distribution via
- * {@code groupBy(col).count()} per column. For numeric columns where all values are unique
- * this equals {@code ln(exactNumDistinctValues)}, but the groupBy is required for correctness
- * when duplicates exist.
+ * {@code groupBy(col).count()} per column.
+ * For numeric columns where all values are unique this equals
+ * {@code ln(exactNumDistinctValues)}, but the groupBy is required for correctness when
+ * duplicates exist.
  *
  * <h3>Uniqueness formula</h3>
  *
- * <p>{@code uniqueness = singletons / nonNull} — Deequ's exact definition (fraction of values
- * appearing exactly once). The singleton count comes from the same per-value frequency pass
- * as entropy, so no additional Spark job is paid for it. (An earlier shortcut,
- * {@code (2 * exactDistinct - nonNull) / nonNull}, is only equivalent when no value occurs
- * more than twice and undercounts otherwise.)
+ * <p>{@code uniqueness = singletons / nonNull}: Deequ's exact definition (fraction of values
+ * appearing exactly once).
+ * The singleton count comes from the same per-value frequency pass as entropy, so no
+ * additional Spark job is paid for it.
+ * (An earlier shortcut, {@code (2 * exactDistinct - nonNull) / nonNull}, is only equivalent
+ * when no value occurs more than twice and undercounts otherwise.)
  *
  * <h3>stdDev</h3>
  *
- * <p>Uses Spark's {@code stddev_pop()} (population standard deviation, dividing by n). Deequ's
- * StandardDeviation metric also uses population stddev — verified against the baseline.
+ * <p>Uses Spark's {@code stddev_pop()} (population standard deviation, dividing by n).
+ * Deequ's StandardDeviation metric also uses population stddev; verified against the baseline.
  */
 public class ColumnProfiler {
 

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -132,7 +132,8 @@ class ProfileJsonSerializer {
   /**
    * Emits the uniqueness-family stats, omitting the keys when they were not computed
    * (exactUniqueness disabled) so consumers deserialize them as absent instead of a
-   * bogus 0. Divergence from Deequ's always-keys-present shape is deliberate.
+   * bogus 0.
+   * Divergence from Deequ's always-keys-present shape is deliberate.
    */
   private void putUniquenessFamily(Map<String, Object> map, ColumnProfile profile) {
     if (profile.getDistinctness() != null) {

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -34,6 +34,9 @@ import java.util.Map;
  * {@code column, dataType, isDataTypeInferred, completeness, numRecordsNonNull, numRecordsNull,
  * distinctness, entropy, uniqueness, approximateNumDistinctValues, exactNumDistinctValues,
  * mean, maximum, minimum, sum, stdDev, correlations, histogram, kll, approxPercentiles}.
+ * The uniqueness-family keys ({@code distinctness, entropy, uniqueness, exactNumDistinctValues})
+ * are omitted when exactUniqueness is disabled — a deliberate divergence from Deequ's
+ * always-keys-present shape, so consumers see them as absent instead of a bogus 0.
  *
  * <p>Categorical/Boolean columns omit {@code mean, maximum, minimum, sum, stdDev, correlations,
  * kll, approxPercentiles}.
@@ -89,11 +92,7 @@ class ProfileJsonSerializer {
     map.put("completeness", profile.getCompleteness());
     map.put("numRecordsNonNull", profile.getNumRecordsNonNull());
     map.put("numRecordsNull", profile.getNumRecordsNull());
-    map.put("distinctness", profile.getDistinctness());
-    map.put("entropy", profile.getEntropy());
-    map.put("uniqueness", profile.getUniqueness());
-    map.put("approximateNumDistinctValues", profile.getApproximateNumDistinctValues());
-    map.put("exactNumDistinctValues", profile.getExactNumDistinctValues());
+    putUniquenessFamily(map, profile);
     map.put("mean", profile.getMean());
     map.put("maximum", profile.getMaximum());
     map.put("minimum", profile.getMinimum());
@@ -123,15 +122,32 @@ class ProfileJsonSerializer {
     map.put("completeness", profile.getCompleteness());
     map.put("numRecordsNonNull", profile.getNumRecordsNonNull());
     map.put("numRecordsNull", profile.getNumRecordsNull());
-    map.put("distinctness", profile.getDistinctness());
-    map.put("entropy", profile.getEntropy());
-    map.put("uniqueness", profile.getUniqueness());
-    map.put("approximateNumDistinctValues", profile.getApproximateNumDistinctValues());
-    map.put("exactNumDistinctValues", profile.getExactNumDistinctValues());
+    putUniquenessFamily(map, profile);
     if (profile.getHistogram() != null) {
       map.put("histogram", profile.getHistogram());
     }
     return map;
+  }
+
+  /**
+   * Emits the uniqueness-family stats, omitting the keys when they were not computed
+   * (exactUniqueness disabled) so consumers deserialize them as absent instead of a
+   * bogus 0. Divergence from Deequ's always-keys-present shape is deliberate.
+   */
+  private void putUniquenessFamily(Map<String, Object> map, ColumnProfile profile) {
+    if (profile.getDistinctness() != null) {
+      map.put("distinctness", profile.getDistinctness());
+    }
+    if (profile.getEntropy() != null) {
+      map.put("entropy", profile.getEntropy());
+    }
+    if (profile.getUniqueness() != null) {
+      map.put("uniqueness", profile.getUniqueness());
+    }
+    map.put("approximateNumDistinctValues", profile.getApproximateNumDistinctValues());
+    if (profile.getExactNumDistinctValues() != null) {
+      map.put("exactNumDistinctValues", profile.getExactNumDistinctValues());
+    }
   }
 
   private List<Map<String, Object>> buildCorrelationsList(Map<String, Double> correlations) {

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -93,11 +93,16 @@ class ProfileJsonSerializer {
     map.put("numRecordsNonNull", profile.getNumRecordsNonNull());
     map.put("numRecordsNull", profile.getNumRecordsNull());
     putUniquenessFamily(map, profile);
-    map.put("mean", profile.getMean());
-    map.put("maximum", profile.getMaximum());
-    map.put("minimum", profile.getMinimum());
-    map.put("sum", profile.getSum());
-    map.put("stdDev", profile.getStdDev());
+    // Spark's avg/min/max/sum/stddev_pop return null over an all-null column.
+    // Emitting "mean": null (etc.) would crash the has()->getDouble() parsers
+    // (org.json has() is true for JSON null, getDouble throws on it), so omit
+    // the key instead: "absent = not computed", the same contract as the
+    // uniqueness family above.
+    putIfNotNull(map, "mean", profile.getMean());
+    putIfNotNull(map, "maximum", profile.getMaximum());
+    putIfNotNull(map, "minimum", profile.getMinimum());
+    putIfNotNull(map, "sum", profile.getSum());
+    putIfNotNull(map, "stdDev", profile.getStdDev());
     if (profile.getCorrelations() != null) {
       map.put("correlations", buildCorrelationsList(profile.getCorrelations()));
     }
@@ -148,6 +153,12 @@ class ProfileJsonSerializer {
     map.put("approximateNumDistinctValues", profile.getApproximateNumDistinctValues());
     if (profile.getExactNumDistinctValues() != null) {
       map.put("exactNumDistinctValues", profile.getExactNumDistinctValues());
+    }
+  }
+
+  private static void putIfNotNull(Map<String, Object> map, String key, Object value) {
+    if (value != null) {
+      map.put(key, value);
     }
   }
 

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -161,6 +161,48 @@ public class ColumnProfilerSmokeTest {
     Assertions.assertNull(cBool.get("kll"), "c_bool must NOT have kll field");
   }
 
+  @Test
+  void omitsUniquenessFamilyWhenExactUniquenessDisabled() throws Exception {
+    Dataset<Row> df = buildDataset();
+
+    String json = new ColumnProfiler().profile(df, null, false, false, 20, false, false);
+
+    JsonNode columns = new ObjectMapper().readTree(json).get("columns");
+    for (JsonNode col : columns) {
+      String name = col.get("column").asText();
+      Assertions.assertFalse(col.has("uniqueness"),
+          name + " must not emit 'uniqueness' when exactUniqueness is disabled");
+      Assertions.assertFalse(col.has("distinctness"),
+          name + " must not emit 'distinctness' when exactUniqueness is disabled");
+      Assertions.assertFalse(col.has("entropy"),
+          name + " must not emit 'entropy' when exactUniqueness is disabled");
+      Assertions.assertFalse(col.has("exactNumDistinctValues"),
+          name + " must not emit 'exactNumDistinctValues' when exactUniqueness is disabled");
+      Assertions.assertTrue(col.has("approximateNumDistinctValues"),
+          name + " must still emit 'approximateNumDistinctValues'");
+    }
+  }
+
+  @Test
+  void emitsUniquenessFamilyWhenExactUniquenessEnabled() throws Exception {
+    Dataset<Row> df = buildDataset();
+
+    String json = new ColumnProfiler().profile(df, null, false, false, 20, true, false);
+
+    JsonNode columns = new ObjectMapper().readTree(json).get("columns");
+    for (JsonNode col : columns) {
+      String name = col.get("column").asText();
+      Assertions.assertTrue(col.has("uniqueness"),
+          name + " must emit 'uniqueness' when exactUniqueness is enabled");
+      Assertions.assertTrue(col.has("distinctness"),
+          name + " must emit 'distinctness' when exactUniqueness is enabled");
+      Assertions.assertTrue(col.has("entropy"),
+          name + " must emit 'entropy' when exactUniqueness is enabled");
+      Assertions.assertTrue(col.has("exactNumDistinctValues"),
+          name + " must emit 'exactNumDistinctValues' when exactUniqueness is enabled");
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -203,6 +203,31 @@ public class ColumnProfilerSmokeTest {
     }
   }
 
+  @Test
+  void uniquenessCountsSingletonsWithHighMultiplicity() throws Exception {
+    // 15 values; 5 occurs three times, 4/3/2/1 twice, 9/8/7/6 once.
+    // Deequ uniqueness = singletons / nonNull = 4/15. The former shortcut
+    // (2*distinct - n)/n gave 3/15 whenever a value occurred more than twice.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("col_1", DataTypes.IntegerType, true),
+    });
+    int[] values = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1, 9, 8, 7, 6, 5};
+    List<Row> rows = new ArrayList<>(values.length);
+    for (int value : values) {
+      rows.add(RowFactory.create(value));
+    }
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, false, 20, true, false);
+
+    JsonNode col = findColumn(new ObjectMapper().readTree(json).get("columns"), "col_1");
+    Assertions.assertNotNull(col);
+    Assertions.assertEquals(4.0 / 15.0, col.get("uniqueness").asDouble(), 1e-9,
+        "uniqueness must be the exact singleton fraction");
+    Assertions.assertEquals(9.0 / 15.0, col.get("distinctness").asDouble(), 1e-9);
+    Assertions.assertEquals(9, col.get("exactNumDistinctValues").asLong());
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/python/hsfs/core/delta_engine.py
+++ b/python/hsfs/core/delta_engine.py
@@ -272,14 +272,14 @@ class DeltaEngine:
             and delta_fg_alias.left_feature_group_start_timestamp is None
         ):
             # snapshot query with end time; resolve the version against the Delta
-            # log's in-commit timestamps instead of passing timestampAsOf. Delta
-            # resolves timestamp bounds against commit-file modification times,
-            # while the backend-recorded commit_time carries the log's in-commit
-            # commitInfo timestamp, which is tens to hundreds of milliseconds
-            # earlier — enough for timestampAsOf to silently resolve to the
-            # previous version (or to be rejected outright when it predates the
-            # first commit, which happens when compute_statistics runs right
-            # after a fresh insert).
+            # log's in-commit timestamps instead of passing timestampAsOf.
+            # Delta resolves timestamp bounds against commit-file modification
+            # times, while the backend-recorded commit_time carries the log's
+            # in-commit commitInfo timestamp, which is tens to hundreds of
+            # milliseconds earlier: enough for timestampAsOf to silently resolve
+            # to the previous version (or to be rejected outright when it
+            # predates the first commit, which happens when compute_statistics
+            # runs right after a fresh insert).
             end_ts = delta_fg_alias.left_feature_group_end_timestamp
             commits = self._get_delta_commits(location) if location else None
             if commits:

--- a/python/hsfs/core/delta_engine.py
+++ b/python/hsfs/core/delta_engine.py
@@ -343,15 +343,28 @@ class DeltaEngine:
         try:
             if self._spark_session is not None:
                 from pyspark.sql import functions as F  # noqa: PLC0415
-
-                log_df = self._spark_session.read.json(
-                    location.rstrip("/") + "/_delta_log/*.json"
+                from pyspark.sql.types import (  # noqa: PLC0415
+                    LongType,
+                    StructField,
+                    StructType,
                 )
-                if "commitInfo" not in log_df.columns:
-                    return None
+
+                # explicit schema: avoids inferring/parsing the large
+                # add/remove action payloads and tolerates commitInfo rows
+                # without a timestamp
+                log_schema = StructType(
+                    [
+                        StructField(
+                            "commitInfo",
+                            StructType([StructField("timestamp", LongType())]),
+                        )
+                    ]
+                )
                 rows = (
-                    log_df.withColumn("_file", F.input_file_name())
-                    .filter(F.col("commitInfo").isNotNull())
+                    self._spark_session.read.schema(log_schema)
+                    .json(location.rstrip("/") + "/_delta_log/*.json")
+                    .withColumn("_file", F.input_file_name())
+                    .filter(F.col("commitInfo.timestamp").isNotNull())
                     .withColumn(
                         "version",
                         F.regexp_extract(F.col("_file"), r"(\d+)\.json", 1).cast(

--- a/python/hsfs/core/delta_engine.py
+++ b/python/hsfs/core/delta_engine.py
@@ -271,17 +271,25 @@ class DeltaEngine:
             delta_fg_alias.left_feature_group_end_timestamp is not None
             and delta_fg_alias.left_feature_group_start_timestamp is None
         ):
-            # snapshot query with end time
+            # snapshot query with end time; resolve the version against the Delta
+            # history instead of passing timestampAsOf. Delta resolves timestamp
+            # bounds against commit-file modification times, while the
+            # backend-recorded commit_time comes from history()'s in-commit
+            # timestamp, which can be tens of milliseconds earlier — enough for
+            # timestampAsOf to silently resolve to the previous version (or to be
+            # rejected outright when it predates the first commit, which happens
+            # when compute_statistics runs right after a fresh insert).
             end_ts = delta_fg_alias.left_feature_group_end_timestamp
-            earliest = self._get_delta_earliest_commit(location) if location else None
-            if earliest is not None and end_ts <= earliest[1]:
-                # Requested time predates the Delta log's first commit.
-                # Happens when compute_statistics runs immediately after a fresh
-                # insert: the backend-recorded commit_time can be a few ms before
-                # the Delta log's first commit, and Delta rejects timestampAsOf
-                # in that range. Fall back to versionAsOf on the earliest commit.
+            commits = self._get_delta_commits(location) if location else None
+            if commits:
+                # latest version committed at or before end_ts; when end_ts
+                # predates the first history timestamp, pin the earliest version
+                version = commits[0][0]
+                for commit_version, commit_ts in commits:
+                    if commit_ts <= end_ts:
+                        version = commit_version
                 delta_options = {
-                    self.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: earliest[0],
+                    self.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: version,
                 }
             else:
                 _delta_commit_end_time = util._get_delta_datestr_from_timestamp(end_ts)
@@ -317,11 +325,13 @@ class DeltaEngine:
 
         return delta_options
 
-    def _get_delta_earliest_commit(self, location: str):
-        """Get earliest commit from the Delta log.
+    def _get_delta_commits(self, location: str):
+        """Get all commits from the Delta log.
 
-        Return (version, timestamp_ms) of the earliest commit in the Delta
-        log at `location`, or None if the history cannot be read.
+        Return a list of (version, timestamp_ms) tuples sorted by version
+        ascending, or None if the history cannot be read or is empty.
+        The timestamps come from the history's in-commit timestamps, the same
+        source the backend-recorded commit times are derived from.
         """
         try:
             if self._spark_session is not None:
@@ -333,26 +343,37 @@ class DeltaEngine:
                     .select("version", "timestamp")
                     .collect()
                 )
-                if not rows:
-                    return None
-                oldest = min(rows, key=lambda r: r["version"])
-                return int(oldest["version"]), int(
-                    oldest["timestamp"].timestamp() * 1000
-                )
+                commits = [
+                    (int(row["version"]), int(row["timestamp"].timestamp() * 1000))
+                    for row in rows
+                ]
+            else:
+                from deltalake import DeltaTable as DeltaRsTable
 
-            from deltalake import DeltaTable as DeltaRsTable
-
-            history = DeltaRsTable(location, storage_options={}).history()
-            if not history:
+                history = DeltaRsTable(location, storage_options={}).history()
+                commits = [
+                    (
+                        int(commit["version"]),
+                        int(util._convert_event_time_to_timestamp(commit["timestamp"])),
+                    )
+                    for commit in history
+                ]
+            if not commits:
                 return None
-            oldest = min(history, key=lambda c: c["version"])
-            return (
-                int(oldest["version"]),
-                int(util._convert_event_time_to_timestamp(oldest["timestamp"])),
-            )
+            commits.sort(key=lambda commit: commit[0])
+            return commits
         except Exception as e:
             _logger.debug(f"Could not read Delta history at {location}: {e}")
             return None
+
+    def _get_delta_earliest_commit(self, location: str):
+        """Get earliest commit from the Delta log.
+
+        Return (version, timestamp_ms) of the earliest commit in the Delta
+        log at `location`, or None if the history cannot be read.
+        """
+        commits = self._get_delta_commits(location)
+        return commits[0] if commits else None
 
     def _delete_record(self, delete_df):
         partition_transforms._require_writable(self._feature_group)

--- a/python/hsfs/core/delta_engine.py
+++ b/python/hsfs/core/delta_engine.py
@@ -272,13 +272,14 @@ class DeltaEngine:
             and delta_fg_alias.left_feature_group_start_timestamp is None
         ):
             # snapshot query with end time; resolve the version against the Delta
-            # history instead of passing timestampAsOf. Delta resolves timestamp
-            # bounds against commit-file modification times, while the
-            # backend-recorded commit_time comes from history()'s in-commit
-            # timestamp, which can be tens of milliseconds earlier — enough for
-            # timestampAsOf to silently resolve to the previous version (or to be
-            # rejected outright when it predates the first commit, which happens
-            # when compute_statistics runs right after a fresh insert).
+            # log's in-commit timestamps instead of passing timestampAsOf. Delta
+            # resolves timestamp bounds against commit-file modification times,
+            # while the backend-recorded commit_time carries the log's in-commit
+            # commitInfo timestamp, which is tens to hundreds of milliseconds
+            # earlier — enough for timestampAsOf to silently resolve to the
+            # previous version (or to be rejected outright when it predates the
+            # first commit, which happens when compute_statistics runs right
+            # after a fresh insert).
             end_ts = delta_fg_alias.left_feature_group_end_timestamp
             commits = self._get_delta_commits(location) if location else None
             if commits:
@@ -329,25 +330,41 @@ class DeltaEngine:
         """Get all commits from the Delta log.
 
         Return a list of (version, timestamp_ms) tuples sorted by version
-        ascending, or None if the history cannot be read or is empty.
-        The timestamps come from the history's in-commit timestamps, the same
-        source the backend-recorded commit times are derived from.
+        ascending, or None if the log cannot be read or is empty.
+
+        The timestamps are the log's in-commit ``commitInfo.timestamp`` values,
+        the same clock the backend-recorded commit times are derived from.
+        ``DeltaTable.history()`` is deliberately NOT used here: its timestamp
+        column carries the commit-file modification time, which lags the
+        in-commit timestamp (tens to hundreds of milliseconds on HopsFS), so
+        resolving a recorded commit time against it can silently land on the
+        previous version.
         """
         try:
             if self._spark_session is not None:
-                from delta.tables import DeltaTable
+                from pyspark.sql import functions as F  # noqa: PLC0415
 
+                log_df = self._spark_session.read.json(
+                    location.rstrip("/") + "/_delta_log/*.json"
+                )
+                if "commitInfo" not in log_df.columns:
+                    return None
                 rows = (
-                    DeltaTable.forPath(self._spark_session, location)
-                    .history()
-                    .select("version", "timestamp")
+                    log_df.withColumn("_file", F.input_file_name())
+                    .filter(F.col("commitInfo").isNotNull())
+                    .withColumn(
+                        "version",
+                        F.regexp_extract(F.col("_file"), r"(\d+)\.json", 1).cast(
+                            "long"
+                        ),
+                    )
+                    .select("version", F.col("commitInfo.timestamp").alias("timestamp"))
                     .collect()
                 )
-                commits = [
-                    (int(row["version"]), int(row["timestamp"].timestamp() * 1000))
-                    for row in rows
-                ]
+                commits = [(int(row["version"]), int(row["timestamp"])) for row in rows]
             else:
+                # delta-rs reads the commit timestamps from the log itself, so
+                # its history() is already on the in-commit clock
                 from deltalake import DeltaTable as DeltaRsTable
 
                 history = DeltaRsTable(location, storage_options={}).history()
@@ -363,7 +380,7 @@ class DeltaEngine:
             commits.sort(key=lambda commit: commit[0])
             return commits
         except Exception as e:
-            _logger.debug(f"Could not read Delta history at {location}: {e}")
+            _logger.debug(f"Could not read Delta log at {location}: {e}")
             return None
 
     def _get_delta_earliest_commit(self, location: str):

--- a/python/hsfs/core/delta_engine.py
+++ b/python/hsfs/core/delta_engine.py
@@ -199,13 +199,15 @@ class DeltaEngine:
             # CDC query - remove duplicates for upserts and do not include deleted rows
             # to match behavior of other engines.
             #
-            # Why retry: Delta's CDF lower-bound check uses the commit file modification
-            # time, while DeltaTable.history() returns the in-commit creation timestamp.
-            # On a freshly-created table these can differ by tens of milliseconds, so a
-            # pre-flight comparison against history() cannot reliably predict whether
-            # Delta will accept the startingTimestamp. Instead we attempt the read with
-            # startingTimestamp and, if Delta rejects it with the "before the earliest
-            # version" error, retry from the earliest commit version (startingVersion).
+            # Why retry: Delta's CDF lower-bound check and DeltaTable.history()
+            # both report the commit-file modification time (without in-commit
+            # timestamps enabled), while the startingTimestamp we pass derives
+            # from the backend-recorded commit_time, which is ~200 ms earlier.
+            # A pre-flight comparison against history() therefore cannot reliably
+            # predict whether Delta will accept the startingTimestamp. Instead we
+            # attempt the read with startingTimestamp and, if Delta rejects it
+            # with the "before the earliest version" error, retry from the
+            # earliest commit version (startingVersion).
             def _do_cdf_read(opts):
                 return (
                     self._spark_session.read.format(self.DELTA_SPARK_FORMAT)
@@ -283,12 +285,21 @@ class DeltaEngine:
             end_ts = delta_fg_alias.left_feature_group_end_timestamp
             commits = self._get_delta_commits(location) if location else None
             if commits:
-                # latest version committed at or before end_ts; when end_ts
-                # predates the first history timestamp, pin the earliest version
+                # Highest version committed at or before end_ts.
+                # commitInfo timestamps are not guaranteed monotonic in version
+                # (concurrent writers / commit retries), so stop at the first
+                # commit past end_ts rather than letting a later out-of-order
+                # commit select too high a version.
+                # When end_ts predates every commit the earliest version is
+                # pinned; if the window genuinely ended before the first commit
+                # this reads post-window data instead of returning empty
+                # (indistinguishable here from clock skew, and mirrors the
+                # Iceberg earliest-snapshot fallback).
                 version = commits[0][0]
                 for commit_version, commit_ts in commits:
-                    if commit_ts <= end_ts:
-                        version = commit_version
+                    if commit_ts > end_ts:
+                        break
+                    version = commit_version
                 delta_options = {
                     self.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: version,
                 }
@@ -339,6 +350,10 @@ class DeltaEngine:
         in-commit timestamp (tens to hundreds of milliseconds on HopsFS), so
         resolving a recorded commit time against it can silently land on the
         previous version.
+        History's modtime clock diverges for tables written by classic Spark
+        (only delta-rs and the Spark Connect writer record the in-commit clock),
+        so reading ``commitInfo.timestamp`` from the log directly is what keeps
+        resolution correct for the pyspark-driver variants too.
         """
         try:
             if self._spark_session is not None:
@@ -366,11 +381,16 @@ class DeltaEngine:
                     .withColumn("_file", F.input_file_name())
                     .filter(F.col("commitInfo.timestamp").isNotNull())
                     .withColumn(
+                        # anchor on the 20-digit commit basename so V2 checkpoint
+                        # manifests (<v>.checkpoint.<uuid>.json) and log-compaction
+                        # files (<x>.<y>.compacted.json) do not match and yield a
+                        # bogus version
                         "version",
-                        F.regexp_extract(F.col("_file"), r"(\d+)\.json", 1).cast(
+                        F.regexp_extract(F.col("_file"), r"(\d{20})\.json$", 1).cast(
                             "long"
                         ),
                     )
+                    .filter(F.col("version").isNotNull())
                     .select("version", F.col("commitInfo.timestamp").alias("timestamp"))
                     .collect()
                 )

--- a/python/hsfs/core/feature_descriptive_statistics.py
+++ b/python/hsfs/core/feature_descriptive_statistics.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import json
+import math
 from typing import TYPE_CHECKING
 
 import humps
@@ -25,6 +26,17 @@ from hsfs import util
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+
+def _finite_or_none(value):
+    """Map non-finite numbers (NaN, Infinity) to None.
+
+    Non-finite values are not valid JSON and not valid SQL numerics: a single
+    one aborts the whole statistics registration on the backend.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    return value
 
 
 @public
@@ -187,25 +199,30 @@ class FeatureDescriptiveStatistics:
         return cls(**stats_dict)
 
     def to_dict(self):
+        percentiles = self._percentiles
+        if isinstance(percentiles, dict):
+            percentiles = {k: _finite_or_none(v) for k, v in percentiles.items()}
+        elif isinstance(percentiles, list):
+            percentiles = [_finite_or_none(v) for v in percentiles]
         _dict = {
             "id": self._id,
             "featureName": self._feature_name,
             "count": self._count,
             "featureType": self._feature_type,
-            "min": self._min,
-            "max": self._max,
-            "sum": self._sum,
-            "mean": self._mean,
-            "stdDev": self._std_dev,
-            "completeness": self._completeness,
+            "min": _finite_or_none(self._min),
+            "max": _finite_or_none(self._max),
+            "sum": _finite_or_none(self._sum),
+            "mean": _finite_or_none(self._mean),
+            "stdDev": _finite_or_none(self._std_dev),
+            "completeness": _finite_or_none(self._completeness),
             "numNonNullValues": self._num_non_null_values,
             "numNullValues": self._num_null_values,
-            "distinctness": self._distinctness,
-            "entropy": self._entropy,
-            "uniqueness": self._uniqueness,
+            "distinctness": _finite_or_none(self._distinctness),
+            "entropy": _finite_or_none(self._entropy),
+            "uniqueness": _finite_or_none(self._uniqueness),
             "approxNumDistinctValues": self._approx_num_distinct_values,
             "exactNumDistinctValues": self._exact_num_distinct_values,
-            "percentiles": self._percentiles,
+            "percentiles": percentiles,
         }
         if self._extended_statistics is not None:
             _dict["extendedStatistics"] = json.dumps(self._extended_statistics)

--- a/python/hsfs/core/feature_descriptive_statistics.py
+++ b/python/hsfs/core/feature_descriptive_statistics.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import math
+import numbers
 from typing import TYPE_CHECKING
 
 import humps
@@ -34,7 +35,7 @@ def _finite_or_none(value):
     Non-finite values are not valid JSON and not valid SQL numerics: a single
     one aborts the whole statistics registration on the backend.
     """
-    if isinstance(value, float) and not math.isfinite(value):
+    if isinstance(value, numbers.Real) and not math.isfinite(value):
         return None
     return value
 

--- a/python/hsfs/core/feature_monitoring_result_engine.py
+++ b/python/hsfs/core/feature_monitoring_result_engine.py
@@ -551,6 +551,10 @@ class FeatureMonitoringResultEngine:
             if specific_value is not None
             else reference_statistics.get_value(metric_lower)
         )
+        if detection_value is None or reference_value is None:
+            # the metric was not computed on one of the sides (e.g. uniqueness
+            # metrics when exact_uniqueness is disabled)
+            return None
         return self._compute_difference_between_specific_values(
             detection_value, reference_value, relative
         )

--- a/python/hsfs/core/iceberg_engine.py
+++ b/python/hsfs/core/iceberg_engine.py
@@ -955,28 +955,25 @@ class IcebergEngine:
         ):
             # snapshot query with end time; Iceberg expects epoch milliseconds
             end_ts = iceberg_fg_alias.left_feature_group_end_timestamp
-            if self._resolve_snapshot_id_at(location, end_ts) is not None:
-                iceberg_options = {
-                    self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts),
-                }
-            else:
+            snapshots = self._read_snapshots(location)
+            if snapshots and (
+                util._convert_event_time_to_timestamp(snapshots[0]["committed_at"])
+                > end_ts
+            ):
                 # Requested time predates the table's first snapshot.
                 # Happens when compute_statistics runs immediately after a fresh
                 # insert: the backend-recorded commit_time can be a few ms before
                 # the first snapshot's commit, and Iceberg rejects as-of-timestamp
                 # in that range. Fall back to reading the earliest snapshot.
-                snapshots = self._read_snapshots(location)
-                if snapshots:
-                    iceberg_options = {
-                        self.ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID: str(
-                            snapshots[0]["snapshot_id"]
-                        ),
-                    }
-                else:
-                    # no snapshots at all; keep the timestamp bound
-                    iceberg_options = {
-                        self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts),
-                    }
+                iceberg_options = {
+                    self.ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID: str(
+                        snapshots[0]["snapshot_id"]
+                    ),
+                }
+            else:
+                iceberg_options = {
+                    self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts),
+                }
         elif iceberg_fg_alias.left_feature_group_start_timestamp is not None:
             # incremental query; Iceberg only supports snapshot-id bounds,
             # so the wallclock bounds are resolved against the snapshot log

--- a/python/hsfs/core/iceberg_engine.py
+++ b/python/hsfs/core/iceberg_engine.py
@@ -954,26 +954,9 @@ class IcebergEngine:
             and iceberg_fg_alias.left_feature_group_start_timestamp is None
         ):
             # snapshot query with end time; Iceberg expects epoch milliseconds
-            end_ts = iceberg_fg_alias.left_feature_group_end_timestamp
-            snapshots = self._read_snapshots(location)
-            if snapshots and (
-                util._convert_event_time_to_timestamp(snapshots[0]["committed_at"])
-                > end_ts
-            ):
-                # Requested time predates the table's first snapshot.
-                # Happens when compute_statistics runs immediately after a fresh
-                # insert: the backend-recorded commit_time can be a few ms before
-                # the first snapshot's commit, and Iceberg rejects as-of-timestamp
-                # in that range. Fall back to reading the earliest snapshot.
-                iceberg_options = {
-                    self.ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID: str(
-                        snapshots[0]["snapshot_id"]
-                    ),
-                }
-            else:
-                iceberg_options = {
-                    self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts),
-                }
+            iceberg_options = self._snapshot_read_opts_at(
+                location, iceberg_fg_alias.left_feature_group_end_timestamp
+            )
         elif iceberg_fg_alias.left_feature_group_start_timestamp is not None:
             # incremental query; Iceberg only supports snapshot-id bounds,
             # so the wallclock bounds are resolved against the snapshot log
@@ -981,19 +964,31 @@ class IcebergEngine:
                 location, iceberg_fg_alias.left_feature_group_start_timestamp
             )
             if start_snapshot_id is None:
-                raise FeatureStoreException(
-                    "Cannot run the incremental query: no Iceberg snapshot exists at or before "
-                    f"the start time {iceberg_fg_alias.left_feature_group_start_timestamp}."
+                # The window starts before the table's first snapshot (e.g. a
+                # rolling monitoring window on a fresh table). start-snapshot-id
+                # is exclusive, so the first snapshot's changes cannot be part
+                # of an incremental scan; read the table state at the end bound
+                # instead, which equals the window content when every commit is
+                # inside the window (mirrors the Delta CDF earliest-version
+                # fallback).
+                end_ts = iceberg_fg_alias.left_feature_group_end_timestamp
+                iceberg_options = (
+                    self._snapshot_read_opts_at(location, end_ts)
+                    if end_ts is not None
+                    else {}
                 )
-            iceberg_options = {
-                self.ICEBERG_START_SNAPSHOT_ID: str(start_snapshot_id),
-            }
-            if iceberg_fg_alias.left_feature_group_end_timestamp is not None:
-                end_snapshot_id = self._resolve_snapshot_id_at(
-                    location, iceberg_fg_alias.left_feature_group_end_timestamp
-                )
-                if end_snapshot_id is not None:
-                    iceberg_options[self.ICEBERG_END_SNAPSHOT_ID] = str(end_snapshot_id)
+            else:
+                iceberg_options = {
+                    self.ICEBERG_START_SNAPSHOT_ID: str(start_snapshot_id),
+                }
+                if iceberg_fg_alias.left_feature_group_end_timestamp is not None:
+                    end_snapshot_id = self._resolve_snapshot_id_at(
+                        location, iceberg_fg_alias.left_feature_group_end_timestamp
+                    )
+                    if end_snapshot_id is not None:
+                        iceberg_options[self.ICEBERG_END_SNAPSHOT_ID] = str(
+                            end_snapshot_id
+                        )
 
         if read_options:
             for key in read_options:
@@ -1010,6 +1005,26 @@ class IcebergEngine:
         )
 
         return iceberg_options
+
+    def _snapshot_read_opts_at(self, location: str, end_ts: int) -> dict[str, str]:
+        """Read options pinning the table state at *end_ts*.
+
+        A time that predates the table's first snapshot pins the earliest
+        snapshot by id instead: compute_statistics runs right after a fresh
+        insert, and the backend-recorded commit_time can be a few ms before
+        the first snapshot's commit, a range where Iceberg rejects
+        as-of-timestamp.
+        """
+        snapshots = self._read_snapshots(location)
+        if snapshots and (
+            util._convert_event_time_to_timestamp(snapshots[0]["committed_at"]) > end_ts
+        ):
+            return {
+                self.ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID: str(
+                    snapshots[0]["snapshot_id"]
+                ),
+            }
+        return {self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts)}
 
     @staticmethod
     def _is_catalog_identifier(address: str) -> bool:

--- a/python/hsfs/core/iceberg_engine.py
+++ b/python/hsfs/core/iceberg_engine.py
@@ -220,6 +220,7 @@ class IcebergEngine:
     ICEBERG_SPARK_FORMAT = "iceberg"
     ICEBERG_SPARK_CATALOG_IMPL = "org.apache.iceberg.spark.SparkCatalog"
     ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP = "as-of-timestamp"
+    ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID = "snapshot-id"
     ICEBERG_START_SNAPSHOT_ID = "start-snapshot-id"
     ICEBERG_END_SNAPSHOT_ID = "end-snapshot-id"
     ICEBERG_DOT_PREFIX = "iceberg."
@@ -953,11 +954,29 @@ class IcebergEngine:
             and iceberg_fg_alias.left_feature_group_start_timestamp is None
         ):
             # snapshot query with end time; Iceberg expects epoch milliseconds
-            iceberg_options = {
-                self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(
-                    iceberg_fg_alias.left_feature_group_end_timestamp
-                ),
-            }
+            end_ts = iceberg_fg_alias.left_feature_group_end_timestamp
+            if self._resolve_snapshot_id_at(location, end_ts) is not None:
+                iceberg_options = {
+                    self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts),
+                }
+            else:
+                # Requested time predates the table's first snapshot.
+                # Happens when compute_statistics runs immediately after a fresh
+                # insert: the backend-recorded commit_time can be a few ms before
+                # the first snapshot's commit, and Iceberg rejects as-of-timestamp
+                # in that range. Fall back to reading the earliest snapshot.
+                snapshots = self._read_snapshots(location)
+                if snapshots:
+                    iceberg_options = {
+                        self.ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID: str(
+                            snapshots[0]["snapshot_id"]
+                        ),
+                    }
+                else:
+                    # no snapshots at all; keep the timestamp bound
+                    iceberg_options = {
+                        self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts),
+                    }
         elif iceberg_fg_alias.left_feature_group_start_timestamp is not None:
             # incremental query; Iceberg only supports snapshot-id bounds,
             # so the wallclock bounds are resolved against the snapshot log

--- a/python/hsfs/core/iceberg_engine.py
+++ b/python/hsfs/core/iceberg_engine.py
@@ -1007,22 +1007,34 @@ class IcebergEngine:
         return iceberg_options
 
     def _snapshot_read_opts_at(self, location: str, end_ts: int) -> dict[str, str]:
-        """Read options pinning the table state at *end_ts*.
+        """Read options pinning the table state at *end_ts* by snapshot id.
 
-        A time before the first snapshot pins the earliest snapshot by id.
-        Fresh inserts record commit times a few ms before the first snapshot.
-        Iceberg rejects as-of-timestamp in that range.
+        The snapshot is resolved client-side against the snapshots' own
+        ``committed_at`` clock, the clock the backend derives the recorded
+        commit time from.
+        Passing ``as-of-timestamp`` instead lets Iceberg resolve the bound
+        server-side against the snapshot-log timestamps, a different clock: a
+        recorded commit time landing just below snapshot N's log timestamp
+        would then silently read snapshot N-1.
+        Resolving here keeps registration and read on one clock, so mid-range
+        resolution is exact.
+
+        When *end_ts* precedes every snapshot the earliest snapshot is pinned.
+        That covers the fresh-insert case (commit times recorded a few ms
+        before the first snapshot) but also a window that genuinely ended
+        before the first commit, which then reads data committed after the
+        window instead of coming back empty.
+        This mirrors the Delta earliest-version fallback and is indistinguishable
+        client-side from the skew case.
+        Only a table with no snapshots at all keeps the timestamp bound.
         """
         snapshots = self._read_snapshots(location)
-        if snapshots and (
-            util._convert_event_time_to_timestamp(snapshots[0]["committed_at"]) > end_ts
-        ):
-            return {
-                self.ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID: str(
-                    snapshots[0]["snapshot_id"]
-                ),
-            }
-        return {self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts)}
+        if not snapshots:
+            return {self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts)}
+        snapshot_id = self._latest_snapshot_id_at(snapshots, end_ts)
+        if snapshot_id is None:
+            snapshot_id = snapshots[0]["snapshot_id"]
+        return {self.ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID: str(snapshot_id)}
 
     @staticmethod
     def _is_catalog_identifier(address: str) -> bool:
@@ -1052,8 +1064,19 @@ class IcebergEngine:
 
     def _resolve_snapshot_id_at(self, location: str, timestamp: int) -> int | None:
         """Return the id of the latest snapshot committed at or before *timestamp*."""
+        return self._latest_snapshot_id_at(self._read_snapshots(location), timestamp)
+
+    @staticmethod
+    def _latest_snapshot_id_at(
+        snapshots: list[dict[str, Any]], timestamp: int
+    ) -> int | None:
+        """Id of the latest snapshot committed at or before *timestamp*.
+
+        Returns None when *timestamp* precedes every snapshot.
+        Expects *snapshots* ordered oldest first.
+        """
         snapshot_id = None
-        for snapshot in self._read_snapshots(location):
+        for snapshot in snapshots:
             committed_at = util._convert_event_time_to_timestamp(
                 snapshot["committed_at"]
             )

--- a/python/hsfs/core/iceberg_engine.py
+++ b/python/hsfs/core/iceberg_engine.py
@@ -1009,11 +1009,9 @@ class IcebergEngine:
     def _snapshot_read_opts_at(self, location: str, end_ts: int) -> dict[str, str]:
         """Read options pinning the table state at *end_ts*.
 
-        A time that predates the table's first snapshot pins the earliest
-        snapshot by id instead: compute_statistics runs right after a fresh
-        insert, and the backend-recorded commit_time can be a few ms before
-        the first snapshot's commit, a range where Iceberg rejects
-        as-of-timestamp.
+        A time before the first snapshot pins the earliest snapshot by id.
+        Fresh inserts record commit times a few ms before the first snapshot.
+        Iceberg rejects as-of-timestamp in that range.
         """
         snapshots = self._read_snapshots(location)
         if snapshots and (

--- a/python/hsfs/core/statistics_engine.py
+++ b/python/hsfs/core/statistics_engine.py
@@ -607,7 +607,7 @@ class StatisticsEngine:
 
     def _parse_deequ_statistics(
         self, stats, exact_uniqueness: bool
-    ) -> list[FeatureDescriptiveStatistics]:
+    ) -> list[FeatureDescriptiveStatistics] | None:
         if stats is None:
             warnings.warn(
                 "There is no Deequ statistics to deserialize. A possible cause might be that Deequ did not succeed in the statistics computation.",

--- a/python/hsfs/core/statistics_engine.py
+++ b/python/hsfs/core/statistics_engine.py
@@ -94,7 +94,9 @@ class StatisticsEngine:
             stats_str = self._profile_statistics_with_config(
                 feature_dataframe, metadata_instance.statistics_config
             )
-            desc_stats = self._parse_deequ_statistics(stats_str)
+            desc_stats = self._parse_deequ_statistics(
+                stats_str, metadata_instance.statistics_config.exact_uniqueness
+            )
             if desc_stats:
                 stats = statistics.Statistics(
                     computation_time=computation_time,
@@ -185,7 +187,7 @@ class StatisticsEngine:
                 kll=kll,
                 histogram_bins=histogram_bins,
             )
-            desc_stats = self._parse_deequ_statistics(stats_str)
+            desc_stats = self._parse_deequ_statistics(stats_str, exact_uniqueness)
 
             stats = statistics.Statistics(
                 computation_time=commit_time,
@@ -298,7 +300,9 @@ class StatisticsEngine:
                 ),
                 td_metadata_instance.statistics_config,
             )
-            desc_stats = self._parse_deequ_statistics(stats_str)
+            desc_stats = self._parse_deequ_statistics(
+                stats_str, td_metadata_instance.statistics_config.exact_uniqueness
+            )
             statistics_of_splits.append(
                 split_statistics.SplitStatistics(
                     name=split_name,
@@ -365,7 +369,8 @@ class StatisticsEngine:
         stats_str = self._profile_transformation_fn_statistics(
             feature_dataframe, columns, label_encoder_features
         )
-        desc_stats = self._parse_deequ_statistics(stats_str)
+        # _profile_transformation_fn_statistics profiles with exact_uniqueness=False
+        desc_stats = self._parse_deequ_statistics(stats_str, False)
         return statistics.Statistics(
             computation_time=computation_time,
             feature_descriptive_statistics=desc_stats,
@@ -600,7 +605,9 @@ class StatisticsEngine:
             )
         return stats
 
-    def _parse_deequ_statistics(self, stats) -> list[FeatureDescriptiveStatistics]:
+    def _parse_deequ_statistics(
+        self, stats, exact_uniqueness: bool
+    ) -> list[FeatureDescriptiveStatistics]:
         if stats is None:
             warnings.warn(
                 "There is no Deequ statistics to deserialize. A possible cause might be that Deequ did not succeed in the statistics computation.",
@@ -610,6 +617,18 @@ class StatisticsEngine:
             return None
         if isinstance(stats, str):
             stats = json.loads(stats)
+        if not exact_uniqueness:
+            # The JVM deequ profiler emits uniqueness-family metrics even when
+            # the Uniqueness analyzer was not requested; drop them so they stay
+            # None instead of a spurious 0.0.
+            for col_stats in stats["columns"]:
+                for key in (
+                    "uniqueness",
+                    "distinctness",
+                    "entropy",
+                    "exactNumDistinctValues",
+                ):
+                    col_stats.pop(key, None)
         return [
             FeatureDescriptiveStatistics._from_deequ_json(col_stats)
             for col_stats in stats["columns"]

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1009,25 +1009,24 @@ class Engine:
         if "count" in stat:
             content_dict["count"] = stat["count"]
         if dataType != "String":
-            if "25%" in stat:
+            # pandas emits NaN for the statistics of all-null or constant
+            # columns; skip those values so they are not serialized (NaN is
+            # not valid JSON and aborts the statistics registration)
+            if "25%" in stat and not pd.isna(stat["25%"]):
                 percentiles = [0] * 100
                 percentiles[24] = stat["25%"]
                 percentiles[49] = stat["50%"]
                 percentiles[74] = stat["75%"]
                 content_dict["approxPercentiles"] = percentiles
-            if "mean" in stat:
+            if "mean" in stat and not pd.isna(stat["mean"]):
                 content_dict["mean"] = stat["mean"]
-            if (
-                "mean" in stat
-                and "count" in stat
-                and isinstance(stat["mean"], numbers.Number)
-            ):
-                content_dict["sum"] = stat["mean"] * stat["count"]
-            if "max" in stat:
+                if "count" in stat and isinstance(stat["mean"], numbers.Number):
+                    content_dict["sum"] = stat["mean"] * stat["count"]
+            if "max" in stat and not pd.isna(stat["max"]):
                 content_dict["maximum"] = stat["max"]
             if "std" in stat and not pd.isna(stat["std"]):
                 content_dict["stdDev"] = stat["std"]
-            if "min" in stat:
+            if "min" in stat and not pd.isna(stat["min"]):
                 content_dict["minimum"] = stat["min"]
         if "unique" in stat:
             content_dict["approximateNumDistinctValues"] = stat["unique"]

--- a/python/tests/core/test_delta_engine.py
+++ b/python/tests/core/test_delta_engine.py
@@ -383,7 +383,7 @@ class TestDeltaEngine:
 
     def test_setup_delta_read_opts_end_before_earliest_uses_version(self, mocker):
         # Snapshot-with-end counterpart of the same skew: an end time before the
-        # Delta log's first commit falls back to versionAsOf on the earliest commit.
+        # Delta log's first commit pins versionAsOf on the earliest commit.
         # Arrange
         _patch_client(mocker, is_external=False)
         fg = _make_fg("hopsfs://nn:8020/p")
@@ -391,15 +391,54 @@ class TestDeltaEngine:
         alias = mock.Mock()
         alias.left_feature_group_start_timestamp = None
         alias.left_feature_group_end_timestamp = 1000
-        mocker.patch.object(
-            engine, "_get_delta_earliest_commit", return_value=(3, 2000)
-        )
+        mocker.patch.object(engine, "_get_delta_commits", return_value=[(3, 2000)])
 
         # Act
         result = engine._setup_delta_read_opts(alias, "hopsfs://nn:8020/p")
 
         # Assert
         assert result == {engine.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: 3}
+
+    def test_setup_delta_read_opts_end_resolves_version_between_commits(self, mocker):
+        # Delta resolves timestampAsOf against commit-file modification times,
+        # which can be tens of milliseconds after the history()'s in-commit
+        # timestamps the backend records: an end bound equal to commit N's
+        # recorded time could silently resolve to version N-1. The end-only read
+        # therefore resolves the version against history() itself.
+        # Arrange
+        _patch_client(mocker, is_external=False)
+        fg = _make_fg("hopsfs://nn:8020/p")
+        engine = DeltaEngine(1, "fs", fg, None, None)
+        alias = mock.Mock()
+        alias.left_feature_group_start_timestamp = None
+        alias.left_feature_group_end_timestamp = 2000
+        mocker.patch.object(
+            engine, "_get_delta_commits", return_value=[(0, 1000), (1, 2000), (2, 3000)]
+        )
+
+        # Act
+        result = engine._setup_delta_read_opts(alias, "hopsfs://nn:8020/p")
+
+        # Assert: end == commit 1's recorded time resolves to exactly version 1
+        assert result == {engine.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: 1}
+
+    def test_setup_delta_read_opts_end_unreadable_history_uses_timestamp(self, mocker):
+        # When the Delta history cannot be read the timestamp bound is kept.
+        # Arrange
+        _patch_client(mocker, is_external=False)
+        fg = _make_fg("hopsfs://nn:8020/p")
+        engine = DeltaEngine(1, "fs", fg, None, None)
+        alias = mock.Mock()
+        alias.left_feature_group_start_timestamp = None
+        alias.left_feature_group_end_timestamp = 2000
+        mocker.patch.object(engine, "_get_delta_commits", return_value=None)
+        mocker.patch("hsfs.util._get_delta_datestr_from_timestamp", return_value="t")
+
+        # Act
+        result = engine._setup_delta_read_opts(alias, "hopsfs://nn:8020/p")
+
+        # Assert
+        assert result == {engine.DELTA_QUERY_TIME_TRAVEL_AS_OF_INSTANT: "t"}
 
     def test_generate_merge_query_primary_key_only(self, mocker):
         # Arrange

--- a/python/tests/core/test_feature_descriptive_statistics.py
+++ b/python/tests/core/test_feature_descriptive_statistics.py
@@ -383,3 +383,45 @@ class TestFeatureDescriptiveStatistics:
         assert kll.get("kllFormat") == "datasketches-native-v1"
         assert kll.get("bytes") == "AgEAAIAAAAAAAAAAAAAAAA=="
         assert "buckets" in kll
+
+    def test_to_dict_scrubs_non_finite_values(self):
+        # NaN/Infinity are not valid JSON and abort the statistics
+        # registration on the backend
+        fds = FeatureDescriptiveStatistics(
+            feature_name="constant_col",
+            count=10,
+            min=1.0,
+            max=float("inf"),
+            sum=float("-inf"),
+            mean=float("nan"),
+            std_dev=float("nan"),
+            completeness=float("nan"),
+            distinctness=float("nan"),
+            entropy=float("inf"),
+            uniqueness=0.5,
+            percentiles=[1.0, float("nan"), 3.0],
+        )
+
+        result = fds.to_dict()
+
+        assert result["min"] == 1.0
+        assert result["max"] is None
+        assert result["sum"] is None
+        assert result["mean"] is None
+        assert result["stdDev"] is None
+        assert result["completeness"] is None
+        assert result["distinctness"] is None
+        assert result["entropy"] is None
+        assert result["uniqueness"] == 0.5
+        assert result["percentiles"] == [1.0, None, 3.0]
+
+    def test_to_dict_scrubs_non_finite_percentiles_mapping(self):
+        fds = FeatureDescriptiveStatistics(
+            feature_name="amount",
+            count=10,
+            percentiles={"25%": 0.4, "50%": float("nan"), "75%": 0.86},
+        )
+
+        result = fds.to_dict()
+
+        assert result["percentiles"] == {"25%": 0.4, "50%": None, "75%": 0.86}

--- a/python/tests/core/test_feature_monitoring_result_engine.py
+++ b/python/tests/core/test_feature_monitoring_result_engine.py
@@ -287,6 +287,31 @@ class TestFeatureMonitoringResultEngine:
         assert count_specific_difference == 2
         assert none_difference is None
 
+    def test_compute_difference_between_stats_missing_metric(self):
+        # Arrange
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        # uniqueness is not computed when exact_uniqueness is disabled
+        detection_statistics = FeatureDescriptiveStatistics(
+            feature_name="amount", count=10
+        )
+        reference_statistics = FeatureDescriptiveStatistics(
+            feature_name="amount", count=10, uniqueness=0.5
+        )
+
+        # Act
+        difference = result_engine._compute_difference_between_stats(
+            detection_statistics=detection_statistics,
+            reference_statistics=reference_statistics,
+            metric="uniqueness",
+            relative=False,
+        )
+
+        # Assert
+        assert difference is None
+
     def test_compute_difference_and_shift(self):
         # Arrange
         from hsfs.core.statistics_comparison_config import StatisticsComparisonConfig

--- a/python/tests/core/test_iceberg_engine.py
+++ b/python/tests/core/test_iceberg_engine.py
@@ -113,6 +113,47 @@ class TestIcebergEngine:
         # Arrange
         iceberg_engine = _make_engine(mocker)
         fg_alias = _make_alias(end_timestamp=1234567890000)
+        mocker.patch.object(iceberg_engine, "_resolve_snapshot_id_at", return_value=1)
+
+        # Act
+        options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
+
+        # Assert
+        assert options == {"as-of-timestamp": "1234567890000"}
+
+    def test_setup_iceberg_read_opts_time_travel_query_before_first_snapshot(
+        self, mocker
+    ):
+        # Arrange: the end timestamp predates the first snapshot (fresh insert),
+        # so the read falls back to the earliest snapshot id
+        iceberg_engine = _make_engine(mocker)
+        fg_alias = _make_alias(end_timestamp=1234567890000)
+        mocker.patch.object(
+            iceberg_engine, "_resolve_snapshot_id_at", return_value=None
+        )
+        mocker.patch.object(
+            iceberg_engine,
+            "_read_snapshots",
+            return_value=[
+                {"committed_at": 1234567890123, "snapshot_id": 11},
+                {"committed_at": 1234567891000, "snapshot_id": 22},
+            ],
+        )
+
+        # Act
+        options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
+
+        # Assert
+        assert options == {"snapshot-id": "11"}
+
+    def test_setup_iceberg_read_opts_time_travel_query_no_snapshots(self, mocker):
+        # Arrange: table without snapshots keeps the timestamp bound
+        iceberg_engine = _make_engine(mocker)
+        fg_alias = _make_alias(end_timestamp=1234567890000)
+        mocker.patch.object(
+            iceberg_engine, "_resolve_snapshot_id_at", return_value=None
+        )
+        mocker.patch.object(iceberg_engine, "_read_snapshots", return_value=[])
 
         # Act
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")

--- a/python/tests/core/test_iceberg_engine.py
+++ b/python/tests/core/test_iceberg_engine.py
@@ -110,21 +110,26 @@ class TestIcebergEngine:
         assert options == {}
 
     def test_setup_iceberg_read_opts_time_travel_query(self, mocker):
-        # Arrange: the first snapshot predates the end timestamp, so the
-        # timestamp is resolvable
+        # Arrange: end timestamp falls between two snapshots. Resolution must
+        # pin the latest snapshot committed at or before it (11), not defer to
+        # Iceberg's server-side timestamp resolution which, on a different
+        # clock, could read the wrong side of the boundary.
         iceberg_engine = _make_engine(mocker)
         fg_alias = _make_alias(end_timestamp=1234567890000)
         mocker.patch.object(
             iceberg_engine,
             "_read_snapshots",
-            return_value=[{"committed_at": 1234567880000, "snapshot_id": 11}],
+            return_value=[
+                {"committed_at": 1234567880000, "snapshot_id": 11},
+                {"committed_at": 1234567895000, "snapshot_id": 22},
+            ],
         )
 
         # Act
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
 
         # Assert
-        assert options == {"as-of-timestamp": "1234567890000"}
+        assert options == {"snapshot-id": "11"}
 
     def test_setup_iceberg_read_opts_time_travel_query_before_first_snapshot(
         self, mocker
@@ -176,7 +181,8 @@ class TestIcebergEngine:
 
     def test_setup_iceberg_read_opts_incremental_query_no_start_snapshot(self, mocker):
         # The window starts before the first snapshot (rolling monitoring window
-        # on a fresh table): fall back to the table state at the end bound.
+        # on a fresh table): fall back to the table state at the end bound,
+        # pinned by snapshot id (the snapshot at or before end_ts).
         # Arrange
         iceberg_engine = _make_engine(mocker)
         fg_alias = _make_alias(
@@ -195,7 +201,7 @@ class TestIcebergEngine:
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
 
         # Assert
-        assert options == {"as-of-timestamp": "1234567892500"}
+        assert options == {"snapshot-id": "11"}
 
     def test_setup_iceberg_read_opts_incremental_query_no_snapshots_at_all(
         self, mocker

--- a/python/tests/core/test_iceberg_engine.py
+++ b/python/tests/core/test_iceberg_engine.py
@@ -110,10 +110,15 @@ class TestIcebergEngine:
         assert options == {}
 
     def test_setup_iceberg_read_opts_time_travel_query(self, mocker):
-        # Arrange
+        # Arrange: the first snapshot predates the end timestamp, so the
+        # timestamp is resolvable
         iceberg_engine = _make_engine(mocker)
         fg_alias = _make_alias(end_timestamp=1234567890000)
-        mocker.patch.object(iceberg_engine, "_resolve_snapshot_id_at", return_value=1)
+        mocker.patch.object(
+            iceberg_engine,
+            "_read_snapshots",
+            return_value=[{"committed_at": 1234567880000, "snapshot_id": 11}],
+        )
 
         # Act
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
@@ -128,9 +133,6 @@ class TestIcebergEngine:
         # so the read falls back to the earliest snapshot id
         iceberg_engine = _make_engine(mocker)
         fg_alias = _make_alias(end_timestamp=1234567890000)
-        mocker.patch.object(
-            iceberg_engine, "_resolve_snapshot_id_at", return_value=None
-        )
         mocker.patch.object(
             iceberg_engine,
             "_read_snapshots",
@@ -150,9 +152,6 @@ class TestIcebergEngine:
         # Arrange: table without snapshots keeps the timestamp bound
         iceberg_engine = _make_engine(mocker)
         fg_alias = _make_alias(end_timestamp=1234567890000)
-        mocker.patch.object(
-            iceberg_engine, "_resolve_snapshot_id_at", return_value=None
-        )
         mocker.patch.object(iceberg_engine, "_read_snapshots", return_value=[])
 
         # Act

--- a/python/tests/core/test_iceberg_engine.py
+++ b/python/tests/core/test_iceberg_engine.py
@@ -175,6 +175,55 @@ class TestIcebergEngine:
         assert options == {"start-snapshot-id": "11", "end-snapshot-id": "22"}
 
     def test_setup_iceberg_read_opts_incremental_query_no_start_snapshot(self, mocker):
+        # The window starts before the first snapshot (rolling monitoring window
+        # on a fresh table): fall back to the table state at the end bound.
+        # Arrange
+        iceberg_engine = _make_engine(mocker)
+        fg_alias = _make_alias(
+            start_timestamp=1234567890000, end_timestamp=1234567892500
+        )
+        mocker.patch.object(
+            iceberg_engine, "_resolve_snapshot_id_at", return_value=None
+        )
+        mocker.patch.object(
+            iceberg_engine,
+            "_read_snapshots",
+            return_value=[{"committed_at": 1234567892000, "snapshot_id": 11}],
+        )
+
+        # Act
+        options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
+
+        # Assert
+        assert options == {"as-of-timestamp": "1234567892500"}
+
+    def test_setup_iceberg_read_opts_incremental_query_no_snapshots_at_all(
+        self, mocker
+    ):
+        # Unresolvable start AND end before the first snapshot: pin the earliest
+        # snapshot, matching the end-only fresh-insert fallback.
+        # Arrange
+        iceberg_engine = _make_engine(mocker)
+        fg_alias = _make_alias(
+            start_timestamp=1234567890000, end_timestamp=1234567891500
+        )
+        mocker.patch.object(
+            iceberg_engine, "_resolve_snapshot_id_at", return_value=None
+        )
+        mocker.patch.object(
+            iceberg_engine,
+            "_read_snapshots",
+            return_value=[{"committed_at": 1234567892000, "snapshot_id": 11}],
+        )
+
+        # Act
+        options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
+
+        # Assert
+        assert options == {"snapshot-id": "11"}
+
+    def test_setup_iceberg_read_opts_incremental_query_no_start_no_end(self, mocker):
+        # Unresolvable start without an end bound reads the latest table state.
         # Arrange
         iceberg_engine = _make_engine(mocker)
         fg_alias = _make_alias(start_timestamp=1000)
@@ -183,11 +232,10 @@ class TestIcebergEngine:
         )
 
         # Act
-        with pytest.raises(FeatureStoreException) as e_info:
-            iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
+        options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
 
         # Assert
-        assert "no Iceberg snapshot exists" in str(e_info.value)
+        assert options == {}
 
     def test_setup_iceberg_read_opts_merges_options(self, mocker):
         # Arrange

--- a/python/tests/core/test_statistics_engine.py
+++ b/python/tests/core/test_statistics_engine.py
@@ -929,3 +929,46 @@ class TestStatisticsEngine:
         assert fds_by_name["loc_delta"].count == 0
         # Assert: a warning was logged
         assert mock_logger.warning.call_count == 1
+
+    def test_parse_deequ_statistics_exact_uniqueness(self, mocker):
+        # Arrange
+        feature_store_id = 99
+
+        mocker.patch("hopsworks_common.client._get_instance")
+
+        s_engine = statistics_engine.StatisticsEngine(feature_store_id, "featuregroup")
+
+        # the deequ profiler emits uniqueness-family metrics (as 0.0) even when
+        # the Uniqueness analyzer was not requested
+        stats_str = json.dumps(
+            {
+                "columns": [
+                    {
+                        "column": "col_1",
+                        "dataType": "Integral",
+                        "numRecordsNull": 0,
+                        "numRecordsNonNull": 4,
+                        "uniqueness": 0.0,
+                        "distinctness": 0.0,
+                        "entropy": 0.0,
+                        "exactNumDistinctValues": 0,
+                    }
+                ]
+            }
+        )
+
+        # Act
+        with_uniqueness = s_engine._parse_deequ_statistics(stats_str, True)
+        without_uniqueness = s_engine._parse_deequ_statistics(stats_str, False)
+
+        # Assert
+        assert with_uniqueness[0].uniqueness == 0.0
+        assert with_uniqueness[0].distinctness == 0.0
+        assert with_uniqueness[0].entropy == 0.0
+        assert with_uniqueness[0].exact_num_distinct_values == 0
+        assert without_uniqueness[0].uniqueness is None
+        assert without_uniqueness[0].distinctness is None
+        assert without_uniqueness[0].entropy is None
+        assert without_uniqueness[0].exact_num_distinct_values is None
+        # non-uniqueness metrics are untouched
+        assert without_uniqueness[0].num_non_null_values == 4

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -2005,6 +2005,31 @@ class TestPython:
             "count": 100,
         }
 
+    def test_convert_pandas_statistics_all_null_column(self):
+        # Arrange: pandas describe() emits NaN for every statistic of an
+        # all-null column
+        python_engine = python.Engine()
+
+        stat = {
+            "25%": float("nan"),
+            "50%": float("nan"),
+            "75%": float("nan"),
+            "mean": float("nan"),
+            "count": 0,
+            "max": float("nan"),
+            "std": float("nan"),
+            "min": float("nan"),
+        }
+
+        # Act
+        result = python_engine._convert_pandas_statistics(stat=stat, dataType="Float")
+
+        # Assert: NaN values are skipped entirely
+        assert result == {
+            "dataType": "Float",
+            "count": 0,
+        }
+
     def test_validate(self):
         # Arrange
         python_engine = python.Engine()


### PR DESCRIPTION
## Summary
- Strip uniqueness-family metrics (uniqueness, distinctness, entropy, exactNumDistinctValues) from parsed deequ statistics when `exact_uniqueness` is disabled, so they deserialize as `None` instead of the JVM profiler's spurious `0.0`; guard the feature monitoring difference computation against `None` metric values.
- Resolve end-bounded Iceberg time-travel reads to a `snapshot-id` client-side, against the snapshots' own `committed_at` clock (the clock the backend derives the recorded commit time from), instead of passing `as-of-timestamp`. Passing the timestamp let Iceberg resolve the bound server-side against the snapshot-log clock, so a recorded commit time landing just below snapshot N's log timestamp could silently read snapshot N-1 (the mid-range skew), and a fresh-insert commit time landing before the first snapshot made `compute_statistics` die with "Cannot find a snapshot older than ...". Resolving here shares one clock, so both cases are handled. When the end bound precedes every snapshot the earliest snapshot is pinned (mirrors the Delta `versionAsOf` fallback); note this reads data committed after the window when the window genuinely ended before the first commit, rather than returning empty.
- Scrub non-finite values (NaN/Infinity) from client-side statistics serialization: `FeatureDescriptiveStatistics.to_dict()` maps them to `None` (all numeric fields + percentiles), and the pandas statistics conversion skips NaN mean/sum/min/max/percentiles (previously only `std` was guarded). Defense-in-depth alongside the backend sanitization in logicalclocks/hopsworks-ee (same ticket branch).

- Omit the uniqueness-family keys from the Java profiler output (`ColumnProfiler`/`ProfileJsonSerializer`) when exact uniqueness is disabled. Cluster verification showed the Python-side strip does not cover HUDI feature groups: their materialization job is the Scala/Java Spark job, which profiles and registers statistics through the Java client. All parsers copy only present keys, so absent keys deserialize as null on every path. The per-column entropy groupBy is also skipped when the flag is off.
- Compute uniqueness from the exact singleton count in the Java profiler: the shortcut `(2*distinct - n)/n` equals Deequ's definition only when no value occurs more than twice; the singleton count now comes from the same frequency pass as entropy.
- Resolve end-bounded Delta reads to a version via the Delta log's in-commit `commitInfo.timestamp` values and pin `versionAsOf`. Two layers fixed on-cluster: `timestampAsOf` resolves against commit-file modification times, and `DeltaTable.history()` also carries modtimes — both lag the in-commit timestamps the backend records as commit times, so end-bounded reads could silently land on the previous version (statistics for commit N computed over commit N-1's data).
- Read Delta commit timestamps from `_delta_log/*.json` (`commitInfo.timestamp`) instead of `DeltaTable.history()`: history() carries commit-file modification times, which lag the in-commit timestamps the backend records, so the version resolution could still land on the previous version.
- Note: the FSTORE-2067 vectorization workarounds (table-creation property and statistics/monitoring read option) live entirely in #1067 now. That PR must merge first: without it, Iceberg statistics and monitoring reads and training dataset creation hit the vectorized-reader executor crash, so the ICEBERG variants of this PR's fixes only work on top of #1067.
- Fall back to an end-bounded snapshot read when an incremental Iceberg window starts before the first snapshot (rolling monitoring windows on fresh tables previously died on the incremental-branch raise).

## Test plan
- [x] Unit: `_parse_deequ_statistics` strips uniqueness metrics with the flag off, preserves them with it on
- [x] Unit: monitoring diff returns `None` when a metric is missing on either side
- [x] Unit: Iceberg end-only read opts — resolvable end bound pins the snapshot at/before it (mid-range case), pre-first-snapshot falls back to earliest `snapshot-id`, no snapshots keeps timestamp bound
- [x] Unit: `to_dict()` NaN/Infinity scrub (fields, percentile list and mapping); pandas conversion of all-null column emits only dataType+count
- [x] Full suite: 3649 passed (5 pre-existing avro/spark environment failures, confirmed failing on clean tree)
- [ ] Integration (pending cluster): `test_statistics[DELTA/HUDI]`, `test_batch[ICEBERG]`, `test_feature_monitoring[ICEBERG]`, `fs_statistics_wide_tables` variants
- [x] Unit (java/spark): profiler omits uniqueness/distinctness/entropy/exactNumDistinctValues when exactUniqueness=false, emits them when true; parity tests unchanged
- [x] Unit (java/spark): uniqueness equals the exact singleton fraction with multiplicity >= 3; profiler parity tests unchanged
- [x] Unit: Delta end-bounded read opts resolve the version between commits, at the earliest commit, and fall back to the timestamp bound when the log is unreadable
- [x] Integration: `test_statistics.py` `test_workflow[DELTA]` + `[HUDI]` pass end-to-end on a cluster (2 passed)
- [x] Integration: `test_feature_monitoring.py` `[DELTA]` + `[HUDI]` + `[ICEBERG]` pass end-to-end on a cluster (3 passed)

https://hopsworks.atlassian.net/browse/FSTORE-2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)




