### PR TITLE
[HWORKS-2922][APPEND] Fix multi-table sink job target updates 

### DIFF
--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -716,6 +716,7 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
             )
         is_new_feature_group = feature_group.id is None
         requested_sink_job_conf = feature_group.sink_job_conf
+        requested_sink_job = feature_group.sink_job
         pre_save_features = list(feature_group.columns) if feature_group.columns else []
         pre_save_rest_endpoint = (
             feature_group.data_source.rest_endpoint
@@ -729,7 +730,6 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
             and not new_fg.data_source.rest_endpoint
         ):
             new_fg.data_source.rest_endpoint = pre_save_rest_endpoint
-        requested_sink_job = feature_group.sink_job
         if feature_group.sink_enabled and isinstance(
             requested_sink_job, MultiTableIngestionJob
         ):

--- a/python/hsfs/core/multi_table_ingestion.py
+++ b/python/hsfs/core/multi_table_ingestion.py
@@ -149,6 +149,7 @@ class MultiTableIngestionJob:
         }
         self._targets: list[TableIngestionTarget] = []
         self._target_index: dict[int, int] = {}
+        self._target_alias_index: dict[int, int] = {}
         self._job: job.Job | None = None
 
     @public
@@ -215,14 +216,18 @@ class MultiTableIngestionJob:
         resolved_id = feature_group_id
         if resolved_id is None and feature_group is not None:
             resolved_id = feature_group.id
-        if resolved_id is None or resolved_id not in self._target_index:
+        if self._job is not None:
+            self._refresh_job_from_server()
+        index = self._target_position(resolved_id) if resolved_id is not None else None
+        if resolved_id is None or index is None:
             raise ValueError(
                 "No target for that feature group; add it with add_target(...) "
                 "or by creating a feature group with sink_job set to this job."
             )
-        self._targets[self._target_index[resolved_id]]._enabled = enabled
+        self._refresh_feature_group_reference(feature_group, index)
+        self._targets[index]._enabled = enabled
         if self._job is not None:
-            self.save()
+            self._save_enabled_state(index, enabled)
         return self
 
     def _add_target_object(self, target: TableIngestionTarget) -> None:
@@ -232,6 +237,70 @@ class MultiTableIngestionJob:
         else:
             self._target_index[key] = len(self._targets)
             self._targets.append(target)
+        self._target_alias_index[key] = self._target_index[key]
+
+    def _target_position(self, feature_group_id: int) -> int | None:
+        return self._target_index.get(
+            feature_group_id, self._target_alias_index.get(feature_group_id)
+        )
+
+    def _refresh_feature_group_reference(
+        self, feature_group: fg.FeatureGroup | None, index: int
+    ) -> None:
+        if feature_group is None:
+            return
+        current_id = self._targets[index]._feature_group_id
+        try:
+            feature_group.id = current_id
+        except AttributeError:
+            feature_group._id = current_id
+
+    def _sync_targets_from_job_config(self, config: dict | None) -> None:
+        if not isinstance(config, dict):
+            return
+        targets = config.get("targets")
+        if not targets:
+            return
+
+        from hopsworks_common.core.sink_job_configuration import TableIngestionTarget
+
+        previous_targets = list(self._targets)
+        previous_alias_index = dict(self._target_alias_index)
+        self._targets = [
+            TableIngestionTarget.from_response_json(target) for target in targets
+        ]
+        self._target_index = {
+            target._feature_group_id: index
+            for index, target in enumerate(self._targets)
+        }
+        self._target_alias_index = dict(self._target_index)
+        for old_id, old_index in previous_alias_index.items():
+            if old_index < len(self._targets):
+                self._target_alias_index[old_id] = old_index
+        for index, old_target in enumerate(previous_targets):
+            if index < len(self._targets):
+                self._target_alias_index[old_target._feature_group_id] = index
+
+    def _refresh_job_from_server(self) -> None:
+        if self._job is None:
+            return
+
+        from hopsworks_common.core.job_api import JobApi
+
+        self._job = JobApi().get(self._name)
+        self._sync_targets_from_job_config(self._job.config)
+
+    def _save_enabled_state(self, index: int, enabled: bool) -> None:
+        targets = (
+            self._job.config.get("targets")
+            if isinstance(self._job.config, dict)
+            else None
+        )
+        if not targets:
+            return
+        targets[index]["enabled"] = enabled
+        self._job = self._job.save()
+        self._sync_targets_from_job_config(self._job.config)
 
     def _attach_feature_group(
         self,
@@ -268,7 +337,7 @@ class MultiTableIngestionJob:
 
         Sends every collected target in a single request, so the job is created
         atomically.
-        Calling `save` again re-creates the job with the current set of targets.
+        Calling `save` again updates the job with the current set of targets.
 
         Returns:
             The created ingestion job.
@@ -300,6 +369,7 @@ class MultiTableIngestionJob:
 
         job_api = JobApi()
         self._job = job_api.create(self._name, sink_job_conf)
+        self._sync_targets_from_job_config(self._job.config)
         if sink_job_conf.schedule_config:
             job_api.create_or_update_schedule_job(
                 self._name, sink_job_conf.schedule_config

--- a/python/hsfs/core/multi_table_ingestion.py
+++ b/python/hsfs/core/multi_table_ingestion.py
@@ -150,6 +150,7 @@ class MultiTableIngestionJob:
         self._targets: list[TableIngestionTarget] = []
         self._target_index: dict[int, int] = {}
         self._target_alias_index: dict[int, int] = {}
+        self._staged_target_ids: set[int] = set()
         self._job: job.Job | None = None
 
     @public
@@ -238,6 +239,8 @@ class MultiTableIngestionJob:
             self._target_index[key] = len(self._targets)
             self._targets.append(target)
         self._target_alias_index[key] = self._target_index[key]
+        if self._job is not None:
+            self._staged_target_ids.add(key)
 
     def _target_position(self, feature_group_id: int) -> int | None:
         return self._target_index.get(
@@ -255,7 +258,9 @@ class MultiTableIngestionJob:
         except AttributeError:
             feature_group._id = current_id
 
-    def _sync_targets_from_job_config(self, config: dict | None) -> None:
+    def _sync_targets_from_job_config(
+        self, config: dict | None, preserve_staged_targets: bool = False
+    ) -> None:
         if not isinstance(config, dict):
             return
         targets = config.get("targets")
@@ -266,9 +271,33 @@ class MultiTableIngestionJob:
 
         previous_targets = list(self._targets)
         previous_alias_index = dict(self._target_alias_index)
-        self._targets = [
+        server_targets = [
             TableIngestionTarget.from_response_json(target) for target in targets
         ]
+        if preserve_staged_targets:
+            staged_target_ids = set(self._staged_target_ids)
+            merged_targets = list(server_targets)
+            staged_positions = [
+                index
+                for index, previous_target in enumerate(previous_targets)
+                if previous_target._feature_group_id in staged_target_ids
+            ]
+            for index in staged_positions:
+                previous_target = previous_targets[index]
+                if index < len(server_targets):
+                    previous_target._feature_group_id = server_targets[
+                        index
+                    ]._feature_group_id
+                    merged_targets[index] = previous_target
+                else:
+                    merged_targets.append(previous_target)
+            self._targets = merged_targets
+            self._staged_target_ids = {
+                self._targets[index]._feature_group_id for index in staged_positions
+            }
+        else:
+            self._targets = server_targets
+            self._staged_target_ids.clear()
         self._target_index = {
             target._feature_group_id: index
             for index, target in enumerate(self._targets)
@@ -288,7 +317,9 @@ class MultiTableIngestionJob:
         from hopsworks_common.core.job_api import JobApi
 
         self._job = JobApi().get(self._name)
-        self._sync_targets_from_job_config(self._job.config)
+        self._sync_targets_from_job_config(
+            self._job.config, preserve_staged_targets=True
+        )
 
     def _save_enabled_state(self, index: int, enabled: bool) -> None:
         targets = (
@@ -300,7 +331,9 @@ class MultiTableIngestionJob:
             return
         targets[index]["enabled"] = enabled
         self._job = self._job.save()
-        self._sync_targets_from_job_config(self._job.config)
+        self._sync_targets_from_job_config(
+            self._job.config, preserve_staged_targets=True
+        )
 
     def _attach_feature_group(
         self,

--- a/python/tests/core/test_feature_group_engine.py
+++ b/python/tests/core/test_feature_group_engine.py
@@ -1595,8 +1595,9 @@ class TestFeatureGroupEngine:
         )
 
         def _save_side_effect(fg):
-            fg._id = 10
-            return fg
+            response = fg.to_dict()
+            response["id"] = 10
+            return fg.update_from_response_json(response)
 
         mock_fg_api.return_value._save.side_effect = _save_side_effect
 
@@ -1657,8 +1658,9 @@ class TestFeatureGroupEngine:
         )
 
         def _save_side_effect(fg):
-            fg._id = 10
-            return fg
+            response = fg.to_dict()
+            response["id"] = 10
+            return fg.update_from_response_json(response)
 
         mock_fg_api.return_value._save.side_effect = _save_side_effect
 
@@ -1845,8 +1847,9 @@ class TestFeatureGroupEngine:
         )
 
         def _save_side_effect(fg):
-            fg._id = 10
-            return fg
+            response = fg.to_dict()
+            response["id"] = 10
+            return fg.update_from_response_json(response)
 
         mock_fg_api.return_value._save.side_effect = _save_side_effect
 

--- a/python/tests/core/test_multi_table_ingestion.py
+++ b/python/tests/core/test_multi_table_ingestion.py
@@ -129,13 +129,65 @@ class TestMultiTableIngestionJob:
 
         with patch("hopsworks_common.core.job_api.JobApi") as MockJobApi:
             api = MockJobApi.return_value
-            api.create.return_value = MagicMock()
+            created = MagicMock()
+            created.config = {"targets": [{"featuregroupId": 1, "enabled": True}]}
+            current = MagicMock()
+            current.config = {"targets": [{"featuregroupId": 1, "enabled": True}]}
+            updated = MagicMock()
+            updated.config = {"targets": [{"featuregroupId": 1, "enabled": False}]}
+            current.save.return_value = updated
+            api.create.return_value = created
+            api.get.return_value = current
             job.save()
             api.create.reset_mock()
 
             job.set_table_enabled(feature_group_id=1, enabled=False)
 
-            api.create.assert_called_once()
+            api.get.assert_called_once_with("crm_ingestion")
+            current.save.assert_called_once()
+            api.create.assert_not_called()
+            assert current.config["targets"][0]["enabled"] is False
+            assert job.job is updated
+
+    def test_set_table_enabled_resolves_recreated_feature_group_ids(self):
+        job = _builder()
+        old_fg = _feature_group(1)
+        job.add_target(feature_group_id=1)
+        job.add_target(feature_group_id=2)
+
+        with patch("hopsworks_common.core.job_api.JobApi") as MockJobApi:
+            api = MockJobApi.return_value
+            created = MagicMock()
+            created.config = {
+                "targets": [
+                    {"featuregroupId": 1, "enabled": True},
+                    {"featuregroupId": 2, "enabled": True},
+                ]
+            }
+            current = MagicMock()
+            current.config = {
+                "targets": [
+                    {"featuregroupId": 11, "enabled": True},
+                    {"featuregroupId": 12, "enabled": True},
+                ]
+            }
+            updated = MagicMock()
+            updated.config = {
+                "targets": [
+                    {"featuregroupId": 11, "enabled": False},
+                    {"featuregroupId": 12, "enabled": True},
+                ]
+            }
+            current.save.return_value = updated
+            api.create.return_value = created
+            api.get.return_value = current
+
+            job.save()
+            job.set_table_enabled(feature_group=old_fg, enabled=False)
+
+        assert current.config["targets"][0]["enabled"] is False
+        assert [target._feature_group_id for target in job.targets] == [11, 12]
+        assert old_fg.id == 11
 
     def test_set_table_enabled_preserves_column_mappings(self):
         job = _builder()

--- a/python/tests/core/test_multi_table_ingestion.py
+++ b/python/tests/core/test_multi_table_ingestion.py
@@ -189,6 +189,70 @@ class TestMultiTableIngestionJob:
         assert [target._feature_group_id for target in job.targets] == [11, 12]
         assert old_fg.id == 11
 
+    def test_set_table_enabled_preserves_pending_target_additions(self):
+        job = _builder()
+        job.add_target(feature_group_id=1)
+
+        with patch("hopsworks_common.core.job_api.JobApi") as MockJobApi:
+            api = MockJobApi.return_value
+            created = MagicMock()
+            created.config = {"targets": [{"featuregroupId": 1, "enabled": True}]}
+            current = MagicMock()
+            current.config = {"targets": [{"featuregroupId": 1, "enabled": True}]}
+            updated = MagicMock()
+            updated.config = {"targets": [{"featuregroupId": 1, "enabled": False}]}
+            current.save.return_value = updated
+            api.create.return_value = created
+            api.get.return_value = current
+
+            job.save()
+            job.add_target(feature_group_id=2, batch_size=777)
+            job.set_table_enabled(feature_group_id=1, enabled=False)
+
+        assert [target._feature_group_id for target in job.targets] == [1, 2]
+        assert job.targets[0].to_dict()["enabled"] is False
+        assert job.targets[1].to_dict()["batchSize"] == 777
+
+    def test_set_table_enabled_preserves_pending_target_edits(self):
+        job = _builder()
+        job.add_target(feature_group_id=1)
+        job.add_target(feature_group_id=2)
+
+        with patch("hopsworks_common.core.job_api.JobApi") as MockJobApi:
+            api = MockJobApi.return_value
+            created = MagicMock()
+            created.config = {
+                "targets": [
+                    {"featuregroupId": 1, "enabled": True},
+                    {"featuregroupId": 2, "enabled": True},
+                ]
+            }
+            current = MagicMock()
+            current.config = {
+                "targets": [
+                    {"featuregroupId": 1, "enabled": True},
+                    {"featuregroupId": 2, "enabled": True},
+                ]
+            }
+            updated = MagicMock()
+            updated.config = {
+                "targets": [
+                    {"featuregroupId": 1, "enabled": False},
+                    {"featuregroupId": 2, "enabled": True},
+                ]
+            }
+            current.save.return_value = updated
+            api.create.return_value = created
+            api.get.return_value = current
+
+            job.save()
+            job.add_target(feature_group_id=2, batch_size=777)
+            job.set_table_enabled(feature_group_id=1, enabled=False)
+
+        assert [target._feature_group_id for target in job.targets] == [1, 2]
+        assert job.targets[0].to_dict()["enabled"] is False
+        assert job.targets[1].to_dict()["batchSize"] == 777
+
     def test_set_table_enabled_preserves_column_mappings(self):
         job = _builder()
         # attach with generated column mappings, as the engine does


### PR DESCRIPTION
Preserve the client-side MultiTableIngestionJob reference before saving a sink-enabled feature group. FeatureGroup.update_from_response_json reinitializes the object from the backend response, which drops the shared builder and caused Google Sheets multi-table ingestion targets to remain empty.

When toggling a table on a saved multi-table ingestion job, refresh the persisted job config first and update the existing job config instead of rebuilding it from stale local targets. Full-load DLT runs recreate feature groups and persist new target ids, so the SDK now keeps positional aliases for old ids, refreshes passed FeatureGroup references, and preserves current target metadata before saving the enabled flag.

Add regressions that simulate backend feature-group response reinitialization, saved target toggles, and target-id changes after full-load recreation.

Verified with: ./.venv/bin/pytest tests/core/test_multi_table_ingestion.py tests/core/test_feature_group_engine.py

Also verified in the loadtest pod by patching the installed SDK and running: /srv/hops/python/bin/pytest -vv -l --tb=long -s workflows/feature_store/python_driver/test_data_sources_ingestion.py -k GOOGLE_SHEETS

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
