### PR TITLE
[FSTORE-2061][4.8] Millisecond timestamp for vector embeddings not handled correctly (#1051)

### DIFF
--- a/python/hsfs/core/vector_db_client.py
+++ b/python/hsfs/core/vector_db_client.py
@@ -216,16 +216,16 @@ class VectorDbClient:
             feature_name = feature.name
             feature_type = feature.type.lower()
             feature_value = result.get(feature_name)
-            if not feature_value:  # Feature value can be null
+            if feature_value is None:
                 continue
             if feature_type == "date":
                 result[feature_name] = datetime.fromtimestamp(
                     feature_value // 10**3, tz=timezone.utc
                 ).date()
             elif feature_type == "timestamp":
-                # convert timestamp in ms to datetime in s
+                # true division so sub-second precision survives, e.g. timestamp(3)
                 result[feature_name] = datetime.fromtimestamp(
-                    feature_value // 10**3, tz=timezone.utc
+                    feature_value / 10**3, tz=timezone.utc
                 ).replace(tzinfo=None)
             elif feature_type == "binary" or (
                 feature.is_complex() and feature not in self._embedding_features

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1630,15 +1630,17 @@ class VectorServer:
                 )
 
     def _handle_timestamp_based_on_dtype(
-        self, timestamp_value: str | int
+        self, timestamp_value: str | int | datetime | None
     ) -> datetime | None:
         """Handle the timestamp based on the dtype which is returned.
 
-        Currently timestamp which are in the database are returned as string. Whereas
-        passed features which were given as datetime are returned as integer timestamp.
+        The rest client returns timestamps as strings.
+        Passed features given as datetime are returned as integer timestamps.
+        The sql client already returns datetime objects.
+        Missing values arrive as None and are passed through.
 
         Parameters:
-            timestamp_value: The timestamp value to be handled, either as int or str.
+            timestamp_value: The timestamp value to be handled.
         """
         if timestamp_value is None:
             return None
@@ -1648,8 +1650,12 @@ class VectorServer:
                 timestamp_value / 1000, tz=timezone.utc
             ).replace(tzinfo=None)
         if isinstance(timestamp_value, str):
-            # rest client returns timestamp as string
-            return datetime.strptime(timestamp_value, self.SQL_TIMESTAMP_STRING_FORMAT)
+            # rest client returns timestamp as string, with fractional seconds
+            # when the online type has sub-second precision, e.g. timestamp(3)
+            fmt = self.SQL_TIMESTAMP_STRING_FORMAT + (
+                ".%f" if "." in timestamp_value else ""
+            )
+            return datetime.strptime(timestamp_value, fmt)
         if isinstance(timestamp_value, datetime):
             # sql client returns already datetime object
             return timestamp_value

--- a/python/tests/core/test_vector_db_client.py
+++ b/python/tests/core/test_vector_db_client.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from datetime import datetime
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -488,3 +489,22 @@ class TestVectorDbClient:
     def test_read_without_pk_or_keys(self):
         with pytest.raises(FeatureStoreException):
             self.target.read(self.fg.id, self.fg.features)
+
+    def test_convert_to_pandas_type_timestamp_keeps_milliseconds(self):
+        # OpenSearch stores timestamps as epoch ms; sub-second precision must
+        # survive the conversion, e.g. for timestamp(3) online types (FSTORE-2061)
+        epoch_ms = convert_event_time_to_timestamp("2024-04-18 12:00:25.789")
+
+        result = self.target._convert_to_pandas_type(
+            self.fg.features, {"f1": 4, "f_ts": epoch_ms}
+        )
+
+        assert result["f_ts"] == datetime(2024, 4, 18, 12, 0, 25, 789000)
+
+    def test_convert_to_pandas_type_epoch_zero_is_not_null(self):
+        # 0 epoch ms is a valid timestamp and must not be skipped as null
+        result = self.target._convert_to_pandas_type(
+            self.fg.features, {"f1": 4, "f_ts": 0}
+        )
+
+        assert result["f_ts"] == datetime(1970, 1, 1)

--- a/python/tests/core/test_vector_server.py
+++ b/python/tests/core/test_vector_server.py
@@ -1,0 +1,43 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from datetime import datetime
+
+import pytest
+from hsfs.core.vector_server import VectorServer
+
+
+class TestVectorServer:
+    @pytest.mark.parametrize(
+        "timestamp_value, expected",
+        [
+            ("2024-04-18 12:00:25", datetime(2024, 4, 18, 12, 0, 25)),
+            # fractional seconds appear when the online type has sub-second
+            # precision, e.g. timestamp(3) (FSTORE-2061)
+            ("2024-04-18 12:00:25.789", datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            ("2024-04-18 12:00:25.789000", datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            (1713441625789, datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            (
+                datetime(2024, 4, 18, 12, 0, 25, 789000),
+                datetime(2024, 4, 18, 12, 0, 25, 789000),
+            ),
+            (None, None),
+        ],
+    )
+    def test_handle_timestamp_based_on_dtype(self, timestamp_value, expected):
+        server = VectorServer.__new__(VectorServer)
+
+        assert server._handle_timestamp_based_on_dtype(timestamp_value) == expected


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2061

Cherry-pick of #1051 (16b4822b0) onto branch-4.8.

The source changes in vector_server.py and vector_db_client.py applied
cleanly; both fixed methods exist under the same names on this branch.
Two test-file conflicts, both because branch-4.8 predates recent work
on main: tests/core/test_vector_server.py does not exist here, so it is
created with only the new parametrized timestamp test; the two new
tests in tests/core/test_vector_db_client.py are adapted to the
pre-HWORKS-2849 public names (convert_event_time_to_timestamp,
fg.features). Both test files pass on this branch (50 passed), ruff
check and format clean.

Signed-off-by: Dhananjay Mukhedkar <dhananjay@logicalclocks.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)