### PR TITLE
[HWORKS-2878][APPEND] Fix fetch data for google sheets data source

### DIFF
--- a/python/hsfs/core/data_source_api.py
+++ b/python/hsfs/core/data_source_api.py
@@ -54,6 +54,22 @@ class DataSourceApi:
 
         return _client._send_request("GET", path_params)
 
+    def _get_google_sheet_names(
+        self, storage_connector: sc.StorageConnector
+    ) -> list[str]:
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "featurestores",
+            storage_connector._featurestore_id,
+            "storageconnectors",
+            storage_connector._name,
+            "sheets",
+        ]
+
+        return _client._send_request("GET", path_params)
+
     def _get_crm_resources(
         self, storage_connector: sc.StorageConnector
     ) -> dsd.DataSourceData:
@@ -113,6 +129,10 @@ class DataSourceApi:
             return self._get_rest_data(storage_connector, data_source, use_cached)
         if storage_connector.type == "CRM":
             return self._get_crm_data(storage_connector, data_source, use_cached)
+        if storage_connector.type == "GOOGLE_SHEETS":
+            return self._get_google_sheets_data(
+                storage_connector, data_source, use_cached
+            )
         raise ValueError("This connector type does not support fetching NoSQL data.")
 
     def _get_rest_data(
@@ -166,6 +186,30 @@ class DataSourceApi:
         query_params = data_source.to_dict()
         if use_cached is not None:
             query_params["forceRefetch"] = not use_cached
+
+        return dsd.DataSourceData.from_response_json(
+            _client._send_request("GET", path_params, query_params=query_params)
+        )
+
+    def _get_google_sheets_data(
+        self,
+        storage_connector: sc.StorageConnector,
+        data_source: ds.DataSource,
+        use_cached=True,
+    ) -> dsd.DataSourceData:
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "featurestores",
+            storage_connector._featurestore_id,
+            "storageconnectors",
+            storage_connector._name,
+            "data_source",
+            "resources",
+            data_source.table,
+        ]
+        query_params = {"forceRefetch": not use_cached}
 
         return dsd.DataSourceData.from_response_json(
             _client._send_request("GET", path_params, query_params=query_params)

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3307,6 +3307,7 @@ class FeatureGroup(FeatureGroupBase):
             and self.storage_connector.type
             in [
                 sc.StorageConnector.CRM,
+                sc.StorageConnector.GOOGLE_SHEETS,
                 sc.StorageConnector.REST,
                 sc.StorageConnector.SNOWFLAKE,
                 sc.StorageConnector.REDSHIFT,
@@ -3334,8 +3335,9 @@ class FeatureGroup(FeatureGroupBase):
             )
             raise FeatureStoreException(
                 f"Sink cannot be enabled for storage connector type '{connector_type}'. "
-                "Supported connector types: CRM, REST, SNOWFLAKE, REDSHIFT, BIGQUERY, MONGODB, "
-                "and SQL connectors with database_type MYSQL, POSTGRESQL, or ORACLE."
+                "Supported connector types: CRM, GOOGLE_SHEETS, REST, SNOWFLAKE, REDSHIFT, "
+                "BIGQUERY, MONGODB, and SQL connectors with database_type MYSQL, POSTGRESQL, "
+                "or ORACLE."
             )
 
         # CRM/Google Sheets/REST connectors always have sink enabled.

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -568,6 +568,13 @@ class StorageConnector(ABC):
                 ds.DataSource(table=resource, storage_connector=self)
                 for resource in (data.supported_resources or [])
             ]
+        if self.type == StorageConnector.GOOGLE_SHEETS:
+            # Sheet tabs are the spreadsheet's "tables"; the backend lists them
+            # only on the dedicated /sheets endpoint, not data_source/tables.
+            return [
+                ds.DataSource(table=sheet_name, storage_connector=self)
+                for sheet_name in self._data_source_api._get_google_sheet_names(self)
+            ]
 
         return self._data_source_api._get_tables(self, database)
 

--- a/skills/data/hops-data-sources/SKILL.md
+++ b/skills/data/hops-data-sources/SKILL.md
@@ -96,6 +96,8 @@ hops datasource delete <name> --yes
 
 DLTHub copies a source into a managed feature group for the cases mounting cannot serve: loading the online store or a vector index, or pulling from an API/SaaS/REST endpoint. Ingestion runs server-side in the `dlthub-ingestion-pipeline` environment, driven by a `SinkJobConfiguration` attached to a sink-enabled feature group. It is configuration plus a server job, not an in-process `dlt` call.
 
+The per-feature-group `sink_job` shown here is for ingesting a **single** table. When ingesting more than one table from the same connector, default to one multi-table job for all of them — see [Ingest many tables with one job](#ingest-many-tables-with-one-job) — instead of looping this pattern.
+
 ```python
 import hopsworks
 from hopsworks.core import SinkJobConfiguration
@@ -139,9 +141,9 @@ class MyTransformer(HopsIngestionTransformer):
 
 ## Ingest many tables with one job
 
-The per-feature-group `sink_job` above creates one ingestion job per feature group. To copy several source tables from the same connector under a **single** job — one worker pod per table, at most `table_parallelism` at a time — create the ingestion job first and pass it in as each feature group is created.
+**This is the default whenever more than one table is ingested from the same connector.** The per-feature-group `sink_job` above creates one ingestion job per feature group — use it only for a single table. To copy several source tables under a **single** job — one worker pod per table, at most `table_parallelism` at a time — create the ingestion job first and pass it in as each feature group is created. Only fall back to a loop of per-FG sink jobs when the tables come from different connectors or genuinely need independent schedules.
 
-Create the empty job with `data_source.new_ingestion_job(name)`, then pass it as `sink_job=` to each feature group. Each `.save()` registers that feature group as a target **locally**; nothing is created on the server until you call the job's `.save()`, so a failed or partial set of feature groups never leaves a half-built job behind. Prefer this over a loop of per-FG sink jobs when the sources share a connector: it is one job to schedule, run, and monitor instead of N.
+Create the empty job with `data_source.new_ingestion_job(name)`, then pass it as `sink_job=` to each feature group. Each `.save()` registers that feature group as a target **locally**; nothing is created on the server until you call the job's `.save()`, so a failed or partial set of feature groups never leaves a half-built job behind. It is one job to schedule, run, and monitor instead of N.
 
 ```python
 import hopsworks
@@ -280,20 +282,25 @@ fg.sink_job.run()   # copies the sheet into the managed feature group
 
 **Multiple sheet tabs → multiple feature groups**
 
-Each feature group targets one sheet tab.
-Reuse the same connector and vary `table` (and `spreadsheet_id` if the tabs live in different spreadsheets):
+Each feature group targets one sheet tab. Reuse the same connector and vary `table` (and `spreadsheet_id` if the tabs live in different spreadsheets). As with any multi-table ingest, default to ONE multi-table job for all tabs (see [Ingest many tables with one job](#ingest-many-tables-with-one-job)) rather than one sink job per tab:
 
 ```python
+ds = fs.get_data_source("my_google_sheets_connector")
+
+job = ds.new_ingestion_job(name="gsheets_ingest", table_parallelism=2)
+
 for tab, fg_name in [("Users", "gs_users"), ("Orders", "gs_orders")]:
-    fg = fs.create_feature_group(
+    fs.get_or_create_feature_group(
         name=fg_name,
         version=1,
         primary_key=["id"],
         data_source=DataSource(storage_connector=connector, table=tab),
         sink_enabled=True,
-    )
-    fg.save()
-    fg.sink_job.run()
+        sink_job=job,
+    ).save()                # local: registers the tab as a target
+
+job.save()   # ONE atomic create with every tab as a target
+job.run()    # one job copies all tabs, one worker pod per tab
 ```
 
 ## Next Steps


### PR DESCRIPTION
The Google Sheets connector could be created from the Python client but none of the data source operations worked: the generic endpoints the client used have no GOOGLE_SHEETS handling on the backend, which routes all Google Sheets operations through dedicated/NoSQL endpoints instead (the UI already uses those, which is why it worked there).

- StorageConnector.get_tables(): list sheet tabs via the dedicated GET storageconnectors/{name}/sheets endpoint instead of data_source/tables, which rejects GOOGLE_SHEETS with 422 "Feature Store connector not supported".
- DataSourceApi._get_no_sql_data(): route GOOGLE_SHEETS to the data_source/resources/{sheet} schema-fetch endpoint (same dlt-based flow as CRM/REST) instead of raising ValueError.
- FeatureGroup._resolve_sink_enabled(): add GOOGLE_SHEETS to the supported sink connector list. It was already in the "always sink-enabled" list below, so the validation unconditionally threw "Sink cannot be enabled" for a connector type that forces sink on.

Verified end-to-end with the loadtest multi-table ingestion workflow (test_data_sources_ingestion.py::test_data_source_sink[GOOGLE_SHEETS]): sheet listing, schema fetch, sink FG creation, multi-table ingestion and Arrow Flight read-back all pass.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
