### PR TITLE
Release 5.0.4 (Spark 3.5.5.2, Hudi 1.0.2.2)

### DIFF
--- a/java/beam/pom.xml
+++ b/java/beam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,8 +28,8 @@
         <lombok.plugin.version>1.18.20.0</lombok.plugin.version>
         <fasterxml.jackson.databind.version>2.10.0</fasterxml.jackson.databind.version>
         <datasketches.version>6.2.0</datasketches.version>
-        <spark.version>3.5.5.1</spark.version>
-        <hudi.version>1.0.2.1</hudi.version>
+        <spark.version>3.5.5.2</spark.version>
+        <hudi.version>1.0.2.2</hudi.version>
         <awssdk.version>2.10.40</awssdk.version>
         <scala.version>2.12.10</scala.version>
         <scala-short.version>2.12</scala-short.version>
@@ -301,7 +301,7 @@
         <profile>
             <id>spark-3.5</id>
             <properties>
-                <spark.version>3.5.5.1</spark.version>
+                <spark.version>3.5.5.2</spark.version>
                 <deequ.version>2.0.7-spark-3.5</deequ.version>
                 <artifact.spark.version>spark3.5</artifact.spark.version>
                 <fasterxml.jackson.databind.version>2.15.2</fasterxml.jackson.databind.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-parent</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
     <modules>
         <module>hsfs</module>
         <module>spark</module>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>hsfs-parent</artifactId>
         <groupId>com.logicalclocks</groupId>
-        <version>5.0.3</version>
+        <version>5.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/python/hopsworks_common/version.py
+++ b/python/hopsworks_common/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "5.0.3"
+__version__ = "5.0.4"

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
 
     <properties>
         <hops.version>3.4.3.1-EE-RC4</hops.version>


### PR DESCRIPTION
Releases the client as **5.0.4** and bumps Spark and Hudi to the latest published versions.

- **Spark 3.5.5.1 → 3.5.5.2** and **Hudi 1.0.2.1 → 1.0.2.2** in `java/pom.xml`. Both Spark properties are updated: the top-level one *and* the `spark-3.5` profile override, which would otherwise silently win over a properties-only edit.
- **Release 5.0.3 → 5.0.4** across the same 7 files as #1047: the parent pom, the 4 module parent refs, `utils/java/pom.xml`, and `python/hopsworks_common/version.py`. `python/pyproject.toml` is `dynamic = ["version"]` off `version.py`, and every other Python reference reads `__version__`, so nothing else needs touching.

**No Hive bump is needed in this repo.** It pins no Hive version at all — `git grep -i 'hive.version'` is empty, and the only Hive coordinate is `org.apache.spark:spark-hive_2.12` at `${spark.version}` (test scope, `java/spark/pom.xml`). The Hive bump arrives through Spark instead: `spark-hive_2.12:3.5.5.2`'s pom pulls `io.hops.hive:*:3.0.0.14.6`. The two Spark branches confirm the carrier — `branch-3.5.5.1` = hadoop `3.4.3.1-EE-RC0` + hive `3.0.0.14.5`, `branch-3.5.5.2` = hadoop `3.4.3.1-EE-RC4` + hive `3.0.0.14.6`. So this PR is also what brings the RC4 client into the Java clients.

Both targets were verified as the latest *published* versions, not just the latest branch: nexus `hops-artifacts` metadata reports `release=3.5.5.2` (the 3.5 line being 3.5.5, 3.5.5.1, 3.5.5.2) and archiva reports `release=1.0.2.2`.

No changes to user-facing APIs.

Not changed, deliberately: `.github/workflows/java.yml` keeps `-Dspark.version=3.5.5 -Dhudi.version=1.0.2`. Those are the upstream *base* versions resolved from Maven Central for unit tests, and the base did not move — #937 only edited that file because 3.3.2 → 3.5.5 moved it. A consequence worth noting for reviewers: CI does not exercise the Hops Spark/Hudi builds this PR points at, which is why the versions were validated locally against nexus/archiva (see below).

JIRA Issue: https://hopsworks.atlassian.net/browse/HOPSFS-388

Priority for Review: -

Related PRs: #1080 (HopsFS RC4 in this repo), logicalclocks/spark#59 (released the 3.5.5.2 dist), logicalclocks/hopsworks-helm#2174 (chart-side RC4 rollout)

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

`mvn -Pspark-3.5,with-hops-ee test -pl hsfs,spark` on **JDK 8** (the JDK the CI workflow uses): 33 + 69 tests, 0 failures, 0 errors. The build really resolved `spark-core_2.12-3.5.5.2` and both Hudi 1.0.2.2 bundles from nexus/archiva, so the new coordinates are confirmed present and compilable against, not just syntactically bumped.

Two notes for anyone reproducing this locally:

1. **Use JDK 8.** On JDK 17 the SparkSession-backed tests (`TestSparkEngine`, `TestStorageConnector`, `ColumnProfiler{Smoke,Parity}Test`, `KllMergeSmokeTest`) fail with `IllegalAccessError: class org.apache.spark.storage.StorageUtils$ ... cannot access class sun.nio.ch.DirectBuffer`, because the build passes no `--add-exports java.base/sun.nio.ch=ALL-UNNAMED`. This is pre-existing and unrelated to the bump: re-running with the old versions pinned on the CLI on the same JVM produces an identical 69-tests/14-errors signature.
2. If Maven reports `Failure to find org.apache.spark:spark-core_2.12:jar:3.5.5.2 ... was cached in the local repository`, that is a stale negative cache from before 3.5.5.2 was published, not a missing artifact. `-U` clears it.

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
