### PR TITLE
[FSTORE-2061][4.7] Millisecond timestamp for vector embeddings not handled correctly (#1051)

### DIFF
--- a/python/hsfs/core/vector_db_client.py
+++ b/python/hsfs/core/vector_db_client.py
@@ -213,15 +213,15 @@ class VectorDbClient:
             feature_name = feature.name
             feature_type = feature.type.lower()
             feature_value = result.get(feature_name)
-            if not feature_value:  # Feature value can be null
+            if feature_value is None:
                 continue
             if feature_type == "date":
                 result[feature_name] = datetime.utcfromtimestamp(
                     feature_value // 10**3
                 ).date()
             elif feature_type == "timestamp":
-                # convert timestamp in ms to datetime in s
-                result[feature_name] = datetime.utcfromtimestamp(feature_value // 10**3)
+                # true division so sub-second precision survives, e.g. timestamp(3)
+                result[feature_name] = datetime.utcfromtimestamp(feature_value / 10**3)
             elif feature_type == "binary" or (
                 feature.is_complex() and feature not in self._embedding_features
             ):

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -1622,15 +1622,17 @@ class VectorServer:
                 )
 
     def _handle_timestamp_based_on_dtype(
-        self, timestamp_value: str | int
+        self, timestamp_value: str | int | datetime | None
     ) -> datetime | None:
         """Handle the timestamp based on the dtype which is returned.
 
-        Currently timestamp which are in the database are returned as string. Whereas
-        passed features which were given as datetime are returned as integer timestamp.
+        The rest client returns timestamps as strings.
+        Passed features given as datetime are returned as integer timestamps.
+        The sql client already returns datetime objects.
+        Missing values arrive as None and are passed through.
 
         Parameters:
-            timestamp_value: The timestamp value to be handled, either as int or str.
+            timestamp_value: The timestamp value to be handled.
         """
         if timestamp_value is None:
             return None
@@ -1640,8 +1642,12 @@ class VectorServer:
                 timestamp_value / 1000, tz=timezone.utc
             ).replace(tzinfo=None)
         if isinstance(timestamp_value, str):
-            # rest client returns timestamp as string
-            return datetime.strptime(timestamp_value, self.SQL_TIMESTAMP_STRING_FORMAT)
+            # rest client returns timestamp as string, with fractional seconds
+            # when the online type has sub-second precision, e.g. timestamp(3)
+            fmt = self.SQL_TIMESTAMP_STRING_FORMAT + (
+                ".%f" if "." in timestamp_value else ""
+            )
+            return datetime.strptime(timestamp_value, fmt)
         if isinstance(timestamp_value, datetime):
             # sql client returns already datetime object
             return timestamp_value

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -84,7 +84,8 @@ dev-no-opt = [
     "moto[s3]==5.0.0",
     "pandas>=2.2.0",
     "typeguard==4.2.1",
-    "delta-spark==3.3.1"
+    "delta-spark==3.3.1",
+    "setuptools; python_version >= '3.12'",
 ]
 dev-pandas1 = [
     "hopsworks[python]",

--- a/python/tests/core/test_vector_db_client.py
+++ b/python/tests/core/test_vector_db_client.py
@@ -13,10 +13,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from datetime import datetime
 from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from hopsworks_common.util import convert_event_time_to_timestamp
 from hsfs.client.exceptions import FeatureStoreException
 from hsfs.core import vector_db_client
 from hsfs.embedding import EmbeddingIndex
@@ -33,7 +35,8 @@ class TestVectorDbClient:
         f1 = Feature("f1", feature_group=fg, primary=True, type="int")
         f2 = Feature("f2", feature_group=fg, primary=True, type="int")
         f3 = Feature("f3", feature_group=fg, type="int")
-        fg.features = [f1, f2, f3]
+        f_ts = Feature("f_ts", feature_group=fg, type="timestamp")
+        fg.features = [f1, f2, f3, f_ts]
         fg2 = FeatureGroup("test_fg", 1, 99, id=2)
         fg2.features = [f1, f2]
 
@@ -231,7 +234,7 @@ class TestVectorDbClient:
 
         expected_query = {
             "query": {"bool": {"must": [{"match": {"f1": 10}}, {"match": {"f2": 20}}]}},
-            "_source": ["f1", "f2", "f3"],
+            "_source": ["f1", "f2", "f3", "f_ts"],
         }
         self.mock_os_wrapper.search.assert_called_once_with(
             body=expected_query, index="2249__embedding_default_embedding"
@@ -245,7 +248,7 @@ class TestVectorDbClient:
         expected_query = {
             "query": {"bool": {"must": {"exists": {"field": "f1"}}}},
             "size": 10,
-            "_source": ["f1", "f2", "f3"],
+            "_source": ["f1", "f2", "f3", "f_ts"],
         }
         self.mock_os_wrapper.search.assert_called_once_with(
             body=expected_query, index="2249__embedding_default_embedding"
@@ -256,3 +259,22 @@ class TestVectorDbClient:
     def test_read_without_pk_or_keys(self):
         with pytest.raises(FeatureStoreException):
             self.target.read(self.fg.id, self.fg.features)
+
+    def test_convert_to_pandas_type_timestamp_keeps_milliseconds(self):
+        # OpenSearch stores timestamps as epoch ms; sub-second precision must
+        # survive the conversion, e.g. for timestamp(3) online types (FSTORE-2061)
+        epoch_ms = convert_event_time_to_timestamp("2024-04-18 12:00:25.789")
+
+        result = self.target._convert_to_pandas_type(
+            self.fg.features, {"f1": 4, "f_ts": epoch_ms}
+        )
+
+        assert result["f_ts"] == datetime(2024, 4, 18, 12, 0, 25, 789000)
+
+    def test_convert_to_pandas_type_epoch_zero_is_not_null(self):
+        # 0 epoch ms is a valid timestamp and must not be skipped as null
+        result = self.target._convert_to_pandas_type(
+            self.fg.features, {"f1": 4, "f_ts": 0}
+        )
+
+        assert result["f_ts"] == datetime(1970, 1, 1)

--- a/python/tests/core/test_vector_server.py
+++ b/python/tests/core/test_vector_server.py
@@ -1,0 +1,43 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from datetime import datetime
+
+import pytest
+from hsfs.core.vector_server import VectorServer
+
+
+class TestVectorServer:
+    @pytest.mark.parametrize(
+        "timestamp_value, expected",
+        [
+            ("2024-04-18 12:00:25", datetime(2024, 4, 18, 12, 0, 25)),
+            # fractional seconds appear when the online type has sub-second
+            # precision, e.g. timestamp(3) (FSTORE-2061)
+            ("2024-04-18 12:00:25.789", datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            ("2024-04-18 12:00:25.789000", datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            (1713441625789, datetime(2024, 4, 18, 12, 0, 25, 789000)),
+            (
+                datetime(2024, 4, 18, 12, 0, 25, 789000),
+                datetime(2024, 4, 18, 12, 0, 25, 789000),
+            ),
+            (None, None),
+        ],
+    )
+    def test_handle_timestamp_based_on_dtype(self, timestamp_value, expected):
+        server = VectorServer.__new__(VectorServer)
+
+        assert server._handle_timestamp_based_on_dtype(timestamp_value) == expected


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2061

Cherry-pick of #1051 (16b4822b0) onto branch-4.7.

One source conflict: branch-4.7 still uses datetime.utcfromtimestamp in
_convert_to_pandas_type, so the fix is applied in that idiom (true
division instead of floor division; behaviour identical to main). The
is-None null check applied cleanly. Test adaptations beyond the 4.8
backport: the f_ts fixture feature and the util import do not exist on
4.7's test file, so they are added, and the two _source assertions in
the read tests are extended with f_ts, mirroring what #1051 did on
main. tests/core/test_vector_server.py does not exist on this branch
and is created with only the new parametrized timestamp test. Both
test files pass on this branch (31 passed), ruff check clean; two
pre-existing formatting drifts outside this diff are left untouched.

This PR also cherry-picks #1039 (c7f47120f, FSTORE-2057), which adds
setuptools for python_version >= '3.12' to the dev-no-opt extra.
branch-4.7 never received that fix, so pyspark==3.5.5 importing
distutils breaks CI on py3.12/3.13. Folded in here rather than opening
a separate PR so this backport goes green. One trivial conflict on the
delta-spark line (missing trailing comma on 4.7), resolved by adding
the comma.

Signed-off-by: Dhananjay Mukhedkar <dhananjay@logicalclocks.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)