### PR TITLE
[HWORKS-2928] Add git_auto_redeploy to the Python client

### DIFF
--- a/python/hopsworks/cli/commands/agent.py
+++ b/python/hopsworks/cli/commands/agent.py
@@ -82,6 +82,7 @@ def agent_info(ctx: click.Context, name: str) -> None:
         ["Description", getattr(agent, "description", "-") or "-"],
         ["Status", _deployment_status(agent)],
     ]
+    rows.extend(_git_rows(agent))
     output.print_table(["FIELD", "VALUE"], rows)
 
 
@@ -402,8 +403,36 @@ def _deployment_status(d: Any) -> str:
     return "-"
 
 
+def _git_rows(d: Any) -> list[list[Any]]:
+    """Git source rows, omitted entirely for an agent deployed from a project file."""
+    git_url = _predictor_attr(d, "git_url", None)
+    if not git_url:
+        return []
+    # Branch is optional: with none configured the clone takes the repository's default, and the
+    # running deployment reports the name it resolved to.
+    branch = _predictor_attr(d, "git_branch", None) or _predictor_attr(
+        d, "git_resolved_branch", None
+    )
+    return [
+        ["Git URL", git_url],
+        ["Git provider", _predictor_attr(d, "git_provider", None) or "-"],
+        ["Git branch", branch or "default branch"],
+        [
+            "Auto-redeploy",
+            "Enabled" if _predictor_attr(d, "git_auto_redeploy", False) else "Disabled",
+        ],
+        ["Deployed commit", _predictor_attr(d, "git_current_commit", None) or "-"],
+    ]
+
+
 def _agent_to_dict(d: Any) -> dict[str, Any]:
     return {
+        "git_url": _predictor_attr(d, "git_url", None),
+        "git_provider": _predictor_attr(d, "git_provider", None),
+        "git_branch": _predictor_attr(d, "git_branch", None),
+        "git_resolved_branch": _predictor_attr(d, "git_resolved_branch", None),
+        "git_auto_redeploy": bool(_predictor_attr(d, "git_auto_redeploy", False)),
+        "git_current_commit": _predictor_attr(d, "git_current_commit", None),
         "id": getattr(d, "id", None),
         "name": getattr(d, "name", None),
         "environment": _predictor_attr(d, "environment", None),

--- a/python/hopsworks/cli/commands/app.py
+++ b/python/hopsworks/cli/commands/app.py
@@ -89,10 +89,7 @@ def app_info(ctx: click.Context, name: str) -> None:
             "Git branch",
             getattr(a, "git_branch", None) or getattr(a, "latest_branch", None) or "-",
         ],
-        [
-            "Auto-redeploy",
-            "Enabled" if getattr(a, "git_auto_redeploy", False) else "Disabled",
-        ],
+        ["Auto-redeploy", _auto_redeploy_text(a)],
         ["Latest commit", getattr(a, "latest_commit", None) or "-"],
         ["Entrypoint script", getattr(a, "entrypoint_script", None) or "-"],
         ["Entrypoint", getattr(a, "entrypoint_command", None) or "-"],
@@ -702,6 +699,17 @@ def _app_to_dict(a: Any) -> dict[str, Any]:
         "description": getattr(a, "description", None),
         "app_url": getattr(a, "app_url", None),
     }
+
+
+def _auto_redeploy_text(a: Any) -> str:
+    """Auto-redeploy state, or "-" for an app that is not git-backed.
+
+    The backend rejects the flag without a git source, so "Disabled" there would
+    imply a setting that could be turned on.
+    """
+    if not getattr(a, "git_url", None):
+        return "-"
+    return "Enabled" if getattr(a, "git_auto_redeploy", False) else "Disabled"
 
 
 def _app_source(a: Any) -> str:

--- a/python/hopsworks/cli/commands/app.py
+++ b/python/hopsworks/cli/commands/app.py
@@ -85,7 +85,10 @@ def app_info(ctx: click.Context, name: str) -> None:
         ["Port", getattr(a, "app_port", None) or "-"],
         ["Git URL", getattr(a, "git_url", None) or "-"],
         ["Git provider", getattr(a, "git_provider", None) or "-"],
-        ["Git branch", getattr(a, "git_branch", None) or "-"],
+        [
+            "Git branch",
+            getattr(a, "git_branch", None) or getattr(a, "latest_branch", None) or "-",
+        ],
         [
             "Auto-redeploy",
             "Enabled" if getattr(a, "git_auto_redeploy", False) else "Disabled",
@@ -684,6 +687,7 @@ def _app_to_dict(a: Any) -> dict[str, Any]:
         "git_url": getattr(a, "git_url", None),
         "git_provider": getattr(a, "git_provider", None),
         "git_branch": getattr(a, "git_branch", None),
+        "latest_branch": getattr(a, "latest_branch", None),
         "git_auto_redeploy": bool(getattr(a, "git_auto_redeploy", False)),
         "latest_commit": getattr(a, "latest_commit", None),
         "entrypoint_script": getattr(a, "entrypoint_script", None),

--- a/python/hopsworks/cli/commands/app.py
+++ b/python/hopsworks/cli/commands/app.py
@@ -86,6 +86,10 @@ def app_info(ctx: click.Context, name: str) -> None:
         ["Git URL", getattr(a, "git_url", None) or "-"],
         ["Git provider", getattr(a, "git_provider", None) or "-"],
         ["Git branch", getattr(a, "git_branch", None) or "-"],
+        [
+            "Auto-redeploy",
+            "Enabled" if getattr(a, "git_auto_redeploy", False) else "Disabled",
+        ],
         ["Latest commit", getattr(a, "latest_commit", None) or "-"],
         ["Entrypoint script", getattr(a, "entrypoint_script", None) or "-"],
         ["Entrypoint", getattr(a, "entrypoint_command", None) or "-"],
@@ -271,6 +275,12 @@ def _report_running(name: str, a: Any) -> None:
     help="Optional Git branch to clone.",
 )
 @click.option(
+    "--git-auto-redeploy",
+    is_flag=True,
+    default=False,
+    help="Roll the app to the branch HEAD whenever a new commit is pushed.",
+)
+@click.option(
     "--entrypoint-script",
     default=None,
     help="Relative .py entrypoint script for Streamlit Git repository apps.",
@@ -316,6 +326,7 @@ def app_create(
     git_url: str | None,
     git_provider: str | None,
     git_branch: str | None,
+    git_auto_redeploy: bool,
     entrypoint_script: str | None,
     app_base_path: str | None,
     readiness_probe_path: str | None,
@@ -340,6 +351,7 @@ def app_create(
         git_url: Git repository URL for git-backed apps.
         git_provider: Git provider for git-backed apps.
         git_branch: Optional Git branch.
+        git_auto_redeploy: Roll the app to the branch HEAD on new commits.
         entrypoint_script: Relative entrypoint script for Streamlit git apps.
         app_base_path: Public mount path for the app.
         readiness_probe_path: Optional readiness probe path override.
@@ -403,6 +415,8 @@ def app_create(
         create_kwargs["git_provider"] = git_provider
     if git_branch is not None:
         create_kwargs["git_branch"] = git_branch
+    if git_auto_redeploy:
+        create_kwargs["git_auto_redeploy"] = True
     if entrypoint_script is not None:
         create_kwargs["entrypoint_script"] = entrypoint_script
     if app_base_path is not None:
@@ -670,6 +684,7 @@ def _app_to_dict(a: Any) -> dict[str, Any]:
         "git_url": getattr(a, "git_url", None),
         "git_provider": getattr(a, "git_provider", None),
         "git_branch": getattr(a, "git_branch", None),
+        "git_auto_redeploy": bool(getattr(a, "git_auto_redeploy", False)),
         "latest_commit": getattr(a, "latest_commit", None),
         "entrypoint_script": getattr(a, "entrypoint_script", None),
         "app_base_path": getattr(a, "app_base_path", None),

--- a/python/hopsworks_common/app.py
+++ b/python/hopsworks_common/app.py
@@ -112,7 +112,7 @@ class App:
         self._git_url = git_url
         self._git_provider = git_provider
         self._git_branch = git_branch
-        self._git_auto_redeploy = git_auto_redeploy or False
+        self._git_auto_redeploy = bool(git_auto_redeploy)
         self._latest_commit = latest_commit
         self._latest_branch = latest_branch
         self._entrypoint_script = entrypoint_script

--- a/python/hopsworks_common/app.py
+++ b/python/hopsworks_common/app.py
@@ -78,6 +78,7 @@ class App:
         git_url=None,
         git_provider=None,
         git_branch=None,
+        git_auto_redeploy=None,
         latest_commit=None,
         entrypoint_script=None,
         app_base_path=None,
@@ -110,6 +111,7 @@ class App:
         self._git_url = git_url
         self._git_provider = git_provider
         self._git_branch = git_branch
+        self._git_auto_redeploy = git_auto_redeploy or False
         self._latest_commit = latest_commit
         self._entrypoint_script = entrypoint_script
         self._app_base_path = app_base_path
@@ -227,6 +229,12 @@ class App:
     def git_branch(self) -> str | None:
         """Configured Git branch."""
         return self._git_branch
+
+    @public
+    @property
+    def git_auto_redeploy(self) -> bool:
+        """Whether the app is rolled to the branch HEAD when a new commit is pushed."""
+        return self._git_auto_redeploy
 
     @public
     @property
@@ -493,6 +501,7 @@ class App:
         self._git_url = updated._git_url
         self._git_provider = updated._git_provider
         self._git_branch = updated._git_branch
+        self._git_auto_redeploy = updated._git_auto_redeploy
         self._latest_commit = updated._latest_commit
         self._entrypoint_script = updated._entrypoint_script
         self._public_access = updated._public_access

--- a/python/hopsworks_common/app.py
+++ b/python/hopsworks_common/app.py
@@ -80,6 +80,7 @@ class App:
         git_branch=None,
         git_auto_redeploy=None,
         latest_commit=None,
+        latest_branch=None,
         entrypoint_script=None,
         app_base_path=None,
         readiness_probe_path=None,
@@ -113,6 +114,7 @@ class App:
         self._git_branch = git_branch
         self._git_auto_redeploy = git_auto_redeploy or False
         self._latest_commit = latest_commit
+        self._latest_branch = latest_branch
         self._entrypoint_script = entrypoint_script
         self._app_base_path = app_base_path
         self._readiness_probe_path = readiness_probe_path
@@ -241,6 +243,16 @@ class App:
     def latest_commit(self) -> str | None:
         """Latest deployed Git commit."""
         return self._latest_commit
+
+    @public
+    @property
+    def latest_branch(self) -> str | None:
+        """Branch the running clone resolved to.
+
+        Only set when no branch was configured, in which case this is the
+        repository's default branch that the app actually checked out.
+        """
+        return self._latest_branch
 
     @public
     @property
@@ -503,6 +515,7 @@ class App:
         self._git_branch = updated._git_branch
         self._git_auto_redeploy = updated._git_auto_redeploy
         self._latest_commit = updated._latest_commit
+        self._latest_branch = updated._latest_branch
         self._entrypoint_script = updated._entrypoint_script
         self._public_access = updated._public_access
         self._public_token = updated._public_token

--- a/python/hopsworks_common/core/app_api.py
+++ b/python/hopsworks_common/core/app_api.py
@@ -145,9 +145,9 @@ class AppApi:
             git_provider: Git provider for git-backed apps (GitHub, GitLab or
                 BitBucket).
             git_branch: Optional branch to clone for git-backed apps.
-            git_auto_redeploy: Roll the app to the branch HEAD whenever a new
-                commit is pushed. Only valid for git-backed apps. The running
-                app keeps serving until the new version is ready.
+            git_auto_redeploy: Roll the app to the branch HEAD whenever a new commit is pushed.
+                Only valid for git-backed apps.
+                The running app keeps serving until the new version is ready.
             entrypoint_script: Relative entrypoint script for Streamlit git apps.
             app_base_path: Public mount path for the app, for example ``/`` or
                 ``/myapp``.

--- a/python/hopsworks_common/core/app_api.py
+++ b/python/hopsworks_common/core/app_api.py
@@ -105,6 +105,7 @@ class AppApi:
         git_url: str | None = None,
         git_provider: str | None = None,
         git_branch: str | None = None,
+        git_auto_redeploy: bool = False,
         entrypoint_script: str | None = None,
         app_base_path: str | None = None,
         readiness_probe_path: str | None = None,
@@ -144,6 +145,9 @@ class AppApi:
             git_provider: Git provider for git-backed apps (GitHub, GitLab or
                 BitBucket).
             git_branch: Optional branch to clone for git-backed apps.
+            git_auto_redeploy: Roll the app to the branch HEAD whenever a new
+                commit is pushed. Only valid for git-backed apps. The running
+                app keeps serving until the new version is ready.
             entrypoint_script: Relative entrypoint script for Streamlit git apps.
             app_base_path: Public mount path for the app, for example ``/`` or
                 ``/myapp``.
@@ -166,6 +170,13 @@ class AppApi:
         readiness_probe_path = self._trim_to_none(readiness_probe_path)
         git_repo_app = bool(git_url)
         streamlit_app = app_kind_name == "STREAMLIT"
+
+        # Mirrors PythonAppJobValidator: the backend rejects the flag without a git
+        # source. Fail here so the caller gets the reason instead of a REST error.
+        if git_auto_redeploy and not git_repo_app:
+            raise ValueError(
+                "git_auto_redeploy is only supported for Git repository apps."
+            )
 
         if streamlit_app:
             if entrypoint_command:
@@ -217,6 +228,7 @@ class AppApi:
         if git_repo_app:
             config["gitUrl"] = git_url
             config["gitProvider"] = git_provider
+            config["gitAutoRedeploy"] = bool(git_auto_redeploy)
             if git_branch:
                 config["gitBranch"] = git_branch
             if streamlit_app:

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -389,6 +389,7 @@ class ModelServing:
         git_url: str | None = None,
         git_provider: str | None = None,
         git_branch: str | None = None,
+        git_auto_redeploy: bool = False,
     ) -> Predictor:
         """Create an Entrypoint metadata object.
 
@@ -423,6 +424,8 @@ class ModelServing:
             git_url: Optional Git repository URL for a git-backed endpoint.
             git_provider: Git provider for git-backed endpoints.
             git_branch: Optional branch to clone for git-backed endpoints.
+            git_auto_redeploy: Roll the endpoint to the branch HEAD whenever a new
+                commit is pushed. Only valid together with `git_url`.
 
         Returns:
             The predictor metadata object.
@@ -433,6 +436,9 @@ class ModelServing:
 
         if git_url is not None:
             _validate_git_agent_source(script_file, git_url, git_provider, git_branch)
+        elif git_auto_redeploy:
+            # Mirrors ServingUtil: the backend rejects the flag without a git source.
+            raise ValueError("git_auto_redeploy requires git_url.")
 
         return Predictor.for_server(
             name=name,
@@ -449,6 +455,7 @@ class ModelServing:
             git_url=git_url,
             git_provider=git_provider,
             git_branch=git_branch,
+            git_auto_redeploy=git_auto_redeploy,
         )
 
     @public
@@ -470,6 +477,7 @@ class ModelServing:
         git_url: str | None = None,
         git_provider: str | None = None,
         git_branch: str | None = None,
+        git_auto_redeploy: bool = False,
     ) -> Deployment:
         """Deploy a Python script or package as an agent.
 
@@ -517,6 +525,9 @@ class ModelServing:
                 a relative path inside the repository and is not uploaded.
             git_provider: Git provider for git-backed agent deployments.
             git_branch: Optional branch to clone for git-backed agent deployments.
+            git_auto_redeploy: Roll the agent to the branch HEAD whenever a new
+                commit is pushed. Only valid together with `git_url`. The running
+                agent keeps serving until the new version is ready.
 
         Returns:
             The deployment metadata object.
@@ -534,6 +545,10 @@ class ModelServing:
         git_provider = _normalize_git_provider(git_provider)
         git_branch = _trim_to_none(git_branch)
         git_backed = git_url is not None
+
+        if not git_backed and git_auto_redeploy:
+            # Mirrors ServingUtil: the backend rejects the flag without a git source.
+            raise ValueError("git_auto_redeploy requires git_url.")
 
         if git_backed:
             _validate_git_agent_source(entry, git_url, git_provider, git_branch)
@@ -615,6 +630,7 @@ class ModelServing:
             git_url=git_url if git_backed else None,
             git_provider=git_provider if git_backed else None,
             git_branch=git_branch if git_backed else None,
+            git_auto_redeploy=git_auto_redeploy if git_backed else False,
         )
 
         existing = self.get_deployment(name)

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -424,8 +424,8 @@ class ModelServing:
             git_url: Optional Git repository URL for a git-backed endpoint.
             git_provider: Git provider for git-backed endpoints.
             git_branch: Optional branch to clone for git-backed endpoints.
-            git_auto_redeploy: Roll the endpoint to the branch HEAD whenever a new
-                commit is pushed. Only valid together with `git_url`.
+            git_auto_redeploy: Roll the endpoint to the branch HEAD whenever a new commit is pushed.
+                Only valid together with `git_url`.
 
         Returns:
             The predictor metadata object.
@@ -525,9 +525,9 @@ class ModelServing:
                 a relative path inside the repository and is not uploaded.
             git_provider: Git provider for git-backed agent deployments.
             git_branch: Optional branch to clone for git-backed agent deployments.
-            git_auto_redeploy: Roll the agent to the branch HEAD whenever a new
-                commit is pushed. Only valid together with `git_url`. The running
-                agent keeps serving until the new version is ready.
+            git_auto_redeploy: Roll the agent to the branch HEAD whenever a new commit is pushed.
+                Only valid together with `git_url`.
+                The running agent keeps serving until the new version is ready.
 
         Returns:
             The deployment metadata object.

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -87,6 +87,8 @@ class Predictor(DeployableComponent):
         git_provider: str | None = None,
         git_branch: str | None = None,
         git_auto_redeploy: bool | None = None,
+        git_current_commit: str | None = None,
+        git_resolved_branch: str | None = None,
         missing_mandatory_tags: list[dict[str, Any]] | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         **kwargs,
@@ -144,6 +146,8 @@ class Predictor(DeployableComponent):
         self._git_provider = git_provider
         self._git_branch = git_branch
         self._git_auto_redeploy = bool(git_auto_redeploy)
+        self._git_current_commit = git_current_commit
+        self._git_resolved_branch = git_resolved_branch
         self._vllm_variant = vllm_variant
         self._vllm_image_tag = vllm_image_tag
 
@@ -350,6 +354,12 @@ class Predictor(DeployableComponent):
         )
         kwargs["git_auto_redeploy"] = util._extract_field_from_json(
             json_decamelized, "git_auto_redeploy"
+        )
+        kwargs["git_current_commit"] = util._extract_field_from_json(
+            json_decamelized, "git_current_commit"
+        )
+        kwargs["git_resolved_branch"] = util._extract_field_from_json(
+            json_decamelized, "git_resolved_branch"
         )
         kwargs["id"] = json_decamelized.pop("id")
         kwargs["created_at"] = json_decamelized.pop("created")
@@ -673,6 +683,26 @@ class Predictor(DeployableComponent):
     @git_auto_redeploy.setter
     def git_auto_redeploy(self, git_auto_redeploy: bool | None):
         self._git_auto_redeploy = bool(git_auto_redeploy)
+
+    @public
+    @property
+    def git_current_commit(self) -> str | None:
+        """Commit this deployment is currently running.
+
+        Read-only, server-managed: recorded when the deployment clones the
+        repository and when auto-redeploy rolls it to a new commit.
+        """
+        return self._git_current_commit
+
+    @public
+    @property
+    def git_resolved_branch(self) -> str | None:
+        """Branch the running clone resolved to.
+
+        Read-only. Only set when no branch was configured, in which case this
+        is the repository's default branch that the deployment checked out.
+        """
+        return self._git_resolved_branch
 
     @public
     @property

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -86,6 +86,7 @@ class Predictor(DeployableComponent):
         git_url: str | None = None,
         git_provider: str | None = None,
         git_branch: str | None = None,
+        git_auto_redeploy: bool | None = None,
         missing_mandatory_tags: list[dict[str, Any]] | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         **kwargs,
@@ -142,6 +143,7 @@ class Predictor(DeployableComponent):
         self._git_url = git_url
         self._git_provider = git_provider
         self._git_branch = git_branch
+        self._git_auto_redeploy = bool(git_auto_redeploy)
         self._vllm_variant = vllm_variant
         self._vllm_image_tag = vllm_image_tag
 
@@ -346,6 +348,9 @@ class Predictor(DeployableComponent):
         kwargs["git_branch"] = util._extract_field_from_json(
             json_decamelized, "git_branch"
         )
+        kwargs["git_auto_redeploy"] = util._extract_field_from_json(
+            json_decamelized, "git_auto_redeploy"
+        )
         kwargs["id"] = json_decamelized.pop("id")
         kwargs["created_at"] = json_decamelized.pop("created")
         kwargs["creator"] = json_decamelized.pop("creator")
@@ -437,6 +442,13 @@ class Predictor(DeployableComponent):
             predictor_dict = {**predictor_dict, "gitProvider": self._git_provider}
         if self._git_branch is not None:
             predictor_dict = {**predictor_dict, "gitBranch": self._git_branch}
+        if self._git_url is not None:
+            # Only meaningful alongside a git source, and the backend rejects it
+            # without one, so it rides with git_url rather than being sent alone.
+            predictor_dict = {
+                **predictor_dict,
+                "gitAutoRedeploy": self._git_auto_redeploy,
+            }
         if self._scaling_configuration is not None:
             predictor_dict = {**predictor_dict, **self._scaling_configuration.to_dict()}
         tags_dict = tag.Tag._tags_to_dict(self._tags)
@@ -654,6 +666,16 @@ class Predictor(DeployableComponent):
 
     @public
     @property
+    def git_auto_redeploy(self) -> bool:
+        """Whether the deployment is rolled to the branch HEAD when a new commit is pushed."""
+        return self._git_auto_redeploy
+
+    @git_auto_redeploy.setter
+    def git_auto_redeploy(self, git_auto_redeploy: bool | None):
+        self._git_auto_redeploy = bool(git_auto_redeploy)
+
+    @public
+    @property
     def created_at(self):
         """Created at date of the predictor."""
         return self._created_at
@@ -855,4 +877,6 @@ class Predictor(DeployableComponent):
             git += f", git_provider: {self._git_provider!r}"
         if self._git_branch is not None:
             git += f", git_branch: {self._git_branch!r}"
+        if self._git_url is not None:
+            git += f", git_auto_redeploy: {self._git_auto_redeploy!r}"
         return f"Predictor(name: {self._name!r}" + desc + git + ")"

--- a/python/tests/core/test_app_api.py
+++ b/python/tests/core/test_app_api.py
@@ -92,9 +92,37 @@ class TestAppApiCreate:
         assert body["gitProvider"] == "GitHub"
         assert body["gitBranch"] == "main"
         assert body["entrypointScript"] == "streamlitapp.py"
+        assert body["gitAutoRedeploy"] is False
         assert "appPath" not in body
         assert "entrypointCommand" not in body
         assert "appPort" not in body
+
+    def test_create_git_app_with_auto_redeploy(self, mock_client, api):
+        api.create_app(
+            "streamlit_git_app",
+            app_kind="STREAMLIT",
+            git_url="https://github.com/gibchikafa/appshopsworkstests.git",
+            git_provider="github",
+            git_branch="main",
+            git_auto_redeploy=True,
+            entrypoint_script="streamlitapp.py",
+        )
+
+        body = json.loads(mock_client._send_request.call_args.kwargs["data"])
+        assert body["gitAutoRedeploy"] is True
+
+    def test_create_app_rejects_auto_redeploy_without_git_source(
+        self, mock_client, api
+    ):
+        # Mirrors PythonAppJobValidator, so the caller gets the reason locally
+        # rather than a REST error.
+        with pytest.raises(ValueError, match="git_auto_redeploy is only supported"):
+            api.create_app(
+                "file_app",
+                app_kind="STREAMLIT",
+                app_path="Resources/app.py",
+                git_auto_redeploy=True,
+            )
 
     def test_create_streamlit_git_app_accepts_provider_like_object(
         self, mock_client, api

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -184,6 +184,36 @@ class TestTracingForwarding:
         assert kwargs["git_provider"] == "GitHub"
         assert kwargs["git_branch"] == "main"
 
+    def test_create_endpoint_forwards_git_auto_redeploy(self, ms, mocker):
+        # Arrange
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.create_endpoint(
+            name="endpoint",
+            script_file="src/endpoint.py",
+            git_url="https://github.com/example/repo.git",
+            git_provider="github",
+            git_auto_redeploy=True,
+        )
+
+        # Assert
+        assert mock_for_server.call_args.kwargs["git_auto_redeploy"] is True
+
+    def test_create_endpoint_rejects_git_auto_redeploy_without_git_url(
+        self, ms, mocker
+    ):
+        # Mirrors ServingUtil: the backend rejects the flag without a git source, so fail
+        # locally rather than after a round trip.
+        mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        with pytest.raises(ValueError, match="git_auto_redeploy requires git_url"):
+            ms.create_endpoint(
+                name="endpoint",
+                script_file="src/endpoint.py",
+                git_auto_redeploy=True,
+            )
+
 
 class TestDeployAgentIdentifierValidation:
     @pytest.fixture
@@ -434,6 +464,33 @@ class TestDeployAgentScript:
         assert kwargs["git_url"] == "https://github.com/example/repo.git"
         assert kwargs["git_provider"] == "GitHub"
         assert kwargs["git_branch"] == "main"
+
+    def test_git_source_forwards_git_auto_redeploy(self, ms, mocker, stub_apis):
+        # Arrange
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(
+            entry="src/agents/my_agent.py",
+            git_url="https://github.com/example/repo.git",
+            git_provider="github",
+            git_auto_redeploy=True,
+        )
+
+        # Assert
+        assert mock_for_server.call_args.kwargs["git_auto_redeploy"] is True
+
+    def test_rejects_git_auto_redeploy_without_git_source(
+        self, ms, mocker, stub_apis, tmp_path
+    ):
+        # The flag is only meaningful for a git-backed agent; the backend rejects it otherwise.
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        script = tmp_path / "my_agent.py"
+        script.write_text("")
+
+        with pytest.raises(ValueError, match="git_auto_redeploy requires git_url"):
+            ms.deploy_agent(entry=str(script), git_auto_redeploy=True)
 
 
 class TestDeployAgentPackage:

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1243,6 +1243,59 @@ class TestPredictor:
         assert restored.git_url == "https://github.com/org/repo.git"
         assert restored.git_provider == "GitHub"
         assert restored.git_branch == "main"
+        # Defaults off, but still serialised so an update can turn it back off.
+        assert serialized["gitAutoRedeploy"] is False
+        assert restored.git_auto_redeploy is False
+
+    def test_git_auto_redeploy_round_trip(self, mocker):
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        mocker.patch(
+            "hsml.predictor.Predictor._validate_serving_tool",
+            return_value=PREDICTOR.SERVING_TOOL_KSERVE,
+        )
+        mocker.patch(
+            "hsml.predictor.Predictor._validate_resources",
+            return_value=resources.PredictorResources(0),
+        )
+
+        p = predictor.Predictor(
+            name="my_agent",
+            model_server=PREDICTOR.MODEL_SERVER_PYTHON,
+            script_file="src/agent.py",
+            model_framework=MODEL.FRAMEWORK_PYTHON,
+            git_url="https://github.com/org/repo.git",
+            git_provider="GitHub",
+            git_branch="main",
+            git_auto_redeploy=True,
+        )
+
+        serialized = p.to_dict()
+        restored = predictor.Predictor.from_response_json(serialized)
+
+        assert serialized["gitAutoRedeploy"] is True
+        assert restored.git_auto_redeploy is True
+
+    def test_git_auto_redeploy_omitted_without_git_source(self, mocker):
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        mocker.patch(
+            "hsml.predictor.Predictor._validate_serving_tool",
+            return_value=PREDICTOR.SERVING_TOOL_KSERVE,
+        )
+        mocker.patch(
+            "hsml.predictor.Predictor._validate_resources",
+            return_value=resources.PredictorResources(0),
+        )
+
+        p = predictor.Predictor(
+            name="my_agent",
+            model_server=PREDICTOR.MODEL_SERVER_PYTHON,
+            script_file="src/agent.py",
+            model_framework=MODEL.FRAMEWORK_PYTHON,
+        )
+
+        # The backend rejects the flag without a git source, so it must not be sent.
+        assert "gitAutoRedeploy" not in p.to_dict()
+        assert p.git_auto_redeploy is False
 
     # vLLM variant round-trip
 

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1275,6 +1275,38 @@ class TestPredictor:
         assert serialized["gitAutoRedeploy"] is True
         assert restored.git_auto_redeploy is True
 
+    def test_git_state_is_read_back_but_never_sent(self, mocker):
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        mocker.patch(
+            "hsml.predictor.Predictor._validate_serving_tool",
+            return_value=PREDICTOR.SERVING_TOOL_KSERVE,
+        )
+        mocker.patch(
+            "hsml.predictor.Predictor._validate_resources",
+            return_value=resources.PredictorResources(0),
+        )
+
+        p = predictor.Predictor(
+            name="my_agent",
+            model_server=PREDICTOR.MODEL_SERVER_PYTHON,
+            script_file="src/agent.py",
+            model_framework=MODEL.FRAMEWORK_PYTHON,
+            git_url="https://github.com/org/repo.git",
+            git_provider="GitHub",
+            git_current_commit="abc123",
+            git_resolved_branch="main",
+        )
+
+        assert p.git_current_commit == "abc123"
+        assert p.git_resolved_branch == "main"
+
+        # Both are server-managed, and the backend does not copy them back on update. Sending
+        # gitResolvedBranch in particular would risk pinning a deployment that tracks the
+        # repository default onto the branch it happened to resolve to.
+        serialized = p.to_dict()
+        assert "gitCurrentCommit" not in serialized
+        assert "gitResolvedBranch" not in serialized
+
     def test_git_auto_redeploy_omitted_without_git_source(self, mocker):
         self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
         mocker.patch(

--- a/skills/hops/hops-agent-deployment/SKILL.md
+++ b/skills/hops/hops-agent-deployment/SKILL.md
@@ -42,7 +42,8 @@ class Predict:
 
 Use the CLI for local HopsFS sources. Git-backed agents are supported too, but
 they are created through the SDK example below with `git_url`,
-`git_provider`, and `git_branch`.
+`git_provider`, and `git_branch`. Add `git_auto_redeploy=True` to roll the agent
+to the branch HEAD whenever a new commit is pushed.
 
 ```bash
 hops agent create my_agent.py --name my_agent \
@@ -96,6 +97,7 @@ deployment = ms.deploy_agent(
     git_url="https://github.com/gibchikafa/my-agent-repo.git",
     git_provider="GitHub",
     git_branch="main",
+    git_auto_redeploy=True,  # roll to branch HEAD on every new commit
     environment="my_agent",
 )
 ```

--- a/skills/hops/hops-agent-deployment/SKILL.md
+++ b/skills/hops/hops-agent-deployment/SKILL.md
@@ -41,14 +41,11 @@ class Predict:
 ## Deploy — CLI (preferred)
 
 Use the CLI for local HopsFS sources. Git-backed agents are supported too, but
-they are created through the SDK example below with `git_url`,
-`git_provider`, and `git_branch`. Add `git_auto_redeploy=True` to roll the agent
-to the branch HEAD whenever a new commit is pushed.
+they are created through the SDK example below with `git_url`, `git_provider`, and `git_branch`.
+Add `git_auto_redeploy=True` to roll the agent to the branch HEAD whenever a new commit is pushed.
 
-`hops agent info` shows the git source, the branch (the resolved default when
-none was configured), and the commit the deployment is running. The same values
-are on the predictor: `git_current_commit` and `git_resolved_branch`, both
-read-only.
+`hops agent info` shows the git source, the branch (the resolved default when none was configured), and the commit the deployment is running.
+The same values are on the predictor: `git_current_commit` and `git_resolved_branch`, both read-only.
 
 ```bash
 hops agent create my_agent.py --name my_agent \

--- a/skills/hops/hops-agent-deployment/SKILL.md
+++ b/skills/hops/hops-agent-deployment/SKILL.md
@@ -45,6 +45,11 @@ they are created through the SDK example below with `git_url`,
 `git_provider`, and `git_branch`. Add `git_auto_redeploy=True` to roll the agent
 to the branch HEAD whenever a new commit is pushed.
 
+`hops agent info` shows the git source, the branch (the resolved default when
+none was configured), and the commit the deployment is running. The same values
+are on the predictor: `git_current_commit` and `git_resolved_branch`, both
+read-only.
+
 ```bash
 hops agent create my_agent.py --name my_agent \
   --requirements requirements.txt --environment my_agent

--- a/skills/hops/hops-app/SKILL.md
+++ b/skills/hops/hops-app/SKILL.md
@@ -50,7 +50,8 @@ Full CLI surface is in **Manage Apps from the CLI** below.
 ## Ask the user (only when state is ambiguous)
 
 - Does the app need **custom libraries** not in `python-app-pipeline`? If so, clone the env and install `app-requirements.txt` (see **Your App uses Custom libraries**).
-- Does the app come from **HopsFS or Git**? If Git, ask for `git_url`, `git_provider`, and (if needed) `git_branch` plus the entrypoint. Also ask whether the app should **auto-redeploy** on new commits (`git_auto_redeploy=True`); it only applies to git-backed apps.
+- Does the app come from **HopsFS or Git**? If Git, ask for `git_url`, `git_provider`, and (if needed) `git_branch` plus the entrypoint.
+- Should a git-backed app **auto-redeploy** on new commits (`git_auto_redeploy=True`)? It only applies to git-backed apps.
 - What **memory / cores** should the app get? Defaults are `memory=2048` MB, `cores=1.0`.
 - Does the app need a specific routing mode or readiness path? New apps should use root routing; keep legacy prefix mode only while migrating an older app that still depends on `APP_BASE_URL_PATH`. If the app is already deployed and still uses `APP_BASE_URL_PATH`, treat it as a migration task and confirm whether the code can switch to root routing. Streamlit defaults to `/_stcore/health`, custom apps default to `/`, and `readinessProbePath` can override the probe path when needed.
 - Does the app need **monitoring** narrowed to specific routes? Monitoring is enabled by default and routes are optional; `hops app info` shows the monitoring state and route list when present.

--- a/skills/hops/hops-app/SKILL.md
+++ b/skills/hops/hops-app/SKILL.md
@@ -50,7 +50,7 @@ Full CLI surface is in **Manage Apps from the CLI** below.
 ## Ask the user (only when state is ambiguous)
 
 - Does the app need **custom libraries** not in `python-app-pipeline`? If so, clone the env and install `app-requirements.txt` (see **Your App uses Custom libraries**).
-- Does the app come from **HopsFS or Git**? If Git, ask for `git_url`, `git_provider`, and (if needed) `git_branch` plus the entrypoint.
+- Does the app come from **HopsFS or Git**? If Git, ask for `git_url`, `git_provider`, and (if needed) `git_branch` plus the entrypoint. Also ask whether the app should **auto-redeploy** on new commits (`git_auto_redeploy=True`); it only applies to git-backed apps.
 - What **memory / cores** should the app get? Defaults are `memory=2048` MB, `cores=1.0`.
 - Does the app need a specific routing mode or readiness path? New apps should use root routing; keep legacy prefix mode only while migrating an older app that still depends on `APP_BASE_URL_PATH`. If the app is already deployed and still uses `APP_BASE_URL_PATH`, treat it as a migration task and confirm whether the code can switch to root routing. Streamlit defaults to `/_stcore/health`, custom apps default to `/`, and `readinessProbePath` can override the probe path when needed.
 - Does the app need **monitoring** narrowed to specific routes? Monitoring is enabled by default and routes are optional; `hops app info` shows the monitoring state and route list when present.
@@ -178,6 +178,7 @@ streamlit_app = apps.create_app(
     git_url="https://github.com/gibchikafa/appshopsworkstests.git",
     git_provider="GitHub",
     git_branch="main",
+    git_auto_redeploy=True,  # roll to branch HEAD on every new commit
     entrypoint_script="streamlitapp.py",
     environment="python-app-pipeline",
 )


### PR DESCRIPTION
Expose the git auto-redeploy flag the backend already supports, for both git-backed apps and git-backed agent deployments.

Apps: new git_auto_redeploy argument on AppApi.create_app, a read-only App.git_auto_redeploy property, and a --git-auto-redeploy flag on `hops app create`. `hops app info` shows the setting alongside the other git rows, in both the table and the JSON output.

Agent deployments: new git_auto_redeploy argument on ModelServing create_endpoint and deploy_agent, plus a Predictor property and setter. The field is serialised only when a git source is present — the backend rejects it otherwise — and is restored from the API response.

Both entry points validate locally that the flag requires a git source, mirroring PythonAppJobValidator and ServingUtil, so callers get the reason instead of a REST error.

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
