### PR TITLE
[FSTORE-2075] Attachment timestamps, keyword API, job and dataset tags, tag CLI

### DIFF
--- a/python/hopsworks/cli/commands/fg.py
+++ b/python/hopsworks/cli/commands/fg.py
@@ -3,7 +3,8 @@
 Covers the full feature-group surface: ``list``, ``info``, ``preview``,
 ``features`` (reads) plus ``create``, ``create-external``, ``insert``,
 ``derive``, ``append-features``, ``delete``, ``stats``, ``search``,
-``keywords``/``add-keyword``/``remove-keyword`` (writes). All operations go
+``keywords``/``add-keyword``/``remove-keyword`` (plain labels) and
+``tags``/``add-tag``/``remove-tag`` (name/value pairs). All operations go
 through the SDK in-process so Hopsworks domain logic is invoked directly, with
 no subprocess hop.
 """
@@ -917,52 +918,77 @@ def fg_search(
     output.print_table(["SCORE", "ROW"], rows)
 
 
+# Printed to stderr rather than raised as a DeprecationWarning: Python's default filters hide
+# DeprecationWarning outside __main__, and these commands run from click, so the one audience that
+# needs to read this would never see it.
+_KEYWORD_SEMANTICS_CHANGED = (
+    "The *-keyword commands now operate on keywords (plain labels without "
+    "values); tag name/value pairs moved to 'hops fg tags/add-tag/remove-tag'."
+)
+
+
 @fg_group.command("keywords")
 @click.argument("name")
 @click.option("--version", type=int, help="Feature group version.")
 @click.pass_context
 def fg_keywords(ctx: click.Context, name: str, version: int | None) -> None:
-    """Show all tags attached to a feature group (aka keywords).
+    """Show all keywords attached to a feature group.
 
     Args:
         ctx: Click context.
         name: Feature group name.
         version: Feature group version.
     """
+    output.warn(_KEYWORD_SEMANTICS_CHANGED)
     fg = _get_fg(ctx, name, version)
     try:
-        tags = fg.get_tags()
+        keywords = fg.get_keywords_metadata()
     except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Could not read tags: {exc}") from exc
+        raise click.ClickException(f"Could not read keywords: {exc}") from exc
 
     if output.JSON_MODE:
-        output.print_json({k: _tag_value(v) for k, v in (tags or {}).items()})
+        output.print_json(
+            {k: output.format_ts(v, empty=None) for k, v in (keywords or {}).items()}
+        )
         return
-    rows = [[k, _tag_value(v)] for k, v in (tags or {}).items()]
-    output.print_table(["KEYWORD", "VALUE"], rows)
+    rows = [[k, output.format_ts(v)] for k, v in (keywords or {}).items()]
+    output.print_table(["KEYWORD", "ADDED"], rows)
 
 
 @fg_group.command("add-keyword")
 @click.argument("name")
 @click.argument("keyword")
-@click.option("--value", default="true", help="Tag value; defaults to 'true'.")
+@click.option(
+    "--value",
+    default=None,
+    help="Retired. Keywords carry no value; use 'hops fg add-tag' for name/value tags.",
+)
 @click.option("--version", type=int, help="Feature group version.")
 @click.pass_context
 def fg_add_keyword(
-    ctx: click.Context, name: str, keyword: str, value: str, version: int | None
+    ctx: click.Context, name: str, keyword: str, value: str | None, version: int | None
 ) -> None:
-    """Attach a keyword (tag) to a feature group.
+    """Attach a keyword to a feature group.
 
     Args:
         ctx: Click context.
         name: Feature group name.
-        keyword: Tag name.
-        value: Tag value.
+        keyword: The keyword.
+        value: Retired; fails loudly when supplied.
         version: Feature group version.
     """
+    output.warn(_KEYWORD_SEMANTICS_CHANGED)
+    # Failing beats both alternatives: dropping the option outright would make
+    # scripts that passed it die on "no such option", while accepting it would
+    # silently turn their tag write into a keyword write.
+    if value is not None:
+        raise click.UsageError(
+            "--value is retired: keywords carry no value. To write a "
+            f"name/value tag use: hops fg add-tag {name} {keyword} --value ..."
+        )
     fg = _get_fg(ctx, name, version)
     try:
-        fg.add_tag(name=keyword, value=value)
+        fg.add_keywords([keyword])
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Could not add keyword: {exc}") from exc
     output.success("✓ Added keyword '%s' to %s", keyword, name)
@@ -976,20 +1002,89 @@ def fg_add_keyword(
 def fg_remove_keyword(
     ctx: click.Context, name: str, keyword: str, version: int | None
 ) -> None:
-    """Remove a keyword (tag) from a feature group.
+    """Remove a keyword from a feature group.
 
     Args:
         ctx: Click context.
         name: Feature group name.
-        keyword: Tag name.
+        keyword: The keyword.
+        version: Feature group version.
+    """
+    output.warn(_KEYWORD_SEMANTICS_CHANGED)
+    fg = _get_fg(ctx, name, version)
+    try:
+        fg.delete_keyword(keyword)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove keyword: {exc}") from exc
+    output.success("✓ Removed keyword '%s' from %s", keyword, name)
+
+
+@fg_group.command("tags")
+@click.argument("name")
+@click.option("--version", type=int, help="Feature group version.")
+@click.pass_context
+def fg_tags(ctx: click.Context, name: str, version: int | None) -> None:
+    """Show all tags attached to a feature group.
+
+    Args:
+        ctx: Click context.
+        name: Feature group name.
         version: Feature group version.
     """
     fg = _get_fg(ctx, name, version)
     try:
-        fg.delete_tag(keyword)
+        tags = fg.get_tags_metadata()
     except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Could not remove keyword: {exc}") from exc
-    output.success("✓ Removed keyword '%s' from %s", keyword, name)
+        raise click.ClickException(f"Could not read tags: {exc}") from exc
+    output.render_tags(tags)
+
+
+@fg_group.command("add-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--value", required=True, help="Tag value, JSON or a plain string.")
+@click.option("--version", type=int, help="Feature group version.")
+@click.pass_context
+def fg_add_tag(
+    ctx: click.Context, name: str, tag: str, value: str, version: int | None
+) -> None:
+    """Attach a tag (name/value pair) to a feature group.
+
+    Args:
+        ctx: Click context.
+        name: Feature group name.
+        tag: Tag name (a registered tag schema).
+        value: Tag value, JSON or a plain string.
+        version: Feature group version.
+    """
+    fg = _get_fg(ctx, name, version)
+    try:
+        fg.add_tag(name=tag, value=output.parse_tag_value(value))
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add tag: {exc}") from exc
+    output.success("✓ Added tag '%s' to %s", tag, name)
+
+
+@fg_group.command("remove-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--version", type=int, help="Feature group version.")
+@click.pass_context
+def fg_remove_tag(ctx: click.Context, name: str, tag: str, version: int | None) -> None:
+    """Remove a tag from a feature group.
+
+    Args:
+        ctx: Click context.
+        name: Feature group name.
+        tag: Tag name.
+        version: Feature group version.
+    """
+    fg = _get_fg(ctx, name, version)
+    try:
+        fg.delete_tag(tag)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove tag: {exc}") from exc
+    output.success("✓ Removed tag '%s' from %s", tag, name)
 
 
 # region Helpers
@@ -1135,13 +1230,6 @@ def _synth_value(dtype: str, i: int) -> Any:
 
         return pd.Timestamp("2026-01-01") + pd.Timedelta(days=i)
     return f"val_{i}"
-
-
-def _tag_value(tag: Any) -> Any:
-    """Normalize an SDK ``Tag`` object (or primitive) to a JSON-friendly value."""
-    if hasattr(tag, "value"):
-        return tag.value
-    return tag
 
 
 def _parse_join(raw: str) -> joinspec.JoinSpec:

--- a/python/hopsworks/cli/commands/fv.py
+++ b/python/hopsworks/cli/commands/fv.py
@@ -49,6 +49,15 @@ def fv_list(ctx: click.Context) -> None:
     output.print_table(["ID", "NAME", "VERSION", "LABELS", "DESCRIPTION"], rows)
 
 
+def _get_fv(ctx: click.Context, name: str, version: int | None) -> Any:
+    """Resolve a feature view or fail with a clean CLI error."""
+    fs = session.get_feature_store(ctx)
+    try:
+        return fs.get_feature_view(name, version=version)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+
+
 @fv_group.command("info")
 @click.argument("name")
 @click.option("--version", type=int, help="Feature view version; defaults to latest.")
@@ -61,11 +70,7 @@ def fv_info(ctx: click.Context, name: str, version: int | None) -> None:
         name: Feature view name.
         version: Specific version to inspect.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
 
     if output.JSON_MODE:
         output.print_json(_fv_to_dict(fv))
@@ -137,11 +142,7 @@ def fv_lineage(ctx: click.Context, name: str, version: int | None) -> None:
         name: Feature view name.
         version: Specific version; latest if omitted.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
     label = f"feature view {getattr(fv, 'name', name)} v{getattr(fv, 'version', '?')}"
     sections = [
         (
@@ -343,11 +344,7 @@ def fv_get(ctx: click.Context, name: str, version: int | None, entry: str) -> No
         version: Feature view version.
         entry: Comma-separated ``key=value`` pairs for the primary keys.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
 
     entry_dict = _parse_entry(entry)
     try:
@@ -396,11 +393,7 @@ def fv_read(
         start_time: ISO timestamp lower bound.
         end_time: ISO timestamp upper bound.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
 
     try:
         df = fv.get_batch_data(
@@ -447,11 +440,7 @@ def fv_delete(
         yes: Skip confirmation when True.
         force: Pass ``force=True`` to the SDK.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
 
     if not yes and not output.JSON_MODE:
         click.confirm(
@@ -463,6 +452,149 @@ def fv_delete(
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Delete failed: {exc}") from exc
     output.success("✓ Deleted feature view %s", name)
+
+
+@fv_group.command("tags")
+@click.argument("name")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_tags(ctx: click.Context, name: str, version: int | None) -> None:
+    """Show all tags attached to a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        tags = fv.get_tags_metadata()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read tags: {exc}") from exc
+    output.render_tags(tags)
+
+
+@fv_group.command("add-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--value", required=True, help="Tag value, JSON or a plain string.")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_add_tag(
+    ctx: click.Context, name: str, tag: str, value: str, version: int | None
+) -> None:
+    """Attach a tag (name/value pair) to a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        tag: Tag name (a registered tag schema).
+        value: Tag value, JSON or a plain string.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        fv.add_tag(name=tag, value=output.parse_tag_value(value))
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add tag: {exc}") from exc
+    output.success("✓ Added tag '%s' to %s", tag, name)
+
+
+@fv_group.command("remove-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_remove_tag(ctx: click.Context, name: str, tag: str, version: int | None) -> None:
+    """Remove a tag from a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        tag: Tag name.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        fv.delete_tag(tag)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove tag: {exc}") from exc
+    output.success("✓ Removed tag '%s' from %s", tag, name)
+
+
+@fv_group.command("keywords")
+@click.argument("name")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_keywords(ctx: click.Context, name: str, version: int | None) -> None:
+    """Show all keywords attached to a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        keywords = fv.get_keywords_metadata()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read keywords: {exc}") from exc
+
+    if output.JSON_MODE:
+        output.print_json(
+            {k: output.format_ts(v, empty=None) for k, v in (keywords or {}).items()}
+        )
+        return
+    rows = [[k, output.format_ts(v)] for k, v in (keywords or {}).items()]
+    output.print_table(["KEYWORD", "ADDED"], rows)
+
+
+@fv_group.command("add-keyword")
+@click.argument("name")
+@click.argument("keyword")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_add_keyword(
+    ctx: click.Context, name: str, keyword: str, version: int | None
+) -> None:
+    """Attach a keyword to a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        keyword: The keyword.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        fv.add_keywords([keyword])
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add keyword: {exc}") from exc
+    output.success("✓ Added keyword '%s' to %s", keyword, name)
+
+
+@fv_group.command("remove-keyword")
+@click.argument("name")
+@click.argument("keyword")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_remove_keyword(
+    ctx: click.Context, name: str, keyword: str, version: int | None
+) -> None:
+    """Remove a keyword from a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        keyword: The keyword.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        fv.delete_keyword(keyword)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove keyword: {exc}") from exc
+    output.success("✓ Removed keyword '%s' from %s", keyword, name)
 
 
 # region Helpers

--- a/python/hopsworks/cli/commands/job.py
+++ b/python/hopsworks/cli/commands/job.py
@@ -120,6 +120,8 @@ def job_info(ctx: click.Context, name: str) -> None:
         ["Type", getattr(job, "job_type", "-")],
         ["Creator", _user_label(getattr(job, "creator", None))],
         ["Created", _ts_label(getattr(job, "creation_time", None))],
+        ["Description", output.first_line(getattr(job, "description", None))],
+        ["Tags", output.format_mapping(output.read_tags(job))],
     ]
     output.print_table(["FIELD", "VALUE"], rows)
 
@@ -144,6 +146,8 @@ def _job_to_dict(job: Any) -> dict[str, Any]:
         "type": getattr(job, "job_type", None),
         "creator": creator,
         "creation_time": getattr(job, "creation_time", None),
+        "description": getattr(job, "description", None),
+        "tags": output.read_tags(job),
         "config": config.to_dict() if hasattr(config, "to_dict") else config,
     }
 
@@ -164,6 +168,7 @@ def _job_to_dict(job: Any) -> dict[str, Any]:
     "--app-path", "app_path", required=True, help="HDFS/HopsFS path to the main file."
 )
 @click.option("--args", "app_args", help="Arguments passed to the program.")
+@click.option("--description", help="Free-form description of the job.")
 @click.pass_context
 def job_create(
     ctx: click.Context,
@@ -171,6 +176,7 @@ def job_create(
     job_type: str,
     app_path: str,
     app_args: str | None,
+    description: str | None,
 ) -> None:
     """Create a new job from a ``type`` + ``--app-path``.
 
@@ -180,6 +186,7 @@ def job_create(
         job_type: One of ``PYTHON``/``PYSPARK``/``SPARK``/``DOCKER``.
         app_path: HopsFS path to the script or JAR.
         app_args: Optional argument string passed to the job.
+        description: Optional free-form description.
     """
     project = session.get_project(ctx)
     api = project.get_job_api()
@@ -190,6 +197,8 @@ def job_create(
     config["appPath"] = app_path
     if app_args:
         config["defaultArgs"] = app_args
+    if description:
+        config["description"] = description
     try:
         job = api.create_job(name=name, config=config)
     except Exception as exc:  # noqa: BLE001
@@ -780,6 +789,87 @@ def job_delete(ctx: click.Context, name: str, yes: bool) -> None:
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Delete failed: {exc}") from exc
     output.success("✓ Deleted job %s", name)
+
+
+@job_group.command("tags")
+@click.argument("name")
+@click.pass_context
+def job_tags(ctx: click.Context, name: str) -> None:
+    """Show all tags attached to a job.
+
+    Args:
+        ctx: Click context.
+        name: Job name.
+    """
+    job = _get_job(ctx, name)
+    try:
+        tags = job.get_tags_metadata()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read tags: {exc}") from exc
+    output.render_tags(tags)
+
+
+@job_group.command("add-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--value", required=True, help="Tag value, JSON or a plain string.")
+@click.pass_context
+def job_add_tag(ctx: click.Context, name: str, tag: str, value: str) -> None:
+    """Attach a tag (name/value pair) to a job.
+
+    Args:
+        ctx: Click context.
+        name: Job name.
+        tag: Tag name (a registered tag schema).
+        value: Tag value, JSON or a plain string.
+    """
+    job = _get_job(ctx, name)
+    try:
+        job.add_tag(name=tag, value=output.parse_tag_value(value))
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add tag: {exc}") from exc
+    output.success("✓ Added tag '%s' to %s", tag, name)
+
+
+@job_group.command("remove-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.pass_context
+def job_remove_tag(ctx: click.Context, name: str, tag: str) -> None:
+    """Remove a tag from a job.
+
+    Args:
+        ctx: Click context.
+        name: Job name.
+        tag: Tag name.
+    """
+    job = _get_job(ctx, name)
+    try:
+        job.delete_tag(tag)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove tag: {exc}") from exc
+    output.success("✓ Removed tag '%s' from %s", tag, name)
+
+
+@job_group.command("describe")
+@click.argument("name")
+@click.option("--description", required=True, help="New description of the job.")
+@click.pass_context
+def job_describe(ctx: click.Context, name: str, description: str) -> None:
+    """Set the description of a job.
+
+    Args:
+        ctx: Click context.
+        name: Job name.
+        description: New description.
+    """
+    job = _get_job(ctx, name)
+    try:
+        job.description = description
+        job.save()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not update description: {exc}") from exc
+    output.success("✓ Updated description of %s", name)
 
 
 def _read_log(path: str | None, tail: int | None) -> str:

--- a/python/hopsworks/cli/commands/search.py
+++ b/python/hopsworks/cli/commands/search.py
@@ -15,7 +15,15 @@ import click
 from hopsworks.cli import output, session
 
 
-_DOC_TYPES = ["all", "feature_group", "feature_view", "training_dataset", "feature"]
+_DOC_TYPES = [
+    "all",
+    "feature_group",
+    "feature_view",
+    "training_dataset",
+    "feature",
+    "job",
+    "dataset",
+]
 
 
 @click.group("search")
@@ -70,8 +78,9 @@ def search_ls(
             is given (the SDK requires at least one of the three).
         global_search: When True, search across all projects.
         doc_type: One of ``all``, ``feature_group``, ``feature_view``,
-            ``training_dataset``, ``feature``.
-        keywords: Repeatable ``--keyword`` filter.
+            ``training_dataset``, ``feature``, ``job``, ``dataset``.
+        keywords: Repeatable ``--keyword`` filter. Jobs and datasets carry
+            no keywords, so a keyword filter never matches them.
         tags: Repeatable ``--tag name:key=value`` filter.
         limit: Page size cap.
     """
@@ -101,6 +110,8 @@ def search_ls(
                 + [_row("feature_view", r) for r in result.feature_views]
                 + [_row("training_dataset", r) for r in result.training_datasets]
                 + [_row("feature", r) for r in result.features]
+                + [_row("job", r) for r in result.jobs]
+                + [_row("dataset", r) for r in result.datasets]
             )
         elif doc_type == "feature_group":
             rows = [
@@ -113,6 +124,10 @@ def search_ls(
                 _row("training_dataset", r)
                 for r in api.training_datasets(**common_kwargs)
             ]
+        elif doc_type == "job":
+            rows = [_row("job", r) for r in api.jobs(**common_kwargs)]
+        elif doc_type == "dataset":
+            rows = [_row("dataset", r) for r in api.datasets(**common_kwargs)]
         else:  # feature
             rows = [_row("feature", r) for r in api.features(**common_kwargs)]
     except Exception as exc:  # noqa: BLE001

--- a/python/hopsworks/cli/commands/tags.py
+++ b/python/hopsworks/cli/commands/tags.py
@@ -1,0 +1,56 @@
+"""``hops tags`` — tag-schema lifecycle (admin only).
+
+Deprecating a schema refuses new attachments while existing values keep
+working; restoring undoes it. Both require the platform-administrator role
+(HOPS_ADMIN), matching schema creation and deletion.
+"""
+
+from __future__ import annotations
+
+import click
+from hopsworks.cli import output, session
+
+
+@click.group("tags")
+def tags_group() -> None:
+    """Tag-schema lifecycle commands (admin only)."""
+
+
+@tags_group.command("deprecate")
+@click.argument("name")
+@click.pass_context
+def tags_deprecate(ctx: click.Context, name: str) -> None:
+    """Deprecate the tag schema NAME, refusing new attachments of it.
+
+    Args:
+        ctx: Click context.
+        name: Tag schema name.
+    """
+    session.get_project(ctx)
+    from hopsworks_common.core.tag_schemas_api import TagSchemasApi  # noqa: PLC0415
+
+    try:
+        TagSchemasApi().deprecate(name)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not deprecate tag schema: {exc}") from exc
+    output.success("✓ Deprecated tag schema '%s'", name)
+
+
+@tags_group.command("restore")
+@click.argument("name")
+@click.pass_context
+def tags_restore(ctx: click.Context, name: str) -> None:
+    """Undo the deprecation of the tag schema NAME.
+
+    Args:
+        ctx: Click context.
+        name: Tag schema name.
+    """
+    session.get_project(ctx)
+    from hopsworks_common.core.tag_schemas_api import TagSchemasApi  # noqa: PLC0415
+
+    try:
+        TagSchemasApi().restore(name)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not restore tag schema: {exc}") from exc
+    output.success("✓ Restored tag schema '%s'", name)

--- a/python/hopsworks/cli/commands/td.py
+++ b/python/hopsworks/cli/commands/td.py
@@ -313,6 +313,101 @@ def td_lineage(
     lineage.render(label, sections)
 
 
+@td_group.command("keywords")
+@click.argument("feature_view")
+@click.argument("td_version", type=int)
+@click.option("--fv-version", "fv_version", type=int, help="Feature view version.")
+@click.pass_context
+def td_keywords(
+    ctx: click.Context, feature_view: str, td_version: int, fv_version: int | None
+) -> None:
+    """Show all keywords attached to a training dataset.
+
+    Args:
+        ctx: Click context.
+        feature_view: Feature view name.
+        td_version: Training dataset version.
+        fv_version: Feature view version; latest if omitted.
+    """
+    fv = _get_fv(ctx, feature_view, fv_version)
+    try:
+        keywords = fv.get_training_dataset_keywords_metadata(td_version)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read keywords: {exc}") from exc
+
+    if output.JSON_MODE:
+        output.print_json(
+            {k: output.format_ts(v, empty=None) for k, v in (keywords or {}).items()}
+        )
+        return
+    rows = [[k, output.format_ts(v)] for k, v in (keywords or {}).items()]
+    output.print_table(["KEYWORD", "ADDED"], rows)
+
+
+@td_group.command("add-keyword")
+@click.argument("feature_view")
+@click.argument("td_version", type=int)
+@click.argument("keyword")
+@click.option("--fv-version", "fv_version", type=int, help="Feature view version.")
+@click.pass_context
+def td_add_keyword(
+    ctx: click.Context,
+    feature_view: str,
+    td_version: int,
+    keyword: str,
+    fv_version: int | None,
+) -> None:
+    """Attach a keyword to a training dataset.
+
+    Args:
+        ctx: Click context.
+        feature_view: Feature view name.
+        td_version: Training dataset version.
+        keyword: The keyword.
+        fv_version: Feature view version; latest if omitted.
+    """
+    fv = _get_fv(ctx, feature_view, fv_version)
+    try:
+        fv.add_training_dataset_keywords(td_version, [keyword])
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add keyword: {exc}") from exc
+    output.success(
+        "✓ Added keyword '%s' to %s td v%s", keyword, feature_view, td_version
+    )
+
+
+@td_group.command("remove-keyword")
+@click.argument("feature_view")
+@click.argument("td_version", type=int)
+@click.argument("keyword")
+@click.option("--fv-version", "fv_version", type=int, help="Feature view version.")
+@click.pass_context
+def td_remove_keyword(
+    ctx: click.Context,
+    feature_view: str,
+    td_version: int,
+    keyword: str,
+    fv_version: int | None,
+) -> None:
+    """Remove a keyword from a training dataset.
+
+    Args:
+        ctx: Click context.
+        feature_view: Feature view name.
+        td_version: Training dataset version.
+        keyword: The keyword.
+        fv_version: Feature view version; latest if omitted.
+    """
+    fv = _get_fv(ctx, feature_view, fv_version)
+    try:
+        fv.delete_training_dataset_keyword(td_version, keyword)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove keyword: {exc}") from exc
+    output.success(
+        "✓ Removed keyword '%s' from %s td v%s", keyword, feature_view, td_version
+    )
+
+
 def _get_fv(ctx: click.Context, name: str, version: int | None) -> Any:
     fs = session.get_feature_store(ctx)
     try:

--- a/python/hopsworks/cli/main.py
+++ b/python/hopsworks/cli/main.py
@@ -45,6 +45,7 @@ _LAZY_SUBCOMMANDS: dict[str, str] = {
     "transformation": "hopsworks.cli.commands.transformation:transformation_group",
     "superset": "hopsworks.cli.commands.superset:superset_group",
     "search": "hopsworks.cli.commands.search:search_group",
+    "tags": "hopsworks.cli.commands.tags:tags_group",
     "trino": "hopsworks.cli.commands.trino:trino_group",
     "sql": "hopsworks.cli.commands.trino:trino_query",  # top-level alias of `trino query`
     "context": "hopsworks.cli.commands.context:context_cmd",

--- a/python/hopsworks/cli/output.py
+++ b/python/hopsworks/cli/output.py
@@ -78,6 +78,70 @@ def read_tags(obj: Any) -> dict[str, Any]:
     return {name: getattr(t, "value", t) for name, t in (raw or {}).items()}
 
 
+def format_ts(value: Any, empty: str = "-") -> str:
+    """Render a datetime (or None) as an ISO-8601 table cell.
+
+    Args:
+        value: A datetime, or None when the timestamp is unknown.
+        empty: Fallback returned for None.
+
+    Returns:
+        An ISO-8601 string, or the ``empty`` placeholder.
+    """
+    if value is None:
+        return empty
+    if hasattr(value, "isoformat"):
+        return value.isoformat(sep=" ", timespec="seconds")
+    return str(value)
+
+
+def parse_tag_value(raw: str) -> Any:
+    """Parse a ``--value`` option as JSON, falling back to the raw string.
+
+    Tag values are arbitrary JSON; a bare word like ``prod`` is accepted as a
+    plain string rather than rejected for not being valid JSON.
+
+    Args:
+        raw: The option value as typed.
+
+    Returns:
+        The decoded JSON value, or ``raw`` unchanged.
+    """
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def render_tags(tags: Any) -> None:
+    """Render a ``{name: Tag}`` mapping as a NAME/VALUE/ADDED table or JSON.
+
+    Args:
+        tags: Mapping of tag name to SDK ``Tag`` objects (with ``value`` and
+            ``created_on``), as returned by the ``get_tags_metadata`` methods.
+    """
+    if JSON_MODE:
+        print_json(
+            {
+                k: {
+                    "value": getattr(t, "value", t),
+                    "added": format_ts(getattr(t, "created_on", None), empty=None),
+                }
+                for k, t in (tags or {}).items()
+            }
+        )
+        return
+    rows = [
+        [
+            k,
+            json.dumps(getattr(t, "value", t), default=str),
+            format_ts(getattr(t, "created_on", None)),
+        ]
+        for k, t in (tags or {}).items()
+    ]
+    print_table(["NAME", "VALUE", "ADDED"], rows)
+
+
 def format_mapping(values: Any, empty: str = "-") -> str:
     """Render a small mapping as ``key=value`` pairs for a one-line cell.
 

--- a/python/hopsworks_common/app.py
+++ b/python/hopsworks_common/app.py
@@ -124,7 +124,15 @@ class App:
         # Not part of the persisted app config — the backend has no field for it.
         self._env_vars: dict[str, str] | None = None
 
+        self._project_id = None
+        self._project_name = None
         self._app_api = app_api.AppApi()
+
+    def _bind_project(self, project_id, project_name):
+        """Address the project this app runs in."""
+        self._project_id = project_id
+        self._project_name = project_name
+        self._app_api = app_api.AppApi(project_id=project_id, project_name=project_name)
 
     @classmethod
     def from_response_json(cls, json_dict):

--- a/python/hopsworks_common/app.py
+++ b/python/hopsworks_common/app.py
@@ -380,7 +380,10 @@ class App:
         if not token:
             return None
         _client = client._get_instance()
-        project = urllib.parse.quote(_client._project_name, safe="")
+        # The bound project when this app was read through a foreign Project; the login project
+        # otherwise. The connection's name built a share URL into the wrong project for a bound app.
+        project_name = self._project_name or _client._project_name
+        project = urllib.parse.quote(project_name, safe="")
         name = urllib.parse.quote(self._name, safe="")
         return (
             _client._base_url.rstrip("/")
@@ -491,9 +494,12 @@ class App:
             The URL to the app page in the Hopsworks UI.
         """
         _client = client._get_instance()
-        return util._get_hostname_replaced_url(
-            "/p/" + str(_client._project_id) + "/apps"
+        # The bound project when this app was read through a foreign Project; the login project
+        # otherwise. The connection's id pointed the UI link at the wrong project for a bound app.
+        project_id = (
+            self._project_id if self._project_id is not None else _client._project_id
         )
+        return util._get_hostname_replaced_url("/p/" + str(project_id) + "/apps")
 
     def _refresh(self) -> App:
         """Re-fetch app state from the backend."""

--- a/python/hopsworks_common/app.py
+++ b/python/hopsworks_common/app.py
@@ -129,7 +129,6 @@ class App:
         self._app_api = app_api.AppApi()
 
     def _bind_project(self, project_id, project_name):
-        """Address the project this app runs in."""
         self._project_id = project_id
         self._project_name = project_name
         self._app_api = app_api.AppApi(project_id=project_id, project_name=project_name)

--- a/python/hopsworks_common/connection.py
+++ b/python/hopsworks_common/connection.py
@@ -196,7 +196,9 @@ class Connection:
 
     @usage._method_logger
     @_connected
-    def _get_model_serving(self) -> ModelServing:
+    def _get_model_serving(
+        self, project_name: str | None = None, project_id: int | None = None
+    ) -> ModelServing:
         """Get a reference to model serving to perform operations on. Model serving operates on top of a model registry, defaulting to the project's default model registry.
 
         Example:
@@ -211,7 +213,7 @@ class Connection:
         Returns:
             A model serving handle object to perform operations on.
         """
-        return self._model_serving_api._get()
+        return self._model_serving_api._get(project_name, project_id)
 
     @usage._method_logger
     @_connected

--- a/python/hopsworks_common/core/alerts_api.py
+++ b/python/hopsworks_common/core/alerts_api.py
@@ -150,7 +150,9 @@ class AlertsApi:
     To obtain an object of this type, use [`project.get_alerts_api`][hopsworks_common.project.Project.get_alerts_api].
     """
 
-    def __init__(self, project_id: int | None = None) -> None:
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
         """Alerts of one project.
 
         Parameters:
@@ -159,15 +161,26 @@ class AlertsApi:
                 Defaults to the project of the connection. A Job obtained from another project passes
                 its own project here, so that manipulating its alerts does not reach a same-named job
                 of the login project.
+            project_name:
+                Name of the same project. Receiver names are qualified with it, so a handle bound by id
+                alone would create an alert on project B's job pointing at project A's receiver.
         """
         self._log = logging.getLogger(__name__)
         self._project_id = project_id
+        self._project_name = project_name
 
     def _pid(self) -> int:
         return (
             self._project_id
             if self._project_id is not None
             else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
         )
 
     @public
@@ -193,7 +206,7 @@ class AlertsApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "service", "alerts"]
+        path_params = ["project", self._pid(), "service", "alerts"]
         headers = {"content-type": "application/json"}
         return alert.ProjectAlert.from_response_json(
             _client._send_request("GET", path_params, headers=headers)
@@ -228,7 +241,7 @@ class AlertsApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "service", "alerts", alert_id]
+        path_params = ["project", self._pid(), "service", "alerts", alert_id]
         headers = {"content-type": "application/json"}
         return alert.ProjectAlert.from_response_json(
             _client._send_request("GET", path_params, headers=headers)
@@ -342,7 +355,7 @@ class AlertsApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "featurestores",
             feature_store_id,
             "featuregroups",
@@ -392,7 +405,7 @@ class AlertsApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "featurestores",
             feature_store_id,
             "featuregroups",
@@ -440,7 +453,7 @@ class AlertsApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "featurestores",
             feature_store_id,
             "featureview",
@@ -494,7 +507,7 @@ class AlertsApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "featurestores",
             feature_store_id,
             "featureview",
@@ -578,8 +591,8 @@ class AlertsApi:
             status = status.replace("feature_validation_", "validation_")
 
         _client = client._get_instance()
-        receiver = self._fix_receiver_name(receiver, _client._project_name)
-        path_params = ["project", _client._project_id, "service", "alerts"]
+        receiver = self._fix_receiver_name(receiver, self._pname())
+        path_params = ["project", self._pid(), "service", "alerts"]
         alert_data = {
             "status": status.upper(),
             "severity": severity.upper(),
@@ -659,10 +672,10 @@ class AlertsApi:
         if severity not in _SEVERITY:
             raise ValueError(f"Severity must be one of the following: {_SEVERITY}.")
         _client = client._get_instance()
-        receiver = self._fix_receiver_name(receiver, _client._project_name)
+        receiver = self._fix_receiver_name(receiver, self._pname())
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "featurestores",
             feature_store_id,
             "featuregroups",
@@ -733,10 +746,10 @@ class AlertsApi:
         if severity not in _SEVERITY:
             raise ValueError(f"Severity must be one of the following: {_SEVERITY}.")
         _client = client._get_instance()
-        receiver = self._fix_receiver_name(receiver, _client._project_name)
+        receiver = self._fix_receiver_name(receiver, self._pname())
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "featurestores",
             feature_store_id,
             "featureview",
@@ -802,7 +815,7 @@ class AlertsApi:
             status = status.replace("job_", "")
 
         _client = client._get_instance()
-        receiver = self._fix_receiver_name(receiver, _client._project_name)
+        receiver = self._fix_receiver_name(receiver, self._pname())
         path_params = [
             "project",
             self._pid(),
@@ -845,7 +858,7 @@ class AlertsApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "alerts", "receivers"]
+        path_params = ["project", self._pid(), "alerts", "receivers"]
         query_params = {"expand": True, "global": True}
         headers = {"content-type": "application/json"}
         return alert_receiver.AlertReceiver.from_response_json(
@@ -884,8 +897,8 @@ class AlertsApi:
         """
         _client = client._get_instance()
 
-        name = self._fix_receiver_name(name, _client._project_name)
-        path_params = ["project", _client._project_id, "alerts", "receivers", name]
+        name = self._fix_receiver_name(name, self._pname())
+        path_params = ["project", self._pid(), "alerts", "receivers", name]
         headers = {"content-type": "application/json"}
         return alert_receiver.AlertReceiver.from_response_json(
             _client._send_request("GET", path_params, headers=headers)
@@ -969,7 +982,7 @@ class AlertsApi:
             )
 
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "alerts", "receivers"]
+        path_params = ["project", self._pid(), "alerts", "receivers"]
         headers = {"content-type": "application/json"}
         data = {
             "name": name,
@@ -1020,7 +1033,7 @@ class AlertsApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "service", "alerts", alert_id]
+        path_params = ["project", self._pid(), "service", "alerts", alert_id]
         headers = {"content-type": "application/json"}
         _client._send_request("DELETE", path_params, headers=headers)
         self._log.info(f"Alert with ID {alert_id} deleted successfully.")
@@ -1070,7 +1083,7 @@ class AlertsApi:
             raise ValueError(f"Severity must be one of the following: {_SEVERITY}.")
         _client = client._get_instance()
         self._create_route_if_not_exist(receiver_name, status, severity)
-        path_params = ["project", _client._project_id, "alerts"]
+        path_params = ["project", self._pid(), "alerts"]
         headers = {"content-type": "application/json"}
         data = {
             "alerts": [
@@ -1132,7 +1145,7 @@ class AlertsApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "alerts"]
+        path_params = ["project", self._pid(), "alerts"]
         query_params = {"active": active, "silenced": silenced, "inhibited": inhibited}
         headers = {"content-type": "application/json"}
         return triggered_alert.TriggeredAlert.from_response_json(
@@ -1148,7 +1161,7 @@ class AlertsApi:
             A list of configured alert receivers.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "alerts", "receivers", "default"]
+        path_params = ["project", self._pid(), "alerts", "receivers", "default"]
         headers = {"content-type": "application/json"}
         return humps.decamelize(
             _client._send_request("GET", path_params, headers=headers)
@@ -1162,15 +1175,15 @@ class AlertsApi:
         if receiver_name is None:
             raise ValueError("Receiver name cannot be None.")
 
-        receiver_name = self._fix_receiver_name(receiver_name, _client._project_name)
+        receiver_name = self._fix_receiver_name(receiver_name, self._pname())
         # Check if the receiver exists
         receiver = self.get_alert_receiver(receiver_name)
         if receiver is None:
             raise ValueError(f"Receiver {receiver_name} does not exist.")
 
         # Only create a route if the receiver is a project receiver
-        if receiver_name.startswith(f"{_client._project_name}__"):
-            path_params = ["project", _client._project_id, "alerts", "routes"]
+        if receiver_name.startswith(f"{self._pname()}__"):
+            path_params = ["project", self._pid(), "alerts", "routes"]
             headers = {"content-type": "application/json"}
             match = [
                 {"key": "status", "value": status},

--- a/python/hopsworks_common/core/alerts_api.py
+++ b/python/hopsworks_common/core/alerts_api.py
@@ -150,8 +150,25 @@ class AlertsApi:
     To obtain an object of this type, use [`project.get_alerts_api`][hopsworks_common.project.Project.get_alerts_api].
     """
 
-    def __init__(self):
+    def __init__(self, project_id: int | None = None) -> None:
+        """Alerts of one project.
+
+        Parameters:
+            project_id:
+                The project whose alerts this handle addresses.
+                Defaults to the project of the connection. A Job obtained from another project passes
+                its own project here, so that manipulating its alerts does not reach a same-named job
+                of the login project.
+        """
         self._log = logging.getLogger(__name__)
+        self._project_id = project_id
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
 
     @public
     @usage._method_logger
@@ -243,7 +260,7 @@ class AlertsApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", job_name, "alerts"]
+        path_params = ["project", self._pid(), "jobs", job_name, "alerts"]
         headers = {"content-type": "application/json"}
         return alert.JobAlert.from_response_json(
             _client._send_request("GET", path_params, headers=headers)
@@ -281,7 +298,7 @@ class AlertsApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             job_name,
             "alerts",
@@ -788,7 +805,7 @@ class AlertsApi:
         receiver = self._fix_receiver_name(receiver, _client._project_name)
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             job_name,
             "alerts",

--- a/python/hopsworks_common/core/app_api.py
+++ b/python/hopsworks_common/core/app_api.py
@@ -66,6 +66,17 @@ class AppApi:
             else client._get_instance()._project_name
         )
 
+    def _stamp(self, apps):
+        """Bind the apps this handle returns to the project it addresses.
+
+        An App builds its own handle, so one read out of another project would be started,
+        stopped and deleted in the login project.
+        """
+        for one in apps if isinstance(apps, list) else [apps]:
+            if one is not None:
+                one._bind_project(self._pid(), self._pname())
+        return apps
+
     @public
     @usage._method_logger
     def get_apps(self) -> list[app.App]:
@@ -80,7 +91,7 @@ class AppApi:
         path_params = ["project", self._pid(), "apps"]
         headers = {"content-type": "application/json"}
         response = _client._send_request("GET", path_params, headers=headers)
-        return app.App.from_response_json_list(response)
+        return self._stamp(app.App.from_response_json_list(response))
 
     @public
     @usage._method_logger
@@ -111,7 +122,7 @@ class AppApi:
             ):
                 return None
             raise
-        return app.App.from_response_json(response)
+        return self._stamp(app.App.from_response_json(response))
 
     @public
     @usage._method_logger

--- a/python/hopsworks_common/core/app_api.py
+++ b/python/hopsworks_common/core/app_api.py
@@ -38,8 +38,33 @@ _GIT_PROVIDER_ALIASES = {
 
 @public("hopsworks.core.app_api.AppApi")
 class AppApi:
-    def __init__(self):
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Apps of one project.
+
+        Parameters:
+            project_id: The project this handle addresses; the connection's project if omitted.
+            project_name: Name of the same project, for the paths that carry it. Resolved from the
+                connection when omitted.
+        """
         self._log = logging.getLogger(__name__)
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
 
     @public
     @usage._method_logger
@@ -52,7 +77,7 @@ class AppApi:
         from hopsworks_common import app
 
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "apps"]
+        path_params = ["project", self._pid(), "apps"]
         headers = {"content-type": "application/json"}
         response = _client._send_request("GET", path_params, headers=headers)
         return app.App.from_response_json_list(response)
@@ -75,7 +100,7 @@ class AppApi:
         from hopsworks_common import app
 
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "apps", name]
+        path_params = ["project", self._pid(), "apps", name]
         headers = {"content-type": "application/json"}
         try:
             response = _client._send_request("GET", path_params, headers=headers)
@@ -207,7 +232,7 @@ class AppApi:
                 )
 
         if app_path and not git_repo_app:
-            app_path = util._convert_to_abs(app_path, _client._project_name)
+            app_path = util._convert_to_abs(app_path, self._pname())
             if not app_path.startswith("hdfs://"):
                 app_path = "hdfs://" + app_path
 
@@ -244,7 +269,7 @@ class AppApi:
         if readiness_probe_path is not None:
             config["readinessProbePath"] = readiness_probe_path
 
-        path_params = ["project", _client._project_id, "jobs", name]
+        path_params = ["project", self._pid(), "jobs", name]
         headers = {"content-type": "application/json"}
         _client._send_request(
             "PUT", path_params, headers=headers, data=json.dumps(config)
@@ -266,7 +291,7 @@ class AppApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             app_name,
             "executions",
@@ -285,7 +310,7 @@ class AppApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             app_name,
             "executions",
@@ -302,7 +327,7 @@ class AppApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "apps",
             app_name,
             "redeploy",
@@ -319,7 +344,7 @@ class AppApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "apps",
             app_name,
             "public",
@@ -334,7 +359,7 @@ class AppApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             app_name,
             "executions",
@@ -350,7 +375,7 @@ class AppApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             app_name,
         ]

--- a/python/hopsworks_common/core/dataset_api.py
+++ b/python/hopsworks_common/core/dataset_api.py
@@ -24,10 +24,10 @@ import os
 import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from hopsworks_apigen import also_available_as, public
-from hopsworks_common import client, tag, usage, util
+from hopsworks_common import client, decorators, tag, usage, util
 from hopsworks_common.client.exceptions import DatasetException, RestAPIError
 from hopsworks_common.core import dataset, inode
 from tqdm.auto import tqdm
@@ -53,8 +53,40 @@ class Chunk:
     "hsml.core.dataset_api.DatasetApi",
 )
 class DatasetApi:
-    def __init__(self):
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Datasets of one project.
+
+        Parameters:
+            project_id: Project whose datasets this reads and writes. Defaults to the
+                connection's project. A search result from another authorized project
+                constructs one for that project, since every path here is built as
+                `project/<id>/dataset/...` and would otherwise resolve against the
+                login project.
+            project_name: Name of the same project, used where a path has to be
+                absolute (`/Projects/<name>/...`). Resolved from the connection when
+                omitted.
+        """
         self._log = logging.getLogger(__name__)
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self) -> int:
+        """The project to address: the one this instance was built for, or the connection's."""
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        """The project name to address, for the paths that have to be absolute."""
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
 
     DEFAULT_UPLOAD_FLOW_CHUNK_SIZE = 10 * 1024 * 1024
     DEFAULT_UPLOAD_SIMULTANEOUS_UPLOADS = 3
@@ -106,7 +138,7 @@ class DatasetApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "dataset",
             "download",
             "with_auth",
@@ -420,7 +452,7 @@ class DatasetApi:
 
     def _upload_request(self, params, path, file_name, chunk):
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", "upload", path]
+        path_params = ["project", self._pid(), "dataset", "upload", path]
 
         # Flow configuration params are sent as form data
         _client._send_request(
@@ -437,7 +469,7 @@ class DatasetApi:
             Dataset metadata.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", path]
+        path_params = ["project", self._pid(), "dataset", path]
         headers = {"content-type": "application/json"}
         return _client._send_request("GET", path_params, headers=headers)
 
@@ -497,7 +529,7 @@ class DatasetApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", path]
+        path_params = ["project", self._pid(), "dataset", path]
         return _client._send_request("DELETE", path_params)
 
     @public
@@ -564,7 +596,7 @@ class DatasetApi:
         if not target_project:
             raise ValueError("target_project must be a non-empty project name")
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", path]
+        path_params = ["project", self._pid(), "dataset", path]
         query_params = {
             "action": "SHARE",
             "target_project": target_project,
@@ -577,8 +609,8 @@ class DatasetApi:
                 raise PermissionError(
                     f"Sharing dataset '{path}' with project '{target_project}' "
                     f"requires the Data Owner role in the source project "
-                    f"'{_client._project_name}'. Ask a data owner of "
-                    f"'{_client._project_name}' to run this, or be granted that role."
+                    f"'{self._pname()}'. Ask a data owner of "
+                    f"'{self._pname()}' to run this, or be granted that role."
                 ) from e
             raise
 
@@ -614,7 +646,7 @@ class DatasetApi:
         if not target_project:
             raise ValueError("target_project must be a non-empty project name")
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", path]
+        path_params = ["project", self._pid(), "dataset", path]
         query_params = {
             "action": "UNSHARE",
             "target_project": target_project,
@@ -626,14 +658,18 @@ class DatasetApi:
                 raise PermissionError(
                     f"Unsharing dataset '{path}' from project '{target_project}' "
                     f"requires the Data Owner role in the source project "
-                    f"'{_client._project_name}'. Ask a data owner of "
-                    f"'{_client._project_name}' to run this, or be granted that role."
+                    f"'{self._pname()}'. Ask a data owner of "
+                    f"'{self._pname()}' to run this, or be granted that role."
                 ) from e
             raise
 
     @public
     @usage._method_logger
-    def mkdir(self, path: str) -> str:
+    def mkdir(
+        self,
+        path: str,
+        tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
+    ) -> str:
         """Create a directory in the Hopsworks Filesystem.
 
         ```python
@@ -644,10 +680,19 @@ class DatasetApi:
         dataset_api = project.get_dataset_api()
 
         directory_path = dataset_api.mkdir("Resources/my_dir")
+
+        # attach tags at creation, e.g. to satisfy a mandatory-tag policy
+        directory_path = dataset_api.mkdir(
+            "my_dataset", tags={"name": "sensitivity", "value": "internal"}
+        )
         ```
 
         Parameters:
             path: Path to directory.
+            tags:
+                Tags to attach to the created top-level dataset, validated before anything is created.
+                A cluster with a mandatory-tag policy for datasets refuses the creation of a top-level dataset without them.
+                Requires a server with dataset tag support; against an older server, create the dataset without tags and attach them afterwards.
 
         Returns:
             Path to the created directory.
@@ -656,7 +701,7 @@ class DatasetApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", path]
+        path_params = ["project", self._pid(), "dataset", path]
         query_params = {
             "action": "create",
             "searchable": "true",
@@ -664,9 +709,22 @@ class DatasetApi:
             "type": "DATASET",
         }
         headers = {"content-type": "application/json"}
-        return _client._send_request(
-            "POST", path_params, headers=headers, query_params=query_params
-        )["attributes"]["path"]
+        # An absent or empty body keeps the endpoint's pre-tags behavior, so old
+        # servers and tag-less calls stay unchanged.
+        data = None
+        if tags:
+            data = json.dumps(tag.Tag._tags_to_dict(tag.Tag._normalize(tags)))
+        response = _client._send_request(
+            "POST", path_params, headers=headers, query_params=query_params, data=data
+        )
+        created = (response.get("attributes") or {}).get("path")
+        if created:
+            return created
+        # A top-level dataset answers with the dataset, whose inode attributes the
+        # create response does not expand, so there is no path to read back. The
+        # requested path is what was created, and the absolute form is what this
+        # method returns for every other path.
+        return f"/Projects/{self._pname()}/{path}"
 
     @public
     @usage._method_logger
@@ -705,7 +763,7 @@ class DatasetApi:
                 )
 
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", source_path]
+        path_params = ["project", self._pid(), "dataset", source_path]
         query_params = {
             "action": "copy",
             "destination_path": destination_path,
@@ -749,7 +807,7 @@ class DatasetApi:
                 )
 
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", source_path]
+        path_params = ["project", self._pid(), "dataset", source_path]
         query_params = {
             "action": "move",
             "destination_path": destination_path,
@@ -843,9 +901,7 @@ class DatasetApi:
 
         files = []
         for item in items:
-            files.append(
-                util._convert_to_project_rel_path(item.path, _client._project_name)
-            )
+            files.append(util._convert_to_project_rel_path(item.path, self._pname()))
         return files
 
     @usage._method_logger
@@ -870,7 +926,7 @@ class DatasetApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "dataset",
             path,
         ]
@@ -904,7 +960,7 @@ class DatasetApi:
 
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "dataset",
             "download",
             "with_auth",
@@ -932,7 +988,7 @@ class DatasetApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", remote_path]
+        path_params = ["project", self._pid(), "dataset", remote_path]
         headers = {"content-type": "application/json"}
         query_params = {"action": "PERMISSION", "permissions": permissions}
         return _client._send_request(
@@ -965,7 +1021,7 @@ class DatasetApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "dataset", remote_path]
+        path_params = ["project", self._pid(), "dataset", remote_path]
 
         query_params = {"action": action}
 
@@ -1086,7 +1142,7 @@ class DatasetApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "dataset",
             "tags",
             "schema",
@@ -1112,7 +1168,7 @@ class DatasetApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "dataset",
             "tags",
             "schema",
@@ -1139,7 +1195,7 @@ class DatasetApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "dataset",
             "tags",
         ]
@@ -1156,6 +1212,66 @@ class DatasetApi:
         return {
             tag._name: tag._value
             for tag in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+
+    @public
+    def get_tag_metadata(self, path: str, name: str) -> tag.Tag | None:
+        """Get a dataset tag with its metadata, including the time it was attached.
+
+        Unlike [`DatasetApi.get_tags`][hopsworks.core.dataset_api.DatasetApi.get_tags], which returns only tag values, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            path: Path of the dataset the tag is attached to.
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object, or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self.get_tags_metadata(path, name=name).get(name)
+
+    @public
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def get_tags_metadata(
+        self, path: str, name: str | None = None
+    ) -> dict[str, tag.Tag]:
+        """Get all tags attached to a dataset, with their metadata.
+
+        Unlike [`DatasetApi.get_tags`][hopsworks.core.dataset_api.DatasetApi.get_tags], which returns only tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            path: Path of the dataset to get the tags for.
+            name: Tag name; all tags if omitted.
+
+        Returns:
+            Dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            self._pid(),
+            "dataset",
+            "tags",
+        ]
+
+        if name is not None:
+            path_params.append("schema")
+            path_params.append(name)
+        else:
+            path_params.append("all")
+
+        path_params.append(path)
+
+        return {
+            t._name: t
+            for t in tag.Tag.from_response_json(
                 _client._send_request("GET", path_params)
             )
         }

--- a/python/hopsworks_common/core/dataset_api.py
+++ b/python/hopsworks_common/core/dataset_api.py
@@ -1220,7 +1220,7 @@ class DatasetApi:
     def get_tag_metadata(self, path: str, name: str) -> tag.Tag | None:
         """Get a dataset tag with its metadata, including the time it was attached.
 
-        Unlike [`DatasetApi.get_tags`][hopsworks.core.dataset_api.DatasetApi.get_tags], which returns only tag values, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`DatasetApi.get_tags`][hopsworks.core.dataset_api.DatasetApi.get_tags], which returns only tag values, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Parameters:
             path: Path of the dataset the tag is attached to.
@@ -1241,7 +1241,7 @@ class DatasetApi:
     ) -> dict[str, tag.Tag]:
         """Get all tags attached to a dataset, with their metadata.
 
-        Unlike [`DatasetApi.get_tags`][hopsworks.core.dataset_api.DatasetApi.get_tags], which returns only tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`DatasetApi.get_tags`][hopsworks.core.dataset_api.DatasetApi.get_tags], which returns only tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Parameters:
             path: Path of the dataset to get the tags for.

--- a/python/hopsworks_common/core/environment_api.py
+++ b/python/hopsworks_common/core/environment_api.py
@@ -24,8 +24,33 @@ from hopsworks_common.engine import environment_engine
 
 @public("hopsworks.core.environment_api.EnvironmentApi")
 class EnvironmentApi:
-    def __init__(self):
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Python environments of one project.
+
+        Parameters:
+            project_id: The project this handle addresses; the connection's project if omitted.
+            project_name: Name of the same project, for the paths that carry it. Resolved from the
+                connection when omitted.
+        """
         self._environment_engine = environment_engine.EnvironmentEngine()
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
 
     @public
     @usage._method_logger
@@ -64,7 +89,7 @@ class EnvironmentApi:
 
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "python",
             "environments",
             name,
@@ -108,7 +133,7 @@ class EnvironmentApi:
         """
         _client = client._get_instance()
 
-        path_params = ["project", _client._project_id, "python", "environments"]
+        path_params = ["project", self._pid(), "python", "environments"]
         query_params = {"expand": ["libraries", "commands"]}
         headers = {"content-type": "application/json"}
         return environment.Environment.from_response_json(
@@ -146,7 +171,7 @@ class EnvironmentApi:
         """
         _client = client._get_instance()
 
-        path_params = ["project", _client._project_id, "python", "environments", name]
+        path_params = ["project", self._pid(), "python", "environments", name]
         query_params = {"expand": ["libraries", "commands"]}
         headers = {"content-type": "application/json"}
         return environment.Environment.from_response_json(
@@ -165,7 +190,7 @@ class EnvironmentApi:
 
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "python",
             "environments",
             name,

--- a/python/hopsworks_common/core/environment_api.py
+++ b/python/hopsworks_common/core/environment_api.py
@@ -34,9 +34,11 @@ class EnvironmentApi:
             project_name: Name of the same project, for the paths that carry it. Resolved from the
                 connection when omitted.
         """
-        self._environment_engine = environment_engine.EnvironmentEngine()
         self._project_id = project_id
         self._project_name = project_name
+        self._environment_engine = environment_engine.EnvironmentEngine(
+            project_id, project_name
+        )
 
     def _pid(self) -> int:
         return (
@@ -51,6 +53,17 @@ class EnvironmentApi:
             if self._project_name is not None
             else client._get_instance()._project_name
         )
+
+    def _stamp(self, envs):
+        """Bind the environments this handle returns to the project it addresses.
+
+        An Environment builds its own handles, so one read out of another project installs and
+        deletes in the login project unless it is told which project it came from.
+        """
+        for env in envs if isinstance(envs, list) else [envs]:
+            if env is not None:
+                env._bind_project(self._pid(), self._pname())
+        return envs
 
     @public
     @usage._method_logger
@@ -99,9 +112,11 @@ class EnvironmentApi:
             "name": name,
             "baseImage": {"name": base_environment_name, "description": description},
         }
-        env = environment.Environment.from_response_json(
-            _client._send_request(
-                "POST", path_params, headers=headers, data=json.dumps(data)
+        env = self._stamp(
+            environment.Environment.from_response_json(
+                _client._send_request(
+                    "POST", path_params, headers=headers, data=json.dumps(data)
+                )
             )
         )
 
@@ -136,9 +151,11 @@ class EnvironmentApi:
         path_params = ["project", self._pid(), "python", "environments"]
         query_params = {"expand": ["libraries", "commands"]}
         headers = {"content-type": "application/json"}
-        return environment.Environment.from_response_json(
-            _client._send_request(
-                "GET", path_params, query_params=query_params, headers=headers
+        return self._stamp(
+            environment.Environment.from_response_json(
+                _client._send_request(
+                    "GET", path_params, query_params=query_params, headers=headers
+                )
             )
         )
 
@@ -174,9 +191,11 @@ class EnvironmentApi:
         path_params = ["project", self._pid(), "python", "environments", name]
         query_params = {"expand": ["libraries", "commands"]}
         headers = {"content-type": "application/json"}
-        return environment.Environment.from_response_json(
-            _client._send_request(
-                "GET", path_params, query_params=query_params, headers=headers
+        return self._stamp(
+            environment.Environment.from_response_json(
+                _client._send_request(
+                    "GET", path_params, query_params=query_params, headers=headers
+                )
             )
         )
 

--- a/python/hopsworks_common/core/execution_api.py
+++ b/python/hopsworks_common/core/execution_api.py
@@ -24,6 +24,28 @@ from hopsworks_common.core import execution_pod_log
 
 @also_available_as("hopsworks.core.execution_api.ExecutionApi")
 class ExecutionApi:
+    def __init__(
+        self,
+        project_id: int | None = None,
+    ) -> None:
+        """Executions of the jobs of one project.
+
+        Parameters:
+            project_id:
+                The project whose jobs this handle addresses.
+                Defaults to the project of the connection, which is wrong for a job obtained from
+                another project: starting or listing its executions would then address a same-named
+                job of the login project.
+        """
+        self._project_id = project_id
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
     def _start(
         self,
         job,
@@ -41,7 +63,7 @@ class ExecutionApi:
         args body for backwards compatibility.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", job.name, "executions"]
+        path_params = ["project", self._pid(), "jobs", job.name, "executions"]
 
         use_json = (
             start_time is not None
@@ -90,7 +112,7 @@ class ExecutionApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             job.name,
             "executions",
@@ -104,7 +126,7 @@ class ExecutionApi:
 
     def _get_all(self, job):
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", job.name, "executions"]
+        path_params = ["project", self._pid(), "jobs", job.name, "executions"]
 
         query_params = {"sort_by": "submissiontime:desc"}
 
@@ -120,7 +142,7 @@ class ExecutionApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             job_name,
             "executions",
@@ -132,7 +154,7 @@ class ExecutionApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             job_name,
             "executions",
@@ -150,7 +172,7 @@ class ExecutionApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             job_name,
             "executions",
@@ -176,7 +198,7 @@ class ExecutionApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "jobs",
             job_name,
             "executions",

--- a/python/hopsworks_common/core/git_api.py
+++ b/python/hopsworks_common/core/git_api.py
@@ -53,11 +53,11 @@ class GitApi:
             project_name: Name of the same project, for the paths that carry it. Resolved from the
                 connection when omitted.
         """
-        self._git_engine = git_engine.GitEngine()
-        self._git_provider_api = git_provider_api.GitProviderApi()
-        self._log = logging.getLogger(__name__)
         self._project_id = project_id
         self._project_name = project_name
+        self._git_engine = git_engine.GitEngine(project_id, project_name)
+        self._git_provider_api = git_provider_api.GitProviderApi()
+        self._log = logging.getLogger(__name__)
 
     def _pid(self) -> int:
         return (
@@ -72,6 +72,17 @@ class GitApi:
             if self._project_name is not None
             else client._get_instance()._project_name
         )
+
+    def _stamp(self, repos):
+        """Bind the repositories this handle returns to the project it addresses.
+
+        A GitRepo builds its own handles, so one read out of another project would check out,
+        commit and delete files through the login project.
+        """
+        for repo in repos if isinstance(repos, list) else [repos]:
+            if repo is not None:
+                repo._bind_project(self._pid(), self._pname())
+        return repos
 
     @public
     @usage._method_logger
@@ -164,8 +175,10 @@ class GitApi:
             "git",
         ]
         query_params = {"expand": "creator"}
-        return git_repo.GitRepo.from_response_json(
-            _client._send_request("GET", path_params, query_params=query_params)
+        return self._stamp(
+            git_repo.GitRepo.from_response_json(
+                _client._send_request("GET", path_params, query_params=query_params)
+            )
         )
 
     @public
@@ -258,8 +271,10 @@ class GitApi:
         ]
         query_params = {"expand": "creator"}
 
-        repos = git_repo.GitRepo.from_response_json(
-            _client._send_request("GET", path_params, query_params=query_params)
+        repos = self._stamp(
+            git_repo.GitRepo.from_response_json(
+                _client._send_request("GET", path_params, query_params=query_params)
+            )
         )
 
         if path is not None:

--- a/python/hopsworks_common/core/git_api.py
+++ b/python/hopsworks_common/core/git_api.py
@@ -43,10 +43,35 @@ from hopsworks_apigen import public
 
 @public("hopsworks.core.git_api.GitApi")
 class GitApi:
-    def __init__(self):
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Git repositories of one project.
+
+        Parameters:
+            project_id: The project this handle addresses; the connection's project if omitted.
+            project_name: Name of the same project, for the paths that carry it. Resolved from the
+                connection when omitted.
+        """
         self._git_engine = git_engine.GitEngine()
         self._git_provider_api = git_provider_api.GitProviderApi()
         self._log = logging.getLogger(__name__)
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
 
     @public
     @usage._method_logger
@@ -87,12 +112,12 @@ class GitApi:
         _client = client._get_instance()
 
         # Support absolute and relative path to dataset
-        path = util._convert_to_abs(path, _client._project_name)
+        path = util._convert_to_abs(path, self._pname())
 
         if provider is None:
             provider = self._git_provider_api._get_default_configured_provider()
 
-        path_params = ["project", _client._project_id, "git", "clone"]
+        path_params = ["project", self._pid(), "git", "clone"]
 
         clone_config = {
             "url": url,
@@ -115,7 +140,7 @@ class GitApi:
         print(
             "Git clone operation running, explore it at "
             + util._get_hostname_replaced_url(
-                "/p/" + str(_client._project_id) + "/settings/git"
+                "/p/" + str(self._pid()) + "/settings/git"
             )
         )
         git_op = self._git_engine._execute_op_blocking(git_op, "CLONE")
@@ -135,7 +160,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
         ]
         query_params = {"expand": "creator"}
@@ -228,7 +253,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
         ]
         query_params = {"expand": "creator"}
@@ -238,7 +263,7 @@ class GitApi:
         )
 
         if path is not None:
-            path = util._convert_to_abs(path, _client._project_name)
+            path = util._convert_to_abs(path, self._pname())
 
         filtered_repos = []
         for repository in repos:
@@ -257,7 +282,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -268,7 +293,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -294,7 +319,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -321,7 +346,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -347,7 +372,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -383,7 +408,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -413,7 +438,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -443,7 +468,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -473,7 +498,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -502,7 +527,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -534,7 +559,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -559,7 +584,7 @@ class GitApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),

--- a/python/hopsworks_common/core/git_op_execution_api.py
+++ b/python/hopsworks_common/core/git_op_execution_api.py
@@ -20,11 +20,31 @@ from hopsworks_common import client, git_op_execution
 
 @also_available_as("hopsworks.core.git_op_execution_api.GitOpExecutionApi")
 class GitOpExecutionApi:
+    def __init__(self, project_id=None, project_name=None):
+        """Git executions of one project.
+
+        Parameters:
+            project_id: The project whose executions this polls, and project_name its name.
+                Both default to the connection's project. A GitEngine driving a repository in
+                another project passes that project's, because an unbound handle polls an
+                execution id in the login project, where it is either absent or someone
+                else's.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self):
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
     def _get_execution(self, repo_id, execution_id):
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),

--- a/python/hopsworks_common/core/git_remote_api.py
+++ b/python/hopsworks_common/core/git_remote_api.py
@@ -21,14 +21,31 @@ from hopsworks_common.engine import git_engine
 
 @also_available_as("hopsworks.core.git_remote_api.GitRemoteApi")
 class GitRemoteApi:
-    def __init__(self):
-        self._git_engine = git_engine.GitEngine()
+    def __init__(self, project_id=None, project_name=None):
+        """Git remotes of one project's repositories.
+
+        Parameters:
+            project_id: The project whose repositories this addresses, and project_name its
+                name. Both default to the connection's project. A GitRepo obtained from
+                another project passes that project's, since a repository id means nothing
+                outside the project that holds it.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+        self._git_engine = git_engine.GitEngine(project_id, project_name)
+
+    def _pid(self):
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
 
     def _get(self, repo_id, name: str):
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -46,7 +63,7 @@ class GitRemoteApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -64,7 +81,7 @@ class GitRemoteApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),
@@ -91,7 +108,7 @@ class GitRemoteApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "git",
             "repository",
             str(repo_id),

--- a/python/hopsworks_common/core/job_api.py
+++ b/python/hopsworks_common/core/job_api.py
@@ -61,12 +61,12 @@ class JobApi:
         self._project_id = project_id
         self._project_name = project_name
 
-    def _get_project_id(self) -> int:
+    def _pid(self) -> int:
         if self._project_id is not None:
             return self._project_id
         return client._get_instance()._project_id
 
-    def _get_project_name(self) -> str:
+    def _pname(self) -> str:
         if self._project_name is not None:
             return self._project_name
         return client._get_instance()._project_name
@@ -81,7 +81,7 @@ class JobApi:
         jobs = result if isinstance(result, list) else [result]
         for j in jobs:
             if j is not None:
-                j._bind_project(self._get_project_id(), self._get_project_name())
+                j._bind_project(self._pid(), self._pname())
         return result
 
     @public
@@ -115,9 +115,9 @@ class JobApi:
         """
         _client = client._get_instance()
 
-        config = util._validate_job_conf(config, self._get_project_name())
+        config = util._validate_job_conf(config, self._pname())
 
-        path_params = ["project", self._get_project_id(), "jobs", name]
+        path_params = ["project", self._pid(), "jobs", name]
 
         headers = {"content-type": "application/json"}
         # Bound before the URL is built, not after: get_url reads the job's project, so printing
@@ -150,7 +150,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             name,
         ]
@@ -175,7 +175,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
         ]
         query_params = {"expand": ["creator"]}
@@ -222,7 +222,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             type.lower(),
             "configuration",
@@ -240,7 +240,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             str(job.name),
         ]
@@ -258,9 +258,9 @@ class JobApi:
         """
         _client = client._get_instance()
 
-        config = util._validate_job_conf(config, self._get_project_name())
+        config = util._validate_job_conf(config, self._pname())
 
-        path_params = ["project", self._get_project_id(), "jobs", name]
+        path_params = ["project", self._pid(), "jobs", name]
 
         headers = {"content-type": "application/json"}
         return self._bind(
@@ -276,7 +276,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             name,
             "schedule",
@@ -295,7 +295,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             name,
             "schedule",
@@ -319,7 +319,7 @@ class JobApi:
         ),
     ) -> job.Job:
         _client = client._get_instance()
-        path_params = ["project", self._get_project_id(), "jobs", name]
+        path_params = ["project", self._pid(), "jobs", name]
 
         headers = {"content-type": "application/json"}
         return self._bind(
@@ -334,7 +334,7 @@ class JobApi:
     @usage._method_logger
     def launch(self, name: str, args: str = None) -> None:
         _client = client._get_instance()
-        path_params = ["project", self._get_project_id(), "jobs", name, "executions"]
+        path_params = ["project", self._pid(), "jobs", name, "executions"]
 
         # The backend has two @POST handlers on this path (text/plain for legacy
         # args and application/json for logical-time params); without an explicit
@@ -346,7 +346,7 @@ class JobApi:
     @usage._method_logger
     def get(self, name: str) -> job.Job:
         _client = client._get_instance()
-        path_params = ["project", self._get_project_id(), "jobs", name]
+        path_params = ["project", self._pid(), "jobs", name]
 
         return self._bind(
             job.Job.from_response_json(_client._send_request("GET", path_params))
@@ -358,7 +358,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             job.name,
             "executions",
@@ -387,7 +387,7 @@ class JobApi:
             schedule_config = schedule_config.to_dict()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             name,
             "schedule",
@@ -408,7 +408,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             name,
             "schedule",
@@ -434,7 +434,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             job.name,
             "tags",
@@ -456,7 +456,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             job.name,
             "tags",
@@ -477,7 +477,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             job.name,
             "tags",
@@ -504,7 +504,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             job.name,
             "tags",
@@ -534,7 +534,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            self._get_project_id(),
+            self._pid(),
             "jobs",
             job.name,
             "tags",

--- a/python/hopsworks_common/core/job_api.py
+++ b/python/hopsworks_common/core/job_api.py
@@ -25,6 +25,7 @@ from hopsworks_common import (
     execution,
     job,
     job_schedule,
+    tag,
     usage,
     util,
 )
@@ -46,6 +47,20 @@ from hopsworks_apigen import public
     "hsfs.core.job_api.JobApi",
 )
 class JobApi:
+    def __init__(self, project_id: int | None = None):
+        """Jobs endpoint for a project.
+
+        Parameters:
+            project_id: The project to resolve jobs against; the connection's project if omitted.
+                A search hit can come from another authorized project, whose jobs are not reachable through the login project's paths.
+        """
+        self._project_id = project_id
+
+    def _get_project_id(self) -> int:
+        if self._project_id is not None:
+            return self._project_id
+        return client._get_instance()._project_id
+
     @public
     @usage._method_logger
     def create_job(self, name: str, config: dict) -> job.Job:
@@ -79,7 +94,7 @@ class JobApi:
 
         config = util._validate_job_conf(config, _client._project_name)
 
-        path_params = ["project", _client._project_id, "jobs", name]
+        path_params = ["project", self._get_project_id(), "jobs", name]
 
         headers = {"content-type": "application/json"}
         created_job = job.Job.from_response_json(
@@ -108,7 +123,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._get_project_id(),
             "jobs",
             name,
         ]
@@ -131,7 +146,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._get_project_id(),
             "jobs",
         ]
         query_params = {"expand": ["creator"]}
@@ -176,7 +191,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._get_project_id(),
             "jobs",
             type.lower(),
             "configuration",
@@ -194,7 +209,7 @@ class JobApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._get_project_id(),
             "jobs",
             str(job.name),
         ]
@@ -214,7 +229,7 @@ class JobApi:
 
         config = util._validate_job_conf(config, _client._project_name)
 
-        path_params = ["project", _client._project_id, "jobs", name]
+        path_params = ["project", self._get_project_id(), "jobs", name]
 
         headers = {"content-type": "application/json"}
         return job.Job.from_response_json(
@@ -226,7 +241,14 @@ class JobApi:
     def _schedule_job(self, name, schedule_config):
         """Attach the `schedule_config` to the job with the given `name`."""
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", name, "schedule", "v2"]
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            name,
+            "schedule",
+            "v2",
+        ]
         headers = {"content-type": "application/json"}
         method = "PUT" if schedule_config.get("id") else "POST"
 
@@ -238,7 +260,14 @@ class JobApi:
 
     def _delete_schedule_job(self, name):
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", name, "schedule", "v2"]
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            name,
+            "schedule",
+            "v2",
+        ]
 
         return _client._send_request(
             "DELETE",
@@ -257,7 +286,7 @@ class JobApi:
         ),
     ) -> job.Job:
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", name]
+        path_params = ["project", self._get_project_id(), "jobs", name]
 
         headers = {"content-type": "application/json"}
         return job.Job.from_response_json(
@@ -270,7 +299,7 @@ class JobApi:
     @usage._method_logger
     def launch(self, name: str, args: str = None) -> None:
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", name, "executions"]
+        path_params = ["project", self._get_project_id(), "jobs", name, "executions"]
 
         # The backend has two @POST handlers on this path (text/plain for legacy
         # args and application/json for logical-time params); without an explicit
@@ -282,7 +311,7 @@ class JobApi:
     @usage._method_logger
     def get(self, name: str) -> job.Job:
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", name]
+        path_params = ["project", self._get_project_id(), "jobs", name]
 
         return job.Job.from_response_json(_client._send_request("GET", path_params))
 
@@ -290,7 +319,13 @@ class JobApi:
     @usage._method_logger
     def last_execution(self, job: job.Job) -> execution.Execution:
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", job.name, "executions"]
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            job.name,
+            "executions",
+        ]
 
         query_params = {"limit": 1, "sort_by": "submissiontime:desc"}
 
@@ -313,7 +348,14 @@ class JobApi:
         # dict this endpoint expects.
         if not isinstance(schedule_config, dict):
             schedule_config = schedule_config.to_dict()
-        path_params = ["project", _client._project_id, "jobs", name, "schedule", "v2"]
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            name,
+            "schedule",
+            "v2",
+        ]
         headers = {"content-type": "application/json"}
         method = "PUT" if schedule_config.get("id") else "POST"
 
@@ -327,9 +369,144 @@ class JobApi:
     @usage._method_logger
     def delete_schedule_job(self, name: str) -> None:
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "jobs", name, "schedule", "v2"]
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            name,
+            "schedule",
+            "v2",
+        ]
 
         return _client._send_request(
             "DELETE",
             path_params,
         )
+
+    def _add_tag(self, job: job.Job, name: str, value: Any) -> None:
+        """Attach a name/value tag to a job.
+
+        A tag consists of a name/value pair. Tag names are unique identifiers.
+        The value of a tag can be any valid json - primitives, arrays or json objects.
+
+        Parameters:
+            job: The job to attach the tag to.
+            name: Name of the tag to be added.
+            value: Value of the tag to be added.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            job.name,
+            "tags",
+            name,
+        ]
+        headers = {"content-type": "application/json"}
+        json_value = json.dumps(value)
+        _client._send_request("PUT", path_params, headers=headers, data=json_value)
+
+    def _delete_tag(self, job: job.Job, name: str) -> None:
+        """Delete a tag from a job.
+
+        Tag names are unique identifiers.
+
+        Parameters:
+            job: The job to remove the tag from.
+            name: Name of the tag to be removed.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            job.name,
+            "tags",
+            name,
+        ]
+        _client._send_request("DELETE", path_params)
+
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_tags(self, job: job.Job) -> dict[str, Any]:
+        """Get all tags attached to a job.
+
+        Parameters:
+            job: The job to get the tags from.
+
+        Returns:
+            Dict of tag name/values.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            job.name,
+            "tags",
+        ]
+        # from_response_json already returns deserialized values.
+        return {
+            t._name: t._value
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return=None)
+    def _get_tag(self, job: job.Job, name: str) -> Any | None:
+        """Get the value of a tag attached to a job.
+
+        Parameters:
+            job: The job to get the tag from.
+            name: Tag name.
+
+        Returns:
+            The value of the tag with the specified name, or `None` if it does not exist.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            job.name,
+            "tags",
+            name,
+        ]
+        tags = {
+            t._name: t._value
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+        return tags.get(name)
+
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_tags_metadata(
+        self, job: job.Job, name: str | None = None
+    ) -> dict[str, tag.Tag]:
+        """Get the tags of a job as Tag objects, keeping metadata such as created_on.
+
+        Parameters:
+            job: The job to get the tags from.
+            name: Tag name; all tags if omitted.
+
+        Returns:
+            Dict of tag name to Tag object.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            self._get_project_id(),
+            "jobs",
+            job.name,
+            "tags",
+        ]
+        if name is not None:
+            path_params.append(name)
+        return {
+            t._name: t
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }

--- a/python/hopsworks_common/core/job_api.py
+++ b/python/hopsworks_common/core/job_api.py
@@ -47,19 +47,42 @@ from hopsworks_apigen import public
     "hsfs.core.job_api.JobApi",
 )
 class JobApi:
-    def __init__(self, project_id: int | None = None):
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
         """Jobs endpoint for a project.
 
         Parameters:
             project_id: The project to resolve jobs against; the connection's project if omitted.
                 A search hit can come from another authorized project, whose jobs are not reachable through the login project's paths.
+            project_name: Name of the same project, used where a job configuration path has to be
+                expanded to an absolute one. Resolved from the connection when omitted.
         """
         self._project_id = project_id
+        self._project_name = project_name
 
     def _get_project_id(self) -> int:
         if self._project_id is not None:
             return self._project_id
         return client._get_instance()._project_id
+
+    def _get_project_name(self) -> str:
+        if self._project_name is not None:
+            return self._project_name
+        return client._get_instance()._project_name
+
+    def _bind(self, result):
+        """Stamp this api's project onto the jobs it just built.
+
+        A Job builds its own JobApi for update, delete, schedule, executions and tags. Left
+        unbound, all of those address the connection's project, so a job fetched from another
+        authorized project would be mutated in the login project instead.
+        """
+        jobs = result if isinstance(result, list) else [result]
+        for j in jobs:
+            if j is not None:
+                j._bind_project(self._get_project_id(), self._get_project_name())
+        return result
 
     @public
     @usage._method_logger
@@ -92,7 +115,7 @@ class JobApi:
         """
         _client = client._get_instance()
 
-        config = util._validate_job_conf(config, _client._project_name)
+        config = util._validate_job_conf(config, self._get_project_name())
 
         path_params = ["project", self._get_project_id(), "jobs", name]
 
@@ -128,8 +151,10 @@ class JobApi:
             name,
         ]
         query_params = {"expand": ["creator"]}
-        return job.Job.from_response_json(
-            _client._send_request("GET", path_params, query_params=query_params)
+        return self._bind(
+            job.Job.from_response_json(
+                _client._send_request("GET", path_params, query_params=query_params)
+            )
         )
 
     @public
@@ -150,8 +175,10 @@ class JobApi:
             "jobs",
         ]
         query_params = {"expand": ["creator"]}
-        return job.Job.from_response_json(
-            _client._send_request("GET", path_params, query_params=query_params)
+        return self._bind(
+            job.Job.from_response_json(
+                _client._send_request("GET", path_params, query_params=query_params)
+            )
         )
 
     @public
@@ -227,14 +254,16 @@ class JobApi:
         """
         _client = client._get_instance()
 
-        config = util._validate_job_conf(config, _client._project_name)
+        config = util._validate_job_conf(config, self._get_project_name())
 
         path_params = ["project", self._get_project_id(), "jobs", name]
 
         headers = {"content-type": "application/json"}
-        return job.Job.from_response_json(
-            _client._send_request(
-                "PUT", path_params, headers=headers, data=json.dumps(config)
+        return self._bind(
+            job.Job.from_response_json(
+                _client._send_request(
+                    "PUT", path_params, headers=headers, data=json.dumps(config)
+                )
             )
         )
 
@@ -289,9 +318,11 @@ class JobApi:
         path_params = ["project", self._get_project_id(), "jobs", name]
 
         headers = {"content-type": "application/json"}
-        return job.Job.from_response_json(
-            _client._send_request(
-                "PUT", path_params, headers=headers, data=job_conf.json()
+        return self._bind(
+            job.Job.from_response_json(
+                _client._send_request(
+                    "PUT", path_params, headers=headers, data=job_conf.json()
+                )
             )
         )
 

--- a/python/hopsworks_common/core/job_api.py
+++ b/python/hopsworks_common/core/job_api.py
@@ -120,9 +120,13 @@ class JobApi:
         path_params = ["project", self._get_project_id(), "jobs", name]
 
         headers = {"content-type": "application/json"}
-        created_job = job.Job.from_response_json(
-            _client._send_request(
-                "PUT", path_params, headers=headers, data=json.dumps(config)
+        # Bound before the URL is built, not after: get_url reads the job's project, so printing
+        # first named the login project even when this handle addresses another one.
+        created_job = self._bind(
+            job.Job.from_response_json(
+                _client._send_request(
+                    "PUT", path_params, headers=headers, data=json.dumps(config)
+                )
             )
         )
         print(f"Job created successfully, explore it at {created_job.get_url()}")
@@ -344,7 +348,9 @@ class JobApi:
         _client = client._get_instance()
         path_params = ["project", self._get_project_id(), "jobs", name]
 
-        return job.Job.from_response_json(_client._send_request("GET", path_params))
+        return self._bind(
+            job.Job.from_response_json(_client._send_request("GET", path_params))
+        )
 
     @public
     @usage._method_logger

--- a/python/hopsworks_common/core/kafka_api.py
+++ b/python/hopsworks_common/core/kafka_api.py
@@ -28,6 +28,7 @@ from hopsworks_common import (
     kafka_topic,
     usage,
 )
+from hopsworks_common.client.exceptions import KafkaException
 
 
 @public("hopsworks.core.kafka_api.KafkaApi", "hsfs.core.kafka_api.KafkaApi")
@@ -58,6 +59,17 @@ class KafkaApi:
             if self._project_name is not None
             else client._get_instance()._project_name
         )
+
+    def _stamp(self, items):
+        """Bind the topics and schemas this handle returns to the project it addresses.
+
+        Each one builds its own handle, so a topic read out of another project would be
+        deleted, and its schema read, in the login project.
+        """
+        for item in items if isinstance(items, list) else [items]:
+            if item is not None:
+                item._bind_project(self._pid(), self._pname())
+        return items
 
     @public
     @usage._method_logger
@@ -106,9 +118,11 @@ class KafkaApi:
         }
 
         headers = {"content-type": "application/json"}
-        return kafka_topic.KafkaTopic.from_response_json(
-            _client._send_request(
-                "POST", path_params, headers=headers, data=json.dumps(data)
+        return self._stamp(
+            kafka_topic.KafkaTopic.from_response_json(
+                _client._send_request(
+                    "POST", path_params, headers=headers, data=json.dumps(data)
+                )
             )
         )
 
@@ -210,8 +224,10 @@ class KafkaApi:
         _client = client._get_instance()
         path_params = ["project", self._pid(), "kafka", "topics"]
 
-        return kafka_topic.KafkaTopic.from_response_json(
-            _client._send_request("GET", path_params)
+        return self._stamp(
+            kafka_topic.KafkaTopic.from_response_json(
+                _client._send_request("GET", path_params)
+            )
         )
 
     def _delete_topic(self, name: str):
@@ -340,8 +356,10 @@ class KafkaApi:
             str(version),
         ]
 
-        return kafka_schema.KafkaSchema.from_response_json(
-            _client._send_request("GET", path_params)
+        return self._stamp(
+            kafka_schema.KafkaSchema.from_response_json(
+                _client._send_request("GET", path_params)
+            )
         )
 
     def _get_broker_endpoints(self, externalListeners: bool = False):
@@ -394,6 +412,18 @@ class KafkaApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         _client = client._get_instance()
+        # The certificate the client materialized belongs to the project it logged into, and it
+        # is the Kafka identity: a producer built from it authenticates as that project, so
+        # returning this configuration for another one would read and write under the wrong
+        # identity and look like it had worked. Materializing a second project's certificate is
+        # not something this connection can do, so the honest answer is to refuse.
+        if self._project_id is not None and self._project_id != _client._project_id:
+            raise KafkaException(
+                f"This handle addresses project {self._pname()}, but the client holds the "
+                f"certificate of project {_client._project_name}, which is the identity a "
+                "Kafka client authenticates with. Log in to "
+                f"{self._pname()} to produce to or consume from it."
+            )
         config = {
             constants.KAFKA_SSL_CONFIG.SECURITY_PROTOCOL_CONFIG: self._get_security_protocol(),
             constants.KAFKA_SSL_CONFIG.SSL_CA_LOCATION_CONFIG: _client._get_ca_chain_path(),

--- a/python/hopsworks_common/core/kafka_api.py
+++ b/python/hopsworks_common/core/kafka_api.py
@@ -32,6 +32,33 @@ from hopsworks_common import (
 
 @public("hopsworks.core.kafka_api.KafkaApi", "hsfs.core.kafka_api.KafkaApi")
 class KafkaApi:
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Kafka topics, schemas and clusters of one project.
+
+        Parameters:
+            project_id: The project this handle addresses; the connection's project if omitted.
+            project_name: Name of the same project, for the paths that carry it. Resolved from the
+                connection when omitted.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
+
     @public
     @usage._method_logger
     def create_topic(
@@ -69,7 +96,7 @@ class KafkaApi:
         """
         _client = client._get_instance()
 
-        path_params = ["project", _client._project_id, "kafka", "topics"]
+        path_params = ["project", self._pid(), "kafka", "topics"]
         data = {
             "name": name,
             "schemaName": schema,
@@ -129,7 +156,7 @@ class KafkaApi:
 
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "kafka",
             "subjects",
             subject,
@@ -181,7 +208,7 @@ class KafkaApi:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "kafka", "topics"]
+        path_params = ["project", self._pid(), "kafka", "topics"]
 
         return kafka_topic.KafkaTopic.from_response_json(
             _client._send_request("GET", path_params)
@@ -196,7 +223,7 @@ class KafkaApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "kafka",
             "topics",
             name,
@@ -213,7 +240,7 @@ class KafkaApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "kafka",
             "subjects",
             subject,
@@ -259,7 +286,7 @@ class KafkaApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "kafka",
             "subjects",
             subject,
@@ -305,7 +332,7 @@ class KafkaApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "kafka",
             "subjects",
             subject,
@@ -321,7 +348,7 @@ class KafkaApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "kafka",
             "clusterinfo",
         ]
@@ -399,7 +426,7 @@ class KafkaApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "featurestores",
             feature_store_id,
             "kafka",

--- a/python/hopsworks_common/core/keywords_api.py
+++ b/python/hopsworks_common/core/keywords_api.py
@@ -1,0 +1,195 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from hopsworks_apigen import also_available_as
+from hopsworks_common import client, tag, usage
+
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from hsfs.feature_group import FeatureGroup
+    from hsfs.training_dataset import TrainingDataset
+
+
+@also_available_as(
+    "hopsworks.core.keywords_api.KeywordsApi", "hsfs.core.keywords_api.KeywordsApi"
+)
+class KeywordsApi:
+    def __init__(
+        self, feature_store_id: int | None = None, entity_type: str | None = None
+    ):
+        """Keywords endpoint for `trainingdatasets`, `featuregroups`, and `featureview` resources.
+
+        Parameters:
+            feature_store_id: id of the respective featurestore
+            entity_type: "trainingdatasets" or "featuregroups"
+
+        Both may be omitted when the instance is only used for `_get_all`, which is not scoped to an artifact.
+        """
+        self._feature_store_id = feature_store_id
+        self._entity_type = entity_type
+
+    @usage._method_logger
+    def _get(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        training_dataset_version=None,
+    ) -> list[str]:
+        """Get the keywords of a feature group, feature view, or training dataset.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to get the keywords for.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            List of keywords.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+        return _client._send_request("GET", path_params).get("keywords") or []
+
+    @usage._method_logger
+    def _get_with_metadata(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        training_dataset_version=None,
+    ) -> dict[str, datetime | None]:
+        """Get the keywords with the time each was attached.
+
+        An old server sends only the plain keyword list, without the `items` carrying the timestamps; every keyword then maps to `None`.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to get the keywords for.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            Dict of keyword to attachment time, `None` when the time is unknown.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+        response = _client._send_request("GET", path_params)
+        created_on = {
+            item["name"]: tag.Tag._parse_created_on(item.get("createdOn"))
+            for item in response.get("items") or []
+            if item.get("name")
+        }
+        return {name: created_on.get(name) for name in response.get("keywords") or []}
+
+    @usage._method_logger
+    def _replace(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        keywords: list[str],
+        training_dataset_version=None,
+    ) -> list[str]:
+        """Replace the whole keyword set of the artifact.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to set the keywords for.
+            keywords: The new keyword set.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            The updated list of keywords.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+        headers = {"content-type": "application/json"}
+        return (
+            _client._send_request(
+                "POST",
+                path_params,
+                headers=headers,
+                data=json.dumps({"keywords": keywords}),
+            ).get("keywords")
+            or []
+        )
+
+    @usage._method_logger
+    def _delete(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        keyword: str,
+        training_dataset_version=None,
+    ) -> list[str]:
+        """Delete a single keyword from the artifact.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to delete the keyword for.
+            keyword: The keyword to remove.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            The updated list of keywords.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+        response = _client._send_request(
+            "DELETE", path_params, query_params={"keyword": keyword}
+        )
+        return (response or {}).get("keywords") or []
+
+    @usage._method_logger
+    def _get_all(self) -> list[str]:
+        """Get the keyword vocabulary in use across the whole cluster.
+
+        Cluster-wide despite the project-scoped path: the backend serves the same vocabulary to every project.
+
+        Returns:
+            List of keywords.
+        """
+        _client = client._get_instance()
+        path_params = ["project", _client._project_id, "featurestores", "keywords"]
+        return _client._send_request("GET", path_params).get("keywords") or []
+
+    @usage._method_logger
+    def _get_path(self, metadata_instance, training_dataset_version=None):
+        _client = client._get_instance()
+        if hasattr(metadata_instance, "training_data"):
+            # Only FeatureView has training_data method
+            path = [
+                "project",
+                _client._project_id,
+                "featurestores",
+                self._feature_store_id,
+                "featureview",
+                metadata_instance.name,
+                "version",
+                metadata_instance.version,
+            ]
+            if training_dataset_version:
+                return path + [
+                    "trainingdatasets",
+                    "version",
+                    training_dataset_version,
+                    "keywords",
+                ]
+            return path + ["keywords"]
+        return [
+            "project",
+            _client._project_id,
+            "featurestores",
+            self._feature_store_id,
+            self._entity_type,
+            metadata_instance.id,
+            "keywords",
+        ]

--- a/python/hopsworks_common/core/library_api.py
+++ b/python/hopsworks_common/core/library_api.py
@@ -22,6 +22,25 @@ from hopsworks_common import client, library
 
 @also_available_as("hopsworks.core.library_api.LibraryApi")
 class LibraryApi:
+    def __init__(self, project_id=None, project_name=None):
+        """Libraries of one project's environments.
+
+        Parameters:
+            project_id: The project whose environments this installs into, and project_name
+                its name. Both default to the connection's project. An Environment obtained
+                from another project passes that project's, because an unbound handle
+                installs into an identically named environment in the login project.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self):
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
     def _install(
         self, library_name: str, name: str, library_spec: dict
     ) -> library.Library:
@@ -42,7 +61,7 @@ class LibraryApi:
 
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "python",
             "environments",
             name,
@@ -72,7 +91,7 @@ class LibraryApi:
 
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "python",
             "environments",
             name,

--- a/python/hopsworks_common/core/opensearch_api.py
+++ b/python/hopsworks_common/core/opensearch_api.py
@@ -55,8 +55,33 @@ class OPENSEARCH_CONFIG:
     "hsfs.core.opensearch_api.OpenSearchApi",
 )
 class OpenSearchApi:
-    def __init__(self) -> None:
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """OpenSearch access for one project.
+
+        Parameters:
+            project_id: The project this handle addresses; the connection's project if omitted.
+            project_name: Name of the same project, which index names are prefixed with. Resolved
+                from the connection when omitted.
+        """
         self._variable_api: VariableApi = VariableApi()
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
 
     def _get_opensearch_url(self) -> str:
         if client._is_external():
@@ -84,7 +109,7 @@ class OpenSearchApi:
             A valid opensearch index name.
         """
         _client = client._get_instance()
-        return (_client._project_name + "_" + index).lower()
+        return (self._pname() + "_" + index).lower()
 
     @public
     @usage._method_logger
@@ -134,7 +159,7 @@ class OpenSearchApi:
         """
         _client = client._get_instance()
         # Do not use feature store id for now since the backend is not yet updated to use it.
-        path_params = ["elastic", "jwt", _client._project_id]
+        path_params = ["elastic", "jwt", self._pid()]
 
         headers = {"content-type": "application/json"}
         return _client._send_request("GET", path_params, headers=headers)["token"]

--- a/python/hopsworks_common/core/search_api.py
+++ b/python/hopsworks_common/core/search_api.py
@@ -152,8 +152,33 @@ class KeywordSearchFilter:
 
 @public("hopsworks.core.search_api.SearchApi")
 class SearchApi:
-    def __init__(self):
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Search over one project's artifacts.
+
+        Parameters:
+            project_id: The project whose artifacts the project-scoped searches address; the
+                connection's project if omitted.
+            project_name: Name of the same project. Resolved from the connection when omitted.
+        """
         self._log = logging.getLogger(__name__)
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
 
     @public
     def feature_store(
@@ -871,7 +896,7 @@ class SearchApi:
         if global_search:
             path_params = ["elastic", "featurestore"]
         else:
-            path_params = ["project", _client._project_id, "elastic", "featurestore"]
+            path_params = ["project", self._pid(), "elastic", "featurestore"]
 
         headers = {"content-type": "application/json"}
         query_params = {

--- a/python/hopsworks_common/core/search_api.py
+++ b/python/hopsworks_common/core/search_api.py
@@ -24,18 +24,28 @@ from hopsworks_apigen import public
 from hopsworks_common import client
 from hopsworks_common.search_results import (
     DatasetSearchResult,
+    DeploymentSearchResult,
     FeatureGroupSearchResult,
     FeatureSearchResult,
     FeaturestoreSearchResult,
     FeatureViewSearchResult,
     JobSearchResult,
+    ModelSearchResult,
     TrainingDatasetSearchResult,
 )
 from hopsworks_common.util import Encoder
 
 
 DOC_TYPE_ARG = Literal[
-    "FEATUREGROUP", "FEATUREVIEW", "TRAININGDATASET", "FEATURE", "JOB", "DATASET", "ALL"
+    "FEATUREGROUP",
+    "FEATUREVIEW",
+    "TRAININGDATASET",
+    "FEATURE",
+    "JOB",
+    "DATASET",
+    "MODEL",
+    "DEPLOYMENT",
+    "ALL",
 ]
 
 
@@ -157,7 +167,7 @@ class SearchApi:
         limit: int = 100,
         global_search: bool = False,
     ) -> FeaturestoreSearchResult:
-        """Search for feature groups, feature views, training datasets, features, jobs, and datasets.
+        """Search for feature groups, feature views, training datasets, features, jobs, datasets, models, and deployments.
 
         Parameters:
             search_term: The term to search for.
@@ -175,7 +185,7 @@ class SearchApi:
                 If `True`, search over all projects.
 
         Returns:
-            The search results containing lists of metadata objects for feature groups, feature views, training datasets, features, jobs, and datasets.
+            The search results containing lists of metadata objects for feature groups, feature views, training datasets, features, jobs, datasets, models, and deployments.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
@@ -625,6 +635,141 @@ class SearchApi:
             global_search=global_search,
         )
         return result.datasets
+
+    @public
+    def models(
+        self,
+        search_term: str | None = None,
+        keyword_filter: str | list[str] | None = None,
+        tag_filter: dict[str, str]
+        | list[dict[str, str] | TagSearchFilter]
+        | None = None,
+        offset: int = 0,
+        limit: int = 100,
+        global_search: bool = False,
+    ) -> list[ModelSearchResult]:
+        """Search for models only.
+
+        The search covers the model's name, description, and tags.
+        Results are scoped by the cluster's cross-project search policy: with `global_search` the caller sees models from other projects only where the policy allows it.
+        A model in a shared registry is also reachable, because sharing the registry is what makes the hit visible.
+        Models carry no keywords, so a `keyword_filter` never matches a model.
+
+        Parameters:
+            search_term: The term to search for.
+            keyword_filter:
+                Filter results by keywords.
+                Models carry no keywords, so any keyword filter returns no models.
+            tag_filter:
+                Filter results by tags.
+                Can be a single dictionary, an array of dictionaries, or an array of TagSearchFilter objects.
+                Each tag filter requires: ``name`` (the tag schema name as defined by Hopsworks Admin), ``key`` (the property within that tag schema), and ``value`` (the value to match).
+            offset: The number of results to skip.
+            limit: The number of search results to return.
+            global_search:
+                If `False`, search in current project only.
+                If `True`, search over all projects.
+
+        Returns:
+            A list of metadata objects for models matching the search criteria.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            search_api = project.get_search_api()
+
+            # Every model an audit has to account for
+            model_metas = search_api.models(
+                tag_filter={"name": "eu_ai_act", "key": "risk_class", "value": "high_risk"}
+            )
+
+            for model_meta in model_metas:
+                print(f"Model: {model_meta.name} v{model_meta.version} ({model_meta.framework})")
+
+                # Get the same Model object as returned by the model registry
+                model = model_meta.get()
+            ```
+        """
+        result = self._search(
+            doc_type="MODEL",
+            search_term=search_term,
+            keyword_filter=keyword_filter,
+            tag_filter=tag_filter,
+            offset=offset,
+            limit=limit,
+            global_search=global_search,
+        )
+        return result.models
+
+    @public
+    def deployments(
+        self,
+        search_term: str | None = None,
+        keyword_filter: str | list[str] | None = None,
+        tag_filter: dict[str, str]
+        | list[dict[str, str] | TagSearchFilter]
+        | None = None,
+        offset: int = 0,
+        limit: int = 100,
+        global_search: bool = False,
+    ) -> list[DeploymentSearchResult]:
+        """Search for deployments only.
+
+        The search covers the deployment's name, description, tags, and the name of the model it serves.
+        Results are scoped by the cluster's cross-project search policy: with `global_search` the caller sees deployments from other projects only where the policy allows it.
+        A deployment is administered in its own project, so a hit from another project can be read as metadata but not fetched as an object.
+        Deployments carry no keywords, so a `keyword_filter` never matches a deployment.
+
+        Parameters:
+            search_term: The term to search for.
+            keyword_filter:
+                Filter results by keywords.
+                Deployments carry no keywords, so any keyword filter returns no deployments.
+            tag_filter:
+                Filter results by tags.
+                Can be a single dictionary, an array of dictionaries, or an array of TagSearchFilter objects.
+                Each tag filter requires: ``name`` (the tag schema name as defined by Hopsworks Admin), ``key`` (the property within that tag schema), and ``value`` (the value to match).
+            offset: The number of results to skip.
+            limit: The number of search results to return.
+            global_search:
+                If `False`, search in current project only.
+                If `True`, search over all projects.
+
+        Returns:
+            A list of metadata objects for deployments matching the search criteria.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            search_api = project.get_search_api()
+
+            # What is serving a given model
+            deployment_metas = search_api.deployments("credit_scoring")
+
+            for deployment_meta in deployment_metas:
+                print(f"{deployment_meta.name} serves {deployment_meta.model_name} v{deployment_meta.model_version}")
+            ```
+        """
+        result = self._search(
+            doc_type="DEPLOYMENT",
+            search_term=search_term,
+            keyword_filter=keyword_filter,
+            tag_filter=tag_filter,
+            offset=offset,
+            limit=limit,
+            global_search=global_search,
+        )
+        return result.deployments
 
     def _parse_keyword_filter(
         self, keyword_filter: str | list[str] | None

--- a/python/hopsworks_common/core/search_api.py
+++ b/python/hopsworks_common/core/search_api.py
@@ -23,17 +23,19 @@ from urllib.parse import quote
 from hopsworks_apigen import public
 from hopsworks_common import client
 from hopsworks_common.search_results import (
+    DatasetSearchResult,
     FeatureGroupSearchResult,
     FeatureSearchResult,
     FeaturestoreSearchResult,
     FeatureViewSearchResult,
+    JobSearchResult,
     TrainingDatasetSearchResult,
 )
 from hopsworks_common.util import Encoder
 
 
 DOC_TYPE_ARG = Literal[
-    "FEATUREGROUP", "FEATUREVIEW", "TRAININGDATASET", "FEATURE", "ALL"
+    "FEATUREGROUP", "FEATUREVIEW", "TRAININGDATASET", "FEATURE", "JOB", "DATASET", "ALL"
 ]
 
 
@@ -155,7 +157,7 @@ class SearchApi:
         limit: int = 100,
         global_search: bool = False,
     ) -> FeaturestoreSearchResult:
-        """Search for feature groups, feature views, training datasets and features.
+        """Search for feature groups, feature views, training datasets, features, jobs, and datasets.
 
         Parameters:
             search_term: The term to search for.
@@ -173,7 +175,7 @@ class SearchApi:
                 If `True`, search over all projects.
 
         Returns:
-            The search results containing lists of metadata objects for feature groups, feature views, training datasets, and features.
+            The search results containing lists of metadata objects for feature groups, feature views, training datasets, features, jobs, and datasets.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
@@ -492,6 +494,137 @@ class SearchApi:
             global_search=global_search,
         )
         return result.features
+
+    @public
+    def jobs(
+        self,
+        search_term: str | None = None,
+        keyword_filter: str | list[str] | None = None,
+        tag_filter: dict[str, str]
+        | list[dict[str, str] | TagSearchFilter]
+        | None = None,
+        offset: int = 0,
+        limit: int = 100,
+        global_search: bool = False,
+    ) -> list[JobSearchResult]:
+        """Search for jobs only.
+
+        The search covers the job's name, description, and tags.
+        Results are scoped by the cluster's cross-project search policy: with `global_search` the caller sees jobs from other projects only where the policy allows it.
+        Jobs carry no keywords, so a `keyword_filter` never matches a job.
+
+        Parameters:
+            search_term: The term to search for.
+            keyword_filter:
+                Filter results by keywords.
+                Jobs carry no keywords, so any keyword filter returns no jobs.
+            tag_filter:
+                Filter results by tags.
+                Can be a single dictionary, an array of dictionaries, or an array of TagSearchFilter objects.
+                Each tag filter requires: ``name`` (the tag schema name as defined by Hopsworks Admin), ``key`` (the property within that tag schema), and ``value`` (the value to match).
+            offset: The number of results to skip.
+            limit: The number of search results to return.
+            global_search:
+                If `False`, search in current project only.
+                If `True`, search over all projects.
+
+        Returns:
+            A list of metadata objects for jobs matching the search criteria.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            search_api = project.get_search_api()
+
+            # Search for jobs
+            job_metas = search_api.jobs("ingestion")
+
+            for job_meta in job_metas:
+                print(f"Job: {job_meta.name} ({job_meta.job_type})")
+
+                # Get the same Job object as returned by the job api
+                job = job_meta.get()
+            ```
+        """
+        result = self._search(
+            doc_type="JOB",
+            search_term=search_term,
+            keyword_filter=keyword_filter,
+            tag_filter=tag_filter,
+            offset=offset,
+            limit=limit,
+            global_search=global_search,
+        )
+        return result.jobs
+
+    @public
+    def datasets(
+        self,
+        search_term: str | None = None,
+        keyword_filter: str | list[str] | None = None,
+        tag_filter: dict[str, str]
+        | list[dict[str, str] | TagSearchFilter]
+        | None = None,
+        offset: int = 0,
+        limit: int = 100,
+        global_search: bool = False,
+    ) -> list[DatasetSearchResult]:
+        """Search for datasets only.
+
+        The search covers the dataset's name, description, and tags.
+        Results are scoped by the cluster's cross-project search policy: with `global_search` the caller sees datasets from other projects only where the policy allows it.
+        Datasets carry no keywords, so a `keyword_filter` never matches a dataset.
+
+        Parameters:
+            search_term: The term to search for.
+            keyword_filter:
+                Filter results by keywords.
+                Datasets carry no keywords, so any keyword filter returns no datasets.
+            tag_filter:
+                Filter results by tags.
+                Can be a single dictionary, an array of dictionaries, or an array of TagSearchFilter objects.
+                Each tag filter requires: ``name`` (the tag schema name as defined by Hopsworks Admin), ``key`` (the property within that tag schema), and ``value`` (the value to match).
+            offset: The number of results to skip.
+            limit: The number of search results to return.
+            global_search:
+                If `False`, search in current project only.
+                If `True`, search over all projects.
+
+        Returns:
+            A list of metadata objects for datasets matching the search criteria.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            search_api = project.get_search_api()
+
+            # Search for datasets
+            dataset_metas = search_api.datasets("reports")
+
+            for dataset_meta in dataset_metas:
+                print(f"Dataset: {dataset_meta.name}")
+            ```
+        """
+        result = self._search(
+            doc_type="DATASET",
+            search_term=search_term,
+            keyword_filter=keyword_filter,
+            tag_filter=tag_filter,
+            offset=offset,
+            limit=limit,
+            global_search=global_search,
+        )
+        return result.datasets
 
     def _parse_keyword_filter(
         self, keyword_filter: str | list[str] | None

--- a/python/hopsworks_common/core/tag_schemas_api.py
+++ b/python/hopsworks_common/core/tag_schemas_api.py
@@ -36,6 +36,26 @@ _ADMIN_HINT = (
     "in a single project is not enough."
 )
 
+_OLD_BACKEND_CASCADE = (
+    "This backend predates reference-checked tag-schema deletion: it ignores "
+    "force=False and deletes every attached value of the schema. Refusing the "
+    "delete. Upgrade the cluster, or pass force=True if losing the attached "
+    "values is intended."
+)
+
+
+def _carries_error_code(err: RestAPIError) -> bool:
+    """Whether the failure is a Hopsworks error payload rather than an unrouted path.
+
+    A backend that has the endpoint answers a missing schema with a JSON body carrying
+    ``errorCode``; one that has never heard of the path 404s from the JAX-RS router with no such
+    body. That difference is what separates "no schema by that name" from "server too old".
+    """
+    try:
+        return "errorCode" in (err.response.json() or {})
+    except Exception:  # noqa: BLE001 - any parse failure means no error payload
+        return False
+
 
 @public(
     "hopsworks.core.tag_schemas_api.TagSchemasApi",
@@ -57,6 +77,10 @@ class TagSchemasApi:
     def list(self) -> dict[str, Any]:
         """List all registered tag schemas.
 
+        Each schema item carries its lifecycle state: ``deprecated``,
+        ``deprecatedOn``, and ``deprecatedBy``. A deprecated schema keeps
+        its existing values but refuses new attachments.
+
         Returns:
             The raw schema-list payload from the backend.
         """
@@ -66,6 +90,10 @@ class TagSchemasApi:
     @public
     def get(self, name: str) -> dict[str, Any]:
         """Fetch a single tag schema by name.
+
+        The payload carries the schema's lifecycle state: ``deprecated``,
+        ``deprecatedOn``, and ``deprecatedBy``. A deprecated schema keeps
+        its existing values but refuses new attachments.
 
         Parameters:
             name: Schema name.
@@ -81,6 +109,97 @@ class TagSchemasApi:
             raise ValueError("name must be a non-empty schema name")
         _client = client._get_instance()
         return _client._send_request("GET", self._path() + [name])
+
+    @public
+    def usage(self, name: str) -> dict[str, Any]:
+        """Report what still references a schema, and whether it can be deleted.
+
+        Requires **HOPS_ADMIN**. Project-level Data Owner is **not**
+        sufficient.
+
+        Parameters:
+            name: Schema name.
+
+        Returns:
+            The raw usage payload from the backend, with per-artifact-type
+            reference counts and a bounded list of the referencing
+            artifacts.
+
+        Raises:
+            PermissionError: If the caller lacks ``HOPS_ADMIN``.
+            hopsworks.client.exceptions.RestAPIError: If the schema does
+                not exist or the backend otherwise rejects the request.
+        """
+        if not name:
+            raise ValueError("name must be a non-empty schema name")
+        _client = client._get_instance()
+        try:
+            return _client._send_request("GET", self._path() + [name, "usage"])
+        except RestAPIError as e:
+            if getattr(e.response, "status_code", None) == 403:
+                raise PermissionError(_ADMIN_HINT) from e
+            raise
+
+    @public
+    def deprecate(self, name: str) -> dict[str, Any]:
+        """Deprecate a tag schema, refusing new attachments of it.
+
+        Existing values keep working; only new attachments are refused.
+        The backend refuses to deprecate a schema that is registered as a
+        mandatory tag.
+
+        Requires **HOPS_ADMIN**. Project-level Data Owner is **not**
+        sufficient.
+
+        Parameters:
+            name: Schema name.
+
+        Returns:
+            The updated schema payload, with ``deprecated``,
+            ``deprecatedOn``, and ``deprecatedBy`` set.
+
+        Raises:
+            PermissionError: If the caller lacks ``HOPS_ADMIN``.
+            hopsworks.client.exceptions.RestAPIError: If the schema does
+                not exist or is registered as mandatory.
+        """
+        if not name:
+            raise ValueError("name must be a non-empty schema name")
+        _client = client._get_instance()
+        try:
+            return _client._send_request("POST", self._path() + [name, "deprecation"])
+        except RestAPIError as e:
+            if getattr(e.response, "status_code", None) == 403:
+                raise PermissionError(_ADMIN_HINT) from e
+            raise
+
+    @public
+    def restore(self, name: str) -> dict[str, Any]:
+        """Undo a deprecation, letting the schema accept new attachments again.
+
+        Requires **HOPS_ADMIN**. Project-level Data Owner is **not**
+        sufficient.
+
+        Parameters:
+            name: Schema name.
+
+        Returns:
+            The updated schema payload, with ``deprecated`` cleared.
+
+        Raises:
+            PermissionError: If the caller lacks ``HOPS_ADMIN``.
+            hopsworks.client.exceptions.RestAPIError: If the schema does
+                not exist.
+        """
+        if not name:
+            raise ValueError("name must be a non-empty schema name")
+        _client = client._get_instance()
+        try:
+            return _client._send_request("DELETE", self._path() + [name, "deprecation"])
+        except RestAPIError as e:
+            if getattr(e.response, "status_code", None) == 403:
+                raise PermissionError(_ADMIN_HINT) from e
+            raise
 
     @public
     def create(self, name: str, schema: dict | str) -> dict[str, Any]:
@@ -154,25 +273,51 @@ class TagSchemasApi:
             raise
 
     @public
-    def delete(self, name: str) -> None:
+    def delete(self, name: str, force: bool = False) -> None:
         """Remove a tag schema from the registry.
+
+        The backend refuses the delete while artifacts still carry a value
+        of the schema; ``usage(name)`` reports what still references it.
+        With ``force`` the referencing values are deleted too.
 
         Requires **HOPS_ADMIN**. Project-level Data Owner is **not**
         sufficient.
 
+        Danger: Potentially dangerous operation
+            ``force=True`` silently removes every attached value of this
+            schema across all projects, leaving no trace of them.
+
         Parameters:
             name: Schema name.
+            force: Also delete all attached values of the schema.
 
         Raises:
             PermissionError: If the caller lacks ``HOPS_ADMIN``.
+            RuntimeError: If the backend is too old to refuse a referenced
+                schema, since there the safe delete would cascade.
             hopsworks.client.exceptions.RestAPIError: If the schema does
-                not exist or the backend otherwise rejects the request.
+                not exist, is still referenced (without ``force``), or the
+                backend otherwise rejects the request.
         """
         if not name:
             raise ValueError("name must be a non-empty schema name")
         _client = client._get_instance()
+        if not force:
+            # An old backend ignores the unknown 'force' parameter and cascade-deletes every
+            # attached value, so asking for the safe delete would get the destructive one, silently.
+            # The usage endpoint shipped together with the refusal, so its absence dates the server.
+            try:
+                self.usage(name)
+            except RestAPIError as e:
+                status = getattr(e.response, "status_code", None)
+                if status in (404, 405) and not _carries_error_code(e):
+                    raise RuntimeError(_OLD_BACKEND_CASCADE) from e
+                raise
+        query_params = {"force": "true"} if force else None
         try:
-            _client._send_request("DELETE", self._path() + [name])
+            _client._send_request(
+                "DELETE", self._path() + [name], query_params=query_params
+            )
         except RestAPIError as e:
             if getattr(e.response, "status_code", None) == 403:
                 raise PermissionError(_ADMIN_HINT) from e

--- a/python/hopsworks_common/core/tags_api.py
+++ b/python/hopsworks_common/core/tags_api.py
@@ -125,6 +125,39 @@ class TagsApi:
         }
 
     @usage._method_logger
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_metadata(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        name: str | None = None,
+        training_dataset_version=None,
+    ) -> dict[str, tag.Tag]:
+        """Get the tags of a training dataset or feature group as Tag objects.
+
+        Unlike `_get`, keeps the `Tag` objects so callers can read metadata such as `created_on`.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to get the tags for.
+            name: Tag name.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            Dict of tag name to Tag object.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+
+        if name is not None:
+            path_params.append(name)
+
+        return {
+            t._name: t
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+
+    @usage._method_logger
     def _get_path(self, metadata_instance, training_dataset_version=None):
         _client = client._get_instance()
         if hasattr(metadata_instance, "training_data"):

--- a/python/hopsworks_common/engine/environment_engine.py
+++ b/python/hopsworks_common/engine/environment_engine.py
@@ -23,6 +23,26 @@ from hopsworks_common.client.exceptions import EnvironmentException, RestAPIErro
 
 @also_available_as("hopsworks.engine.environment_engine.EnvironmentEngine")
 class EnvironmentEngine:
+    def __init__(self, project_id=None, project_name=None):
+        """Poll the environment commands of one project.
+
+        Parameters:
+            project_id: The project whose commands this polls, and project_name its name.
+                Both default to the connection's project. An EnvironmentApi bound to another
+                project passes that project's, because an unbound engine creates the
+                environment in one project and then waits for a command in another, where it
+                either never appears or belongs to something else.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self):
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
     def _await_library_command(self, environment_name, library_name):
         commands = [command.Command(status="ONGOING")]
         while len(commands) > 0 and not self._is_final_status(commands[0]):
@@ -49,7 +69,7 @@ class EnvironmentEngine:
 
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "python",
             "environments",
             environment_name,
@@ -78,7 +98,7 @@ class EnvironmentEngine:
 
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "python",
             "environments",
             environment_name,

--- a/python/hopsworks_common/engine/execution_engine.py
+++ b/python/hopsworks_common/engine/execution_engine.py
@@ -34,9 +34,19 @@ if TYPE_CHECKING:
 
 @also_available_as("hopsworks.engine.execution_engine.ExecutionEngine")
 class ExecutionEngine:
-    def __init__(self):
-        self._dataset_api = dataset_api.DatasetApi()
-        self._execution_api = execution_api.ExecutionApi()
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Waiting, log aggregation and log download for one project's executions.
+
+        Parameters:
+            project_id: The project the executions belong to; the connection's project if omitted.
+            project_name: Name of the same project, for the dataset paths the logs are read from.
+        """
+        self._dataset_api = dataset_api.DatasetApi(
+            project_id=project_id, project_name=project_name
+        )
+        self._execution_api = execution_api.ExecutionApi(project_id=project_id)
         self._log = logging.getLogger(__name__)
 
     def _download_logs(

--- a/python/hopsworks_common/engine/git_engine.py
+++ b/python/hopsworks_common/engine/git_engine.py
@@ -30,8 +30,18 @@ if TYPE_CHECKING:
 
 @also_available_as("hopsworks.engine.git_engine.GitEngine")
 class GitEngine:
-    def __init__(self):
-        self._git_op_execution_api = git_op_execution_api.GitOpExecutionApi()
+    def __init__(self, project_id=None, project_name=None):
+        """Poll the git executions of one project.
+
+        Parameters:
+            project_id: The project whose executions this waits on, and project_name its name.
+                Both default to the connection's project. A GitApi bound to another project
+                passes that project's, so that an operation started there is not waited on in
+                the login project.
+        """
+        self._git_op_execution_api = git_op_execution_api.GitOpExecutionApi(
+            project_id, project_name
+        )
         self._log = logging.getLogger(__name__)
 
     def _execute_op_blocking(

--- a/python/hopsworks_common/environment.py
+++ b/python/hopsworks_common/environment.py
@@ -54,9 +54,34 @@ class Environment:
             command.Command.from_response_json(commands) if commands else None
         )
 
+        self._project_id = None
+        self._project_name = None
         self._environment_engine = environment_engine.EnvironmentEngine()
         self._library_api = library_api.LibraryApi()
         self._environment_api = environment_api.EnvironmentApi()
+
+    def _bind_project(self, project_id, project_name):
+        """Address the project this environment belongs to.
+
+        Every handle is rebuilt, engine included: an environment read out of another project
+        otherwise installs a library into an identically named environment in the login
+        project, waits for that project's commands, and deletes the wrong environment.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+        self._environment_engine = environment_engine.EnvironmentEngine(
+            project_id, project_name
+        )
+        self._library_api = library_api.LibraryApi(project_id, project_name)
+        self._environment_api = environment_api.EnvironmentApi(project_id, project_name)
+
+    def _pname(self):
+        """The project whose Resources a library path is resolved against."""
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
 
     @classmethod
     def from_response_json(cls, json_dict):
@@ -116,8 +141,7 @@ class Environment:
 
         library_name = os.path.basename(path)
 
-        _client = client._get_instance()
-        path = util._convert_to_abs(path, _client._project_name)
+        path = util._convert_to_abs(path, self._pname())
 
         library_spec = {
             "dependencyUrl": path,
@@ -163,8 +187,7 @@ class Environment:
 
         library_name = os.path.basename(path)
 
-        _client = client._get_instance()
-        path = util._convert_to_abs(path, _client._project_name)
+        path = util._convert_to_abs(path, self._pname())
 
         library_spec = {
             "dependencyUrl": path,

--- a/python/hopsworks_common/execution.py
+++ b/python/hopsworks_common/execution.py
@@ -63,8 +63,15 @@ class Execution:
         self._hdfs_user = hdfs_user
         self._job = job
 
-        self._execution_engine = execution_engine.ExecutionEngine()
-        self._execution_api = execution_api.ExecutionApi()
+        # An execution belongs to its job's project, which is not always the connection's: a job
+        # obtained from another authorized project hands out executions, and awaiting, stopping,
+        # deleting or reading the logs of one has to address the same project the job does.
+        self._project_id = getattr(job, "_project_id", None)
+        self._project_name = getattr(job, "_project_name", None)
+        self._execution_engine = execution_engine.ExecutionEngine(
+            project_id=self._project_id, project_name=self._project_name
+        )
+        self._execution_api = execution_api.ExecutionApi(project_id=self._project_id)
 
     @classmethod
     def from_response_json(cls, json_dict, job):
@@ -77,7 +84,9 @@ class Execution:
 
     def update_from_response_json(self, json_dict):
         json_decamelized = humps.decamelize(json_dict)
-        self.__init__(**json_decamelized)
+        # The job is carried over. Re-initialising without it dropped it, which broke job_name and
+        # job_type outright and silently rebound every handle to the login project.
+        self.__init__(**json_decamelized, job=self._job)
         return self
 
     @public
@@ -338,12 +347,10 @@ class Execution:
     @public
     def get_url(self):
         """Get url to view execution details in Hopsworks UI."""
-        _client = client._get_instance()
-        path = (
-            "/p/"
-            + str(_client._project_id)
-            + "/jobs/named/"
-            + self.job_name
-            + "/executions"
+        project_id = (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
         )
+        path = "/p/" + str(project_id) + "/jobs/named/" + self.job_name + "/executions"
         return util._get_hostname_replaced_url(path)

--- a/python/hopsworks_common/git_repo.py
+++ b/python/hopsworks_common/git_repo.py
@@ -63,9 +63,24 @@ class GitRepo:
         self._items = items
         self._count = count
 
+        self._project_id = None
+        self._project_name = None
         self._git_api = git_api.GitApi()
         self._git_remote_api = git_remote_api.GitRemoteApi()
         self._dataset_api = dataset_api.DatasetApi()
+
+    def _bind_project(self, project_id, project_name):
+        """Address the project this repository lives in.
+
+        A repository id is only meaningful inside its project, so every handle is rebuilt:
+        the git API that checks out and commits, the remote API, and the dataset API that
+        deletes the repository's files.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+        self._git_api = git_api.GitApi(project_id, project_name)
+        self._git_remote_api = git_remote_api.GitRemoteApi(project_id, project_name)
+        self._dataset_api = dataset_api.DatasetApi(project_id, project_name)
 
     @classmethod
     def from_response_json(cls, json_dict):

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -82,13 +82,16 @@ class Job:
     def _bind_project(self, project_id: int, project_name: str) -> None:
         """Address the project this job actually belongs to.
 
-        Everything a Job does afterwards goes through the handle rebuilt here: update, delete,
-        schedule, executions, tags. Without it a job fetched from another authorized project would
-        be mutated in the login project, which is the same defect dataset search results had.
+        Every handle a Job holds is rebuilt here, not only the job one. Rebinding the job API alone
+        left a job obtained from another project able to update its tags there while starting an
+        execution, manipulating an alert, or opening a URL in the login project instead: same class of
+        defect, one layer down.
         """
         self._project_id = project_id
         self._project_name = project_name
         self._job_api = job_api.JobApi(project_id=project_id, project_name=project_name)
+        self._execution_api = execution_api.ExecutionApi(project_id=project_id)
+        self._alerts_api = alerts_api.AlertsApi(project_id=project_id)
 
     @classmethod
     def from_response_json(cls, json_dict):
@@ -737,6 +740,12 @@ class Job:
     @public
     def get_url(self):
         """Get url to the job in Hopsworks."""
-        _client = client._get_instance()
-        path = "/p/" + str(_client._project_id) + "/jobs/named/" + self.name
+        # The job's own project, so a link to a job from another project opens that job rather than
+        # whatever the login project happens to have under the same name.
+        project_id = (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+        path = "/p/" + str(project_id) + "/jobs/named/" + self.name
         return util._get_hostname_replaced_url(path)

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -74,9 +74,21 @@ class Job:
 
         self._execution_engine = execution_engine.ExecutionEngine()
         self._execution_api = execution_api.ExecutionApi()
-        self._execution_engine = execution_engine.ExecutionEngine()
         self._job_api = job_api.JobApi()
         self._alerts_api = alerts_api.AlertsApi()
+        self._project_id = None
+        self._project_name = None
+
+    def _bind_project(self, project_id: int, project_name: str) -> None:
+        """Address the project this job actually belongs to.
+
+        Everything a Job does afterwards goes through the handle rebuilt here: update, delete,
+        schedule, executions, tags. Without it a job fetched from another authorized project would
+        be mutated in the login project, which is the same defect dataset search results had.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+        self._job_api = job_api.JobApi(project_id=project_id, project_name=project_name)
 
     @classmethod
     def from_response_json(cls, json_dict):

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -703,7 +703,7 @@ class Job:
     def get_tag_metadata(self, name: str) -> tag.Tag | None:
         """Get a tag with its metadata, including the time it was attached.
 
-        Unlike [`Job.get_tag`][hopsworks.job.Job.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`Job.get_tag`][hopsworks.job.Job.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Parameters:
             name: Name of the tag to get.
@@ -720,7 +720,7 @@ class Job:
     def get_tags_metadata(self) -> dict[str, tag.Tag]:
         """Retrieve all tags attached to the job, with their metadata.
 
-        Unlike [`Job.get_tags`][hopsworks.job.Job.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`Job.get_tags`][hopsworks.job.Job.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Returns:
             Dictionary of tag names to tag objects.

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -91,7 +91,15 @@ class Job:
         self._project_name = project_name
         self._job_api = job_api.JobApi(project_id=project_id, project_name=project_name)
         self._execution_api = execution_api.ExecutionApi(project_id=project_id)
-        self._alerts_api = alerts_api.AlertsApi(project_id=project_id)
+        self._alerts_api = alerts_api.AlertsApi(
+            project_id=project_id, project_name=project_name
+        )
+        # The engine too. It owns the dataset and execution handles that await, stop and log download
+        # go through, so leaving it built against the connection meant a bound job still waited on,
+        # and downloaded logs from, the login project.
+        self._execution_engine = execution_engine.ExecutionEngine(
+            project_id=project_id, project_name=project_name
+        )
 
     @classmethod
     def from_response_json(cls, json_dict):

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import warnings
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import humps
 from hopsworks_apigen import public
@@ -31,6 +31,7 @@ from hopsworks_common.job_schedule import JobSchedule
 
 
 if TYPE_CHECKING:
+    from hopsworks_common import tag
     from hopsworks_common.execution import Execution
 
 
@@ -53,6 +54,7 @@ class Job:
         items=None,
         count=None,
         job_schedule=None,
+        description=None,
         **kwargs,
     ):
         self._id = id
@@ -63,6 +65,7 @@ class Job:
         self._creator = creator
         self._executions = executions
         self._href = href
+        self._description = description
         self._job_schedule = (
             JobSchedule.from_response_json(job_schedule)
             if job_schedule
@@ -124,6 +127,25 @@ class Job:
 
     @public
     @property
+    def description(self):
+        """Description of the job.
+
+        An old server does not send the scalar field; the description then comes from the job configuration.
+        """
+        if self._description is not None:
+            return self._description
+        if isinstance(self._config, dict):
+            return self._config.get("description")
+        return None
+
+    @description.setter
+    def description(self, description: str):
+        # Written into the config too, so the existing save() persists it.
+        self._description = description
+        self._config["description"] = description
+
+    @public
+    @property
     def job_type(self):
         """Type of the job."""
         return self._job_type
@@ -151,12 +173,6 @@ class Job:
     def href(self):
         """The URL of the job in Hopsworks UI, use `get_url` instead."""
         return self._href
-
-    @public
-    @property
-    def config(self):
-        """Configuration for the job."""
-        return self._config
 
     @public
     @usage._method_logger
@@ -597,6 +613,99 @@ class Job:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         return self._alerts_api.create_job_alert(self._name, receiver, status, severity)
+
+    @public
+    @usage._method_logger
+    def add_tag(self, name: str, value: Any) -> None:
+        """Attach a tag to the job.
+
+        A tag consists of a name-value pair.
+        Tag names are unique identifiers across the whole cluster.
+        The value of a tag can be any valid json - primitives, arrays or json objects.
+
+        ```python
+        job.add_tag(name="example_tag", value="42")
+        ```
+
+        Parameters:
+            name: Name of the tag to be added.
+            value: Value of the tag to be added.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        self._job_api._add_tag(self, name, value)
+
+    @public
+    @usage._method_logger
+    def delete_tag(self, name: str) -> None:
+        """Delete a tag attached to the job.
+
+        Parameters:
+            name: Name of the tag to be removed.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        self._job_api._delete_tag(self, name)
+
+    @public
+    def get_tag(self, name: str) -> Any | None:
+        """Get the value of a tag attached to the job.
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            Tag value or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._job_api._get_tag(self, name)
+
+    @public
+    def get_tags(self) -> dict[str, Any]:
+        """Retrieve all tags attached to the job.
+
+        Returns:
+            Dictionary of tag names and values.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._job_api._get_tags(self)
+
+    @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`Job.get_tag`][hopsworks.job.Job.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._job_api._get_tags_metadata(self, name).get(name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Retrieve all tags attached to the job, with their metadata.
+
+        Unlike [`Job.get_tags`][hopsworks.job.Job.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            Dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._job_api._get_tags_metadata(self)
 
     def _update_schedule(self, job_schedule):
         self._job_schedule = self._job_api.create_or_update_schedule_job(

--- a/python/hopsworks_common/kafka_schema.py
+++ b/python/hopsworks_common/kafka_schema.py
@@ -43,7 +43,6 @@ class KafkaSchema:
         self._kafka_api = kafka_api.KafkaApi()
 
     def _bind_project(self, project_id, project_name):
-        """Address the project this schema belongs to."""
         self._project_id = project_id
         self._project_name = project_name
         self._kafka_api = kafka_api.KafkaApi(

--- a/python/hopsworks_common/kafka_schema.py
+++ b/python/hopsworks_common/kafka_schema.py
@@ -38,7 +38,17 @@ class KafkaSchema:
         self._version = version
         self._schema = schema
 
+        self._project_id = None
+        self._project_name = None
         self._kafka_api = kafka_api.KafkaApi()
+
+    def _bind_project(self, project_id, project_name):
+        """Address the project this schema belongs to."""
+        self._project_id = project_id
+        self._project_name = project_name
+        self._kafka_api = kafka_api.KafkaApi(
+            project_id=project_id, project_name=project_name
+        )
 
     @classmethod
     def from_response_json(cls, json_dict):
@@ -51,7 +61,12 @@ class KafkaSchema:
 
     def update_from_response_json(self, json_dict):
         json_decamelized = humps.decamelize(json_dict)
+        project_id, project_name = self._project_id, self._project_name
         self.__init__(**json_decamelized)
+        # __init__ rebuilds the handle unbound, and a re-read must not move the object back to
+        # the login project.
+        if project_id is not None or project_name is not None:
+            self._bind_project(project_id, project_name)
         return self
 
     @public

--- a/python/hopsworks_common/kafka_topic.py
+++ b/python/hopsworks_common/kafka_topic.py
@@ -62,7 +62,17 @@ class KafkaTopic:
         self._shared = shared
         self._accepted = accepted
 
+        self._project_id = None
+        self._project_name = None
         self._kafka_api = kafka_api.KafkaApi()
+
+    def _bind_project(self, project_id, project_name):
+        """Address the project this topic belongs to."""
+        self._project_id = project_id
+        self._project_name = project_name
+        self._kafka_api = kafka_api.KafkaApi(
+            project_id=project_id, project_name=project_name
+        )
 
     @public
     def describe(self):
@@ -116,7 +126,12 @@ class KafkaTopic:
 
     def update_from_response_json(self, json_dict):
         json_decamelized = humps.decamelize(json_dict)
+        project_id, project_name = self._project_id, self._project_name
         self.__init__(**json_decamelized)
+        # __init__ rebuilds the handle unbound, and a re-read must not move the object back to
+        # the login project.
+        if project_id is not None or project_name is not None:
+            self._bind_project(project_id, project_name)
         return self
 
     @public

--- a/python/hopsworks_common/kafka_topic.py
+++ b/python/hopsworks_common/kafka_topic.py
@@ -67,7 +67,6 @@ class KafkaTopic:
         self._kafka_api = kafka_api.KafkaApi()
 
     def _bind_project(self, project_id, project_name):
-        """Address the project this topic belongs to."""
         self._project_id = project_id
         self._project_name = project_name
         self._kafka_api = kafka_api.KafkaApi(

--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -86,7 +86,9 @@ class Project:
         self._opensearch_api = opensearch_api.OpenSearchApi(
             project_id=project_id, project_name=project_name
         )
-        self._kafka_api = kafka_api.KafkaApi(project_id=project_id, project_name=project_name)
+        self._kafka_api = kafka_api.KafkaApi(
+            project_id=project_id, project_name=project_name
+        )
         # Bound to THIS project, not to the connection's. A Project object for another authorized
         # project would otherwise hand out handles that address the login project, which is how a
         # cross-project search result ends up reading the wrong artifact.
@@ -106,7 +108,9 @@ class Project:
         self._alerts_api = alerts_api.AlertsApi(
             project_id=project_id, project_name=project_name
         )
-        self._search_api = search_api.SearchApi(project_id=project_id, project_name=project_name)
+        self._search_api = search_api.SearchApi(
+            project_id=project_id, project_name=project_name
+        )
         self._project_namespace = project_namespace
         self._trino_api = None
         self._superset_api = None

--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -189,7 +189,11 @@ class Project:
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
-        return client._get_connection()._get_feature_store(name)
+        # This project's own feature store when the caller did not name one. A Project object for
+        # another project used to hand back the CONNECTION's feature store here, which is the same
+        # defect the job and dataset handles carried: a foreign Project quietly answering for the
+        # login project.
+        return client._get_connection()._get_feature_store(name or self._shared_name())
 
     @public
     def get_model_registry(self) -> ModelRegistry:
@@ -210,7 +214,20 @@ class Project:
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
-        return client._get_connection()._get_model_registry()
+        return client._get_connection()._get_model_registry(self._shared_name())
+
+    def _shared_name(self) -> str | None:
+        """This project's name when it is NOT the connection's, otherwise None.
+
+        The feature store and model registry APIs take a project name to open a SHARED one, and
+        refuse a name that is the connection's own project. So a foreign Project has to pass its
+        name and the connection's own must not, and neither can be hard-coded here.
+        """
+        try:
+            connected = client._get_instance()._project_name
+        except Exception:
+            return None
+        return self._name if self._name and self._name != connected else None
 
     @public
     def get_model_serving(self) -> ModelServing:

--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -79,9 +79,14 @@ class Project:
         self._description = description
         self._created = created
 
-        self._app_api = app_api.AppApi()
-        self._opensearch_api = opensearch_api.OpenSearchApi()
-        self._kafka_api = kafka_api.KafkaApi()
+        # Every handle carries THIS project, not the connection's. A Project object for another
+        # authorized project that handed out connection-scoped handles answered successfully for the
+        # wrong project, which is the defect class this whole constructor exists to close.
+        self._app_api = app_api.AppApi(project_id=project_id, project_name=project_name)
+        self._opensearch_api = opensearch_api.OpenSearchApi(
+            project_id=project_id, project_name=project_name
+        )
+        self._kafka_api = kafka_api.KafkaApi(project_id=project_id, project_name=project_name)
         # Bound to THIS project, not to the connection's. A Project object for another authorized
         # project would otherwise hand out handles that address the login project, which is how a
         # cross-project search result ends up reading the wrong artifact.
@@ -90,16 +95,18 @@ class Project:
         # to B's REST endpoint carrying /Projects/A/... paths from the login project.
         self._job_api = job_api.JobApi(project_id=project_id, project_name=project_name)
         self._jobs_api = self._job_api  # deprecated
-        self._git_api = git_api.GitApi()
+        self._git_api = git_api.GitApi(project_id=project_id, project_name=project_name)
         self._dataset_api = dataset_api.DatasetApi(
             project_id=project_id, project_name=project_name
         )
-        self._environment_api = environment_api.EnvironmentApi()
+        self._environment_api = environment_api.EnvironmentApi(
+            project_id=project_id, project_name=project_name
+        )
         # Alert receivers are qualified by project name, so this handle needs both too.
         self._alerts_api = alerts_api.AlertsApi(
             project_id=project_id, project_name=project_name
         )
-        self._search_api = search_api.SearchApi()
+        self._search_api = search_api.SearchApi(project_id=project_id, project_name=project_name)
         self._project_namespace = project_namespace
         self._trino_api = None
         self._superset_api = None
@@ -248,7 +255,9 @@ class Project:
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
-        return client._get_connection()._get_model_serving()
+        # This project's serving, not the connection's, for the same reason every other handle here
+        # carries its own project.
+        return client._get_connection()._get_model_serving(self._name, self._id)
 
     @public
     def get_kafka_api(self) -> kafka_api.KafkaApi:

--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -82,10 +82,15 @@ class Project:
         self._app_api = app_api.AppApi()
         self._opensearch_api = opensearch_api.OpenSearchApi()
         self._kafka_api = kafka_api.KafkaApi()
-        self._job_api = job_api.JobApi()
+        # Bound to THIS project, not to the connection's. A Project object for another authorized
+        # project would otherwise hand out handles that address the login project, which is how a
+        # cross-project search result ends up reading the wrong artifact.
+        self._job_api = job_api.JobApi(project_id=project_id)
         self._jobs_api = self._job_api  # deprecated
         self._git_api = git_api.GitApi()
-        self._dataset_api = dataset_api.DatasetApi()
+        self._dataset_api = dataset_api.DatasetApi(
+            project_id=project_id, project_name=project_name
+        )
         self._environment_api = environment_api.EnvironmentApi()
         self._alerts_api = alerts_api.AlertsApi()
         self._search_api = search_api.SearchApi()

--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -85,14 +85,20 @@ class Project:
         # Bound to THIS project, not to the connection's. A Project object for another authorized
         # project would otherwise hand out handles that address the login project, which is how a
         # cross-project search result ends up reading the wrong artifact.
-        self._job_api = job_api.JobApi(project_id=project_id)
+        # The NAME as well as the id. A job configuration carries paths, and expanding a relative
+        # application path uses the project name: bound by id alone, a job created for project B went
+        # to B's REST endpoint carrying /Projects/A/... paths from the login project.
+        self._job_api = job_api.JobApi(project_id=project_id, project_name=project_name)
         self._jobs_api = self._job_api  # deprecated
         self._git_api = git_api.GitApi()
         self._dataset_api = dataset_api.DatasetApi(
             project_id=project_id, project_name=project_name
         )
         self._environment_api = environment_api.EnvironmentApi()
-        self._alerts_api = alerts_api.AlertsApi()
+        # Alert receivers are qualified by project name, so this handle needs both too.
+        self._alerts_api = alerts_api.AlertsApi(
+            project_id=project_id, project_name=project_name
+        )
         self._search_api = search_api.SearchApi()
         self._project_namespace = project_namespace
         self._trino_api = None

--- a/python/hopsworks_common/search_results.py
+++ b/python/hopsworks_common/search_results.py
@@ -369,7 +369,9 @@ class JobSearchResult(SearchResultItem):
         """
         from hopsworks_common.core import job_api
 
-        return job_api.JobApi(project_id=self.project.id).get_job(self.name)
+        return job_api.JobApi(
+            project_id=self.project.id, project_name=self.project.name
+        ).get_job(self.name)
 
     def json(self) -> dict:
         """Convert to JSON-serializable dictionary.
@@ -399,9 +401,15 @@ class DatasetSearchResult(SearchResultItem):
     def _dataset_api(self) -> DatasetApi:
         from hopsworks_common.core import dataset_api
 
+        # Fail closed. Falling back to the connection's project would answer about a same-named
+        # dataset of the wrong project, which reads as success; a hit without project metadata is a
+        # hit nothing can be done with.
+        if self.project is None:
+            raise ValueError(
+                "this search result carries no project, so its dataset cannot be resolved"
+            )
         return dataset_api.DatasetApi(
-            project_id=self.project.id if self.project else None,
-            project_name=self.project.name if self.project else None,
+            project_id=self.project.id, project_name=self.project.name
         )
 
     @public

--- a/python/hopsworks_common/search_results.py
+++ b/python/hopsworks_common/search_results.py
@@ -34,6 +34,24 @@ if TYPE_CHECKING:
     from hsml.model import Model
 
 
+def _shared_registry_name(project_name: str | None) -> str | None:
+    """The name to open a model registry with, or None for the connection's own.
+
+    The registry API reads any name it is given as a request for a SHARED registry, and the
+    project's own `Models` dataset is in the list it matches against, so passing the login
+    project's own name matches and marks the registry shared.
+    Every path built from it then addresses `<project>::Models`, which names a dataset shared
+    into the project from elsewhere and does not exist for the project's own.
+    Search hits are in the login project by default, so this is the ordinary case, not an edge one.
+    Mirrors `Project._shared_name`.
+    """
+    try:
+        connected = client._get_instance()._project_name
+    except Exception:
+        return None
+    return project_name if project_name and project_name != connected else None
+
+
 @public("hopsworks.core.search_api.Project")
 class Project:
     """Represents a project associated with a search result."""
@@ -371,6 +389,11 @@ class JobSearchResult(SearchResultItem):
         """
         from hopsworks_common.core import job_api
 
+        # Fail closed, for the reason given on DatasetSearchResult._dataset_api.
+        if self.project is None:
+            raise ValueError(
+                "this search result carries no project, so its job cannot be resolved"
+            )
         return job_api.JobApi(
             project_id=self.project.id, project_name=self.project.name
         ).get_job(self.name)
@@ -493,7 +516,9 @@ class ModelSearchResult(SearchResultItem):
             raise ValueError(
                 "this search result carries no project, so its model cannot be resolved"
             )
-        mr = client._get_connection()._get_model_registry(self.project.name)
+        mr = client._get_connection()._get_model_registry(
+            _shared_registry_name(self.project.name)
+        )
         return mr.get_model(self.name, version=self.version)
 
     def json(self) -> dict:

--- a/python/hopsworks_common/search_results.py
+++ b/python/hopsworks_common/search_results.py
@@ -448,8 +448,7 @@ class DatasetSearchResult(SearchResultItem):
         """Tags attached to the dataset, with the time each was attached.
 
         Returns:
-            Dictionary of tag names to [`Tag`][hopsworks.tag.Tag] objects, whose
-                [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+            Dictionary of tag names to [`Tag`][hopsworks.tag.Tag] objects, each carrying the time it was attached.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.

--- a/python/hopsworks_common/search_results.py
+++ b/python/hopsworks_common/search_results.py
@@ -16,13 +16,17 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hopsworks_apigen import public
 from hopsworks_common import client
+from hopsworks_common.client.exceptions import RestAPIError
 
 
 if TYPE_CHECKING:
+    from hopsworks_common.core.dataset_api import DatasetApi
+    from hopsworks_common.job import Job
+    from hopsworks_common.tag import Tag
     from hsfs.feature_group import FeatureGroup
     from hsfs.feature_view import FeatureView
     from hsfs.training_dataset import TrainingDataset
@@ -336,6 +340,113 @@ class FeatureSearchResult(SearchResultItem):
     """Search result for a Feature."""
 
 
+@public("hopsworks.core.search_api.JobSearchResult")
+class JobSearchResult(SearchResultItem):
+    """Search result for a Job."""
+
+    def __init__(self, data: dict):
+        super().__init__(data)
+        self._job_type = data.get("jobType")
+
+    @public
+    @property
+    def job_type(self) -> str | None:
+        """Type of the job, e.g. `SPARK` or `PYTHON`."""
+        return self._job_type
+
+    @public
+    def get(self) -> Job | None:
+        """Retrieve the full Job object.
+
+        The job is fetched from the project this search result belongs to,
+        which is not necessarily the login project.
+
+        Returns:
+            The full Job object corresponding to this search result, or `None` if it no longer exists.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        from hopsworks_common.core import job_api
+
+        return job_api.JobApi(project_id=self.project.id).get_job(self.name)
+
+    def json(self) -> dict:
+        """Convert to JSON-serializable dictionary.
+
+        Returns:
+            A dictionary representation of the search result item.
+        """
+        return {**super().json(), "job_type": self._job_type}
+
+
+@public("hopsworks.core.search_api.DatasetSearchResult")
+class DatasetSearchResult(SearchResultItem):
+    """Search result for a Dataset.
+
+    Every method here resolves in the project the hit belongs to, which is not
+    necessarily the login project: a cross-project hit is the case dataset
+    search exists to serve, and reading it against the login project would
+    either 404 or, worse, answer about a same-named dataset of another project.
+    """
+
+    @public
+    @property
+    def path(self) -> str:
+        """Path of the dataset within its project, which for a dataset root is its name."""
+        return self._name
+
+    def _dataset_api(self) -> DatasetApi:
+        from hopsworks_common.core import dataset_api
+
+        return dataset_api.DatasetApi(
+            project_id=self.project.id if self.project else None,
+            project_name=self.project.name if self.project else None,
+        )
+
+    @public
+    def get(self) -> dict | None:
+        """Retrieve the dataset's metadata.
+
+        Returns:
+            The dataset metadata, or `None` if it no longer exists.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        try:
+            return self._dataset_api()._get(self.path)
+        except RestAPIError as e:
+            if getattr(e.response, "status_code", None) == 404:
+                return None
+            raise
+
+    @public
+    def get_tags(self) -> dict[str, Any]:
+        """Tags attached to the dataset, as name to value.
+
+        Returns:
+            Dictionary of tag names to values, empty when the dataset carries none.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._dataset_api().get_tags(self.path)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, Tag]:
+        """Tags attached to the dataset, with the time each was attached.
+
+        Returns:
+            Dictionary of tag names to [`Tag`][hopsworks.tag.Tag] objects, whose
+                [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._dataset_api().get_tags_metadata(self.path)
+
+
 @public("hopsworks.core.search_api.FeaturestoreSearchResult")
 class FeaturestoreSearchResult:
     """Container for all featurestore search results."""
@@ -356,6 +467,10 @@ class FeaturestoreSearchResult:
         self._features = [
             FeatureSearchResult(f) for f in response_data.get("features", [])
         ]
+        self._jobs = [JobSearchResult(j) for j in response_data.get("jobs", [])]
+        self._datasets = [
+            DatasetSearchResult(d) for d in response_data.get("datasets", [])
+        ]
 
         # Store metadata about result counts
         self._feature_groups_offset = response_data.get("featuregroupsFrom", 0)
@@ -366,6 +481,10 @@ class FeaturestoreSearchResult:
         self._training_datasets_total = response_data.get("trainingdatasetsTotal", 0)
         self._features_offset = response_data.get("featuresFrom", 0)
         self._features_total = response_data.get("featuresTotal", 0)
+        self._jobs_offset = response_data.get("jobsFrom", 0)
+        self._jobs_total = response_data.get("jobsTotal", 0)
+        self._datasets_offset = response_data.get("datasetsFrom", 0)
+        self._datasets_total = response_data.get("datasetsTotal", 0)
 
     @public
     @property
@@ -390,6 +509,18 @@ class FeaturestoreSearchResult:
     def features(self) -> list[FeatureSearchResult]:
         """List of Feature search results."""
         return self._features
+
+    @public
+    @property
+    def jobs(self) -> list[JobSearchResult]:
+        """List of Job search results."""
+        return self._jobs
+
+    @public
+    @property
+    def datasets(self) -> list[DatasetSearchResult]:
+        """List of Dataset search results."""
+        return self._datasets
 
     @public
     @property
@@ -439,6 +570,30 @@ class FeaturestoreSearchResult:
         """Total number of Features matching the search."""
         return self._features_total
 
+    @public
+    @property
+    def jobs_offset(self) -> int:
+        """Total offset for the returned list of jobs within the whole result."""
+        return self._jobs_offset
+
+    @public
+    @property
+    def jobs_total(self) -> int:
+        """Total number of Jobs matching the search."""
+        return self._jobs_total
+
+    @public
+    @property
+    def datasets_offset(self) -> int:
+        """Total offset for the returned list of datasets within the whole result."""
+        return self._datasets_offset
+
+    @public
+    @property
+    def datasets_total(self) -> int:
+        """Total number of Datasets matching the search."""
+        return self._datasets_total
+
     def json(self) -> dict:
         """Convert to JSON-serializable dictionary.
 
@@ -458,6 +613,12 @@ class FeaturestoreSearchResult:
             "features": [f.json() for f in self._features],
             "featuresFrom": self._features_offset,
             "featuresTotal": self._features_total,
+            "jobs": [j.json() for j in self._jobs],
+            "jobsFrom": self._jobs_offset,
+            "jobsTotal": self._jobs_total,
+            "datasets": [d.json() for d in self._datasets],
+            "datasetsFrom": self._datasets_offset,
+            "datasetsTotal": self._datasets_total,
         }
 
     def __repr__(self):
@@ -466,5 +627,7 @@ class FeaturestoreSearchResult:
             f"feature_groups={len(self._feature_groups)}/{self._feature_groups_total}, "
             f"feature_views={len(self._feature_views)}/{self._feature_views_total}, "
             f"training_datasets={len(self._training_datasets)}/{self._training_datasets_total}, "
-            f"features={len(self._features)}/{self._features_total})"
+            f"features={len(self._features)}/{self._features_total}, "
+            f"jobs={len(self._jobs)}/{self._jobs_total}, "
+            f"datasets={len(self._datasets)}/{self._datasets_total})"
         )

--- a/python/hopsworks_common/search_results.py
+++ b/python/hopsworks_common/search_results.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from hsfs.feature_group import FeatureGroup
     from hsfs.feature_view import FeatureView
     from hsfs.training_dataset import TrainingDataset
+    from hsml.deployment import Deployment
+    from hsml.model import Model
 
 
 @public("hopsworks.core.search_api.Project")
@@ -455,6 +457,131 @@ class DatasetSearchResult(SearchResultItem):
         return self._dataset_api().get_tags_metadata(self.path)
 
 
+@public("hopsworks.core.search_api.ModelSearchResult")
+class ModelSearchResult(SearchResultItem):
+    """Search result for a Model.
+
+    A model resolves in the registry project the hit belongs to, which for a shared
+    registry is not the login project.
+    """
+
+    def __init__(self, data: dict):
+        super().__init__(data)
+        self._framework = data.get("framework")
+
+    @public
+    @property
+    def framework(self) -> str | None:
+        """Framework the model was trained with, e.g. `PYTHON` or `TORCH`."""
+        return self._framework
+
+    @public
+    def get(self) -> Model | None:
+        """Retrieve the full Model object.
+
+        The model is fetched from the registry project this search result belongs to.
+        For that to work the registry has to be shared with the login project, which is
+        the same condition under which the hit was visible.
+
+        Returns:
+            The full Model object corresponding to this search result, or `None` if it no longer exists.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        # Fail closed, for the reason given on DatasetSearchResult._dataset_api.
+        if self.project is None:
+            raise ValueError(
+                "this search result carries no project, so its model cannot be resolved"
+            )
+        mr = client._get_connection()._get_model_registry(self.project.name)
+        return mr.get_model(self.name, version=self.version)
+
+    def json(self) -> dict:
+        """Convert to JSON-serializable dictionary.
+
+        Returns:
+            A dictionary representation of the search result item.
+        """
+        return {**super().json(), "framework": self._framework}
+
+
+@public("hopsworks.core.search_api.DeploymentSearchResult")
+class DeploymentSearchResult(SearchResultItem):
+    """Search result for a Deployment."""
+
+    def __init__(self, data: dict):
+        super().__init__(data)
+        self._serving_tool = data.get("servingTool")
+        self._model_name = data.get("modelName")
+        self._model_version = data.get("modelVersion")
+        self._model_framework = data.get("modelFramework")
+
+    @public
+    @property
+    def serving_tool(self) -> str | None:
+        """Tool serving the deployment, e.g. `KSERVE`."""
+        return self._serving_tool
+
+    @public
+    @property
+    def model_name(self) -> str | None:
+        """Name of the model the deployment serves, `None` when it serves no registered model."""
+        return self._model_name
+
+    @public
+    @property
+    def model_version(self) -> int | None:
+        """Version of the model the deployment serves, `None` when it serves no registered model."""
+        return self._model_version
+
+    @public
+    @property
+    def model_framework(self) -> str | None:
+        """Framework of the model the deployment serves."""
+        return self._model_framework
+
+    @public
+    def get(self) -> Deployment | None:
+        """Retrieve the full Deployment object.
+
+        Returns:
+            The full Deployment object corresponding to this search result, or `None` if it no longer exists.
+
+        Raises:
+            ValueError: If the deployment belongs to another project.
+                Deployments are project-local, so there is no way to read one from outside its project.
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        if self.project is None:
+            raise ValueError(
+                "this search result carries no project, so its deployment cannot be resolved"
+            )
+        login_project = client._get_instance()._project_name
+        if self.project.name != login_project:
+            raise ValueError(
+                f"deployment '{self.name}' belongs to project '{self.project.name}', "
+                f"and deployments cannot be read from outside their own project; "
+                f"log in to '{self.project.name}' to fetch it"
+            )
+        ms = client._get_connection()._get_model_serving()
+        return ms.get_deployment(self.name)
+
+    def json(self) -> dict:
+        """Convert to JSON-serializable dictionary.
+
+        Returns:
+            A dictionary representation of the search result item.
+        """
+        return {
+            **super().json(),
+            "serving_tool": self._serving_tool,
+            "model_name": self._model_name,
+            "model_version": self._model_version,
+            "model_framework": self._model_framework,
+        }
+
+
 @public("hopsworks.core.search_api.FeaturestoreSearchResult")
 class FeaturestoreSearchResult:
     """Container for all featurestore search results."""
@@ -479,6 +606,10 @@ class FeaturestoreSearchResult:
         self._datasets = [
             DatasetSearchResult(d) for d in response_data.get("datasets", [])
         ]
+        self._models = [ModelSearchResult(m) for m in response_data.get("models", [])]
+        self._deployments = [
+            DeploymentSearchResult(d) for d in response_data.get("deployments", [])
+        ]
 
         # Store metadata about result counts
         self._feature_groups_offset = response_data.get("featuregroupsFrom", 0)
@@ -493,6 +624,10 @@ class FeaturestoreSearchResult:
         self._jobs_total = response_data.get("jobsTotal", 0)
         self._datasets_offset = response_data.get("datasetsFrom", 0)
         self._datasets_total = response_data.get("datasetsTotal", 0)
+        self._models_offset = response_data.get("modelsFrom", 0)
+        self._models_total = response_data.get("modelsTotal", 0)
+        self._deployments_offset = response_data.get("deploymentsFrom", 0)
+        self._deployments_total = response_data.get("deploymentsTotal", 0)
 
     @public
     @property
@@ -602,6 +737,42 @@ class FeaturestoreSearchResult:
         """Total number of Datasets matching the search."""
         return self._datasets_total
 
+    @public
+    @property
+    def models(self) -> list[ModelSearchResult]:
+        """List of Model search results."""
+        return self._models
+
+    @public
+    @property
+    def models_offset(self) -> int:
+        """Total offset for the returned list of models within the whole result."""
+        return self._models_offset
+
+    @public
+    @property
+    def models_total(self) -> int:
+        """Total number of Models matching the search."""
+        return self._models_total
+
+    @public
+    @property
+    def deployments(self) -> list[DeploymentSearchResult]:
+        """List of Deployment search results."""
+        return self._deployments
+
+    @public
+    @property
+    def deployments_offset(self) -> int:
+        """Total offset for the returned list of deployments within the whole result."""
+        return self._deployments_offset
+
+    @public
+    @property
+    def deployments_total(self) -> int:
+        """Total number of Deployments matching the search."""
+        return self._deployments_total
+
     def json(self) -> dict:
         """Convert to JSON-serializable dictionary.
 
@@ -627,6 +798,12 @@ class FeaturestoreSearchResult:
             "datasets": [d.json() for d in self._datasets],
             "datasetsFrom": self._datasets_offset,
             "datasetsTotal": self._datasets_total,
+            "models": [m.json() for m in self._models],
+            "modelsFrom": self._models_offset,
+            "modelsTotal": self._models_total,
+            "deployments": [d.json() for d in self._deployments],
+            "deploymentsFrom": self._deployments_offset,
+            "deploymentsTotal": self._deployments_total,
         }
 
     def __repr__(self):
@@ -637,5 +814,7 @@ class FeaturestoreSearchResult:
             f"training_datasets={len(self._training_datasets)}/{self._training_datasets_total}, "
             f"features={len(self._features)}/{self._features_total}, "
             f"jobs={len(self._jobs)}/{self._jobs_total}, "
-            f"datasets={len(self._datasets)}/{self._datasets_total})"
+            f"datasets={len(self._datasets)}/{self._datasets_total}, "
+            f"models={len(self._models)}/{self._models_total}, "
+            f"deployments={len(self._deployments)}/{self._deployments_total})"
         )

--- a/python/hopsworks_common/tag.py
+++ b/python/hopsworks_common/tag.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from datetime import datetime, timezone
 from typing import Any
 
 import humps
@@ -39,6 +40,7 @@ class Tag:
         self,
         name: str,
         value: dict[str, Any] | str,
+        created_on: datetime | None = None,
         schema=None,
         href=None,
         expand=None,
@@ -53,10 +55,12 @@ class Tag:
             raise ValueError("Tag value cannot be None")
         self._name = name
         self._value = value
+        self._created_on = created_on
 
     def to_dict(self):
         # Backend expects value to always be a string
         # If value is a dict, serialize it to JSON string
+        # created_on is server-assigned, so it is deliberately not sent back
         value = self._value
         if isinstance(value, dict):
             value = json.dumps(value)
@@ -111,7 +115,14 @@ class Tag:
     @classmethod
     def from_response_json(cls, json_dict):
         json_decamelized = humps.decamelize(json_dict)
-        if "count" not in json_decamelized or json_decamelized["count"] == 0:
+        # A request naming one tag answers with that tag, not with a collection: the dataset tag
+        # endpoints do this, and reading it as an empty collection lost the tag entirely.
+        if "count" not in json_decamelized:
+            if "name" in json_decamelized and "value" in json_decamelized:
+                json_decamelized = {"count": 1, "items": [json_decamelized]}
+            else:
+                return []
+        if json_decamelized["count"] == 0:
             return []
         tags = []
         for tag_dict in json_decamelized["items"]:
@@ -124,9 +135,38 @@ class Tag:
                 with contextlib.suppress(json.JSONDecodeError, ValueError):
                     tag_dict["value"] = json.loads(tag_dict["value"])
 
-            # Only pass name and value to avoid issues with extra fields like schema
-            tags.append(cls(name=tag_dict["name"], value=tag_dict["value"]))
+            tags.append(
+                cls(
+                    name=tag_dict["name"],
+                    value=tag_dict["value"],
+                    created_on=cls._parse_created_on(tag_dict.get("created_on")),
+                )
+            )
         return tags
+
+    @staticmethod
+    def _parse_created_on(raw: Any) -> datetime | None:
+        """Parse the attachment time the backend sent, in whichever form it sent it.
+
+        Both epoch milliseconds and ISO-8601 are accepted because the backend's JSON date format
+        is not pinned across versions, and a client that only understood one of them would report
+        no attachment time at all against the other.
+        Anything unrecognized becomes None rather than raising: an unreadable timestamp must not
+        stop a tag from being read.
+        """
+        if raw is None:
+            return None
+        if isinstance(raw, datetime):
+            return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+        if isinstance(raw, (int, float)):
+            return datetime.fromtimestamp(raw / 1000, tz=timezone.utc)
+        if isinstance(raw, str):
+            with contextlib.suppress(ValueError):
+                return datetime.fromtimestamp(int(raw) / 1000, tz=timezone.utc)
+            with contextlib.suppress(ValueError):
+                parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+                return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        return None
 
     @public
     @property
@@ -151,6 +191,18 @@ class Tag:
         if value is None:
             raise ValueError("Tag value cannot be None")
         self._value = value
+
+    @public
+    @property
+    def created_on(self) -> datetime | None:
+        """When the tag was attached, as an aware UTC datetime.
+
+        `None` for a tag attached before Hopsworks recorded attachment times, and for legacy
+        per-file dataset tags, which are stored as HopsFS extended attributes and carry no
+        timestamp.
+        `None` therefore means the attachment time is unknown, not that the tag is new.
+        """
+        return self._created_on
 
     def __str__(self):
         return self.json()

--- a/python/hsfs/core/feature_group_base_engine.py
+++ b/python/hsfs/core/feature_group_base_engine.py
@@ -19,7 +19,13 @@ from typing import TYPE_CHECKING, Any
 
 from hopsworks_common.client.exceptions import FeatureStoreException
 from hsfs import util
-from hsfs.core import feature_group_api, kafka_api, storage_connector_api, tags_api
+from hsfs.core import (
+    feature_group_api,
+    kafka_api,
+    keywords_api,
+    storage_connector_api,
+    tags_api,
+)
 
 
 if TYPE_CHECKING:
@@ -34,6 +40,9 @@ class FeatureGroupBaseEngine:
     def __init__(self, feature_store_id):
         self._feature_store_id = feature_store_id
         self._tags_api = tags_api.TagsApi(feature_store_id, self.ENTITY_TYPE)
+        self._keywords_api = keywords_api.KeywordsApi(
+            feature_store_id, self.ENTITY_TYPE
+        )
         self._feature_group_api = feature_group_api.FeatureGroupApi()
         self._storage_connector_api = storage_connector_api.StorageConnectorApi()
         self._kafka_api = kafka_api.KafkaApi()
@@ -90,6 +99,37 @@ class FeatureGroupBaseEngine:
         if tags:
             return tags
         return {}
+
+    def _get_tag_metadata(self, feature_group: FeatureGroup, name: str):
+        """Get the tag with a certain name as a Tag object, or None if it does not exist."""
+        return self._tags_api._get_metadata(feature_group, name).get(name)
+
+    def _get_tags_metadata(self, feature_group: FeatureGroup):
+        """Get all tags for a feature group as Tag objects."""
+        return self._tags_api._get_metadata(feature_group)
+
+    def _get_keywords(self, feature_group: FeatureGroup):
+        """Get all keywords of a feature group."""
+        return self._keywords_api._get(feature_group)
+
+    def _get_keywords_metadata(self, feature_group: FeatureGroup):
+        """Get all keywords of a feature group with their attachment times."""
+        return self._keywords_api._get_with_metadata(feature_group)
+
+    def _set_keywords(self, feature_group: FeatureGroup, keywords: list[str]):
+        """Replace the whole keyword set of a feature group."""
+        return self._keywords_api._replace(feature_group, keywords)
+
+    def _add_keywords(self, feature_group: FeatureGroup, keywords: list[str]):
+        """Add keywords to a feature group, keeping the existing ones."""
+        current = self._keywords_api._get(feature_group)
+        return self._keywords_api._replace(
+            feature_group, list(dict.fromkeys(current + keywords))
+        )
+
+    def _delete_keyword(self, feature_group: FeatureGroup, keyword: str):
+        """Remove a single keyword from a feature group."""
+        return self._keywords_api._delete(feature_group, keyword)
 
     def _get_parent_feature_groups(
         self, feature_group: FeatureGroup

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -36,6 +36,7 @@ from hsfs.constructor.filter import Filter, Logic
 from hsfs.constructor.query import Query
 from hsfs.core import (
     feature_view_api,
+    keywords_api,
     query_constructor_api,
     statistics_engine,
     tags_api,
@@ -73,6 +74,9 @@ class FeatureViewEngine:
 
         self._feature_view_api = feature_view_api.FeatureViewApi(feature_store_id)
         self._tags_api = tags_api.TagsApi(feature_store_id, self.ENTITY_TYPE)
+        self._keywords_api = keywords_api.KeywordsApi(
+            feature_store_id, self.ENTITY_TYPE
+        )
         self._statistics_engine = statistics_engine.StatisticsEngine(
             feature_store_id, self._TRAINING_DATA_API_PATH
         )
@@ -1154,6 +1158,65 @@ class FeatureViewEngine:
     def _get_tags(self, feature_view_obj, training_dataset_version=None):
         return self._tags_api._get(
             feature_view_obj, training_dataset_version=training_dataset_version
+        )
+
+    def _get_tag_metadata(
+        self, feature_view_obj, name: str, training_dataset_version=None
+    ):
+        """Get the tag with a certain name as a Tag object, or None if it does not exist."""
+        return self._tags_api._get_metadata(
+            feature_view_obj, name, training_dataset_version=training_dataset_version
+        ).get(name)
+
+    def _get_tags_metadata(self, feature_view_obj, training_dataset_version=None):
+        """Get all tags for a feature view or training dataset as Tag objects."""
+        return self._tags_api._get_metadata(
+            feature_view_obj, training_dataset_version=training_dataset_version
+        )
+
+    def _get_keywords(self, feature_view_obj, training_dataset_version=None):
+        """Get all keywords of a feature view or one of its training datasets."""
+        return self._keywords_api._get(
+            feature_view_obj, training_dataset_version=training_dataset_version
+        )
+
+    def _get_keywords_metadata(self, feature_view_obj, training_dataset_version=None):
+        """Get all keywords of a feature view or one of its training datasets with their attachment times."""
+        return self._keywords_api._get_with_metadata(
+            feature_view_obj, training_dataset_version=training_dataset_version
+        )
+
+    def _set_keywords(
+        self, feature_view_obj, keywords: list[str], training_dataset_version=None
+    ):
+        """Replace the whole keyword set of a feature view or one of its training datasets."""
+        return self._keywords_api._replace(
+            feature_view_obj,
+            keywords,
+            training_dataset_version=training_dataset_version,
+        )
+
+    def _add_keywords(
+        self, feature_view_obj, keywords: list[str], training_dataset_version=None
+    ):
+        """Add keywords to a feature view or one of its training datasets, keeping the existing ones."""
+        current = self._keywords_api._get(
+            feature_view_obj, training_dataset_version=training_dataset_version
+        )
+        return self._keywords_api._replace(
+            feature_view_obj,
+            list(dict.fromkeys(current + keywords)),
+            training_dataset_version=training_dataset_version,
+        )
+
+    def _delete_keyword(
+        self, feature_view_obj, keyword: str, training_dataset_version=None
+    ):
+        """Remove a single keyword from a feature view or one of its training datasets."""
+        return self._keywords_api._delete(
+            feature_view_obj,
+            keyword,
+            training_dataset_version=training_dataset_version,
         )
 
     def _get_parent_feature_groups(

--- a/python/hsfs/core/training_dataset_engine.py
+++ b/python/hsfs/core/training_dataset_engine.py
@@ -20,6 +20,7 @@ import warnings
 from hsfs import engine, training_dataset_feature
 from hsfs.constructor import query
 from hsfs.core import (
+    keywords_api,
     tags_api,
     training_dataset_api,
 )
@@ -37,6 +38,9 @@ class TrainingDatasetEngine:
             feature_store_id
         )
         self._tags_api = tags_api.TagsApi(feature_store_id, self.ENTITY_TYPE)
+        self._keywords_api = keywords_api.KeywordsApi(
+            feature_store_id, self.ENTITY_TYPE
+        )
 
     def _save(self, training_dataset, features, user_write_options):
         if isinstance(features, query.Query):
@@ -158,6 +162,37 @@ class TrainingDatasetEngine:
             training_dataset: The training dataset to read tags from.
         """
         return self._tags_api._get(training_dataset)
+
+    def _get_tag_metadata(self, training_dataset, name):
+        """Get the tag with a certain name as a Tag object, or None if it does not exist."""
+        return self._tags_api._get_metadata(training_dataset, name).get(name)
+
+    def _get_tags_metadata(self, training_dataset):
+        """Get all tags for a training dataset as Tag objects."""
+        return self._tags_api._get_metadata(training_dataset)
+
+    def _get_keywords(self, training_dataset):
+        """Get all keywords of a training dataset."""
+        return self._keywords_api._get(training_dataset)
+
+    def _get_keywords_metadata(self, training_dataset):
+        """Get all keywords of a training dataset with their attachment times."""
+        return self._keywords_api._get_with_metadata(training_dataset)
+
+    def _set_keywords(self, training_dataset, keywords):
+        """Replace the whole keyword set of a training dataset."""
+        return self._keywords_api._replace(training_dataset, keywords)
+
+    def _add_keywords(self, training_dataset, keywords):
+        """Add keywords to a training dataset, keeping the existing ones."""
+        current = self._keywords_api._get(training_dataset)
+        return self._keywords_api._replace(
+            training_dataset, list(dict.fromkeys(current + keywords))
+        )
+
+    def _delete_keyword(self, training_dataset, keyword):
+        """Remove a single keyword from a training dataset."""
+        return self._keywords_api._delete(training_dataset, keyword)
 
     def _update_statistics_config(self, training_dataset):
         """Update the statistics configuration of a training dataset.

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -1015,7 +1015,7 @@ class FeatureGroupBase:
     def get_tag_metadata(self, name: str) -> tag.Tag | None:
         """Get a tag with its metadata, including the time it was attached.
 
-        Unlike [`FeatureGroupBase.get_tag`][hsfs.feature_group.FeatureGroupBase.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`FeatureGroupBase.get_tag`][hsfs.feature_group.FeatureGroupBase.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Example:
             ```python
@@ -1038,7 +1038,7 @@ class FeatureGroupBase:
     def get_tags_metadata(self) -> dict[str, tag.Tag]:
         """Retrieves all tags attached to a feature group, with their metadata.
 
-        Unlike [`FeatureGroupBase.get_tags`][hsfs.feature_group.FeatureGroupBase.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`FeatureGroupBase.get_tags`][hsfs.feature_group.FeatureGroupBase.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Returns:
             The dictionary of tag names to tag objects.

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -974,7 +974,7 @@ class FeatureGroupBase:
         self._feature_group_engine._delete_tag(self, name)
 
     @public
-    def get_tag(self, name: str) -> tag.Tag | None:
+    def get_tag(self, name: str) -> Any | None:
         """Get the tags of a feature group.
 
         Example:
@@ -1000,16 +1000,132 @@ class FeatureGroupBase:
         return self._feature_group_engine._get_tag(self, name)
 
     @public
-    def get_tags(self) -> dict[str, tag.Tag]:
+    def get_tags(self) -> dict[str, Any]:
         """Retrieves all tags attached to a feature group.
 
         Returns:
-            The dictionary of tags.
+            The dictionary of tag names and values.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         return self._feature_group_engine._get_tags(self)
+
+    @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`FeatureGroupBase.get_tag`][hsfs.feature_group.FeatureGroupBase.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Example:
+            ```python
+            fg_tag = fg.get_tag_metadata("example_tag")
+            print(fg_tag.value, fg_tag.created_on)
+            ```
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._get_tag_metadata(self, name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Retrieves all tags attached to a feature group, with their metadata.
+
+        Unlike [`FeatureGroupBase.get_tags`][hsfs.feature_group.FeatureGroupBase.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            The dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._get_tags_metadata(self)
+
+    @public
+    def get_keywords(self) -> list[str]:
+        """Retrieve all keywords attached to a feature group.
+
+        A keyword is a plain label without a value, used to categorize and search for artifacts.
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._get_keywords(self)
+
+    @public
+    def get_keywords_metadata(self) -> dict[str, datetime | None]:
+        """Retrieve all keywords attached to a feature group, with the time each was attached.
+
+        Returns:
+            Dictionary of keyword to attachment time.
+            The time is `None` when it is unknown, for example for a keyword attached before Hopsworks recorded attachment times.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._get_keywords_metadata(self)
+
+    @public
+    def set_keywords(self, keywords: list[str]) -> list[str]:
+        """Replace the whole keyword set of a feature group.
+
+        Keywords not in `keywords` are removed.
+
+        Parameters:
+            keywords: The new keyword set.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._set_keywords(self, keywords)
+
+    @public
+    def add_keywords(self, keywords: str | list[str]) -> list[str]:
+        """Add keywords to a feature group, keeping the existing ones.
+
+        This reads the current keywords and writes back their union with `keywords`, so a concurrent `add_keywords` or [`FeatureGroupBase.set_keywords`][hsfs.feature_group.FeatureGroupBase.set_keywords] call can lose additions.
+        When the full keyword set is known, prefer [`FeatureGroupBase.set_keywords`][hsfs.feature_group.FeatureGroupBase.set_keywords].
+
+        Parameters:
+            keywords: A keyword or a list of keywords to add.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return self._feature_group_engine._add_keywords(self, keywords)
+
+    @public
+    def delete_keyword(self, keyword: str) -> list[str]:
+        """Remove a single keyword from a feature group.
+
+        Parameters:
+            keyword: The keyword to remove.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._delete_keyword(self, keyword)
 
     @public
     def get_parent_feature_groups(self) -> explicit_provenance.Links | None:

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -40,6 +40,7 @@ from hsfs.core import (
     feature_group_api,
     feature_group_engine,
     feature_view_engine,
+    keywords_api,
     search_api,
     storage_connector_api,
     training_dataset_api,
@@ -3001,3 +3002,18 @@ class FeatureStore:
             limit=limit,
             global_search=global_search,
         )
+
+    @public
+    @usage._method_logger
+    def get_all_keywords(self) -> list[str]:
+        """Retrieve the keyword vocabulary in use across the whole cluster.
+
+        Despite being accessed through a feature store, the vocabulary is cluster-wide, not project-scoped: it contains every keyword attached to any artifact in any project.
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return keywords_api.KeywordsApi()._get_all()

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -1513,7 +1513,7 @@ class FeatureView:
         return self._feature_view_engine._add_tag(self, name, value)
 
     @public
-    def get_tag(self, name: str) -> tag.Tag | None:
+    def get_tag(self, name: str) -> Any | None:
         """Get the tags of a feature view.
 
         Example:
@@ -1540,7 +1540,7 @@ class FeatureView:
         return self._feature_view_engine._get_tag(self, name)
 
     @public
-    def get_tags(self) -> dict[str, tag.Tag]:
+    def get_tags(self) -> dict[str, Any]:
         """Returns all tags attached to a feature view.
 
         Example:
@@ -1556,12 +1556,128 @@ class FeatureView:
             ```
 
         Returns:
-            The dictionary of tags.
+            The dictionary of tag names and values.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         return self._feature_view_engine._get_tags(self)
+
+    @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`FeatureView.get_tag`][hsfs.feature_view.FeatureView.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Example:
+            ```python
+            fv_tag = feature_view.get_tag_metadata("example_tag")
+            print(fv_tag.value, fv_tag.created_on)
+            ```
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._get_tag_metadata(self, name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Returns all tags attached to a feature view, with their metadata.
+
+        Unlike [`FeatureView.get_tags`][hsfs.feature_view.FeatureView.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            The dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._get_tags_metadata(self)
+
+    @public
+    def get_keywords(self) -> list[str]:
+        """Retrieve all keywords attached to a feature view.
+
+        A keyword is a plain label without a value, used to categorize and search for artifacts.
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._get_keywords(self)
+
+    @public
+    def get_keywords_metadata(self) -> dict[str, datetime | None]:
+        """Retrieve all keywords attached to a feature view, with the time each was attached.
+
+        Returns:
+            Dictionary of keyword to attachment time.
+            The time is `None` when it is unknown, for example for a keyword attached before Hopsworks recorded attachment times.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._get_keywords_metadata(self)
+
+    @public
+    def set_keywords(self, keywords: list[str]) -> list[str]:
+        """Replace the whole keyword set of a feature view.
+
+        Keywords not in `keywords` are removed.
+
+        Parameters:
+            keywords: The new keyword set.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._set_keywords(self, keywords)
+
+    @public
+    def add_keywords(self, keywords: str | list[str]) -> list[str]:
+        """Add keywords to a feature view, keeping the existing ones.
+
+        This reads the current keywords and writes back their union with `keywords`, so a concurrent `add_keywords` or [`FeatureView.set_keywords`][hsfs.feature_view.FeatureView.set_keywords] call can lose additions.
+        When the full keyword set is known, prefer [`FeatureView.set_keywords`][hsfs.feature_view.FeatureView.set_keywords].
+
+        Parameters:
+            keywords: A keyword or a list of keywords to add.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return self._feature_view_engine._add_keywords(self, keywords)
+
+    @public
+    def delete_keyword(self, keyword: str) -> list[str]:
+        """Remove a single keyword from a feature view.
+
+        Parameters:
+            keyword: The keyword to remove.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._delete_keyword(self, keyword)
 
     @public
     def get_parent_feature_groups(self) -> explicit_provenance.Links | None:
@@ -3593,7 +3709,7 @@ class FeatureView:
     @usage._method_logger
     def get_training_dataset_tag(
         self, training_dataset_version: int, name: str
-    ) -> tag.Tag | None:
+    ) -> Any | None:
         """Get the tags of a training dataset.
 
         Example:
@@ -3629,7 +3745,7 @@ class FeatureView:
     @usage._method_logger
     def get_training_dataset_tags(
         self, training_dataset_version: int
-    ) -> dict[str, tag.Tag]:
+    ) -> dict[str, Any]:
         """Returns all tags attached to a training dataset.
 
         Example:
@@ -3650,13 +3766,169 @@ class FeatureView:
             training_dataset_version: The training dataset version to get tags for.
 
         Returns:
-            Dictionary of tags.
+            Dictionary of tag names and values.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
         """
         return self._feature_view_engine._get_tags(
             self, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def get_training_dataset_tag_metadata(
+        self, training_dataset_version: int, name: str
+    ) -> tag.Tag | None:
+        """Get a training dataset tag with its metadata, including the time it was attached.
+
+        Unlike [`FeatureView.get_training_dataset_tag`][hsfs.feature_view.FeatureView.get_training_dataset_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            training_dataset_version: training dataset version
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._get_tag_metadata(
+            self, name, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def get_training_dataset_tags_metadata(
+        self, training_dataset_version: int
+    ) -> dict[str, tag.Tag]:
+        """Returns all tags attached to a training dataset, with their metadata.
+
+        Unlike [`FeatureView.get_training_dataset_tags`][hsfs.feature_view.FeatureView.get_training_dataset_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            training_dataset_version: The training dataset version to get tags for.
+
+        Returns:
+            Dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._get_tags_metadata(
+            self, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def get_training_dataset_keywords(self, training_dataset_version: int) -> list[str]:
+        """Retrieve all keywords attached to a training dataset.
+
+        A keyword is a plain label without a value, used to categorize and search for artifacts.
+
+        Parameters:
+            training_dataset_version: training dataset version
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._get_keywords(
+            self, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def get_training_dataset_keywords_metadata(
+        self, training_dataset_version: int
+    ) -> dict[str, datetime | None]:
+        """Retrieve all keywords attached to a training dataset, with the time each was attached.
+
+        Parameters:
+            training_dataset_version: training dataset version
+
+        Returns:
+            Dictionary of keyword to attachment time.
+            The time is `None` when it is unknown, for example for a keyword attached before Hopsworks recorded attachment times.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._get_keywords_metadata(
+            self, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def set_training_dataset_keywords(
+        self, training_dataset_version: int, keywords: list[str]
+    ) -> list[str]:
+        """Replace the whole keyword set of a training dataset.
+
+        Keywords not in `keywords` are removed.
+
+        Parameters:
+            training_dataset_version: training dataset version
+            keywords: The new keyword set.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._set_keywords(
+            self, keywords, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def add_training_dataset_keywords(
+        self, training_dataset_version: int, keywords: str | list[str]
+    ) -> list[str]:
+        """Add keywords to a training dataset, keeping the existing ones.
+
+        This reads the current keywords and writes back their union with `keywords`, so a concurrent add or [`FeatureView.set_training_dataset_keywords`][hsfs.feature_view.FeatureView.set_training_dataset_keywords] call can lose additions.
+        When the full keyword set is known, prefer [`FeatureView.set_training_dataset_keywords`][hsfs.feature_view.FeatureView.set_training_dataset_keywords].
+
+        Parameters:
+            training_dataset_version: training dataset version
+            keywords: A keyword or a list of keywords to add.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return self._feature_view_engine._add_keywords(
+            self, keywords, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def delete_training_dataset_keyword(
+        self, training_dataset_version: int, keyword: str
+    ) -> list[str]:
+        """Remove a single keyword from a training dataset.
+
+        Parameters:
+            training_dataset_version: training dataset version
+            keyword: The keyword to remove.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._delete_keyword(
+            self, keyword, training_dataset_version=training_dataset_version
         )
 
     @public

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -1567,7 +1567,7 @@ class FeatureView:
     def get_tag_metadata(self, name: str) -> tag.Tag | None:
         """Get a tag with its metadata, including the time it was attached.
 
-        Unlike [`FeatureView.get_tag`][hsfs.feature_view.FeatureView.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`FeatureView.get_tag`][hsfs.feature_view.FeatureView.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Example:
             ```python
@@ -1590,7 +1590,7 @@ class FeatureView:
     def get_tags_metadata(self) -> dict[str, tag.Tag]:
         """Returns all tags attached to a feature view, with their metadata.
 
-        Unlike [`FeatureView.get_tags`][hsfs.feature_view.FeatureView.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`FeatureView.get_tags`][hsfs.feature_view.FeatureView.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Returns:
             The dictionary of tag names to tag objects.
@@ -3782,7 +3782,7 @@ class FeatureView:
     ) -> tag.Tag | None:
         """Get a training dataset tag with its metadata, including the time it was attached.
 
-        Unlike [`FeatureView.get_training_dataset_tag`][hsfs.feature_view.FeatureView.get_training_dataset_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`FeatureView.get_training_dataset_tag`][hsfs.feature_view.FeatureView.get_training_dataset_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Parameters:
             training_dataset_version: training dataset version
@@ -3805,7 +3805,7 @@ class FeatureView:
     ) -> dict[str, tag.Tag]:
         """Returns all tags attached to a training dataset, with their metadata.
 
-        Unlike [`FeatureView.get_training_dataset_tags`][hsfs.feature_view.FeatureView.get_training_dataset_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`FeatureView.get_training_dataset_tags`][hsfs.feature_view.FeatureView.get_training_dataset_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Parameters:
             training_dataset_version: The training dataset version to get tags for.

--- a/python/hsfs/training_dataset.py
+++ b/python/hsfs/training_dataset.py
@@ -877,7 +877,7 @@ class TrainingDataset(TrainingDatasetBase):
     def get_tag_metadata(self, name: str) -> tag.Tag | None:
         """Get a tag with its metadata, including the time it was attached.
 
-        Unlike [`TrainingDataset.get_tag`][hsfs.training_dataset.TrainingDataset.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`TrainingDataset.get_tag`][hsfs.training_dataset.TrainingDataset.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Parameters:
             name: Name of the tag to get.
@@ -894,7 +894,7 @@ class TrainingDataset(TrainingDatasetBase):
     def get_tags_metadata(self) -> dict[str, tag.Tag]:
         """Returns all tags attached to a training dataset, with their metadata.
 
-        Unlike [`TrainingDataset.get_tags`][hsfs.training_dataset.TrainingDataset.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`TrainingDataset.get_tags`][hsfs.training_dataset.TrainingDataset.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Returns:
             Dictionary of tag names to tag objects.

--- a/python/hsfs/training_dataset.py
+++ b/python/hsfs/training_dataset.py
@@ -39,6 +39,8 @@ from hsfs.training_dataset_split import TrainingDatasetSplit
 
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from hopsworks_common.core.constants import HAS_NUMPY
     from hopsworks_common.job import Job
     from hsfs.statistics import Statistics
@@ -860,16 +862,126 @@ class TrainingDataset(TrainingDatasetBase):
         return self._training_dataset_engine._get_tag(self, name)
 
     @public
-    def get_tags(self) -> dict[str, tag.Tag]:
+    def get_tags(self) -> dict[str, Any]:
         """Returns all tags attached to a training dataset.
 
         Returns:
-            Dictionary of tags.
+            Dictionary of tag names and values.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tags.
         """
         return self._training_dataset_engine._get_tags(self)
+
+    @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`TrainingDataset.get_tag`][hsfs.training_dataset.TrainingDataset.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tag.
+        """
+        return self._training_dataset_engine._get_tag_metadata(self, name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Returns all tags attached to a training dataset, with their metadata.
+
+        Unlike [`TrainingDataset.get_tags`][hsfs.training_dataset.TrainingDataset.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            Dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tags.
+        """
+        return self._training_dataset_engine._get_tags_metadata(self)
+
+    @public
+    def get_keywords(self) -> list[str]:
+        """Retrieve all keywords attached to a training dataset.
+
+        A keyword is a plain label without a value, used to categorize and search for artifacts.
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the keywords.
+        """
+        return self._training_dataset_engine._get_keywords(self)
+
+    @public
+    def get_keywords_metadata(self) -> dict[str, datetime | None]:
+        """Retrieve all keywords attached to a training dataset, with the time each was attached.
+
+        Returns:
+            Dictionary of keyword to attachment time.
+            The time is `None` when it is unknown, for example for a keyword attached before Hopsworks recorded attachment times.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the keywords.
+        """
+        return self._training_dataset_engine._get_keywords_metadata(self)
+
+    @public
+    def set_keywords(self, keywords: list[str]) -> list[str]:
+        """Replace the whole keyword set of a training dataset.
+
+        Keywords not in `keywords` are removed.
+
+        Parameters:
+            keywords: The new keyword set.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to set the keywords.
+        """
+        return self._training_dataset_engine._set_keywords(self, keywords)
+
+    @public
+    def add_keywords(self, keywords: str | list[str]) -> list[str]:
+        """Add keywords to a training dataset, keeping the existing ones.
+
+        This reads the current keywords and writes back their union with `keywords`, so a concurrent `add_keywords` or [`TrainingDataset.set_keywords`][hsfs.training_dataset.TrainingDataset.set_keywords] call can lose additions.
+        When the full keyword set is known, prefer [`TrainingDataset.set_keywords`][hsfs.training_dataset.TrainingDataset.set_keywords].
+
+        Parameters:
+            keywords: A keyword or a list of keywords to add.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to add the keywords.
+        """
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return self._training_dataset_engine._add_keywords(self, keywords)
+
+    @public
+    def delete_keyword(self, keyword: str) -> list[str]:
+        """Remove a single keyword from a training dataset.
+
+        Parameters:
+            keyword: The keyword to remove.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to delete the keyword.
+        """
+        return self._training_dataset_engine._delete_keyword(self, keyword)
 
     @public
     def update_statistics_config(self) -> TrainingDataset:

--- a/python/hsml/core/model_api.py
+++ b/python/hsml/core/model_api.py
@@ -302,6 +302,38 @@ class ModelApi:
         }
         return tags.get(name)
 
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_tags_metadata(
+        self, model_instance: model.Model, name: str | None = None
+    ) -> dict[str, tag.Tag]:
+        """Get the tags as Tag objects, keeping metadata such as created_on.
+
+        Parameters:
+            model_instance: model instance to get the tags from
+            name: tag name; all tags if omitted
+
+        Returns:
+            dict of tag name to Tag object
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "modelregistries",
+            str(model_instance.model_registry_id),
+            "models",
+            model_instance.id,
+            "tags",
+        ]
+        if name is not None:
+            path_params.append(name)
+        return {
+            t._name: t
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+
     def _get_feature_view_provenance(
         self, model_instance
     ) -> explicit_provenance.Links | None:

--- a/python/hsml/core/model_serving_api.py
+++ b/python/hsml/core/model_serving_api.py
@@ -14,6 +14,8 @@
 #   limitations under the License.
 #
 
+from __future__ import annotations
+
 import socket
 
 from hopsworks_common.client.exceptions import ModelRegistryException
@@ -29,21 +31,30 @@ class ModelServingApi:
         self._dataset_api = dataset_api.DatasetApi()
         self._serving_api = serving_api.ServingApi()
 
-    def _get(self) -> ModelServing:
-        """Get model serving for specific project.
+    def _get(
+        self, project_name: str | None = None, project_id: int | None = None
+    ) -> ModelServing:
+        """Get model serving for a specific project.
+
+        Parameters:
+            project_name: The project whose serving this handle addresses, and project_id its id.
+                Both default to the connection's project. A Project object for another project
+                passes its own, so that its deployments are not the login project's.
 
         Returns:
             the model serving metadata
         """
         _client = client._get_instance()
+        project_name = project_name or _client._project_name
+        project_id = project_id if project_id is not None else _client._project_id
 
         # Validate that there is a Models dataset in the connected project
         if not self._dataset_api.path_exists("Models"):
             raise ModelRegistryException(
-                f"No Models dataset exists in project {_client._project_name}, Please enable the Serving service or create the dataset manually."
+                f"No Models dataset exists in project {project_name}, Please enable the Serving service or create the dataset manually."
             )
 
-        return ModelServing(_client._project_name, _client._project_id)
+        return ModelServing(project_name, project_id)
 
     def _load_default_configuration(self):
         """Load default configuration and set istio client for model serving."""

--- a/python/hsml/core/model_serving_api.py
+++ b/python/hsml/core/model_serving_api.py
@@ -48,8 +48,11 @@ class ModelServingApi:
         project_name = project_name or _client._project_name
         project_id = project_id if project_id is not None else _client._project_id
 
-        # Validate that there is a Models dataset in the connected project
-        if not self._dataset_api.path_exists("Models"):
+        # Validate that there is a Models dataset in THAT project. Asking the connection's
+        # dataset API answers for the login project, which for a foreign handle is a check of
+        # the wrong project: it passes when the login project has serving enabled and the
+        # named one does not, and the failure then surfaces later as an empty deployment list.
+        if not dataset_api.DatasetApi(project_id, project_name).exists("Models"):
             raise ModelRegistryException(
                 f"No Models dataset exists in project {project_name}, Please enable the Serving service or create the dataset manually."
             )

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -36,8 +36,33 @@ from hsml.constants import INFERENCE_ENDPOINTS as IE
 
 
 class ServingApi:
-    def __init__(self):
-        pass
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Address one project's deployments.
+
+        Parameters:
+            project_id: The project this handle addresses, and project_name its name.
+                Both default to the connection's project, which is what a login-project
+                handle wants. A ModelServing for another project passes that project's,
+                so that its deployments are not read out of the login project.
+        """
+        self._project_id = project_id
+        self._project_name = project_name
+
+    def _pid(self) -> int:
+        return (
+            self._project_id
+            if self._project_id is not None
+            else client._get_instance()._project_id
+        )
+
+    def _pname(self) -> str:
+        return (
+            self._project_name
+            if self._project_name is not None
+            else client._get_instance()._project_name
+        )
 
     @decorators._catch_not_found("hsml.deployment.Deployment", fallback_return=None)
     def _get_by_id(self, id: int) -> deployment.Deployment | None:
@@ -52,7 +77,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             str(id),
         ]
@@ -62,8 +87,8 @@ class ServingApi:
             "GET", path_params, query_params=query_params
         )
         deployment_instance = deployment.Deployment.from_response_json(deployment_json)
-        deployment_instance.model_registry_id = _client._project_id
-        deployment_instance.project_name = _client._project_name
+        deployment_instance.model_registry_id = self._pid()
+        deployment_instance.project_name = self._pname()
         return deployment_instance
 
     @decorators._catch_not_found("hsml.deployment.Deployment", fallback_return=None)
@@ -77,15 +102,15 @@ class ServingApi:
             Deployment metadata object.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "serving"]
+        path_params = ["project", self._pid(), "serving"]
         query_params = {"name": name, "expand": ["mandatorytags"]}
 
         deployment_json = _client._send_request(
             "GET", path_params, query_params=query_params
         )
         deployment_instance = deployment.Deployment.from_response_json(deployment_json)
-        deployment_instance.model_registry_id = _client._project_id
-        deployment_instance.project_name = _client._project_name
+        deployment_instance.model_registry_id = self._pid()
+        deployment_instance.project_name = self._pname()
         return deployment_instance
 
     def _get_all(
@@ -101,7 +126,7 @@ class ServingApi:
             List of deployment metadata objects.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "serving"]
+        path_params = ["project", self._pid(), "serving"]
         query_params = {
             "model": model_name,
             "status": status.capitalize() if status is not None else None,
@@ -113,8 +138,8 @@ class ServingApi:
             deployments_json
         )
         for deployment_instance in deployment_instances:
-            deployment_instance.model_registry_id = _client._project_id
-            deployment_instance.project_name = _client._project_name
+            deployment_instance.model_registry_id = self._pid()
+            deployment_instance.project_name = self._pname()
         return deployment_instances
 
     def _set_tag(
@@ -134,7 +159,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             str(deployment_instance.id),
             "tags",
@@ -158,7 +183,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             str(deployment_instance.id),
             "tags",
@@ -179,7 +204,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             str(deployment_instance.id),
             "tags",
@@ -207,7 +232,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             str(deployment_instance.id),
             "tags",
@@ -237,7 +262,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             str(deployment_instance.id),
             "tags",
@@ -258,7 +283,7 @@ class ServingApi:
             Inference endpoints for the current project.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "inference", "endpoints"]
+        path_params = ["project", self._pid(), "inference", "endpoints"]
         endpoints_json = _client._send_request("GET", path_params)
         return inference_endpoint.InferenceEndpoint.from_response_json(endpoints_json)
 
@@ -272,7 +297,7 @@ class ServingApi:
             Updated metadata object of the deployment.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "serving"]
+        path_params = ["project", self._pid(), "serving"]
         headers = {"content-type": "application/json"}
 
         deployment_instance = deployment_instance.update_from_response_json(
@@ -283,8 +308,8 @@ class ServingApi:
                 data=deployment_instance.json(),
             )
         )
-        deployment_instance.model_registry_id = _client._project_id
-        deployment_instance.project_name = _client._project_name
+        deployment_instance.model_registry_id = self._pid()
+        deployment_instance.project_name = self._pname()
         return deployment_instance
 
     def _post(self, deployment_instance: deployment.Deployment, action: str):
@@ -297,7 +322,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             deployment_instance.id,
         ]
@@ -313,7 +338,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             deployment_instance.id,
         ]
@@ -333,7 +358,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             str(deployment_instance.id),
         ]
@@ -352,15 +377,15 @@ class ServingApi:
             Deployment with reset values.
         """
         _client = client._get_instance()
-        path_params = ["project", _client._project_id, "serving"]
+        path_params = ["project", self._pid(), "serving"]
         query_params = {"name": deployment_instance.name}
         deployment_json = _client._send_request(
             "GET", path_params, query_params=query_params
         )
         deployment_aux = deployment_instance.update_from_response_json(deployment_json)
         # TODO: remove when model_registry_id is added properly to deployments in backend
-        deployment_aux.model_registry_id = _client._project_id
-        deployment_aux.project_name = _client._project_name
+        deployment_aux.model_registry_id = self._pid()
+        deployment_aux.project_name = self._pname()
         return deployment_aux
 
     def _send_inference_request(
@@ -398,7 +423,7 @@ class ServingApi:
             # use Hopsworks client
             _client = client._get_instance()
             path_params = self._get_hopsworks_inference_path(
-                _client._project_id, deployment_instance
+                self._pid(), deployment_instance
             )
             with_base_path_params = True
         else:
@@ -411,7 +436,7 @@ class ServingApi:
                 # fallback to Hopsworks client
                 _client = client._get_instance()
                 path_params = self._get_hopsworks_inference_path(
-                    _client._project_id, deployment_instance
+                    self._pid(), deployment_instance
                 )
                 with_base_path_params = True
 
@@ -535,7 +560,7 @@ class ServingApi:
         _client = client._get_instance()
         path_params = [
             "project",
-            _client._project_id,
+            self._pid(),
             "serving",
             deployment_instance.id,
             "logs",

--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -221,6 +221,36 @@ class ServingApi:
         }
         return tags.get(name)
 
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_tags_metadata(
+        self, deployment_instance: deployment.Deployment, name: str | None = None
+    ) -> dict[str, tag.Tag]:
+        """Get the tags as Tag objects, keeping metadata such as created_on.
+
+        Parameters:
+            deployment_instance: deployment instance to get the tags from
+            name: tag name; all tags if omitted
+
+        Returns:
+            dict of tag name to Tag object
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "serving",
+            str(deployment_instance.id),
+            "tags",
+        ]
+        if name is not None:
+            path_params.append(name)
+        return {
+            t._name: t
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+
     def _get_inference_endpoints(self) -> list[inference_endpoint.InferenceEndpoint]:
         """Get inference endpoints.
 

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -749,12 +749,23 @@ class Deployment:
         )
 
     def update_from_response_json(self, json_dict):
+        # The refresh rebuilds this object through __init__, which resets the api and the engine to
+        # the connection's project, and the predictor's refresh does the same to its project name. A
+        # deployment bound to a foreign project must stay bound across a refresh: the
+        # duplicate-create recovery in ServingEngine._create refreshes exactly here, and an unbound
+        # result would start, stop and read the logs of the login project's deployment instead.
+        model_registry_id = self._model_registry_id
+        project_name = self._predictor._project_name
         self._predictor.update_from_response_json(json_dict)
         self.__init__(
             predictor=self._predictor,
             name=self._predictor._name,
             description=self._predictor._description,
         )
+        if model_registry_id is not None or project_name is not None:
+            self._model_registry_id = model_registry_id
+            self._predictor._project_name = project_name
+            self._rebind()
         return self
 
     def json(self):

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -28,6 +28,7 @@ from hsml.engine import serving_engine
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from hopsworks_common import tag
     from hsfs.core.feature_monitoring_config import FeatureMonitoringConfig
     from hsml.client.istio.utils.infer_type import InferInput
     from hsml.deployment_tracing_config import DeploymentTracingConfig
@@ -219,6 +220,37 @@ class Deployment:
             hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tags.
         """
         return self._serving_engine._get_tags(self)
+
+    @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`Deployment.get_tag`][hsml.deployment.Deployment.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object, or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tag.
+        """
+        return self._serving_engine._get_tag_metadata(self, name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Retrieve all tags attached to a deployment, with their metadata.
+
+        Unlike [`Deployment.get_tags`][hsml.deployment.Deployment.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            Dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tags.
+        """
+        return self._serving_engine._get_tags_metadata(self)
 
     @public
     @property

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -243,7 +243,7 @@ class Deployment:
     def get_tag_metadata(self, name: str) -> tag.Tag | None:
         """Get a tag with its metadata, including the time it was attached.
 
-        Unlike [`Deployment.get_tag`][hsml.deployment.Deployment.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`Deployment.get_tag`][hsml.deployment.Deployment.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Parameters:
             name: Name of the tag to get.
@@ -260,7 +260,7 @@ class Deployment:
     def get_tags_metadata(self) -> dict[str, tag.Tag]:
         """Retrieve all tags attached to a deployment, with their metadata.
 
-        Unlike [`Deployment.get_tags`][hsml.deployment.Deployment.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`Deployment.get_tags`][hsml.deployment.Deployment.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Returns:
             Dictionary of tag names to tag objects.

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -78,6 +78,24 @@ class Deployment:
         self._grpc_channel = None
         self._model_registry_id = None
 
+    def _rebind(self):
+        """Point this deployment's API and engine at the project that owns it.
+
+        A deployment read out of another project carries that project's id and name, and every
+        call it then makes has to go there: an engine left on the connection's project starts,
+        stops and reads the logs of whatever the login project holds under the same id.
+        Rebinding happens as the two attributes are set, which is how the deployment learns
+        which project it came from.
+        """
+        self._serving_api = serving_api.ServingApi(
+            self._model_registry_id, self._predictor._project_name
+        )
+        self._serving_engine = serving_engine.ServingEngine(
+            self._model_registry_id, self._predictor._project_name
+        )
+        # The predictor builds the inference URLs, and the Hopsworks one carries a project id.
+        self._predictor._project_id = self._model_registry_id
+
     @public
     @usage._method_logger
     def save(self, await_update: int | None = 600):
@@ -966,6 +984,7 @@ class Deployment:
     @model_registry_id.setter
     def model_registry_id(self, model_registry_id: int):
         self._model_registry_id = model_registry_id
+        self._rebind()
 
     @public
     @property
@@ -1028,6 +1047,7 @@ class Deployment:
     @project_name.setter
     def project_name(self, project_name: str):
         self._predictor._project_name = project_name
+        self._rebind()
 
     @public
     @property

--- a/python/hsml/engine/model_engine.py
+++ b/python/hsml/engine/model_engine.py
@@ -949,6 +949,14 @@ class ModelEngine:
         """
         return self._model_api._get_tags(model_instance)
 
+    def _get_tag_metadata(self, model_instance, name):
+        """Get the tag with a certain name as a Tag object, or None if it does not exist."""
+        return self._model_api._get_tags_metadata(model_instance, name).get(name)
+
+    def _get_tags_metadata(self, model_instance):
+        """Get all tags for a model as Tag objects."""
+        return self._model_api._get_tags_metadata(model_instance)
+
     def _get_feature_view_provenance(
         self, model_instance
     ) -> explicit_provenance.Links | None:

--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -65,9 +65,20 @@ class ServingEngine:
         PREDICTOR_STATE.CONDITION_TYPE_STOPPED,
     ]
 
-    def __init__(self):
-        self._serving_api = serving_api.ServingApi()
-        self._dataset_api = dataset_api.DatasetApi()
+    def __init__(
+        self, project_id: int | None = None, project_name: str | None = None
+    ) -> None:
+        """Operate on the deployments of one project.
+
+        Parameters:
+            project_id: The project that owns the deployments this engine acts on, and
+                project_name its name. Both default to the connection's project. A
+                deployment read out of another project binds them to that project, so
+                that starting it, reading its logs or downloading its artifacts does not
+                address the login project instead.
+        """
+        self._serving_api = serving_api.ServingApi(project_id, project_name)
+        self._dataset_api = dataset_api.DatasetApi(project_id, project_name)
 
         self._engine = local_engine.LocalEngine()
 

--- a/python/hsml/engine/serving_engine.py
+++ b/python/hsml/engine/serving_engine.py
@@ -107,6 +107,14 @@ class ServingEngine:
         """
         return self._serving_api._get_tags(deployment_instance)
 
+    def _get_tag_metadata(self, deployment_instance, name: str):
+        """Get the tag with a certain name as a Tag object, or None if it does not exist."""
+        return self._serving_api._get_tags_metadata(deployment_instance, name).get(name)
+
+    def _get_tags_metadata(self, deployment_instance):
+        """Get all tags for a deployment as Tag objects."""
+        return self._serving_api._get_tags_metadata(deployment_instance)
+
     def _poll_deployment_status(
         self, deployment_instance, status: str, await_status: int, update_progress=None
     ):

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -538,7 +538,7 @@ class Model:
     def get_tag_metadata(self, name: str) -> tag.Tag | None:
         """Get a tag with its metadata, including the time it was attached.
 
-        Unlike [`Model.get_tag`][hsml.model.Model.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`Model.get_tag`][hsml.model.Model.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Parameters:
             name: Name of the tag to get.
@@ -555,7 +555,7 @@ class Model:
     def get_tags_metadata(self) -> dict[str, tag.Tag]:
         """Retrieve all tags attached to a model, with their metadata.
 
-        Unlike [`Model.get_tags`][hsml.model.Model.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+        Unlike [`Model.get_tags`][hsml.model.Model.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
 
         Returns:
             Dictionary of tag names to tag objects.

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -535,6 +535,37 @@ class Model:
         return self._model_engine._get_tags(model_instance=self)
 
     @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`Model.get_tag`][hsml.model.Model.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object, or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: in case the backend fails to retrieve the tag.
+        """
+        return self._model_engine._get_tag_metadata(model_instance=self, name=name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Retrieve all tags attached to a model, with their metadata.
+
+        Unlike [`Model.get_tags`][hsml.model.Model.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            Dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: In case of a server error.
+        """
+        return self._model_engine._get_tags_metadata(model_instance=self)
+
+    @public
     @property
     def missing_mandatory_tags(self) -> list[dict[str, Any]]:
         """Mandatory tags configured for models that this model is missing.

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -74,7 +74,10 @@ class ModelServing:
         self._project_name = project_name
         self._project_id = project_id
 
-        self._serving_api = serving_api.ServingApi()
+        # Bound to this project, not the connection's: every serving path is
+        # project/<id>/serving, so an unbound API would list and mutate the login project's
+        # deployments through a handle that names another project.
+        self._serving_api = serving_api.ServingApi(project_id, project_name)
 
     @public
     @usage._method_logger
@@ -583,8 +586,10 @@ class ModelServing:
 
         agent_dir = f"{_normalize_upload_dir(upload_dir)}/{name}"
 
-        ds_api = _dataset_api.DatasetApi()
-        env_api = _environment_api.EnvironmentApi()
+        # This project's, not the connection's: the agent's files are uploaded into the project
+        # whose serving is being deployed to, and its environment is built there.
+        ds_api = _dataset_api.DatasetApi(self._project_id, self._project_name)
+        env_api = _environment_api.EnvironmentApi(self._project_id, self._project_name)
 
         requirements_abs = None
         if requirements is not None:

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -140,6 +140,7 @@ class Predictor(DeployableComponent):
         self._environment = environment
         self._project_namespace = project_namespace
         self._project_name = None
+        self._project_id = None
         self._env_vars = env_vars
         self._tracing = util._get_obj_from_json(tracing, DeploymentTracingConfig)
         self._git_url = git_url
@@ -890,7 +891,10 @@ class Predictor(DeployableComponent):
         # Fallback to Hopsworks REST API path
         hopsworks_client = client._get_instance()
         path_parts = serving._get_hopsworks_inference_path(
-            hopsworks_client._project_id, self
+            self._project_id
+            if self._project_id is not None
+            else hopsworks_client._project_id,
+            self,
         )
         return f"{hopsworks_client._base_url}/hopsworks-api/api/{'/'.join(str(p) for p in path_parts)}"
 

--- a/python/tests/cli/test_writes.py
+++ b/python/tests/cli/test_writes.py
@@ -9,6 +9,7 @@ test.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -108,11 +109,15 @@ def test_fg_append_features_rejects_bad_spec(mock_project):
 def test_fg_keywords_table(mock_project):
     fs = mock_project.get_feature_store.return_value
     fg = mock.MagicMock()
-    fg.get_tags.return_value = {"prod": mock.Mock(value="true")}
+    fg.get_keywords_metadata.return_value = {"prod": datetime(2026, 3, 4, 5, 6, 7)}
     fs.get_feature_group.return_value = fg
     result = CliRunner().invoke(cli, ["fg", "keywords", "txn"])
     assert result.exit_code == 0, result.output
     assert "prod" in result.output
+    assert "2026-03-04" in result.output
+    # The semantics notice has to be visible, which is why it goes to stderr
+    # rather than through the warnings module.
+    assert "moved to 'hops fg tags/add-tag/remove-tag'" in result.output
 
 
 def test_fg_add_keyword(mock_project):
@@ -121,7 +126,21 @@ def test_fg_add_keyword(mock_project):
     fs.get_feature_group.return_value = fg
     result = CliRunner().invoke(cli, ["fg", "add-keyword", "txn", "prod"])
     assert result.exit_code == 0, result.output
-    fg.add_tag.assert_called_with(name="prod", value="true")
+    fg.add_keywords.assert_called_with(["prod"])
+    fg.add_tag.assert_not_called()
+
+
+def test_fg_add_keyword_value_is_retired(mock_project):
+    fs = mock_project.get_feature_store.return_value
+    fg = mock.MagicMock()
+    fs.get_feature_group.return_value = fg
+    result = CliRunner().invoke(
+        cli, ["fg", "add-keyword", "txn", "prod", "--value", "true"]
+    )
+    assert result.exit_code != 0
+    assert "hops fg add-tag txn prod" in result.output
+    fg.add_keywords.assert_not_called()
+    fg.add_tag.assert_not_called()
 
 
 def test_fg_remove_keyword(mock_project):
@@ -130,7 +149,43 @@ def test_fg_remove_keyword(mock_project):
     fs.get_feature_group.return_value = fg
     result = CliRunner().invoke(cli, ["fg", "remove-keyword", "txn", "prod"])
     assert result.exit_code == 0, result.output
-    fg.delete_tag.assert_called_with("prod")
+    fg.delete_keyword.assert_called_with("prod")
+    fg.delete_tag.assert_not_called()
+
+
+# --- fg tags / add-tag / remove-tag ---------------------------------------
+
+
+def test_fg_tags_table(mock_project):
+    fs = mock_project.get_feature_store.return_value
+    fg = mock.MagicMock()
+    fg.get_tags_metadata.return_value = {
+        "owner": {"value": {"team": "risk"}, "createdOn": datetime(2026, 3, 4)}
+    }
+    fs.get_feature_group.return_value = fg
+    result = CliRunner().invoke(cli, ["fg", "tags", "txn"])
+    assert result.exit_code == 0, result.output
+    assert "owner" in result.output
+
+
+def test_fg_add_tag_parses_json_value(mock_project):
+    fs = mock_project.get_feature_store.return_value
+    fg = mock.MagicMock()
+    fs.get_feature_group.return_value = fg
+    result = CliRunner().invoke(
+        cli, ["fg", "add-tag", "txn", "owner", "--value", '{"team": "risk"}']
+    )
+    assert result.exit_code == 0, result.output
+    fg.add_tag.assert_called_with(name="owner", value={"team": "risk"})
+
+
+def test_fg_remove_tag(mock_project):
+    fs = mock_project.get_feature_store.return_value
+    fg = mock.MagicMock()
+    fs.get_feature_group.return_value = fg
+    result = CliRunner().invoke(cli, ["fg", "remove-tag", "txn", "owner"])
+    assert result.exit_code == 0, result.output
+    fg.delete_tag.assert_called_with("owner")
 
 
 # --- fg stats --------------------------------------------------------------

--- a/python/tests/core/test_dataset_api.py
+++ b/python/tests/core/test_dataset_api.py
@@ -15,6 +15,7 @@
 #
 
 import json
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -130,3 +131,113 @@ class TestDatasetApiTags:
 
         # Assert
         assert result == {"meta": value}
+
+    def test_get_tags_metadata_keeps_tag_objects(self, mocker):
+        # Arrange
+        api = DatasetApi()
+        response = {
+            "count": 1,
+            "items": [{"name": "meta", "value": "v", "createdOn": 1785474813000}],
+        }
+        client_instance = self._patch_client(mocker, response)
+
+        # Act
+        result = api.get_tags_metadata("my_dataset")
+
+        # Assert
+        assert result["meta"].value == "v"
+        assert result["meta"].created_on == datetime(
+            2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc
+        )
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == ["project", 1, "dataset", "tags", "all", "my_dataset"]
+
+    def test_get_tag_metadata_by_name_uses_schema_path(self, mocker):
+        # Arrange
+        api = DatasetApi()
+        response = {"count": 1, "items": [{"name": "meta", "value": "v"}]}
+        client_instance = self._patch_client(mocker, response)
+
+        # Act
+        result = api.get_tag_metadata("my_dataset", "meta")
+
+        # Assert
+        assert result.name == "meta"
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == [
+            "project",
+            1,
+            "dataset",
+            "tags",
+            "schema",
+            "meta",
+            "my_dataset",
+        ]
+
+    def test_get_tag_metadata_missing_is_none(self, mocker):
+        # Arrange
+        api = DatasetApi()
+        self._patch_client(mocker, {"count": 0, "items": []})
+
+        # Act & Assert
+        assert api.get_tag_metadata("my_dataset", "meta") is None
+
+
+class TestDatasetApiMkdir:
+    def _patch_client(self, mocker) -> MagicMock:
+        client_instance = MagicMock()
+        client_instance._project_id = 1
+        client_instance._send_request.return_value = {
+            "attributes": {"path": "/Projects/p/my_dataset"}
+        }
+        mocker.patch(
+            "hopsworks_common.core.dataset_api.client._get_instance",
+            return_value=client_instance,
+        )
+        return client_instance
+
+    def test_mkdir_without_tags_sends_no_body(self, mocker):
+        # Existing clients and old servers rely on the body staying absent.
+        # Arrange
+        api = DatasetApi()
+        client_instance = self._patch_client(mocker)
+
+        # Act
+        result = api.mkdir("my_dataset")
+
+        # Assert
+        assert result == "/Projects/p/my_dataset"
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "POST"
+        assert call.kwargs["data"] is None
+
+    def test_mkdir_with_tags_sends_tags_dto_body(self, mocker):
+        # Arrange
+        api = DatasetApi()
+        client_instance = self._patch_client(mocker)
+
+        # Act
+        api.mkdir(
+            "my_dataset",
+            tags=[{"name": "sensitivity", "value": {"level": "internal"}}],
+        )
+
+        # Assert
+        call = client_instance._send_request.call_args
+        body = json.loads(call.kwargs["data"])
+        assert body["count"] == 1
+        # Non-string values are JSON-serialized the way tag values are elsewhere.
+        assert body["items"] == [
+            {"name": "sensitivity", "value": json.dumps({"level": "internal"})}
+        ]
+
+    def test_mkdir_with_empty_tags_sends_no_body(self, mocker):
+        # Arrange
+        api = DatasetApi()
+        client_instance = self._patch_client(mocker)
+
+        # Act
+        api.mkdir("my_dataset", tags=[])
+
+        # Assert
+        assert client_instance._send_request.call_args.kwargs["data"] is None

--- a/python/tests/core/test_feature_group_base_engine.py
+++ b/python/tests/core/test_feature_group_base_engine.py
@@ -51,6 +51,54 @@ class TestFeatureGroupBaseEngine:
         # Assert
         assert mock_tags_api.return_value._add.call_count == 1
 
+    def test_get_tag_metadata(self, mocker):
+        # Arrange
+        mock_tags_api = mocker.patch("hsfs.core.tags_api.TagsApi")
+        tag_obj = mocker.Mock()
+        mock_tags_api.return_value._get_metadata.return_value = {"meta": tag_obj}
+
+        fg_base_engine = feature_group_base_engine.FeatureGroupBaseEngine(
+            feature_store_id=99
+        )
+
+        # Act & Assert
+        assert fg_base_engine._get_tag_metadata(None, "meta") is tag_obj
+        assert fg_base_engine._get_tag_metadata(None, "missing") is None
+
+    def test_add_keywords_unions_with_existing(self, mocker):
+        # A read-modify-write: the union must keep the existing keywords and
+        # not duplicate re-added ones.
+        # Arrange
+        mock_keywords_api = mocker.patch("hsfs.core.keywords_api.KeywordsApi")
+        mock_keywords_api.return_value._get.return_value = ["a", "b"]
+
+        fg_base_engine = feature_group_base_engine.FeatureGroupBaseEngine(
+            feature_store_id=99
+        )
+
+        # Act
+        fg_base_engine._add_keywords(None, ["b", "c"])
+
+        # Assert
+        mock_keywords_api.return_value._replace.assert_called_once_with(
+            None, ["a", "b", "c"]
+        )
+
+    def test_set_keywords_replaces(self, mocker):
+        # Arrange
+        mock_keywords_api = mocker.patch("hsfs.core.keywords_api.KeywordsApi")
+
+        fg_base_engine = feature_group_base_engine.FeatureGroupBaseEngine(
+            feature_store_id=99
+        )
+
+        # Act
+        fg_base_engine._set_keywords(None, ["a"])
+
+        # Assert
+        mock_keywords_api.return_value._replace.assert_called_once_with(None, ["a"])
+        mock_keywords_api.return_value._get.assert_not_called()
+
     def test_delete_tag(self, mocker):
         # Arrange
         feature_store_id = 99

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -741,13 +741,63 @@ class TestJobProjectBinding:
         assert job._project_id is None
         assert job._job_api._project_id is None
 
-    def test_binding_rebuilds_the_handle(self):
+    def test_binding_rebuilds_every_handle(self):
         job = self._job()
         job._bind_project(42, "other_project")
-        # Every later operation goes through this handle: update, delete,
-        # schedule, executions, tags.
+        # All of them, not only the job handle: tags used to be bound while
+        # executions, alerts and the URL still addressed the login project.
         assert job._job_api._project_id == 42
         assert job._job_api._project_name == "other_project"
+        assert job._execution_api._project_id == 42
+        assert job._alerts_api._project_id == 42
+
+    def test_executions_address_the_bound_project(self, mocker):
+        job = self._job()
+        job._bind_project(42, "other_project")
+        instance = mocker.Mock(_project_id=5, _project_name="login_project")
+        mocker.patch("hopsworks_common.client._get_instance", return_value=instance)
+        instance._send_request.return_value = {"count": 0, "items": []}
+
+        job._execution_api._get_all(job)
+
+        path_params = instance._send_request.call_args[0][1]
+        assert path_params[:2] == ["project", 42], path_params
+
+    def test_alerts_address_the_bound_project(self, mocker):
+        job = self._job()
+        job._bind_project(42, "other_project")
+        instance = mocker.Mock(_project_id=5, _project_name="login_project")
+        mocker.patch("hopsworks_common.client._get_instance", return_value=instance)
+        instance._send_request.return_value = {"count": 0, "items": []}
+
+        job._alerts_api.get_job_alerts(job.name)
+
+        path_params = instance._send_request.call_args[0][1]
+        assert path_params[:2] == ["project", 42], path_params
+
+    def test_url_points_at_the_bound_project(self, mocker):
+        job = self._job()
+        job._bind_project(42, "other_project")
+        mocker.patch(
+            "hopsworks_common.client._get_instance",
+            return_value=mocker.Mock(_project_id=5, _project_name="login_project"),
+        )
+        mocker.patch(
+            "hopsworks_common.util._get_hostname_replaced_url", side_effect=lambda p: p
+        )
+
+        assert job.get_url() == "/p/42/jobs/named/nightly"
+
+    def test_an_unbound_job_still_uses_the_connection(self, mocker):
+        job = self._job()
+        instance = mocker.Mock(_project_id=5, _project_name="login_project")
+        mocker.patch("hopsworks_common.client._get_instance", return_value=instance)
+        instance._send_request.return_value = {"count": 0, "items": []}
+
+        job._execution_api._get_all(job)
+
+        path_params = instance._send_request.call_args[0][1]
+        assert path_params[:2] == ["project", 5], path_params
 
     def test_job_api_stamps_the_jobs_it_returns(self, mocker):
         from hopsworks_common.core import job_api

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -719,3 +719,48 @@ class TestJobTags:
 
         assert j.get_tags_metadata() == {"meta": tag_obj}
         api._get_tags_metadata.assert_called_once_with(j)
+
+
+class TestJobProjectBinding:
+    """A job addresses the project it came from, not the connection's."""
+
+    def _job(self):
+        from hopsworks_common.job import Job
+
+        return Job(
+            id=7,
+            name="nightly",
+            creation_time="2026-08-03T00:00:00Z",
+            config={"type": "sparkJobConfiguration"},
+            job_type="SPARK",
+            creator=None,
+        )
+
+    def test_unbound_job_uses_the_connection(self):
+        job = self._job()
+        assert job._project_id is None
+        assert job._job_api._project_id is None
+
+    def test_binding_rebuilds_the_handle(self):
+        job = self._job()
+        job._bind_project(42, "other_project")
+        # Every later operation goes through this handle: update, delete,
+        # schedule, executions, tags.
+        assert job._job_api._project_id == 42
+        assert job._job_api._project_name == "other_project"
+
+    def test_job_api_stamps_the_jobs_it_returns(self, mocker):
+        from hopsworks_common.core import job_api
+
+        api = job_api.JobApi(project_id=42, project_name="other_project")
+        job = self._job()
+        assert api._bind(job) is job
+        assert job._job_api._project_id == 42
+
+    def test_bind_tolerates_a_list_and_none(self):
+        from hopsworks_common.core import job_api
+
+        api = job_api.JobApi(project_id=9, project_name="p")
+        jobs = [self._job(), None]
+        api._bind(jobs)
+        assert jobs[0]._job_api._project_id == 9

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -750,6 +750,46 @@ class TestJobProjectBinding:
         assert job._job_api._project_name == "other_project"
         assert job._execution_api._project_id == 42
         assert job._alerts_api._project_id == 42
+        assert job._alerts_api._project_name == "other_project"
+        # The engine owns the handles that awaiting and log download go through.
+        assert job._execution_engine._execution_api._project_id == 42
+        assert job._execution_engine._dataset_api._project_id == 42
+        assert job._execution_engine._dataset_api._project_name == "other_project"
+
+    def test_executions_of_a_bound_job_stay_bound(self, mocker):
+        job = self._job()
+        job._bind_project(42, "other_project")
+        instance = mocker.Mock(_project_id=5, _project_name="login_project")
+        mocker.patch("hopsworks_common.client._get_instance", return_value=instance)
+        mocker.patch(
+            "hopsworks_common.util._get_hostname_replaced_url", side_effect=lambda p: p
+        )
+        instance._send_request.return_value = {
+            "count": 1,
+            "items": [{"id": 3, "state": "RUNNING"}],
+        }
+
+        execution = job.get_executions()[0]
+
+        assert execution._project_id == 42
+        assert execution._execution_api._project_id == 42
+        assert execution._execution_engine._execution_api._project_id == 42
+        assert execution.get_url() == "/p/42/jobs/named/nightly/executions"
+
+    def test_refreshing_an_execution_keeps_its_project(self, mocker):
+        job = self._job()
+        job._bind_project(42, "other_project")
+        from hopsworks_common.execution import Execution
+
+        execution = Execution.from_response_json({"id": 3, "state": "RUNNING"}, job)
+
+        execution.update_from_response_json({"id": 3, "state": "FINISHED"})
+
+        # Re-initialising used to drop the job entirely, which rebound every handle to the login
+        # project and left job_name raising.
+        assert execution.job_name == "nightly"
+        assert execution._project_id == 42
+        assert execution._execution_api._project_id == 42
 
     def test_executions_address_the_bound_project(self, mocker):
         job = self._job()

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -607,3 +607,115 @@ class TestExecution:
 
         # Act + Assert
         assert ex.app_url is None
+
+
+class TestJobDescription:
+    def _job(self, mocker, **kwargs):
+        mocker.patch("hopsworks_common.client._get_instance")
+        return job.Job(
+            id=1,
+            name="test",
+            creation_time=None,
+            config={"appPath": "app.py"},
+            job_type="PYTHON",
+            creator=None,
+            **kwargs,
+        )
+
+    def test_description_from_constructor(self, mocker):
+        j = self._job(mocker, description="scalar description")
+
+        assert j.description == "scalar description"
+
+    def test_description_falls_back_to_config(self, mocker):
+        # An old server does not send the scalar field; the config carries it.
+        j = self._job(mocker)
+        j._config["description"] = "config description"
+
+        assert j.description == "config description"
+
+    def test_description_none_when_absent_everywhere(self, mocker):
+        j = self._job(mocker)
+
+        assert j.description is None
+
+    def test_description_setter_writes_config_too(self, mocker):
+        # save() persists the config, so the setter must write it there.
+        j = self._job(mocker)
+
+        j.description = "new description"
+
+        assert j._description == "new description"
+        assert j._config["description"] == "new description"
+
+    def test_config_setter_survives(self, mocker):
+        # A duplicate `config` property definition used to shadow this setter.
+        j = self._job(mocker)
+
+        j.config = {"appPath": "other.py"}
+
+        assert j.config == {"appPath": "other.py"}
+
+
+class TestJobTags:
+    def _job(self, mocker):
+        mocker.patch("hopsworks_common.client._get_instance")
+        mock_job_api = mocker.patch("hopsworks_common.core.job_api.JobApi")
+        j = job.Job(
+            id=1,
+            name="test",
+            creation_time=None,
+            config={},
+            job_type="PYTHON",
+            creator=None,
+        )
+        return j, mock_job_api.return_value
+
+    def test_add_tag_delegates(self, mocker):
+        j, api = self._job(mocker)
+
+        j.add_tag("meta", {"k": "v"})
+
+        api._add_tag.assert_called_once_with(j, "meta", {"k": "v"})
+
+    def test_delete_tag_delegates(self, mocker):
+        j, api = self._job(mocker)
+
+        j.delete_tag("meta")
+
+        api._delete_tag.assert_called_once_with(j, "meta")
+
+    def test_get_tag_delegates(self, mocker):
+        j, api = self._job(mocker)
+        api._get_tag.return_value = "v"
+
+        assert j.get_tag("meta") == "v"
+        api._get_tag.assert_called_once_with(j, "meta")
+
+    def test_get_tags_delegates(self, mocker):
+        j, api = self._job(mocker)
+        api._get_tags.return_value = {"meta": "v"}
+
+        assert j.get_tags() == {"meta": "v"}
+
+    def test_get_tag_metadata_delegates(self, mocker):
+        j, api = self._job(mocker)
+        tag_obj = mocker.Mock()
+        api._get_tags_metadata.return_value = {"meta": tag_obj}
+
+        assert j.get_tag_metadata("meta") is tag_obj
+        api._get_tags_metadata.assert_called_once_with(j, "meta")
+
+    def test_get_tag_metadata_missing_is_none(self, mocker):
+        j, api = self._job(mocker)
+        api._get_tags_metadata.return_value = {}
+
+        assert j.get_tag_metadata("meta") is None
+
+    def test_get_tags_metadata_delegates(self, mocker):
+        j, api = self._job(mocker)
+        tag_obj = mocker.Mock()
+        api._get_tags_metadata.return_value = {"meta": tag_obj}
+
+        assert j.get_tags_metadata() == {"meta": tag_obj}
+        api._get_tags_metadata.assert_called_once_with(j)

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -781,7 +781,9 @@ class TestJobProjectBinding:
             b.get_opensearch_api(),
             b.get_search_api(),
         ):
-            assert handle._pid() == 42, f"{type(handle).__name__} addresses the wrong project"
+            assert handle._pid() == 42, (
+                f"{type(handle).__name__} addresses the wrong project"
+            )
             assert handle._pname() == "project_b", (
                 f"{type(handle).__name__} carries the wrong project name"
             )

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -756,6 +756,36 @@ class TestJobProjectBinding:
         assert job._execution_engine._dataset_api._project_id == 42
         assert job._execution_engine._dataset_api._project_name == "other_project"
 
+    def test_every_project_handle_addresses_that_project(self, mocker):
+        """Every getter on a foreign Project, not only the ones a review happened to name.
+
+        The defect is always the same shape: a handle built with no project reads the connection's
+        when it is called, and answers successfully for the wrong project.
+        """
+        from hopsworks_common.project import Project
+
+        mocker.patch(
+            "hopsworks_common.client._get_instance",
+            return_value=mocker.Mock(_project_id=5, _project_name="login_project"),
+        )
+        b = Project(project_id=42, project_name="project_b")
+
+        for handle in (
+            b.get_job_api(),
+            b.get_dataset_api(),
+            b.get_alerts_api(),
+            b.get_app_api(),
+            b.get_git_api(),
+            b.get_environment_api(),
+            b.get_kafka_api(),
+            b.get_opensearch_api(),
+            b.get_search_api(),
+        ):
+            assert handle._pid() == 42, f"{type(handle).__name__} addresses the wrong project"
+            assert handle._pname() == "project_b", (
+                f"{type(handle).__name__} carries the wrong project name"
+            )
+
     def test_executions_of_a_bound_job_stay_bound(self, mocker):
         job = self._job()
         job._bind_project(42, "other_project")

--- a/python/tests/core/test_job_api.py
+++ b/python/tests/core/test_job_api.py
@@ -1,0 +1,143 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hopsworks_common.core.job_api import JobApi
+
+
+def _patch_client(mocker, send_request_return=None) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 1
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hopsworks_common.core.job_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+def _job() -> SimpleNamespace:
+    return SimpleNamespace(name="my_job")
+
+
+class TestJobApiTags:
+    def test_add_tag_puts_json_value_on_job_tags_path(self, mocker):
+        # Arrange
+        api = JobApi()
+        client_instance = _patch_client(mocker)
+
+        # Act
+        api._add_tag(_job(), "meta", {"k": "v"})
+
+        # Assert
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "PUT"
+        assert call.args[1] == ["project", 1, "jobs", "my_job", "tags", "meta"]
+        assert json.loads(call.kwargs["data"]) == {"k": "v"}
+
+    def test_delete_tag_uses_job_tags_path(self, mocker):
+        # Arrange
+        api = JobApi()
+        client_instance = _patch_client(mocker)
+
+        # Act
+        api._delete_tag(_job(), "meta")
+
+        # Assert
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "DELETE"
+        assert call.args[1] == ["project", 1, "jobs", "my_job", "tags", "meta"]
+
+    def test_get_tags_returns_values(self, mocker):
+        # Arrange
+        api = JobApi()
+        _patch_client(
+            mocker,
+            {
+                "count": 1,
+                "items": [{"name": "meta", "value": json.dumps({"k": "v"})}],
+            },
+        )
+
+        # Act
+        result = api._get_tags(_job())
+
+        # Assert
+        assert result == {"meta": {"k": "v"}}
+
+    def test_get_tag_returns_value(self, mocker):
+        # Arrange
+        api = JobApi()
+        client_instance = _patch_client(
+            mocker, {"count": 1, "items": [{"name": "meta", "value": "v"}]}
+        )
+
+        # Act
+        result = api._get_tag(_job(), "meta")
+
+        # Assert
+        assert result == "v"
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == ["project", 1, "jobs", "my_job", "tags", "meta"]
+
+    def test_get_tags_metadata_keeps_tag_objects(self, mocker):
+        # Arrange
+        api = JobApi()
+        _patch_client(
+            mocker,
+            {
+                "count": 1,
+                "items": [{"name": "meta", "value": "v", "createdOn": 1785474813000}],
+            },
+        )
+
+        # Act
+        result = api._get_tags_metadata(_job())
+
+        # Assert
+        assert result["meta"].created_on == datetime(
+            2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc
+        )
+
+
+class TestJobApiProjectScoping:
+    def test_paths_default_to_connection_project(self, mocker):
+        # Arrange
+        api = JobApi()
+        client_instance = _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        api._get_tags(_job())
+
+        # Assert
+        assert client_instance._send_request.call_args.args[1][1] == 1
+
+    def test_explicit_project_id_overrides_connection(self, mocker):
+        # A search hit can come from another authorized project; its jobs are
+        # not reachable through the login project's paths.
+        # Arrange
+        api = JobApi(project_id=42)
+        client_instance = _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        api._get_tags(_job())
+
+        # Assert
+        assert client_instance._send_request.call_args.args[1][1] == 42

--- a/python/tests/core/test_keywords_api.py
+++ b/python/tests/core/test_keywords_api.py
@@ -1,0 +1,197 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hopsworks_common.core.keywords_api import KeywordsApi
+
+
+def _patch_client(mocker, send_request_return) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 1
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hopsworks_common.core.keywords_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+# A feature-group-like metadata object: an id and no `training_data` attribute,
+# so KeywordsApi._get_path takes the featuregroups/trainingdatasets branch.
+def _fg_metadata() -> SimpleNamespace:
+    return SimpleNamespace(id=14)
+
+
+def _fv_metadata() -> SimpleNamespace:
+    return SimpleNamespace(name="my_fv", version=1, training_data=lambda: None)
+
+
+class TestKeywordsApi:
+    def test_get_returns_keyword_list(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": ["pii", "prod"]})
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == ["pii", "prod"]
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == [
+            "project",
+            1,
+            "featurestores",
+            99,
+            "featuregroups",
+            14,
+            "keywords",
+        ]
+
+    def test_get_tolerates_missing_keywords(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, {})
+
+        # Act & Assert
+        assert api._get(_fg_metadata()) == []
+
+    def test_get_with_metadata_parses_created_on(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(
+            mocker,
+            {
+                "keywords": ["pii", "prod"],
+                "items": [
+                    {"name": "pii", "createdOn": 1785474813000},
+                    {"name": "prod", "createdOn": None},
+                ],
+            },
+        )
+
+        # Act
+        result = api._get_with_metadata(_fg_metadata())
+
+        # Assert
+        assert result == {
+            "pii": datetime(2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc),
+            "prod": None,
+        }
+
+    def test_get_with_metadata_old_server_without_items(self, mocker):
+        # An old server sends only the plain keyword list; every keyword maps to None.
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, {"keywords": ["pii", "prod"]})
+
+        # Act
+        result = api._get_with_metadata(_fg_metadata())
+
+        # Assert
+        assert result == {"pii": None, "prod": None}
+
+    def test_replace_posts_keyword_dto(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": ["a", "b"]})
+
+        # Act
+        result = api._replace(_fg_metadata(), ["a", "b"])
+
+        # Assert
+        assert result == ["a", "b"]
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "POST"
+        assert json.loads(call.kwargs["data"]) == {"keywords": ["a", "b"]}
+
+    def test_delete_sends_keyword_query_param(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": ["b"]})
+
+        # Act
+        result = api._delete(_fg_metadata(), "a")
+
+        # Assert
+        assert result == ["b"]
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "DELETE"
+        assert call.kwargs["query_params"] == {"keyword": "a"}
+
+    def test_get_all_uses_featurestores_keywords_path(self, mocker):
+        # Arrange
+        api = KeywordsApi()
+        client_instance = _patch_client(mocker, {"keywords": ["pii"]})
+
+        # Act
+        result = api._get_all()
+
+        # Assert
+        assert result == ["pii"]
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == ["project", 1, "featurestores", "keywords"]
+
+    def test_feature_view_path(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": []})
+
+        # Act
+        api._get(_fv_metadata())
+
+        # Assert
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == [
+            "project",
+            1,
+            "featurestores",
+            99,
+            "featureview",
+            "my_fv",
+            "version",
+            1,
+            "keywords",
+        ]
+
+    def test_feature_view_training_dataset_path(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": []})
+
+        # Act
+        api._get(_fv_metadata(), training_dataset_version=7)
+
+        # Assert
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == [
+            "project",
+            1,
+            "featurestores",
+            99,
+            "featureview",
+            "my_fv",
+            "version",
+            1,
+            "trainingdatasets",
+            "version",
+            7,
+            "keywords",
+        ]

--- a/python/tests/core/test_project_binding.py
+++ b/python/tests/core/test_project_binding.py
@@ -66,6 +66,9 @@ class Recorder:
     def _get_client_key_path(self):
         return "/tmp/client_key.pem"
 
+    def _replace_public_host(self, url_parsed):
+        return url_parsed
+
 
 @pytest.fixture
 def recorder(mocker):
@@ -322,3 +325,45 @@ class TestModelServingBinding:
         url = deployment.predictor.get_inference_url()
 
         assert f"/project/{OTHER_ID}/inference/" in url
+
+    def test_a_deployment_stays_bound_across_a_refresh(
+        self, recorder, backend_fixtures
+    ):
+        """A refresh must not unbind the deployment.
+
+        update_from_response_json rebuilds the object through __init__, which reset the api and
+        the engine to the login project. The duplicate-create recovery in ServingEngine._create
+        refreshes exactly there, so the deployment it hands back operated on the wrong project.
+        """
+        from hsml.model_serving import ModelServing
+
+        recorder(_deployment_body(backend_fixtures))
+        deployment = ModelServing(OTHER_NAME, OTHER_ID).get_deployment_by_id(1)
+
+        deployment.update_from_response_json(_deployment_body(backend_fixtures))
+
+        assert deployment.model_registry_id == OTHER_ID
+        assert deployment.project_name == OTHER_NAME
+        assert deployment._serving_api._project_id == OTHER_ID
+        assert deployment._serving_engine._serving_api._project_id == OTHER_ID
+
+
+class TestAppBinding:
+    def test_a_bound_apps_urls_name_its_project(self, recorder):
+        from hopsworks_common.app import App
+
+        recorder({})
+        app = App(name="my_app", public_access=True, public_token="tok")
+        app._bind_project(OTHER_ID, OTHER_NAME)
+
+        assert f"/{OTHER_NAME}/" in app.public_url
+        assert f"/p/{OTHER_ID}/apps" in app.get_url()
+
+    def test_an_unbound_app_still_uses_the_connection(self, recorder):
+        from hopsworks_common.app import App
+
+        recorder({})
+        app = App(name="my_app", public_access=True, public_token="tok")
+
+        assert f"/{LOGIN_NAME}/" in app.public_url
+        assert f"/p/{LOGIN_ID}/apps" in app.get_url()

--- a/python/tests/core/test_project_binding.py
+++ b/python/tests/core/test_project_binding.py
@@ -1,0 +1,313 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""What a handle for another project actually puts on the wire.
+
+Three reviews found the same defect in whichever handle was looked at, and each fix was
+verified by asserting that the handle carried the right project id. That is not the same
+question: a bound handle can still reach the connection's project one layer down, through
+the engine that polls a command, or through an object it hands back. So these tests read
+the recorded request paths rather than the objects' attributes, and they drive the nested
+paths a review has to guess at otherwise.
+
+The login project is 5 throughout, and 42 is the project every assertion is about.
+"""
+
+import pytest
+from hopsworks_common.client.exceptions import KafkaException
+
+
+LOGIN_ID = 5
+LOGIN_NAME = "login_project"
+OTHER_ID = 42
+OTHER_NAME = "project_b"
+
+
+class Recorder:
+    """A client that answers requests from a canned body and remembers what was asked."""
+
+    def __init__(self, response=None):
+        self._project_id = LOGIN_ID
+        self._project_name = LOGIN_NAME
+        self._base_url = "https://hopsworks"
+        self._host = "hopsworks.example.com"
+        self.response = response if response is not None else {}
+        self.paths = []
+        self.payloads = []
+
+    def _send_request(self, method, path_params, **kwargs):
+        path = [str(p) for p in path_params]
+        self.paths.append(path)
+        self.payloads.append(kwargs.get("data"))
+        return self.response(path) if callable(self.response) else self.response
+
+    def _is_external(self):
+        return False
+
+    def _get_ca_chain_path(self):
+        return "/tmp/ca_chain.pem"
+
+    def _get_client_cert_path(self):
+        return "/tmp/client_cert.pem"
+
+    def _get_client_key_path(self):
+        return "/tmp/client_key.pem"
+
+
+@pytest.fixture
+def recorder(mocker):
+    """Install a recording client under every name the code under test looks it up by."""
+    from hopsworks_common import client
+
+    # Deployment payloads are parsed through the serving limits, which a live connection reads
+    # from the cluster.
+    client._set_serving_num_instances_limits([1, -1])
+
+    def _install(response=None):
+        rec = Recorder(response)
+        for module in ("hopsworks_common.client", "hsml.client"):
+            mocker.patch(f"{module}._get_instance", return_value=rec)
+        return rec
+
+    yield _install
+    client._set_serving_num_instances_limits(None)
+
+
+def project_ids(paths):
+    """The project each recorded path addressed, in order."""
+    return [p[1] for p in paths if len(p) > 1 and p[0] == "project"]
+
+
+def _deployment_body(backend_fixtures):
+    """One deployment, as the single-deployment endpoints return it."""
+    return backend_fixtures["predictor"]["get_deployments_singleton"]["response"]["items"][0]
+
+
+class TestEnvironmentBinding:
+    def test_creation_polls_the_project_it_created_in(self, recorder, mocker):
+        """The engine used to poll the connection's project for a command created in another.
+
+        The environment appears in project 42 and the command that builds it is 42's, so an
+        engine on the login project either waits for something that never arrives or reads a
+        command belonging to a different environment of the same name.
+        """
+        from hopsworks_common.core import environment_api
+
+        rec = recorder({"name": "env", "commands": {"items": [{"status": "SUCCESS"}]}})
+        mocker.patch("time.sleep")
+
+        environment_api.EnvironmentApi(OTHER_ID, OTHER_NAME).create_environment("env")
+
+        assert project_ids(rec.paths) == [str(OTHER_ID), str(OTHER_ID)]
+
+    def test_a_returned_environment_installs_where_it_lives(self, recorder):
+        """An Environment builds its own handles, and used to build them unbound."""
+        from hopsworks_common.core import environment_api
+
+        environment_body = {"name": "env", "commands": {"items": [{"status": "SUCCESS"}]}}
+        library_body = {
+            "channel": "requirements_txt",
+            "package_source": "REQUIREMENTS_TXT",
+            "library": "requirements.txt",
+            "version": "1.0",
+        }
+        rec = recorder(
+            lambda path: library_body if "libraries" in path else environment_body
+        )
+        env = environment_api.EnvironmentApi(OTHER_ID, OTHER_NAME).get_environment("env")
+
+        env.install_requirements("Resources/requirements.txt", await_installation=False)
+
+        assert project_ids(rec.paths) == [str(OTHER_ID), str(OTHER_ID), str(OTHER_ID)]
+        # And the file is resolved against that project's Resources, not the login project's.
+        assert f"/Projects/{OTHER_NAME}/Resources/requirements.txt" in rec.payloads[-1]
+
+    def test_a_returned_environment_deletes_itself_where_it_lives(self, recorder):
+        from hopsworks_common.core import environment_api
+
+        rec = recorder({"name": "env"})
+        env = environment_api.EnvironmentApi(OTHER_ID, OTHER_NAME).get_environment("env")
+
+        env.delete()
+
+        assert project_ids(rec.paths)[-1] == str(OTHER_ID)
+
+    def test_an_unbound_environment_still_uses_the_connection(self, recorder):
+        from hopsworks_common.core import environment_api
+
+        rec = recorder({"name": "env"})
+        env = environment_api.EnvironmentApi().get_environment("env")
+
+        env.delete()
+
+        assert project_ids(rec.paths) == [str(LOGIN_ID), str(LOGIN_ID)]
+
+
+class TestGitBinding:
+    def test_execution_polling_addresses_the_bound_project(self, recorder):
+        """GitApi started the operation in 42 and its engine polled 5 for the result."""
+        from hopsworks_common.core import git_api
+
+        rec = recorder(
+            {
+                "id": 3,
+                "submission_time": "",
+                "execution_start": 0,
+                "execution_stop": 0,
+                "user": None,
+                "git_command_configuration": {},
+                "state": "SUCCESS",
+                "config_secret": "",
+                "repository": {"id": 9, "name": "repo", "creator": None},
+            }
+        )
+        api = git_api.GitApi(OTHER_ID, OTHER_NAME)
+
+        api._git_engine._git_op_execution_api._get_execution(9, 3)
+
+        assert project_ids(rec.paths) == [str(OTHER_ID)]
+
+    def test_a_returned_repository_stays_in_its_project(self, recorder):
+        from hopsworks_common.core import git_api
+
+        recorder({"count": 1, "items": [{"id": 9, "name": "repo", "creator": None}]})
+        repos = git_api.GitApi(OTHER_ID, OTHER_NAME).get_repos()
+
+        # The git handle, the remote handle, and the dataset handle its file operations use.
+        assert repos[0]._git_api._project_id == OTHER_ID
+        assert repos[0]._git_remote_api._project_id == OTHER_ID
+        assert repos[0]._dataset_api._project_id == OTHER_ID
+        assert repos[0]._dataset_api._project_name == OTHER_NAME
+        # Including the engine the remote handle waits on.
+        assert (
+            repos[0]._git_remote_api._git_engine._git_op_execution_api._project_id
+            == OTHER_ID
+        )
+
+
+class TestKafkaBinding:
+    def test_a_returned_topic_is_deleted_where_it_lives(self, recorder):
+        from hopsworks_common.core import kafka_api
+
+        rec = recorder({"count": 1, "items": [{"name": "topic"}]})
+        topic = kafka_api.KafkaApi(OTHER_ID, OTHER_NAME).get_topics()[0]
+
+        topic._kafka_api._delete_topic("topic")
+
+        assert project_ids(rec.paths) == [str(OTHER_ID), str(OTHER_ID)]
+
+    def test_a_returned_topic_keeps_its_project_across_a_reread(self, recorder):
+        from hopsworks_common.core import kafka_api
+
+        recorder({"count": 1, "items": [{"name": "topic"}]})
+        topic = kafka_api.KafkaApi(OTHER_ID, OTHER_NAME).get_topics()[0]
+
+        topic.update_from_response_json({"name": "topic"})
+
+        assert topic._kafka_api._project_id == OTHER_ID
+
+    def test_default_config_refuses_a_project_the_certificate_is_not_for(self, recorder):
+        """The certificate is the Kafka identity, and it belongs to the login project.
+
+        Returning this configuration for another project would produce and consume as the
+        wrong identity and look like it had worked.
+        """
+        from hopsworks_common.core import kafka_api
+
+        recorder()
+
+        with pytest.raises(KafkaException) as e:
+            kafka_api.KafkaApi(OTHER_ID, OTHER_NAME).get_default_config()
+
+        assert OTHER_NAME in str(e.value)
+        assert LOGIN_NAME in str(e.value)
+
+    def test_default_config_still_serves_the_login_project(self, recorder):
+        from hopsworks_common.core import kafka_api
+
+        recorder({"brokers": ["INTERNAL://broker:9091"]})
+
+        config = kafka_api.KafkaApi(LOGIN_ID, LOGIN_NAME).get_default_config()
+
+        assert config["ssl.certificate.location"] == "/tmp/client_cert.pem"
+
+
+class TestModelServingBinding:
+    def test_the_named_projects_models_dataset_is_the_one_validated(self, recorder):
+        """The check answered for the login project, so serving-disabled in 42 passed."""
+        from hsml.core import model_serving_api
+
+        rec = recorder({"attributes": {}})
+
+        model_serving_api.ModelServingApi()._get(OTHER_NAME, OTHER_ID)
+
+        assert project_ids(rec.paths) == [str(OTHER_ID)]
+
+    def test_deployments_are_read_and_operated_in_their_project(
+        self, recorder, backend_fixtures
+    ):
+        from hsml.model_serving import ModelServing
+
+        rec = recorder(_deployment_body(backend_fixtures))
+        deployment = ModelServing(OTHER_NAME, OTHER_ID).get_deployment_by_id(1)
+
+        assert project_ids(rec.paths) == [str(OTHER_ID)]
+        # The deployment carries the project it came from into everything it then does.
+        assert deployment.model_registry_id == OTHER_ID
+        assert deployment.project_name == OTHER_NAME
+        assert deployment._serving_api._project_id == OTHER_ID
+        assert deployment._serving_engine._serving_api._project_id == OTHER_ID
+        assert deployment._serving_engine._dataset_api._project_id == OTHER_ID
+        assert deployment._serving_engine._dataset_api._project_name == OTHER_NAME
+
+    def test_a_deployments_tags_are_written_in_its_project(
+        self, recorder, backend_fixtures
+    ):
+        from hsml.model_serving import ModelServing
+
+        rec = recorder(_deployment_body(backend_fixtures))
+        deployment = ModelServing(OTHER_NAME, OTHER_ID).get_deployment_by_id(1)
+
+        deployment.add_tag("owner", "team")
+
+        assert project_ids(rec.paths)[-1] == str(OTHER_ID)
+        assert rec.paths[-1][-2:] == ["tags", "owner"]
+
+    def test_a_deployments_logs_are_read_in_its_project(
+        self, recorder, backend_fixtures
+    ):
+        from hsml.model_serving import ModelServing
+
+        rec = recorder(_deployment_body(backend_fixtures))
+        deployment = ModelServing(OTHER_NAME, OTHER_ID).get_deployment_by_id(1)
+
+        deployment._serving_api._get_logs(deployment, "predictor", 10)
+
+        assert project_ids(rec.paths)[-1] == str(OTHER_ID)
+        assert rec.paths[-1][-1] == "logs"
+
+    def test_the_inference_url_names_the_deployments_project(
+        self, recorder, backend_fixtures
+    ):
+        """The Hopsworks inference path carried the login project id for a foreign deployment."""
+        from hsml.model_serving import ModelServing
+
+        recorder(_deployment_body(backend_fixtures))
+        deployment = ModelServing(OTHER_NAME, OTHER_ID).get_deployment_by_id(1)
+
+        url = deployment.predictor.get_inference_url()
+
+        assert f"/project/{OTHER_ID}/inference/" in url

--- a/python/tests/core/test_project_binding.py
+++ b/python/tests/core/test_project_binding.py
@@ -93,7 +93,9 @@ def project_ids(paths):
 
 def _deployment_body(backend_fixtures):
     """One deployment, as the single-deployment endpoints return it."""
-    return backend_fixtures["predictor"]["get_deployments_singleton"]["response"]["items"][0]
+    return backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+        "items"
+    ][0]
 
 
 class TestEnvironmentBinding:
@@ -117,7 +119,10 @@ class TestEnvironmentBinding:
         """An Environment builds its own handles, and used to build them unbound."""
         from hopsworks_common.core import environment_api
 
-        environment_body = {"name": "env", "commands": {"items": [{"status": "SUCCESS"}]}}
+        environment_body = {
+            "name": "env",
+            "commands": {"items": [{"status": "SUCCESS"}]},
+        }
         library_body = {
             "channel": "requirements_txt",
             "package_source": "REQUIREMENTS_TXT",
@@ -127,7 +132,9 @@ class TestEnvironmentBinding:
         rec = recorder(
             lambda path: library_body if "libraries" in path else environment_body
         )
-        env = environment_api.EnvironmentApi(OTHER_ID, OTHER_NAME).get_environment("env")
+        env = environment_api.EnvironmentApi(OTHER_ID, OTHER_NAME).get_environment(
+            "env"
+        )
 
         env.install_requirements("Resources/requirements.txt", await_installation=False)
 
@@ -139,7 +146,9 @@ class TestEnvironmentBinding:
         from hopsworks_common.core import environment_api
 
         rec = recorder({"name": "env"})
-        env = environment_api.EnvironmentApi(OTHER_ID, OTHER_NAME).get_environment("env")
+        env = environment_api.EnvironmentApi(OTHER_ID, OTHER_NAME).get_environment(
+            "env"
+        )
 
         env.delete()
 
@@ -219,7 +228,9 @@ class TestKafkaBinding:
 
         assert topic._kafka_api._project_id == OTHER_ID
 
-    def test_default_config_refuses_a_project_the_certificate_is_not_for(self, recorder):
+    def test_default_config_refuses_a_project_the_certificate_is_not_for(
+        self, recorder
+    ):
         """The certificate is the Kafka identity, and it belongs to the login project.
 
         Returning this configuration for another project would produce and consume as the

--- a/python/tests/core/test_search_results.py
+++ b/python/tests/core/test_search_results.py
@@ -15,6 +15,8 @@
 #
 
 from hopsworks_common import search_results
+from hopsworks_common.client.exceptions import RestAPIError
+from hopsworks_common.core import dataset_api
 
 
 class TestSearchResults:
@@ -162,6 +164,57 @@ class TestSearchResults:
         assert fg.highlights.keywords == ["<em>keyword1</em>"]
         assert fg.highlights.has_highlights()
 
+    def test_search_result_parses_jobs_and_datasets(self):
+        json_dict = {
+            "featuregroups": [],
+            "featureViews": [],
+            "trainingdatasets": [],
+            "features": [],
+            "jobs": [
+                {
+                    "name": "test_job",
+                    "description": "ingestion job",
+                    "jobType": "PYSPARK",
+                    "parentProjectId": 1,
+                    "parentProjectName": "test_project",
+                    "highlights": {"description": "<em>ingestion</em> job"},
+                },
+            ],
+            "datasets": [
+                {
+                    "name": "test_dataset",
+                    "description": "reports",
+                    "parentProjectId": 1,
+                    "parentProjectName": "test_project",
+                    "highlights": {},
+                },
+            ],
+            "jobsFrom": 0,
+            "jobsTotal": 3,
+            "datasetsFrom": 0,
+            "datasetsTotal": 2,
+        }
+
+        result = search_results.FeaturestoreSearchResult(json_dict)
+
+        assert len(result.jobs) == 1
+        assert result.jobs[0].name == "test_job"
+        assert result.jobs[0].job_type == "PYSPARK"
+        assert result.jobs[0].project.name == "test_project"
+        assert len(result.datasets) == 1
+        assert result.datasets[0].name == "test_dataset"
+        assert result.jobs_total == 3
+        assert result.datasets_total == 2
+
+    def test_search_result_without_jobs_and_datasets(self):
+        # An old server sends no jobs/datasets fields at all.
+        result = search_results.FeaturestoreSearchResult({})
+
+        assert result.jobs == []
+        assert result.datasets == []
+        assert result.jobs_total == 0
+        assert result.datasets_total == 0
+
     def test_search_result_project_info(self):
         json_dict = {
             "featuregroups": [
@@ -191,3 +244,63 @@ class TestSearchResults:
         fg = result.feature_groups[0]
         assert fg.project.id == 123
         assert fg.project.name == "my_project"
+
+
+class TestDatasetSearchResultProjectAwareness:
+    """A dataset hit resolves in its own project, not the login project."""
+
+    def _hit(self):
+        return search_results.DatasetSearchResult(
+            {
+                "name": "sales_raw",
+                "description": "raw sales drops",
+                "parentProjectId": 77,
+                "parentProjectName": "other_project",
+                "highlights": {},
+            }
+        )
+
+    def test_path_is_the_dataset_name(self):
+        assert self._hit().path == "sales_raw"
+
+    def test_dataset_api_is_built_for_the_hit_project(self, mocker):
+        api = self._hit()._dataset_api()
+        # Explicitly the hit's project, so no path is built from the connection's.
+        assert api._project_id == 77
+        assert api._project_name == "other_project"
+
+    def test_get_reads_the_hit_project(self, mocker):
+        hit = self._hit()
+        get = mocker.patch(
+            "hopsworks_common.core.dataset_api.DatasetApi._get",
+            return_value={"attributes": {"path": "/Projects/other_project/sales_raw"}},
+        )
+        assert hit.get()["attributes"]["path"].startswith("/Projects/other_project/")
+        get.assert_called_once_with("sales_raw")
+
+    def test_get_returns_none_when_gone(self, mocker):
+        hit = self._hit()
+        # RestAPIError parses the body, so the mock has to answer json().
+        response = mocker.Mock(status_code=404)
+        response.json.return_value = {}
+        mocker.patch(
+            "hopsworks_common.core.dataset_api.DatasetApi._get",
+            side_effect=RestAPIError("url", response),
+        )
+        assert hit.get() is None
+
+    def test_get_tags_metadata_reads_the_hit_project(self, mocker):
+        hit = self._hit()
+        tags = mocker.patch(
+            "hopsworks_common.core.dataset_api.DatasetApi.get_tags_metadata",
+            return_value={},
+        )
+        assert hit.get_tags_metadata() == {}
+        tags.assert_called_once_with("sales_raw")
+
+    def test_a_dataset_api_without_a_project_falls_back_to_the_connection(self, mocker):
+        instance = mocker.Mock(_project_id=5, _project_name="login_project")
+        mocker.patch("hopsworks_common.client._get_instance", return_value=instance)
+        api = dataset_api.DatasetApi()
+        assert api._pid() == 5
+        assert api._pname() == "login_project"

--- a/python/tests/core/test_search_results.py
+++ b/python/tests/core/test_search_results.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 
+import pytest
 from hopsworks_common import search_results
 from hopsworks_common.client.exceptions import RestAPIError
 from hopsworks_common.core import dataset_api
@@ -244,6 +245,120 @@ class TestSearchResults:
         fg = result.feature_groups[0]
         assert fg.project.id == 123
         assert fg.project.name == "my_project"
+
+
+class TestModelAndDeploymentSearchResults:
+    """Model and deployment hits, and how each resolves back to a real object."""
+
+    def _response(self):
+        return {
+            "models": [
+                {
+                    "name": "credit_scoring",
+                    "version": 2,
+                    "description": "logistic regression",
+                    "framework": "PYTHON",
+                    "parentProjectId": 77,
+                    "parentProjectName": "other_project",
+                    "highlights": {},
+                },
+            ],
+            "deployments": [
+                {
+                    "name": "creditscoring",
+                    "description": "serving the scorer",
+                    "servingTool": "KSERVE",
+                    "modelName": "credit_scoring",
+                    "modelVersion": 2,
+                    "modelFramework": "PYTHON",
+                    "parentProjectId": 5,
+                    "parentProjectName": "login_project",
+                    "highlights": {},
+                },
+            ],
+            "modelsFrom": 0,
+            "modelsTotal": 4,
+            "deploymentsFrom": 0,
+            "deploymentsTotal": 1,
+        }
+
+    def test_models_and_deployments_are_parsed(self):
+        result = search_results.FeaturestoreSearchResult(self._response())
+
+        model = result.models[0]
+        assert model.name == "credit_scoring"
+        assert model.version == 2
+        assert model.framework == "PYTHON"
+        assert model.project.name == "other_project"
+        assert result.models_total == 4
+
+        deployment = result.deployments[0]
+        assert deployment.name == "creditscoring"
+        assert deployment.serving_tool == "KSERVE"
+        assert deployment.model_name == "credit_scoring"
+        assert deployment.model_version == 2
+        assert result.deployments_total == 1
+
+    def test_an_old_server_sends_neither(self):
+        result = search_results.FeaturestoreSearchResult({})
+
+        assert result.models == []
+        assert result.deployments == []
+        assert result.models_total == 0
+        assert result.deployments_total == 0
+
+    def test_a_model_resolves_in_its_registry_project(self, mocker):
+        model = search_results.FeaturestoreSearchResult(self._response()).models[0]
+        registry = mocker.Mock()
+        connection = mocker.Mock()
+        connection._get_model_registry.return_value = registry
+        mocker.patch("hopsworks_common.client._get_connection", return_value=connection)
+
+        model.get()
+
+        # The registry project of the hit, which for a shared registry is not the login project.
+        connection._get_model_registry.assert_called_once_with("other_project")
+        registry.get_model.assert_called_once_with("credit_scoring", version=2)
+
+    def test_a_model_without_a_project_fails_closed(self):
+        model = search_results.ModelSearchResult({"name": "m", "version": 1})
+
+        with pytest.raises(ValueError, match="carries no project"):
+            model.get()
+
+    def test_a_deployment_resolves_in_the_login_project(self, mocker):
+        deployment = search_results.FeaturestoreSearchResult(
+            self._response()
+        ).deployments[0]
+        mocker.patch(
+            "hopsworks_common.client._get_instance",
+            return_value=mocker.Mock(_project_name="login_project"),
+        )
+        serving = mocker.Mock()
+        connection = mocker.Mock()
+        connection._get_model_serving.return_value = serving
+        mocker.patch("hopsworks_common.client._get_connection", return_value=connection)
+
+        deployment.get()
+
+        serving.get_deployment.assert_called_once_with("creditscoring")
+
+    def test_a_deployment_of_another_project_cannot_be_fetched(self, mocker):
+        # Deployments are project-local, so there is no client call that could answer this.
+        deployment = search_results.DeploymentSearchResult(
+            {
+                "name": "creditscoring",
+                "parentProjectId": 77,
+                "parentProjectName": "other_project",
+            }
+        )
+        mocker.patch(
+            "hopsworks_common.client._get_instance",
+            return_value=mocker.Mock(_project_name="login_project"),
+        )
+
+        with pytest.raises(ValueError, match="outside their own project"):
+            deployment.get()
 
 
 class TestDatasetSearchResultProjectAwareness:

--- a/python/tests/core/test_tag_schemas_api.py
+++ b/python/tests/core/test_tag_schemas_api.py
@@ -1,0 +1,128 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.client.exceptions import RestAPIError
+from hopsworks_common.core.tag_schemas_api import TagSchemasApi
+
+
+def _patch_client(mocker, send_request_return=None) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hopsworks_common.core.tag_schemas_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+def _forbidden() -> RestAPIError:
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.json.return_value = {"errorCode": 200003}
+    return RestAPIError("http://localhost/tags", mock_response)
+
+
+class TestTagSchemasApiLifecycle:
+    def test_usage_uses_usage_path(self, mocker):
+        # Arrange
+        client_instance = _patch_client(mocker, {"total": 3})
+
+        # Act
+        result = TagSchemasApi().usage("schema1")
+
+        # Assert
+        assert result == {"total": 3}
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "GET"
+        assert call.args[1] == ["tags", "schema1", "usage"]
+
+    def test_deprecate_posts_deprecation(self, mocker):
+        # Arrange
+        client_instance = _patch_client(mocker, {"deprecated": True})
+
+        # Act
+        result = TagSchemasApi().deprecate("schema1")
+
+        # Assert
+        assert result == {"deprecated": True}
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "POST"
+        assert call.args[1] == ["tags", "schema1", "deprecation"]
+
+    def test_restore_deletes_deprecation(self, mocker):
+        # Arrange
+        client_instance = _patch_client(mocker, {"deprecated": False})
+
+        # Act
+        result = TagSchemasApi().restore("schema1")
+
+        # Assert
+        assert result == {"deprecated": False}
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "DELETE"
+        assert call.args[1] == ["tags", "schema1", "deprecation"]
+
+    def test_delete_without_force_sends_no_query(self, mocker):
+        # Arrange
+        client_instance = _patch_client(mocker)
+
+        # Act
+        TagSchemasApi().delete("schema1")
+
+        # Assert
+        call = client_instance._send_request.call_args
+        assert call.args[1] == ["tags", "schema1"]
+        assert call.kwargs["query_params"] is None
+
+    def test_delete_with_force_sends_force_query(self, mocker):
+        # Arrange
+        client_instance = _patch_client(mocker)
+
+        # Act
+        TagSchemasApi().delete("schema1", force=True)
+
+        # Assert
+        call = client_instance._send_request.call_args
+        assert call.kwargs["query_params"] == {"force": "true"}
+
+    @pytest.mark.parametrize("method", ["usage", "deprecate", "restore"])
+    def test_403_surfaces_as_permission_error(self, mocker, method):
+        # Arrange
+        client_instance = _patch_client(mocker)
+        client_instance._send_request.side_effect = _forbidden()
+
+        # Act & Assert
+        with pytest.raises(PermissionError, match="HOPS_ADMIN"):
+            getattr(TagSchemasApi(), method)("schema1")
+
+    def test_delete_403_surfaces_as_permission_error(self, mocker):
+        # Arrange
+        client_instance = _patch_client(mocker)
+        client_instance._send_request.side_effect = _forbidden()
+
+        # Act & Assert
+        with pytest.raises(PermissionError, match="HOPS_ADMIN"):
+            TagSchemasApi().delete("schema1", force=True)
+
+    @pytest.mark.parametrize("method", ["usage", "deprecate", "restore", "delete"])
+    def test_empty_name_raises_value_error(self, mocker, method):
+        _patch_client(mocker)
+
+        with pytest.raises(ValueError):
+            getattr(TagSchemasApi(), method)("")

--- a/python/tests/core/test_tags_api.py
+++ b/python/tests/core/test_tags_api.py
@@ -15,6 +15,7 @@
 #
 
 import json
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -137,3 +138,48 @@ class TestTagsApi:
 
         # Assert
         assert result == {"t": bad_value}
+
+    def test_get_metadata_keeps_tag_objects(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        response = {
+            "count": 1,
+            "items": [
+                {"name": "meta", "value": "v", "createdOn": 1785474813000},
+            ],
+        }
+        _patch_client(mocker, response)
+
+        # Act
+        result = api._get_metadata(_fg_metadata())
+
+        # Assert
+        assert set(result) == {"meta"}
+        assert result["meta"].value == "v"
+        assert result["meta"].created_on == datetime(
+            2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc
+        )
+
+    def test_get_metadata_by_name_appends_name_to_path(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, _tags_response("meta", "v"))
+
+        # Act
+        result = api._get_metadata(_fg_metadata(), name="meta")
+
+        # Assert
+        assert result["meta"].name == "meta"
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params[-1] == "meta"
+
+    def test_get_metadata_empty_returns_empty_dict(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        result = api._get_metadata(_fg_metadata())
+
+        # Assert
+        assert result == {}

--- a/python/tests/test_search_results.py
+++ b/python/tests/test_search_results.py
@@ -18,6 +18,7 @@ from hopsworks_common.connection import Connection
 from hopsworks_common.search_results import (
     FeatureGroupSearchResult,
     FeatureViewSearchResult,
+    JobSearchResult,
     TrainingDatasetSearchResult,
 )
 
@@ -74,3 +75,15 @@ class TestSearchResults:
         assert result == "TD"
         conn._get_feature_store.assert_called_once_with("proj")
         fs.get_training_dataset.assert_called_once_with("entity", version=1)
+
+    def test_job_search_result_get_scopes_job_api_to_hit_project(self, mocker):
+        # Every JobApi path builds on a project id; a hit from another
+        # authorized project must not resolve against the login project.
+        mock_job_api = mocker.patch("hopsworks_common.core.job_api.JobApi")
+        mock_job_api.return_value.get_job.return_value = "JOB"
+
+        result = JobSearchResult({**_DATA, "jobType": "SPARK"}).get()
+
+        assert result == "JOB"
+        mock_job_api.assert_called_once_with(project_id=1)
+        mock_job_api.return_value.get_job.assert_called_once_with("entity")

--- a/python/tests/test_search_results.py
+++ b/python/tests/test_search_results.py
@@ -77,13 +77,14 @@ class TestSearchResults:
         fs.get_training_dataset.assert_called_once_with("entity", version=1)
 
     def test_job_search_result_get_scopes_job_api_to_hit_project(self, mocker):
-        # Every JobApi path builds on a project id; a hit from another
-        # authorized project must not resolve against the login project.
+        # Every JobApi path builds on a project id, and a job configuration path
+        # is expanded with a project name; a hit from another authorized project
+        # must not resolve either against the login project.
         mock_job_api = mocker.patch("hopsworks_common.core.job_api.JobApi")
         mock_job_api.return_value.get_job.return_value = "JOB"
 
         result = JobSearchResult({**_DATA, "jobType": "SPARK"}).get()
 
         assert result == "JOB"
-        mock_job_api.assert_called_once_with(project_id=1)
+        mock_job_api.assert_called_once_with(project_id=1, project_name="proj")
         mock_job_api.return_value.get_job.assert_called_once_with("entity")

--- a/python/tests/test_tag.py
+++ b/python/tests/test_tag.py
@@ -15,6 +15,7 @@
 #
 
 import json as json_module
+from datetime import datetime, timezone
 
 import humps
 import pytest
@@ -134,3 +135,120 @@ class TestTag:
         # Act & Assert
         with pytest.raises(ValueError, match="Tag value cannot be None"):
             tag.Tag._normalize([{"name": "test_name", "value": None}])
+
+    def test_created_on_defaults_to_none(self):
+        # Arrange
+        t = tag.Tag(name="test_name", value="test_value")
+
+        # Assert
+        assert t.created_on is None
+
+    def test_from_response_json_parses_epoch_millis(self):
+        # Arrange
+        json_dict = {
+            "count": 1,
+            "items": [
+                {
+                    "name": "test_name",
+                    "value": "test_value",
+                    "createdOn": 1785474813000,
+                }
+            ],
+        }
+
+        # Act
+        tags = tag.Tag.from_response_json(json_dict)
+
+        # Assert
+        assert tags[0].created_on == datetime(
+            2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc
+        )
+
+    def test_from_response_json_parses_iso_8601(self):
+        # Arrange
+        json_dict = {
+            "count": 1,
+            "items": [
+                {
+                    "name": "test_name",
+                    "value": "test_value",
+                    "createdOn": "2026-07-31T05:13:33Z",
+                }
+            ],
+        }
+
+        # Act
+        tags = tag.Tag.from_response_json(json_dict)
+
+        # Assert
+        assert tags[0].created_on == datetime(
+            2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc
+        )
+
+    def test_from_response_json_missing_created_on_is_none(self):
+        # Arrange
+        json_dict = {
+            "count": 1,
+            "items": [{"name": "test_name", "value": "test_value"}],
+        }
+
+        # Act
+        tags = tag.Tag.from_response_json(json_dict)
+
+        # Assert
+        assert tags[0].created_on is None
+
+    def test_from_response_json_unparseable_created_on_is_none(self):
+        # A timestamp we cannot read must not stop the tag from being read.
+        # Arrange
+        json_dict = {
+            "count": 1,
+            "items": [
+                {
+                    "name": "test_name",
+                    "value": "test_value",
+                    "createdOn": "not a date",
+                }
+            ],
+        }
+
+        # Act
+        tags = tag.Tag.from_response_json(json_dict)
+
+        # Assert
+        assert tags[0].name == "test_name"
+        assert tags[0].created_on is None
+
+    def test_to_dict_omits_created_on(self):
+        # It is server-assigned, so sending it back would be meaningless.
+        # Arrange
+        t = tag.Tag(
+            name="test_name",
+            value="test_value",
+            created_on=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        )
+
+        # Act
+        result = t.to_dict()
+
+        # Assert
+        assert result == {"name": "test_name", "value": "test_value"}
+
+
+class TestTagSingleObjectResponse:
+    def test_from_response_json_single_tag(self):
+        # A request naming one tag answers with that tag rather than a collection.
+        tags = tag.Tag.from_response_json(
+            {
+                "name": "owner",
+                "value": '{"team": "risk"}',
+                "createdOn": 1785736991000,
+            }
+        )
+        assert len(tags) == 1
+        assert tags[0].name == "owner"
+        assert tags[0].value == {"team": "risk"}
+        assert tags[0].created_on is not None
+
+    def test_from_response_json_single_without_value_is_empty(self):
+        assert tag.Tag.from_response_json({"name": "owner"}) == []


### PR DESCRIPTION
Ticket: [FSTORE-2075](https://hopsworks.atlassian.net/browse/FSTORE-2075)

Client half of the tag lifecycle work. Companion PRs: hopsworks-ee, hopsworks-front, hopsworks-helm, loadtest (linked below).

## What this adds

**Attachment timestamps.** `Tag` gains `created_on`. Both epoch milliseconds and ISO-8601 are accepted, because the backend's JSON date format is not pinned across versions and a client that understood only one would report no attachment time at all against a cluster that sends the other. An unreadable value becomes `None` rather than raising: a timestamp we cannot parse must not stop a tag from being read. `None` also means "unknown", not "new".

**A keyword API.** Keywords stop travelling as valueless tags. `keywords_api` mirrors `tags_api`'s path resolution with a `keywords` segment, and `FeatureGroup`, `FeatureView` and `TrainingDataset` expose `get_keywords`, `get_keywords_metadata`, `set_keywords`, `add_keywords` and `delete_keyword`. `add_keywords` is a read-modify-write over a replacing POST, so concurrent calls can lose additions; the docstring says so and points at `set_keywords`.

**Job and dataset tags, and their search.** Jobs carry tags and a first-class description; dataset roots carry tags with their attachment time; `SearchApi` gains `jobs()` and `datasets()`. `JobApi` takes an optional `project_id` so `JobSearchResult.get()` resolves the hit's own project: every path builds `project/<id>/...`, so a hit from another authorized project would otherwise resolve against the login project and return a same-named job from the wrong one.

**Dataset creation with tags**, which is what a mandatory-tag policy needs. An absent or empty body keeps the endpoint's pre-tags behaviour, so old callers are unaffected.

**Search results resolve in the project they belong to.** `DatasetApi` takes an optional `project_id` / `project_name`, defaulting to the connection's, and `DatasetSearchResult` exposes `path`, `get()`, `get_tags()` and `get_tags_metadata()` bound to the hit's project. `Project` now builds both its dataset and job handles for its own project rather than for the connection's: a `Project` for another authorized project was handing out handles that read and wrote the login project, which a cluster run demonstrated by creating a dataset in the wrong project.

**Tag-schema administration.** `usage`, `deprecate`, `restore`, and `delete(force=...)`. The unforced delete refuses to run against a server that predates reference-checked deletion: such a server ignores the unknown parameter and cascade-deletes every attached value, turning the safest-looking call into the most destructive one. It probes the usage endpoint, which shipped with the refusal, and names `force=True` for a deliberate cascade.

**CLI.** Tag commands for feature groups, feature views, training datasets and jobs, plus schema administration. The `*-keyword` commands now operate on keywords and print a notice on stderr; `--value` fails loudly naming `add-tag` rather than silently writing a keyword.

## Compatibility

Against an old server: keywords fall back to `{name: None}` where `items` is absent, and the job description falls back to `config["description"]`. `delete(force=False)` refuses rather than cascading, as above. The `--value` option stays accepted for one release and fails with the replacement named.

## Testing

`pytest python/tests` is green (the five `test_spark` avro failures are a missing spark-avro jar in the local environment and reproduce on an unmodified checkout). `ruff`, `docsig` and the public-API check pass. Cluster coverage is in the loadtest PR.


The loadtest suite (logicalclocks/loadtest#967) ran green against a cluster running the companion backend: 10 tests, 0 failures. It found four client defects, fixed here: `mkdir` on a top-level dataset raised `KeyError: 'path'` because the create response answers with the dataset rather than the inode; `Tag.from_response_json` returned nothing for a response carrying a single tag, which is what the dataset tag endpoints answer when a name is given; a dataset search hit resolved against the login project; and a `Project` object for another project handed out handles bound to the connection.

**One pre-existing gap left alone:** the cluster-wide `/elastic/*` endpoints carry only `@JWTRequired`, so `global_search=True` returns 401 for any api-key client, for every doc type, although this client documents the parameter. Widening auth on cross-project search belongs with that policy decision rather than here.

## Round six: a foreign project's jobs are bound by name as well as id

`Project` handed its job API only the project id, so `JobApi` fell back to the connection's project name. Job configuration validation expands a relative application path with that name, which meant a job created through project B went to B's REST endpoint carrying `/Projects/A/...` paths from the login project.

The engine was unbound too. `Job._bind_project` rebuilt the job, execution and alert handles but not the `ExecutionEngine`, which owns the dataset and execution handles that awaiting, log aggregation and log download go through, so a bound job still waited on and downloaded logs from the login project. `Execution` built its own unbound handles regardless of the job it belonged to, and `get_url` pointed at the connection's project. Both now take the job's binding, and `update_from_response_json` carries the job through instead of dropping it, which had also been breaking `job_name` and `job_type` outright.

Alert receivers are qualified with the project name, so `AlertsApi` takes one as well and uses it everywhere a receiver name is built; every path it constructs now uses its own project rather than the connection's. `project.get_alerts_api()` was returning an entirely unbound handle.

Covered by `tests/core/test_job.py::TestJobProjectBinding`: binding rebuilds every handle including the engine and the alerts handle's project name, and an execution obtained from a bound job keeps that project through a refresh and in its URL.

## And the model registry had the same shape

`Project.get_model_registry()` asked the connection for a registry without naming a project, so a `Project` object for another project answered with the **login** project's registry; `get_feature_store()` did the same when called with no argument. Found while writing the cross-project model loadtest: two models of the same name, one saved through each `Project`, both landed in the login project's registry and the peer's read back empty. Both APIs take a project name to open a shared store and refuse a name that is the connection's own project, so the name is passed only when this `Project` is not the connected one.

Covered by `logicalclocks/loadtest#967`'s `shared_registry_search.py`, which asserts that a hit naming another project resolves through that project's registry, green on `jim-tags`.

## Round seven: all of them, not the named ones

Three review rounds found the same defect three times, each in whichever handle was looked at. `AppApi`, `GitApi`, `EnvironmentApi`, `KafkaApi`, `OpenSearchApi` and `SearchApi` now take `project_id` and `project_name` and fall back to the connection through the same `_pid()`/`_pname()` helpers the already-bound handles use; `ModelServingApi._get()` takes the binding, so `get_model_serving()` returns this project's serving; `JobApi`'s older `_get_project_id`/`_get_project_name` are renamed to match. The new test constructs a foreign `Project` and asserts every getter's handle addresses it, rather than naming the three or four a reviewer thought of.

## Round eight: bind what a handle hands back, not only the handle

The previous round bound every API a `Project` hands out, and asserted it by reading `_pid()` off each one. A review then found the same defect one layer down, which is a fair result: a bound handle can still reach the connection's project through the engine that polls a command, or through an object it returns, and neither is visible in that assertion.

**Model serving was the worst of it.** `get_model_serving()` for another project validated the *login* project's `Models` dataset, so a project without serving enabled passed the check and the failure surfaced later as an empty deployment list. The `ModelServing` it returned built an unbound `ServingApi`, so listing, starting, stopping, tagging and reading the logs of a deployment all addressed whatever the login project held under that id. A `Deployment` now rebinds its API and its engine as it learns which project it came from, and the predictor carries that project id into the Hopsworks inference URL.

**The same shape, three more times.** An environment created in another project was awaited in the login project, and the `Environment` that came back installed libraries, resolved upload paths and deleted itself there. A git operation started in one project was polled for in another. Apps, topics and schemas came back holding unbound handles. Each is bound where it is created now, through the `_bind_project` pattern `Job` already used.

**Kafka's certificate is the exception, and it refuses instead.** The materialized certificate is the client's Kafka identity and it belongs to the project that was logged into, so `get_default_config()` for another project would produce and consume under the wrong identity and look like it had worked. Materializing a second project's certificate is not something one connection can do, so the honest answer is an error naming both projects. Everything about Kafka that is a REST path stays bound and works.

`tests/core/test_project_binding.py` reads the recorded request paths rather than the handles' attributes, and drives the nested paths directly: environment creation polling, library installation, git execution polling, topic deletion and re-read, a deployment's tags and logs, and the inference URL. Thirteen of its fifteen tests fail without this change.

## Revalidation on a cluster rebuilt from empty

`jim-tags` was torn down, reinstalled from empty on published upstream code, and upgraded to this branch (the full sequence is in the hopsworks-ee PR). The loadtest battery that exercises this client ran against the result: **16 passed, 0 failed** in 8 minutes (tags 4, job metadata 3, dataset tags 4, global-search flag 1, model search 3, shared-registry search 1).

Not covered by this run, and stated rather than implied: the nested bindings above are asserted by unit tests reading request paths, not by the loadtest, which still only covers model-registry resolution. Model serving, environments, git and Kafka in another project have no cluster coverage.

## Review round ten (Codex, 2026-08-08)

An external Codex review found two binding gaps of the known round-eight class (bound at the top, lost one layer down), fixed in `40eeff631`:

- **`Deployment.update_from_response_json` unbound the deployment.** It rebuilds the object through `__init__`, which resets the serving api, the engine and the registry id to the login project, and the predictor's own refresh clears its project name. The duplicate-create recovery in `ServingEngine._create` refreshes exactly there, so the deployment it handed back started, stopped and read logs in the wrong project. The binding is captured before the rebuild and reapplied through `_rebind` after it.
- **`App`'s URL helpers ignored the binding**: `public_url` shared a path in the login project's namespace and `get_url` pointed the UI link at the login project. Both now prefer the bound project, falling back to the connection for unbound objects.

Three tests extend the recorded-path binding suite (18/18 green): a refresh preserves the binding, a bound app's URLs name its project, an unbound app still uses the connection.

## Companion PRs

- hopsworks-ee: logicalclocks/hopsworks-ee#3191
- hopsworks-api: logicalclocks/hopsworks-api#1079
- hopsworks-front: logicalclocks/hopsworks-front#2023
- hopsworks-helm: logicalclocks/hopsworks-helm#2164
- loadtest: logicalclocks/loadtest#967

## Round seventeen (specification revision 26)

**A model search hit in the login project resolved as if its registry were shared.**
`ModelSearchResult.get()` passed `self.project.name` to `_get_model_registry` unconditionally, and
`ModelRegistryApi._get` reads any non-`None` name as a request for a SHARED registry. The list it
matches against includes the project's own `Models` dataset, so the login project's own name matched
and came back with `shared_registry_project_name` set. Every path the model then built addressed
`<project>::Models`, which names a dataset shared into the project from elsewhere and does not exist
for the project's own, so `download()` and every other path operation resolved against nothing. Search
returns login-project hits by default, so this was the ordinary case rather than an edge one. It now
follows the same rule as the rest of the client, which `Project._shared_name` already encoded: pass a
name only when it is not the connection's own project.

**`JobSearchResult.get()` lacked the fail-closed guard its three siblings have**, so a hit whose
payload carried no project raised an attribute error on `None` instead of the deliberate refusal. It
fails either way; the diagnostic is now the same one everywhere.

Unit tests: 22 in the search-results and project-binding suites, ruff and format clean.


[FSTORE-2075]: https://hopsworks.atlassian.net/browse/FSTORE-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
