### PR TITLE
[HWORKS-2988] apt-get upgrade -y in the image build (5.0 backport)

### DIFF
--- a/locust_benchmark/Dockerfile
+++ b/locust_benchmark/Dockerfile
@@ -2,7 +2,7 @@ FROM locustio/locust:2.23.1
 
 USER root
 
-RUN apt-get update -y && apt-get -y install gcc python3-dev librdkafka-dev git
+RUN apt-get update -y && apt-get upgrade -y && apt-get -y install gcc python3-dev librdkafka-dev git
 
 USER locust
 WORKDIR /home/locust


### PR DESCRIPTION
5.0 backport of #1078 (clean cherry-pick, `-x` recorded).

`apt-get upgrade -y` in the locust-hsfs benchmark image, whose base
(`locustio/locust:2.23.1`) is not one of ours and so is never upgraded upstream.
