### PR TITLE
[HWORKS-2988] apt-get upgrade -y in the image build

### DIFF
--- a/locust_benchmark/Dockerfile
+++ b/locust_benchmark/Dockerfile
@@ -2,7 +2,7 @@ FROM locustio/locust:2.23.1
 
 USER root
 
-RUN apt-get update -y && apt-get -y install gcc python3-dev librdkafka-dev git
+RUN apt-get update -y && apt-get upgrade -y && apt-get -y install gcc python3-dev librdkafka-dev git
 
 USER locust
 WORKDIR /home/locust


### PR DESCRIPTION
Part of [HWORKS-2988](https://hopsworks.atlassian.net/browse/HWORKS-2988) — fleet-wide rollout of the HES-221 / HWORKS-2987 pattern: `apt-get upgrade -y` after `apt-get update` so every build lands at the distro's current security state, independent of base-image or build-cache staleness.

**This repo**: locust-hsfs image — 128 findings apt-fixable today (5 Critical, 24 High).

Context: across all our Harbor images, 1,783 findings (30 Critical / 193 High) are fixable today purely by this upgrade at rebuild. A three-way measurement (stale base / fresh base / upgrade) showing why the upgrade line beats fresh-base rebuilds — Canonical's tag rebuilds lag the security archive by ~a month — is documented in HWORKS-2987/2988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HWORKS-2988]: https://hopsworks.atlassian.net/browse/HWORKS-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ