### PR TITLE
[HWORKS-2807] Append fix spark unit tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,6 +45,15 @@ jobs:
           uv cache clean hopsworks
           uv sync --extra dev --project python --reinstall-package hopsworks
 
+      # A transient Maven Central failure while resolving spark-avro kills the
+      # Spark JVM at launch (JAVA_GATEWAY_EXITED) and fails every Spark test in
+      # the job. Cache the resolved ivy artifacts so warm runs never re-resolve.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
+
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -164,6 +164,15 @@ jobs:
       - name: Display Python version
         run: python --version
 
+      # A transient Maven Central failure while resolving spark-avro kills the
+      # Spark JVM at launch (JAVA_GATEWAY_EXITED) and fails every Spark test in
+      # the job. Cache the resolved ivy artifacts so warm runs never re-resolve.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
+
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
 
@@ -204,6 +213,15 @@ jobs:
         run: |
           uv cache clean hopsworks
           uv sync --extra dev-no-opt --project python --reinstall-package hopsworks
+
+      # A transient Maven Central failure while resolving spark-avro kills the
+      # Spark JVM at launch (JAVA_GATEWAY_EXITED) and fails every Spark test in
+      # the job. Cache the resolved ivy artifacts so warm runs never re-resolve.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
@@ -249,6 +267,15 @@ jobs:
       - name: Display Python version
         run: python --version
 
+      # A transient Maven Central failure while resolving spark-avro kills the
+      # Spark JVM at launch (JAVA_GATEWAY_EXITED) and fails every Spark test in
+      # the job. Cache the resolved ivy artifacts so warm runs never re-resolve.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
+
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
 
@@ -292,6 +319,15 @@ jobs:
 
       - name: Pin Great Expectations and Polars to lower bounds
         run: uv pip install "great-expectations==0.18.12" "polars==0.20.31"
+
+      # A transient Maven Central failure while resolving spark-avro kills the
+      # Spark JVM at launch (JAVA_GATEWAY_EXITED) and fails every Spark test in
+      # the job. Cache the resolved ivy artifacts so warm runs never re-resolve.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
@@ -337,6 +373,15 @@ jobs:
       - name: Display Python version
         run: python --version
 
+      # A transient Maven Central failure while resolving spark-avro kills the
+      # Spark JVM at launch (JAVA_GATEWAY_EXITED) and fails every Spark test in
+      # the job. Cache the resolved ivy artifacts so warm runs never re-resolve.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
+
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
 
@@ -368,6 +413,15 @@ jobs:
         run: |
           uv cache clean hopsworks
           uv sync --extra dev --project python --reinstall-package hopsworks
+
+      # A transient Maven Central failure while resolving spark-avro kills the
+      # Spark JVM at launch (JAVA_GATEWAY_EXITED) and fails every Spark test in
+      # the job. Cache the resolved ivy artifacts so warm runs never re-resolve.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
@@ -409,6 +463,14 @@ jobs:
 
       - name: Display Python version
         run: python --version
+
+      # See the ubuntu jobs: cached ivy artifacts keep a Maven Central blip
+      # from failing every Spark test in the job.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         shell: cmd
@@ -452,6 +514,14 @@ jobs:
 
       - name: Display pip freeze
         run: uv pip freeze
+
+      # See the ubuntu jobs: cached ivy artifacts keep a Maven Central blip
+      # from failing every Spark test in the job.
+      - name: Cache Spark ivy packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ivy-spark-avro-3.5.5
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         shell: cmd

--- a/python/tests/core/test_delta_engine.py
+++ b/python/tests/core/test_delta_engine.py
@@ -26,6 +26,8 @@ from hopsworks_common.client.exceptions import FeatureStoreException
 from hsfs.core.delta_engine import DeltaEngine
 from hsfs.feature_group_commit import FeatureGroupCommit
 
+from tests import util
+
 
 class _FakeType:
     """A Spark-data-type stand-in: a struct carries `.fields`, else a leaf."""
@@ -1730,9 +1732,7 @@ class TestDeltaEngine:
         # pyspark's functions (F.col, F.input_file_name) require an active
         # SparkContext even against mocked DataFrames; create one so the test
         # does not depend on an earlier test having started Spark.
-        from pyspark.sql import SparkSession
-
-        SparkSession.builder.master("local[1]").getOrCreate()
+        util.get_or_create_local_spark_session()
         mocker.patch(
             "hopsworks_common.spark_connect_utils._is_spark_connect_session",
             return_value=True,

--- a/python/tests/core/test_partition_grains.py
+++ b/python/tests/core/test_partition_grains.py
@@ -28,6 +28,8 @@ from types import SimpleNamespace
 import pytest
 from hsfs.core import partition_grains
 
+from tests import util
+
 
 def _fg(partitioned_by=None, event_time="event_ts"):
     return SimpleNamespace(partitioned_by=partitioned_by, event_time=event_time)
@@ -97,9 +99,7 @@ def test_spark_noop_when_event_time_column_missing():
 
 @pytest.fixture(scope="module")
 def spark_session():
-    from pyspark.sql import SparkSession
-
-    return SparkSession.builder.master("local[1]").getOrCreate()
+    return util.get_or_create_local_spark_session()
 
 
 def test_spark_materializes_grains_from_timestamp(spark_session):

--- a/python/tests/util.py
+++ b/python/tests/util.py
@@ -15,6 +15,7 @@
 #
 
 import os
+import sys
 from functools import wraps
 
 
@@ -29,3 +30,21 @@ def changes_environ(f):
             os.environ.update(old_environ)
 
     return g
+
+
+def get_or_create_local_spark_session():
+    # Single entry point for tests that need a real SparkSession. The worker
+    # and driver interpreters are pinned to the running interpreter at session
+    # creation: a session created here outlives the creating test (Spark keeps
+    # one JVM per process), and an unpinned session makes every later
+    # worker-forking test resolve `python3` from PATH, which on CI runners is
+    # the system interpreter, not the venv (PYTHON_VERSION_MISMATCH).
+    from pyspark.sql import SparkSession
+
+    return (
+        SparkSession.builder.master("local[1]")
+        .appName("hopsworks-unit-tests")
+        .config("spark.pyspark.python", sys.executable)
+        .config("spark.pyspark.driver.python", sys.executable)
+        .getOrCreate()
+    )


### PR DESCRIPTION
JIRA: https://hopsworks.atlassian.net/browse/HWORKS-2807

Append fix for the Spark unit test failures first seen on the `python` workflow of #1063 (`Unit Tests (No Optional Dependencies)`: 208 failed, 84 errors).

## Root cause

The job log shows ~198 Spark JVM launch attempts, almost all dying at startup with:

```
java.lang.RuntimeException: [unresolved dependency: org.apache.spark#spark-avro_2.12;3.5.5: not found]
```

A transient Maven Central resolution failure on the runner killed the JVM at launch (`JAVA_GATEWAY_EXITED`), failing every Spark test in the job; the same commit passed `coverage` and all four version-matrix legs on other runners. The handful of `PYTHON_VERSION_MISMATCH` failures came from the few JVMs that did come up: the real `SparkSession`s created by the HWORKS-2807 tests (`test_partition_grains.py`, `test_delta_engine.py`) pin no interpreter, a session outlives its creating test, and later worker-forking tests then resolve the runner's system `python3` (3.12) against the venv driver (3.11).

## Fix

- Cache `~/.ivy2` (`actions/cache`, key `ivy-spark-avro-3.5.5`) in every pytest job of `python.yml` and in `coverage.yml`, so warm runs never re-resolve the package and a Central blip cannot take down the JVM.
- Add `tests.util.get_or_create_local_spark_session()` pinning `spark.pyspark.python` / `spark.pyspark.driver.python` to `sys.executable` at session creation, and route both real-Spark session creation sites through it.

## Verification

- `pytest python/tests/core/test_partition_grains.py python/tests/core/test_delta_engine.py`: 126 passed, in a `dev-no-opt` Python 3.11 environment on a machine whose system `python3` is 3.12 (the CI runner's exact interpreter layout).
- Full `pytest python/tests` in the same environment passes.
- Ruff check and format clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
