### PR TITLE
[FSTORE-1412][APPEND] Widen ColumnProfilerParityTest extreme-tail percentile tolerance

### DIFF
--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerParityTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerParityTest.java
@@ -106,11 +106,19 @@ public class ColumnProfilerParityTest {
   // This is a spec extension documented here — not a tolerance loosening for Gaussian columns.
   private static final double TOL_PERC_NO_KLL     = 1e-1;
   private static final double TOL_PERC_KLL        = 5e-2;
-  // KLL tail accuracy on wide-range integer columns (c_long up to 10^10) exceeds K=2048's
-  // ~0.13% normalized rank error at the extremes. Observed run-to-run drift up to ~5.5%
-  // at p0.01 due to partition-order sensitivity in the mapPartitions merge. 6% floor
-  // accommodates this; still tight enough to catch real drift in the body of the distribution.
-  private static final double TOL_PERC_REL        = 0.06;  // 6% relative floor for large-scale tails
+  // KLL/percentile_approx accuracy on wide-range integer columns (c_long up to 10^10, c_int
+  // up to 10^6) exceeds K=2048's ~0.13% normalized rank error at the extremes. The KLL sketch
+  // is built per-partition and merged on the driver (see KllAggregator), so the quantile
+  // estimate at a given fraction depends on how Spark splits the rows into partitions, which
+  // varies with the executor core count. This makes the tails environment-sensitive: value
+  // drift vs the Deequ baseline stays ~1-3% through the body of the distribution but reaches
+  // 6-8% at p0.01/p0.99 across CI runners (observed 7.57% at c_int p0.01). We therefore apply a
+  // 6% relative floor to the body and a wider 15% floor to the extreme tail (p<=0.02, p>=0.98).
+  // The body floor still catches real drift; the tail floor absorbs partition-count-dependent
+  // merge noise without masking a genuine regression (which moves the whole distribution, not a
+  // single tail point).
+  private static final double TOL_PERC_REL        = 0.06;  // body relative floor
+  private static final double TOL_PERC_REL_TAIL   = 0.15;  // extreme-tail (p<=0.02, p>=0.98) floor
   // HLL relative tolerance: 5%
   private static final double TOL_HLL_REL         = 0.05;
   // stdDev tolerance: ColumnProfiler uses stddev_pop matching Deequ, so diff is within
@@ -457,16 +465,20 @@ public class ColumnProfilerParityTest {
       double bv = bPercs.get(i).asDouble();
       double nv = nPercs.get(i).asDouble();
       double diff = Math.abs(bv - nv);
-      // Effective tolerance: absolute spec floor OR 3% relative for large-scale integer columns.
-      double effectiveTol = Math.max(absTolerance, TOL_PERC_REL * Math.abs(bv));
+      // Effective tolerance: absolute spec floor OR a relative floor for large-scale integer
+      // columns. The extreme tail (p<=0.02, p>=0.98) uses a wider relative floor because the
+      // per-partition KLL merge is most sensitive to partition count there (see TOL_PERC_REL).
+      boolean extremeTail = i <= 1 || i >= bPercs.size() - 2;
+      double relFloor = (extremeTail ? TOL_PERC_REL_TAIL : TOL_PERC_REL) * Math.abs(bv);
+      double effectiveTol = Math.max(absTolerance, relFloor);
       if (diff > maxDrift) {
         maxDrift = diff;
         maxDriftIdx = i;
       }
       if (diff > effectiveTol) {
         hardFails.add(fmt(
-            "[%-20s] approxPercentiles[%d] (p%.2f): Deequ=%.10f new=%.10f | diff=%.4f > effectiveTol=%.4f (abs=%.4f, rel3pct=%.4f)",
-            col, i, (i + 1) / 100.0, bv, nv, diff, effectiveTol, absTolerance, TOL_PERC_REL * Math.abs(bv)));
+            "[%-20s] approxPercentiles[%d] (p%.2f): Deequ=%.10f new=%.10f | diff=%.4f > effectiveTol=%.4f (abs=%.4f, relFloor=%.4f)",
+            col, i, (i + 1) / 100.0, bv, nv, diff, effectiveTol, absTolerance, relFloor));
       }
     }
     if (maxDrift > 0.0) {


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-1412

Backport of the extreme-tail percentile tolerance fix to `branch-5.0`. `ColumnProfilerParityTest.testParityKllTrue` fails on `branch-5.0`:

```
[c_int] approxPercentiles[0] (p0.01): Deequ=10190.0000000000 new=9419.0000000000
        | diff=771.0000 > effectiveTol=611.4000 (abs=0.0500, rel3pct=611.4000)
```

611.4 is the 6% flat relative floor (`TOL_PERC_REL`); the observed drift is 7.57%.

### Why it flakes

The KLL sketch backing `approxPercentiles` is built per-partition and merged on the driver (`KllAggregator`), so the quantile estimate at a given fraction depends on how Spark splits the seeded 10k-row fixture into partitions and in which order the per-partition sketches are merged. That varies between JVMs on the same machine — the two Maven invocations of the failing build (`hsfs-spark-spark3.5` and `hsfs-spark-spark3.3`, both compiled against the same Spark 3.5.5.1, since the `spark-3.3` profile only renames the published artifact) reported different tail drift, and only the second exceeded the floor:

| | run 1 (spark3.5) | run 2 (spark3.3) |
| --- | --- | --- |
| c_long p0.87 drift | 11,683,852 | 11,506,956 |
| c_long kll median | 5023834252 | 5024694032 |
| c_int p0.01 | within floor | **771 > 611.4 → FAIL** |

Drift vs the Deequ baseline stays ~1-3% through the body of the distribution but reaches 6-8% at p0.01/p0.99.

### The change

Apply a wider 15% floor (`TOL_PERC_REL_TAIL`) to the extreme tail only (p<=0.02, p>=0.98) and keep the 6% floor for the body. The body floor still catches a real regression, which would shift the whole distribution rather than a single tail point.

### Provenance

Test-only change, cherry-picked from main `777f4f9f3` (`[HWORKS-2802][Append]`, #1016), which fixed the same failure on main on 2026-06-21 citing the identical numbers. Only the test hunk was taken — the hsfs-utils hudi/pom half of that squashed PR and the FSTORE-2066 `ColumnProfiler.java` changes are excluded. `git diff origin/main -- <test file>` is now empty, so the file matches main byte-for-byte.

### Testing

Not exercised locally: the `hsfs-spark` module cannot resolve `io.hops.hive` artifacts without HiveEE nexus credentials (401 Unauthorized); `hsfs-parent` and `hsfs` build fine. Relying on CI for the parity run, plus the arithmetic: the failing point is index 0, `extremeTail` covers `i <= 1`, and 15% x 10190 = 1528.5 vs the observed diff of 771. Checkstyle is unaffected — `sourceDirectories` is `src/main/java` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[HWORKS-2802]: https://hopsworks.atlassian.net/browse/HWORKS-2802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ