### PR TITLE
[HOPSFS-388] Bump HopsFS to 3.4.3.1-EE-RC4

### DIFF
--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -161,7 +161,7 @@
                 <dependency>
                     <groupId>io.hops</groupId>
                     <artifactId>hadoop-client</artifactId>
-                    <version>3.4.3.1-EE-RC0</version>
+                    <version>3.4.3.1-EE-RC4</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -8,7 +8,7 @@
     <version>5.0.3</version>
 
     <properties>
-        <hops.version>3.4.3.1-EE-RC0</hops.version>
+        <hops.version>3.4.3.1-EE-RC4</hops.version>
         <hsfs.version>${project.version}</hsfs.version>
         <slf4j.version>2.0.17</slf4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Bumps HopsFS to 3.4.3.1-EE-RC4.
Tracked by HOPSFS-388.
