### PR TITLE
[HWORKS-2981] Treat stranded QUEUE_TIMEOUT executions as terminal job failures

### DIFF
--- a/python/hopsworks_common/constants.py
+++ b/python/hopsworks_common/constants.py
@@ -32,13 +32,18 @@ DEFAULT = Default()  # TODO: figure out what to do with it
 
 
 class JOBS:
-    SUCCESS_STATES = ["FINISHED", "SUCCEEDED"]
+    # COMPLETED is defensive: the monitors currently normalize it to FINISHED
+    # before persisting, but it is in the server's final-states set and would
+    # otherwise reproduce the same await_termination hang if ever persisted.
+    SUCCESS_STATES = ["FINISHED", "SUCCEEDED", "COMPLETED"]
     ERROR_STATES = [
         "FAILED",
         "KILLED",
         "FRAMEWORK_FAILURE",
         "APP_MASTER_START_FAILED",
         "INITIALIZATION_FAILED",
+        "SUBMISSION_FAILED",
+        "QUEUE_TIMEOUT",
     ]
 
 

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -420,6 +420,89 @@ class TestJob:
         # Assert
         assert str(e_info.value) == "The Hopsworks Job was stopped"
 
+    def test_run_await_termination_python_raises_on_queue_timeout(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange — the backend normally persists QUEUE_TIMEOUT together with
+        # final_status=FAILED, but updateState and updateFinalStatus are two
+        # separate facade calls: if the jobs monitor dies between them the row
+        # is stranded at state=QUEUE_TIMEOUT, final_status=UNDEFINED forever
+        # (QUEUE_TIMEOUT is not in the server's final-states set, so nothing
+        # reconciles it). await_termination must raise on state alone, not hang.
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hopsworks_common.execution.Execution.get_url")
+        mock_execution_api = mocker.patch(
+            "hopsworks_common.core.execution_api.ExecutionApi",
+        )
+        python_job_mock = mocker.Mock()
+        python_job_mock.job_type = "PYTHON"
+        mock_execution_api.return_value._start.return_value = execution.Execution(
+            job=python_job_mock
+        )
+        mock_execution_api.return_value._get.return_value = execution.Execution(
+            id=1, state="QUEUE_TIMEOUT", final_status="UNDEFINED", job=python_job_mock
+        )
+
+        j = job.Job(
+            id="test_id",
+            name="test_name",
+            creation_time=None,
+            config={},
+            job_type="PYTHON",
+            creator=None,
+        )
+
+        # Act
+        with pytest.raises(exceptions.JobExecutionException) as e_info:
+            j.run(await_termination=True)
+
+        # Assert
+        assert (
+            str(e_info.value)
+            == "Execution failed with status: QUEUE_TIMEOUT. See the logs for more information."
+        )
+
+    def test_run_await_termination_python_raises_on_queue_timeout_failed(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange — the state the backend actually writes on queue timeout:
+        # KubeJobsMonitor.updateFailedState persists state=QUEUE_TIMEOUT and
+        # final_status=FAILED in the same pass. This case passed even before
+        # QUEUE_TIMEOUT joined ERROR_STATES (final_status=FAILED already
+        # matched); it pins the production path against regressions.
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hopsworks_common.execution.Execution.get_url")
+        mock_execution_api = mocker.patch(
+            "hopsworks_common.core.execution_api.ExecutionApi",
+        )
+        python_job_mock = mocker.Mock()
+        python_job_mock.job_type = "PYTHON"
+        mock_execution_api.return_value._start.return_value = execution.Execution(
+            job=python_job_mock
+        )
+        mock_execution_api.return_value._get.return_value = execution.Execution(
+            id=1, state="QUEUE_TIMEOUT", final_status="FAILED", job=python_job_mock
+        )
+
+        j = job.Job(
+            id="test_id",
+            name="test_name",
+            creation_time=None,
+            config={},
+            job_type="PYTHON",
+            creator=None,
+        )
+
+        # Act
+        with pytest.raises(exceptions.JobExecutionException) as e_info:
+            j.run(await_termination=True)
+
+        # Assert
+        assert (
+            str(e_info.value)
+            == "Execution failed with status: QUEUE_TIMEOUT. See the logs for more information."
+        )
+
     # --- PYTHON_APP tests ---
 
     def test_run_python_app_waits_for_running(self, mocker, backend_fixtures):


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-2981

Adds `QUEUE_TIMEOUT` and `SUBMISSION_FAILED` to the Python SDK's job `ERROR_STATES` and `COMPLETED` to `SUCCESS_STATES`, so `await_termination` raises instead of polling forever on executions stranded in those states.

The backend normally persists `state=QUEUE_TIMEOUT` together with `final_status=FAILED` (`KubeJobsMonitor.updateFailedState`), which `ERROR_STATES` already catches through `final_status`. The hazard is the crash window: `updateState` and `updateFinalStatus` are two separate facade calls, and if the jobs monitor dies between them the row stays at `state=QUEUE_TIMEOUT, final_status=UNDEFINED` forever. `QUEUE_TIMEOUT` is not in the server's `JobState.getFinalStates()`, so `ExecutionFacade.findExpiredFinished` never reconciles it, and a client polling `await_termination` hangs indefinitely.

`SUBMISSION_FAILED` and `COMPLETED` are defensive: the Spark and Ray monitors currently rewrite `SUBMISSION_FAILED` to `FAILED` and normalize `COMPLETED` to `FINISHED` before persisting, but both are one persistence change away from reproducing the identical hang.

Tests cover both the stranded row (`final_status="UNDEFINED"`, fails without this change) and the state the backend actually writes (`final_status="FAILED"`, green before and after, pinning the production path).

Split out of #1019 per review (unrelated to KServe; original commit message misattributed the root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
