### PR TITLE
[HWORKS-2967] Add platform intelligence support for identifying duplicate features

### DIFF
--- a/python/hopsworks_common/client/exceptions.py
+++ b/python/hopsworks_common/client/exceptions.py
@@ -292,17 +292,28 @@ class PlatformIntelligenceException(Exception):
     """Raised when a platform-intelligence call cannot be served.
 
     Either the cluster's LLM is not configured (admin has not set
-    `PLATFORM_INTELLIGENCE_LLM_API_KEY`) or the LLM call itself failed.
+    `PLATFORM_INTELLIGENCE_LLM_API_KEY`), the requested capability is
+    disabled, or the LLM call itself failed.
     Inspect the ``reason`` attribute, which is set to one of the constants
     below, to disambiguate.
 
     Attributes:
         NOT_CONFIGURED: Reason value when the cluster has no LLM API key configured.
         INFERENCE_FAILED: Reason value when the LLM call itself failed.
+        DUPLICATE_CHECK_FAILED: Reason value when the duplicate feature group check failed on the backend.
+        DUPLICATE_CHECK_DISABLED: Reason value when a duplicate check was requested but the check is disabled or unconfigured on the cluster.
+        DUPLICATE_CHECK_NOT_FOUND: Reason value when no duplicate check result exists for the feature group.
+        DUPLICATE_CHECK_ALREADY_RUNNING: Reason value when a recheck was rejected because a check is already in flight for the feature group.
+        DUPLICATE_CHECK_NOT_OWNER: Reason value when a recheck was rejected because the caller's project does not own the feature group.
     """
 
     NOT_CONFIGURED = "not_configured"
     INFERENCE_FAILED = "inference_failed"
+    DUPLICATE_CHECK_FAILED = "duplicate_check_failed"
+    DUPLICATE_CHECK_DISABLED = "duplicate_check_disabled"
+    DUPLICATE_CHECK_NOT_FOUND = "duplicate_check_not_found"
+    DUPLICATE_CHECK_ALREADY_RUNNING = "duplicate_check_already_running"
+    DUPLICATE_CHECK_NOT_OWNER = "duplicate_check_not_owner"
 
     def __init__(self, reason: str, message: str) -> None:
         self.reason = reason

--- a/python/hsfs/core/feature_group_api.py
+++ b/python/hsfs/core/feature_group_api.py
@@ -17,7 +17,12 @@ from __future__ import annotations
 
 import warnings
 
+import humps
 from hopsworks_common import client
+from hopsworks_common.client.exceptions import (
+    PlatformIntelligenceException,
+    RestAPIError,
+)
 from hsfs import decorators, feature_group_commit, util
 from hsfs import feature_group as fg_mod
 from hsfs.core import (
@@ -26,6 +31,16 @@ from hsfs.core import (
     ingestion_job_conf,
     job,
 )
+
+
+# Backend PlatformIntelligenceErrorCode values: range 520000 + the per-code
+# offset, see RESTCodes.java in hopsworks-rest-utils.
+_PI_LLM_NOT_CONFIGURED = 520012
+_PI_DUPLICATE_CHECK_FAILED = 520016
+_PI_DUPLICATE_CHECK_DISABLED = 520017
+_PI_DUPLICATE_CHECK_NOT_FOUND = 520018
+_PI_DUPLICATE_CHECK_ALREADY_RUNNING = 520019
+_PI_DUPLICATE_CHECK_NOT_OWNER = 520020
 
 
 class FeatureGroupApi:
@@ -64,6 +79,8 @@ class FeatureGroupApi:
                 "mandatorytags",
             ]
         }
+        if getattr(feature_group_instance, "_not_check_duplicate", False):
+            query_params["skipDuplicateCheck"] = True
         headers = {"content-type": "application/json"}
         return feature_group_instance.update_from_response_json(
             _client._send_request(
@@ -74,6 +91,93 @@ class FeatureGroupApi:
                 query_params=query_params,
             ),
         )
+
+    def _check_duplicates(
+        self,
+        feature_group_instance: fg_mod.FeatureGroup
+        | fg_mod.ExternalFeatureGroup
+        | fg_mod.SpineGroup,
+        recheck: bool = False,
+    ) -> dict:
+        """Fetch the duplicate-check result stored for a feature group.
+
+        Parameters:
+            feature_group_instance: metadata object of the feature group to check
+            recheck: run a fresh synchronous check instead of returning the stored result
+
+        Returns:
+            decamelized duplicate-check result
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "featurestores",
+            feature_group_instance.feature_store_id,
+            "featuregroups",
+            feature_group_instance.id,
+            "duplicates",
+        ]
+        # A recheck mutates the stored result and spends LLM budget, so the
+        # backend exposes it as a POST subresource rather than a GET flag.
+        if recheck:
+            method, path = "POST", path_params + ["recheck"]
+        else:
+            method, path = "GET", path_params
+
+        try:
+            response = _client._send_request(method, path)
+        except RestAPIError as err:
+            # Translate the backend PlatformIntelligenceErrorCodes the
+            # duplicate-check path can raise into a typed exception so callers
+            # don't have to string-match server messages.
+            if err.error_code == _PI_LLM_NOT_CONFIGURED:
+                raise PlatformIntelligenceException(
+                    PlatformIntelligenceException.NOT_CONFIGURED,
+                    "Platform intelligence is not enabled on this Hopsworks "
+                    "cluster: the LLM API key is not configured. Ask the "
+                    "cluster admin to set PLATFORM_INTELLIGENCE_LLM_API_KEY.",
+                ) from err
+            if err.error_code == _PI_DUPLICATE_CHECK_FAILED:
+                raise PlatformIntelligenceException(
+                    PlatformIntelligenceException.DUPLICATE_CHECK_FAILED,
+                    "Platform intelligence call failed while checking for "
+                    f"duplicate feature groups: {err}",
+                ) from err
+            if err.error_code == _PI_DUPLICATE_CHECK_DISABLED:
+                raise PlatformIntelligenceException(
+                    PlatformIntelligenceException.DUPLICATE_CHECK_DISABLED,
+                    "The duplicate feature group check is disabled on this "
+                    "Hopsworks cluster. Ask the cluster admin to enable the "
+                    "enable_duplicate_feature_check variable and configure "
+                    "platform intelligence.",
+                ) from err
+            if err.error_code == _PI_DUPLICATE_CHECK_NOT_FOUND:
+                raise PlatformIntelligenceException(
+                    PlatformIntelligenceException.DUPLICATE_CHECK_NOT_FOUND,
+                    "No duplicate check result found for feature group "
+                    f"`{feature_group_instance.name}`, version "
+                    f"`{feature_group_instance.version}`.",
+                ) from err
+            if err.error_code == _PI_DUPLICATE_CHECK_ALREADY_RUNNING:
+                raise PlatformIntelligenceException(
+                    PlatformIntelligenceException.DUPLICATE_CHECK_ALREADY_RUNNING,
+                    "A duplicate check is already running for feature group "
+                    f"`{feature_group_instance.name}`, version "
+                    f"`{feature_group_instance.version}`; retry once it "
+                    "completes.",
+                ) from err
+            if err.error_code == _PI_DUPLICATE_CHECK_NOT_OWNER:
+                raise PlatformIntelligenceException(
+                    PlatformIntelligenceException.DUPLICATE_CHECK_NOT_OWNER,
+                    "Only the project that owns feature group "
+                    f"`{feature_group_instance.name}` can rerun its duplicate "
+                    "check; a shared feature group can be read but not "
+                    "rechecked from a consumer project.",
+                ) from err
+            raise
+
+        return humps.decamelize(response)
 
     @decorators._catch_not_found(
         "hsfs.feature_group.FeatureGroupBase", fallback_return=[]

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -3200,6 +3200,44 @@ class FeatureGroupBase:
         self._feature_group_engine._update_ttl(self, None, False)
         return self
 
+    @public
+    def check_duplicates(self, recheck: bool = False) -> dict:
+        """Retrieve the result of the duplicate feature group check for this feature group.
+
+        When a feature group is created, Hopsworks asynchronously checks whether it duplicates features of existing feature groups and stores the result.
+        This method returns that stored result as a dictionary with keys such as `status`, `suspected_duplicates`, and `matches`.
+        `status` is one of `"NOT_CHECKED"`, `"PENDING"`, `"RUNNING"`, `"SUCCEEDED"`, or `"FAILED"`.
+        Each entry in `matches` describes a suspected duplicate feature group, including the matched features, the reason, and the suspected duplicate feature names.
+        The same result is also available from the feature store through [`FeatureStore.check_feature_group_duplicates`][hsfs.feature_store.FeatureStore.check_feature_group_duplicates].
+
+        Example:
+            ```python
+            # connect to the Feature Store
+            fs = ...
+
+            # get the Feature Group instance
+            fg = fs.get_or_create_feature_group(...)
+
+            # get the stored duplicate check result
+            result = fg.check_duplicates()
+            if result["suspected_duplicates"]:
+                print(result["matches"])
+            ```
+
+        Parameters:
+            recheck: If `True`, run a fresh synchronous platform-intelligence check instead of returning the stored result.
+
+        Returns:
+            The duplicate check result.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+            hopsworks.client.exceptions.PlatformIntelligenceException: If platform intelligence is not configured on the cluster, the duplicate check is disabled, or the check failed.
+        """
+        return self._feature_group_engine._feature_group_api._check_duplicates(
+            self, recheck=recheck
+        )
+
 
 @public
 @typechecked
@@ -3266,6 +3304,7 @@ class FeatureGroup(FeatureGroupBase):
         clustered_by: list[str] | None = None,
         bucket_index: dict[str, Any] | None = None,
         sort_order: list[str] | None = None,
+        not_check_duplicate: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -3333,6 +3372,7 @@ class FeatureGroup(FeatureGroupBase):
             None if sort_order is None else list(sort_order)
         )
         self._online_partition_columns: bool = bool(online_partition_columns)
+        self._not_check_duplicate: bool = not_check_duplicate
 
         self._materialization_job: Job = None
 

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -794,6 +794,7 @@ class FeatureStore:
         clustered_by: list[str] | None = None,
         bucket_index: dict[str, Any] | None = None,
         sort_order: list[str] | None = None,
+        not_check_duplicate: bool = False,
     ) -> feature_group.FeatureGroup:
         """Create a feature group metadata object.
 
@@ -975,6 +976,9 @@ class FeatureStore:
                 A persistent Iceberg write sort order, e.g. `["merchant_id asc", "amount desc nulls last"]`; ICEBERG only.
                 New writes are range-distributed and sorted on these fields, and [`FeatureGroup.optimize`][hsfs.feature_group.FeatureGroup.optimize] with `strategy="sort"` rewrites existing files to the order.
                 Mutually exclusive with `zorder_by` (the two prescribe conflicting file layouts); defaults to `None`.
+            not_check_duplicate:
+                If `True`, skip the automatic duplicate feature group check that Hopsworks runs when the feature group is saved.
+                The stored result of that check is available through [`FeatureGroupBase.check_duplicates`][hsfs.feature_group.FeatureGroupBase.check_duplicates].
 
         Returns:
             The feature group metadata object.
@@ -1032,6 +1036,7 @@ class FeatureStore:
             clustered_by=clustered_by,
             bucket_index=bucket_index,
             sort_order=sort_order,
+            not_check_duplicate=not_check_duplicate,
         )
         feature_group_object.feature_store = self
         return feature_group_object
@@ -1083,6 +1088,7 @@ class FeatureStore:
         clustered_by: list[str] | None = None,
         bucket_index: dict[str, Any] | None = None,
         sort_order: list[str] | None = None,
+        not_check_duplicate: bool = False,
     ) -> (
         feature_group.FeatureGroup
         | feature_group.ExternalFeatureGroup
@@ -1257,6 +1263,9 @@ class FeatureStore:
                 A persistent Iceberg write sort order, e.g. `["merchant_id asc", "amount desc nulls last"]`; ICEBERG only.
                 New writes are range-distributed and sorted on these fields, and [`FeatureGroup.optimize`][hsfs.feature_group.FeatureGroup.optimize] with `strategy="sort"` rewrites existing files to the order.
                 Mutually exclusive with `zorder_by` (the two prescribe conflicting file layouts); defaults to `None`.
+            not_check_duplicate:
+                If `True`, skip the automatic duplicate feature group check that Hopsworks runs when the feature group is saved.
+                The stored result of that check is available through [`FeatureGroupBase.check_duplicates`][hsfs.feature_group.FeatureGroupBase.check_duplicates].
 
         Returns:
             The feature group metadata object.
@@ -1318,6 +1327,7 @@ class FeatureStore:
                 clustered_by=clustered_by,
                 bucket_index=bucket_index,
                 sort_order=sort_order,
+                not_check_duplicate=not_check_duplicate,
             )
         elif sink_job is not None:
             # The feature group already exists: attach it to a shared multi-table
@@ -1343,6 +1353,48 @@ class FeatureStore:
                 )
         feature_group_object.feature_store = self
         return feature_group_object
+
+    @public
+    @usage._method_logger
+    def check_feature_group_duplicates(
+        self,
+        feature_group: (
+            feature_group.FeatureGroup
+            | feature_group.ExternalFeatureGroup
+            | feature_group.SpineGroup
+        ),
+        recheck: bool = False,
+    ) -> dict:
+        """Retrieve the result of the duplicate feature group check for a feature group.
+
+        When a feature group is created, Hopsworks asynchronously checks whether it duplicates features of existing feature groups and stores the result.
+        This method returns that stored result as a dictionary with keys such as `status`, `suspected_duplicates`, and `matches`.
+        It is the feature-store-level equivalent of [`FeatureGroupBase.check_duplicates`][hsfs.feature_group.FeatureGroupBase.check_duplicates].
+
+        Example:
+            ```python
+            # connect to the Feature Store
+            fs = ...
+
+            # get the Feature Group instance
+            fg = fs.get_feature_group("electricity_prices", version=1)
+
+            # get the stored duplicate check result
+            result = fs.check_feature_group_duplicates(fg)
+            ```
+
+        Parameters:
+            feature_group: The feature group to fetch the duplicate check result for.
+            recheck: If `True`, run a fresh synchronous platform-intelligence check instead of returning the stored result.
+
+        Returns:
+            The duplicate check result.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+            hopsworks.client.exceptions.PlatformIntelligenceException: If platform intelligence is not configured on the cluster, the duplicate check is disabled, or the check failed.
+        """
+        return self._feature_group_api._check_duplicates(feature_group, recheck=recheck)
 
     @public
     @usage._method_logger

--- a/python/tests/core/test_feature_group_api.py
+++ b/python/tests/core/test_feature_group_api.py
@@ -15,8 +15,13 @@
 #
 
 import warnings
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
+import pytest
+from hopsworks_common.client.exceptions import (
+    PlatformIntelligenceException,
+    RestAPIError,
+)
 from hsfs import feature_group as fg_mod
 from hsfs.core import feature_group_api
 
@@ -78,3 +83,158 @@ class TestFeatureGroupApi:
 
         # Assert
         assert len(warning_record) == 1
+
+
+class TestFeatureGroupApiSave:
+    def _arrange(self, mocker, backend_fixtures):
+        fg_api = feature_group_api.FeatureGroupApi()
+        json = backend_fixtures["feature_group"]["get"]["response"]
+        fg = fg_mod.FeatureGroup.from_response_json(json)
+        mocker.patch.object(fg, "update_from_response_json", return_value=fg)
+        client_mock = Mock()
+        client_mock._project_id = 119
+        client_mock._send_request.return_value = {}
+        mocker.patch("hopsworks_common.client._get_instance", return_value=client_mock)
+        return fg_api, fg, client_mock
+
+    def test_save_does_not_emit_skip_duplicate_check_by_default(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        fg_api, fg, client_mock = self._arrange(mocker, backend_fixtures)
+
+        # Act
+        fg_api._save(fg)
+
+        # Assert
+        query_params = client_mock._send_request.call_args.kwargs["query_params"]
+        assert "skipDuplicateCheck" not in query_params
+
+    def test_save_emits_skip_duplicate_check_when_flag_set(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        fg_api, fg, client_mock = self._arrange(mocker, backend_fixtures)
+        fg._not_check_duplicate = True
+
+        # Act
+        fg_api._save(fg)
+
+        # Assert
+        query_params = client_mock._send_request.call_args.kwargs["query_params"]
+        assert query_params["skipDuplicateCheck"] is True
+
+
+class TestFeatureGroupApiCheckDuplicates:
+    def _arrange(self, mocker, backend_fixtures, response=None, side_effect=None):
+        fg_api = feature_group_api.FeatureGroupApi()
+        json = backend_fixtures["feature_group"]["get"]["response"]
+        fg = fg_mod.FeatureGroup.from_response_json(json)
+        client_mock = Mock()
+        client_mock._project_id = 119
+        if side_effect is not None:
+            client_mock._send_request.side_effect = side_effect
+        else:
+            client_mock._send_request.return_value = response or {}
+        mocker.patch("hopsworks_common.client._get_instance", return_value=client_mock)
+        return fg_api, fg, client_mock
+
+    def _make_rest_api_error(self, error_code: int) -> RestAPIError:
+        # Build a real RestAPIError without going through HTTP — we just need
+        # the parsed-error-object path to set self.error_code to our value.
+        response = MagicMock()
+        response.json.return_value = {"errorCode": error_code, "errorMsg": "x"}
+        response.status_code = 400
+        response.reason = "Bad Request"
+        response.content = b""
+        return RestAPIError("http://test/url", response)
+
+    def test_check_duplicates_builds_path_and_decamelizes(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        fg_api, fg, client_mock = self._arrange(
+            mocker,
+            backend_fixtures,
+            response={
+                "status": "SUCCEEDED",
+                "suspectedDuplicates": True,
+                "matches": [{"featureGroupName": "customer_profiles"}],
+            },
+        )
+
+        # Act
+        result = fg_api._check_duplicates(fg)
+
+        # Assert — a plain read is a GET on the duplicates subresource
+        call_args = client_mock._send_request.call_args
+        assert call_args.args[0] == "GET"
+        assert call_args.args[1] == [
+            "project",
+            119,
+            "featurestores",
+            fg.feature_store_id,
+            "featuregroups",
+            fg.id,
+            "duplicates",
+        ]
+        assert result["suspected_duplicates"] is True
+        assert result["matches"][0]["feature_group_name"] == "customer_profiles"
+
+    def test_check_duplicates_recheck_posts_to_recheck_subresource(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange — a recheck mutates the stored result, so it must never
+        # travel on GET (observers are auto-authorized for GETs server-side).
+        fg_api, fg, client_mock = self._arrange(
+            mocker, backend_fixtures, response={"status": "SUCCEEDED"}
+        )
+
+        # Act
+        fg_api._check_duplicates(fg, recheck=True)
+
+        # Assert
+        call_args = client_mock._send_request.call_args
+        assert call_args.args[0] == "POST"
+        assert call_args.args[1][-2:] == ["duplicates", "recheck"]
+
+    @pytest.mark.parametrize(
+        "error_code, reason",
+        [
+            (520012, PlatformIntelligenceException.NOT_CONFIGURED),
+            (520016, PlatformIntelligenceException.DUPLICATE_CHECK_FAILED),
+            (520017, PlatformIntelligenceException.DUPLICATE_CHECK_DISABLED),
+            (520018, PlatformIntelligenceException.DUPLICATE_CHECK_NOT_FOUND),
+            (520019, PlatformIntelligenceException.DUPLICATE_CHECK_ALREADY_RUNNING),
+            (520020, PlatformIntelligenceException.DUPLICATE_CHECK_NOT_OWNER),
+        ],
+    )
+    def test_check_duplicates_translates_platform_intelligence_errors(
+        self, mocker, backend_fixtures, error_code, reason
+    ):
+        # Arrange
+        fg_api, fg, _ = self._arrange(
+            mocker,
+            backend_fixtures,
+            side_effect=self._make_rest_api_error(error_code),
+        )
+
+        # Act / Assert
+        with pytest.raises(PlatformIntelligenceException) as excinfo:
+            fg_api._check_duplicates(fg)
+
+        assert excinfo.value.reason == reason
+
+    def test_check_duplicates_unrelated_rest_error_is_not_translated(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange — any other backend error must surface as RestAPIError, not PIE.
+        fg_api, fg, _ = self._arrange(
+            mocker,
+            backend_fixtures,
+            side_effect=self._make_rest_api_error(270009),
+        )
+
+        # Act / Assert
+        with pytest.raises(RestAPIError):
+            fg_api._check_duplicates(fg)

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -391,6 +391,36 @@ class TestFeatureGroup:
         assert len(features) == 2
         assert {f.name for f in features} == {"f1", "f2"}
 
+    def test_check_duplicates_delegates_to_api(self, mocker):
+        # Arrange
+        fg = get_test_feature_group()
+        mock_check = mocker.patch(
+            "hsfs.core.feature_group_api.FeatureGroupApi._check_duplicates",
+            return_value={"status": "SUCCEEDED", "suspected_duplicates": False},
+        )
+
+        # Act
+        result = fg.check_duplicates(recheck=True)
+
+        # Assert
+        mock_check.assert_called_once_with(fg, recheck=True)
+        assert result == {"status": "SUCCEEDED", "suspected_duplicates": False}
+
+    def test_not_check_duplicate_defaults_to_false(self):
+        fg = get_test_feature_group()
+        assert fg._not_check_duplicate is False
+
+    def test_not_check_duplicate_stored_when_set(self):
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=1,
+            primary_key=["pk"],
+            partition_key=[],
+            not_check_duplicate=True,
+        )
+        assert fg._not_check_duplicate is True
+
     def test_materialization_job(self, mocker):
         mock_job = mocker.Mock()
         mock_job_api = mocker.patch(

--- a/python/tests/test_feature_store.py
+++ b/python/tests/test_feature_store.py
@@ -233,6 +233,77 @@ class TestFeatureStore:
         # Assert
         assert fg_res.bucket_index == {"field": "cc_num", "num_buckets": 16}
 
+    def test_create_feature_group_passes_not_check_duplicate(
+        self, backend_fixtures, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        mocker.patch(
+            "hsfs.feature_group.FeatureGroup._has_deltalake", return_value=True
+        )
+        json = backend_fixtures["feature_store"]["get"]["response"]
+        fs = feature_store_mod.FeatureStore.from_response_json(json)
+
+        # Act
+        fg_res = fs.create_feature_group(
+            "test_feature_group_name",
+            version=1,
+            primary_key=["cc_num"],
+            not_check_duplicate=True,
+        )
+
+        # Assert
+        assert fg_res._not_check_duplicate is True
+
+    def test_get_or_create_feature_group_passes_not_check_duplicate(
+        self, backend_fixtures, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        mocker.patch(
+            "hsfs.feature_group.FeatureGroup._has_deltalake", return_value=True
+        )
+        mocker.patch(
+            "hsfs.core.feature_group_api.FeatureGroupApi._get", return_value=None
+        )
+        json = backend_fixtures["feature_store"]["get"]["response"]
+        fs = feature_store_mod.FeatureStore.from_response_json(json)
+
+        # Act
+        fg_res = fs.get_or_create_feature_group(
+            "test_feature_group_name",
+            version=1,
+            primary_key=["cc_num"],
+            not_check_duplicate=True,
+        )
+
+        # Assert
+        assert fg_res._not_check_duplicate is True
+
+    def test_check_feature_group_duplicates_delegates_to_api(
+        self, backend_fixtures, mocker
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        json = backend_fixtures["feature_store"]["get"]["response"]
+        fs = feature_store_mod.FeatureStore.from_response_json(json)
+        fg = feature_group_mod.FeatureGroup.from_response_json(
+            backend_fixtures["feature_group"]["get"]["response"]
+        )
+        mock_check = mocker.patch(
+            "hsfs.core.feature_group_api.FeatureGroupApi._check_duplicates",
+            return_value={"status": "NOT_CHECKED", "suspected_duplicates": False},
+        )
+
+        # Act
+        result = fs.check_feature_group_duplicates(fg, recheck=True)
+
+        # Assert
+        mock_check.assert_called_once_with(fg, recheck=True)
+        assert result == {"status": "NOT_CHECKED", "suspected_duplicates": False}
+
     def test_create_feature_group_normalizes_tags(self, backend_fixtures, mocker):
         # Arrange
         from hopsworks_common.tag import Tag


### PR DESCRIPTION
JIRA: https://hopsworks.atlassian.net/browse/HWORKS-2967

Python-client part of the platform-intelligence duplicate feature check. Sibling PRs: hopsworks-ee (backend) and hopsworks-front (UI warning).

## What this PR does

- `FeatureGroup.check_duplicates(recheck=False) -> dict` on `FeatureGroupBase` (all feature group flavours): returns the stored duplicate-check result as a decamelized dict (`status`, `suspected_duplicates`, `matches` with reason, duplicated features, and the matched group's reader-authorized metadata). `recheck=True` POSTs to the backend's `/duplicates/recheck` subresource (a recheck mutates the stored result and spends LLM budget, so it never travels on GET); a concurrent recheck is rejected with 409, translated to `PlatformIntelligenceException` (`duplicate_check_already_running`).
- `FeatureStore.check_feature_group_duplicates(feature_group, recheck=False) -> dict`: feature-store-level entry point.
- `not_check_duplicate=False` kwarg on `create_feature_group` and `get_or_create_feature_group`, emitted as the create POST's `skipDuplicateCheck` query parameter.
- Backend platform-intelligence error codes (520012/520016/520017/520018/520019/520020) translate to `PlatformIntelligenceException` with reason constants, including `duplicate_check_not_owner` (a recheck from a non-owning project) and `duplicate_check_already_running` (409).

## Verification

- 16 new pytest tests (path shape and POST recheck subresource, query params, decamelization, error translation incl. 409, kwarg threading); ruff check/format clean; docsig clean; `check_pep8_public.py` passes.
- Verified live against a dev cluster running the sibling backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)