### PR TITLE
[HWORKS-2807] Append - fix loadtests and connectors

### DIFF
--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -1584,13 +1584,25 @@ class SnowflakeConnector(StorageConnector):
     @public
     @property
     def password(self) -> str | None:
-        """Password of the Snowflake storage connector."""
+        """Password or programmatic access token (PAT) of the Snowflake storage connector.
+
+        Snowflake is removing single-factor password sign-ins, so a plain account
+        password will stop working. A PAT is supplied through this same field: the
+        JDBC driver behind the Spark connector has no PAT authenticator and expects
+        the token in the password position. Do not use `token` for a PAT, that field
+        sets `authenticator=oauth`, which Snowflake rejects for PATs.
+        """
         return self._password
 
     @public
     @property
     def token(self) -> str | None:
-        """OAuth token of the Snowflake storage connector."""
+        """OAuth token of the Snowflake storage connector.
+
+        This is an OAuth access token only. It renders as `authenticator=oauth`.
+        Programmatic access tokens (PATs) are not OAuth tokens and are rejected
+        here with `390303 Invalid OAuth access token`, pass them via `password`.
+        """
         return self._token
 
     @public

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -1708,11 +1708,15 @@ class SnowflakeConnector(StorageConnector):
             "account": self.account,
             "database": self._database + "/" + self._schema,
         }
+        # Same precedence as `spark_options`. The backend guarantees exactly one
+        # of the three is set, so no branch means no credential to send.
         if self._password:
             props["password"] = self._password
-        else:
+        elif self._token:
             props["authenticator"] = "oauth"
             props["token"] = self._token
+        elif self._private_key:
+            props["private_key"] = self._read_private_key_der()
         if self._warehouse:
             props["warehouse"] = self._warehouse
         if self._application:
@@ -1745,6 +1749,24 @@ class SnowflakeConnector(StorageConnector):
             props["dbtable"] = self._table
 
         return props
+
+    def _read_private_key_der(self) -> bytes:
+        """Loads the private key as DER bytes for the `snowflake.connector` library.
+
+        The Spark connector takes the key as a header-stripped PEM string, see
+        `_read_private_key`, while `snowflake.connector` expects DER bytes on its
+        `private_key` argument.
+        """
+        p_key = serialization.load_pem_private_key(
+            self._private_key.encode(),
+            password=self._passphrase.encode() if self._passphrase else None,
+            backend=default_backend(),
+        )
+        return p_key.private_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
 
     def _read_private_key(self) -> str | None:
         """Reads the private key from the specified key path."""


### PR DESCRIPTION
## Why

Snowflake is removing single-factor password sign-ins, so the account password behind the Snowflake data source stops working. A programmatic access token (PAT) takes its place.

PATs need the `password` field. The connector `token` field renders `authenticator=oauth`, which Snowflake rejects for PATs. Verified against a live account:

- `X-Snowflake-Authorization-Token-Type: PROGRAMMATIC_ACCESS_TOKEN` -> HTTP 200
- `X-Snowflake-Authorization-Token-Type: OAUTH` -> HTTP 401 `390303 Invalid OAuth access token`

The JDBC driver behind `net.snowflake.spark.snowflake` has no PAT authenticator either, so a PAT is passed in the password position. The password auth method is therefore relabelled rather than removed, which keeps PAT support available.

## What changed

Docstrings on `SnowflakeConnector.password` and `SnowflakeConnector.token` recording which credential belongs in which field, including the `390303` error a PAT produces when passed as `token`.

## Also fixed: key-pair auth in `connector_options()`

`connector_options()` advertises `snowflake.connector.connect(**sc.connector_options())` in its own docstring, but it emitted `authenticator="oauth", token=None` for any key-pair connector, so that documented flow failed for all of them.

It now follows the same password / token / private key precedence as `spark_options()`, and a new `_read_private_key_der()` hands the key to `snowflake.connector` as the DER bytes it expects. The Spark path keeps the header-stripped PEM string that `pem_private_key` requires. Verified that an encrypted PEM plus passphrase converts to DER and reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs

Same branch, same ticket, one per repo:

- logicalclocks/hopsworks-helm#2152 (loadtest CI)
- logicalclocks/hopsworks-front#2015 (UI relabel)
- logicalclocks/hopsworks-api#1071 (docstrings)
- logicalclocks/logicalclocks.github.io#621 (docs)
