### PR TITLE
[HWORKS-2991] Make hops env install upload a local requirements file

### DIFF
--- a/python/hopsworks/cli/commands/env.py
+++ b/python/hopsworks/cli/commands/env.py
@@ -11,6 +11,8 @@ heads-up warning, since installs can take several minutes.
 
 from __future__ import annotations
 
+import contextlib
+import os
 from typing import Any
 
 import click
@@ -122,28 +124,49 @@ def env_clone(
     "-f",
     "--file",
     "requirements_file",
-    type=click.Path(exists=True, dir_okay=False, readable=True),
     required=True,
-    help="Path to a requirements.txt file to install.",
+    help="requirements.txt: a local file (uploaded to HopsFS) or an existing "
+    "HopsFS path.",
+)
+@click.option(
+    "--upload-dir",
+    default=None,
+    help="HopsFS dir to upload a local requirements file to "
+    "(default: Resources/environments/<env_name>).",
+)
+@click.option(
+    "--overwrite/--no-overwrite",
+    default=True,
+    show_default=True,
+    help="Overwrite the uploaded requirements file if it exists.",
 )
 @click.pass_context
 def env_install(
     ctx: click.Context,
     env_name: str,
     requirements_file: str,
+    upload_dir: str | None,
+    overwrite: bool,
 ) -> None:
     """Install a requirements.txt into ENV_NAME.
 
+    ``--file`` is either a local file — uploaded to HopsFS first, since the
+    backend can only read paths inside the project — or a path that already
+    exists in the project (e.g. ``Users/<username>/requirements.txt``).
+
     Blocks until the install completes. This usually takes several
-    minutes — the file is uploaded, conda/pip resolves the dependencies,
-    and the resulting libraries are committed to the environment image.
+    minutes — conda/pip resolves the dependencies and the resulting
+    libraries are committed to the environment image.
 
     Args:
         ctx: Click context.
         env_name: Environment to install into.
-        requirements_file: Path to a requirements.txt file.
+        requirements_file: Local file to upload, or an existing HopsFS path.
+        upload_dir: HopsFS directory for a local requirements upload.
+        overwrite: Overwrite an existing uploaded requirements file.
     """
-    api = _api(ctx)
+    project = session.get_project(ctx)
+    api = project.get_environment_api()
     try:
         env = api.get_environment(env_name)
     except Exception as exc:  # noqa: BLE001
@@ -152,17 +175,38 @@ def env_install(
         raise click.ClickException(
             f"No environment named '{env_name}'. Run `hops env list` to see what exists."
         )
+
+    # Resolve the requirements path — upload when a local file was given, so the
+    # backend (which resolves against /Projects/<project>/) can read it. Same
+    # convention as `hops job deploy` resolving its script argument.
+    remote_path = requirements_file
+    if os.path.isfile(requirements_file):
+        dataset = project.get_dataset_api()
+        dest_dir = upload_dir or f"Resources/environments/{env_name}"
+        with contextlib.suppress(Exception):  # directory may already exist
+            dataset.mkdir(dest_dir)
+        try:
+            uploaded = dataset.upload(
+                local_path=requirements_file, upload_path=dest_dir, overwrite=overwrite
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise click.ClickException(f"Could not upload requirements: {exc}") from exc
+        remote_path = uploaded or f"{dest_dir}/{os.path.basename(requirements_file)}"
+        output.success(
+            "✓ Uploaded %s -> %s", os.path.basename(requirements_file), remote_path
+        )
+
     output.warn(
         "Installing '%s' into '%s' — this can take several minutes. Waiting for "
         "the backend to finish before returning.",
-        requirements_file,
+        remote_path,
         env_name,
     )
     try:
-        env.install_requirements(requirements_file, await_installation=True)
+        env.install_requirements(remote_path, await_installation=True)
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Install failed: {exc}") from exc
     if output.JSON_MODE:
-        output.print_json({"environment": env_name, "installed": requirements_file})
+        output.print_json({"environment": env_name, "installed": remote_path})
     else:
-        output.success(f"Installed '{requirements_file}' into environment '{env_name}'")
+        output.success(f"Installed '{remote_path}' into environment '{env_name}'")

--- a/python/tests/cli/test_env.py
+++ b/python/tests/cli/test_env.py
@@ -1,0 +1,108 @@
+"""CLI tests for ``hops env install`` — the upload-or-passthrough contract.
+
+The backend resolves whatever string it receives against the project root, so
+the command must upload a local file before installing and must hand any other
+string through untouched.
+Everything here pins that resolution logic; the install call itself is the
+SDK's problem.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+from hopsworks.cli.main import cli
+
+
+def _env_api(mock_project, env_name="my_env"):
+    api = mock_project.get_environment_api.return_value
+    env = api.get_environment.return_value
+    env.name = env_name
+    return api, env
+
+
+def test_env_install_uploads_local_file(mock_project, tmp_path):
+    _, env = _env_api(mock_project)
+    dataset = mock_project.get_dataset_api.return_value
+    dataset.upload.return_value = "Resources/environments/my_env/requirements.txt"
+    reqs = tmp_path / "requirements.txt"
+    reqs.write_text("ibis-framework\n")
+
+    result = CliRunner().invoke(cli, ["env", "install", "my_env", "-f", str(reqs)])
+
+    assert result.exit_code == 0, result.output
+    dataset.upload.assert_called_once_with(
+        local_path=str(reqs),
+        upload_path="Resources/environments/my_env",
+        overwrite=True,
+    )
+    env.install_requirements.assert_called_once_with(
+        "Resources/environments/my_env/requirements.txt", await_installation=True
+    )
+
+
+def test_env_install_passes_project_path_through(mock_project):
+    _, env = _env_api(mock_project)
+    dataset = mock_project.get_dataset_api.return_value
+
+    result = CliRunner().invoke(
+        cli, ["env", "install", "my_env", "-f", "Users/me/requirements.txt"]
+    )
+
+    assert result.exit_code == 0, result.output
+    dataset.upload.assert_not_called()
+    env.install_requirements.assert_called_once_with(
+        "Users/me/requirements.txt", await_installation=True
+    )
+
+
+def test_env_install_honors_upload_dir_and_no_overwrite(mock_project, tmp_path):
+    _env_api(mock_project)
+    dataset = mock_project.get_dataset_api.return_value
+    dataset.upload.return_value = None  # command falls back to dest/basename
+    reqs = tmp_path / "requirements.txt"
+    reqs.write_text("pandas\n")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "env",
+            "install",
+            "my_env",
+            "-f",
+            str(reqs),
+            "--upload-dir",
+            "Users/me/reqs",
+            "--no-overwrite",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    dataset.upload.assert_called_once_with(
+        local_path=str(reqs), upload_path="Users/me/reqs", overwrite=False
+    )
+
+
+def test_env_install_reports_upload_failure(mock_project, tmp_path):
+    _, env = _env_api(mock_project)
+    dataset = mock_project.get_dataset_api.return_value
+    dataset.upload.side_effect = RuntimeError("disk full")
+    reqs = tmp_path / "requirements.txt"
+    reqs.write_text("pandas\n")
+
+    result = CliRunner().invoke(cli, ["env", "install", "my_env", "-f", str(reqs)])
+
+    assert result.exit_code != 0
+    assert "Could not upload requirements" in result.output
+    env.install_requirements.assert_not_called()
+
+
+def test_env_install_unknown_environment(mock_project):
+    api = mock_project.get_environment_api.return_value
+    api.get_environment.return_value = None
+
+    result = CliRunner().invoke(
+        cli, ["env", "install", "nope", "-f", "Users/me/requirements.txt"]
+    )
+
+    assert result.exit_code != 0
+    assert "No environment named 'nope'" in result.output

--- a/skills/hops/hops-environments/SKILL.md
+++ b/skills/hops/hops-environments/SKILL.md
@@ -15,15 +15,76 @@ workload at the clone.
 ## Contract
 - **Input:** a base environment name + a `requirements.txt` (or a `.whl`).
 - **Output:** a cloned environment with the dependencies installed.
-- **Pre-condition:** the requirements file / wheel is uploaded to the project
-  (a Hopsworks path like `Users/<username>/app-requirements.txt`), or local for
-  the CLI to upload.
+- **Pre-condition:** the requirements file / wheel **already exists inside the
+  project filesystem** at a project-relative path such as
+  `Users/<username>/app-requirements.txt`. Neither the SDK nor the CLI uploads
+  it for you — see *Requirements-file paths* below. Writing the file into the
+  project FUSE mount (`/hopsfs/...`) is how you put it there.
+
+## Requirements-file paths (read this before running `install`)
+
+**The path is always a project path, for both the SDK and the CLI.** The CLI's
+`-f/--file` flag does **not** upload a local file; `hops env install` passes the
+string straight to `env.install_requirements()`, and the backend resolves it
+against the project root `/Projects/<project>/`. Getting this wrong is the most
+common failure:
+
+```
+Error: Install failed: ... HTTP code: 404 ...
+{"errorCode":110008,"usrMsg":"path: /Projects/<project>/requirements.txt",
+ "errorMsg":"File not found."}
+```
+
+That means the backend looked at the project root and found nothing — the file
+existed only on the local disk.
+
+There is a second trap layered on top: the CLI declares `-f` as
+`click.Path(exists=True)`, so the path must **also** resolve locally from the
+current working directory. A bare project path fails Click's check before any
+request is sent:
+
+```
+Error: Invalid value for '-f' / '--file': File 'Users/me/requirements.txt' does not exist.
+```
+
+**Both constraints are satisfied at once by writing the file into the project
+FUSE mount and invoking the CLI from the project root**, so that one relative
+path is simultaneously a valid local path and the correct project path:
+
+```bash
+# /hopsfs is the FUSE mount of the project root (/Projects/<project>).
+# Confirm with: ls /hopsfs   ->   Users/ Models/ Resources/ Jupyter/ Logs/ ...
+printf 'ibis-framework\n' > /hopsfs/Users/<username>/requirements.txt
+
+cd /hopsfs                                    # cwd == project root
+hops env install my_env -f Users/<username>/requirements.txt
+```
+
+Rule of thumb: **`cd` to the project root mount first, then pass a
+project-relative path.** Absolute local paths (`/tmp/...`, or even
+`/hopsfs/Users/...`) pass Click's check and then 404 on the backend, because the
+backend prepends the project root to whatever string it receives.
+
+With the SDK there is no local-existence check, so only the project path matters:
+
+```python
+env.install_requirements("Users/<username>/requirements.txt", await_installation=True)
+```
+
+If you cannot write to a FUSE mount (no `/hopsfs` in this context), upload the
+file explicitly first and then pass the path the upload returns:
+
+```python
+ds = project.get_dataset_api()
+ds.upload("requirements.txt", "Users/<username>", overwrite=True)   # -> Users/<username>/requirements.txt
+env.install_requirements("Users/<username>/requirements.txt", await_installation=True)
+```
 
 ## Smoke-test (cheap pre/post-flight)
 ```bash
-hops env list                                   # base + cloned environments
-hops env clone my_env --from python-feature-pipeline   # blocks minutes; provisions the clone
-hops env install my_env -f requirements.txt     # blocks minutes; resolves + commits libs
+hops env list                                          # base + cloned environments
+hops env clone my_env --from pandas-training-pipeline  # provisions the clone
+cd /hopsfs && hops env install my_env -f Users/<username>/requirements.txt
 ```
 
 ## Base environments (pick by workload)
@@ -42,8 +103,12 @@ the workload, then add libs.
 `hops env list` shows the live set for the project — it can differ from this table.
 
 ## Clone-then-install (the core workflow)
-Both steps **block for several minutes** (the backend builds the image from the base
-and runs the install). Warn the user before starting.
+Both steps block until the backend finishes. Duration varies with the base image
+and how heavy the dependency set is: a small pure-Python install can complete in
+under a minute, while a large one (torch, CUDA wheels, conflicting pins) can run
+for many minutes. Tell the user it may take several minutes before you start,
+and prefer running it in the background rather than blocking the session.
+
 ```python
 import hopsworks
 project = hopsworks.login()
@@ -57,12 +122,21 @@ cloned = env_api.create_environment(
     await_creation=True,                           # return only when provisioned
 )
 
-# 2. Install dependencies into the CLONE (Hopsworks path to an uploaded file)
+# 2. Install into the CLONE — path is a PROJECT path (see above)
 cloned.install_requirements("Users/<username>/app-requirements.txt", await_installation=True)
-# or a wheel:
+# or a wheel — same project-path rule:
 cloned.install_wheel("Users/<username>/my_pkg-0.1.0-py3-none-any.whl")
 ```
 Then attach `my_app_env` when creating the job / app / deployment.
+
+## Verifying an install
+`await_installation=True` returning without raising **is** the success signal —
+the backend only reports completion once the libraries are committed to the
+image. The SDK's `Environment` object exposes no library-listing method
+(`get_libraries()` does not exist), so do not try to enumerate packages that way.
+To actually confirm a package imports, run a one-line job/app in the cloned
+environment, or check the environment's library list in the Hopsworks UI under
+*Project Settings → Python Environments*.
 
 ## Manage
 ```python
@@ -76,25 +150,32 @@ env.delete()                               # remove the environment
 ## Ask the user (only when state is ambiguous)
 - Which base matches the workload (training vs inference vs app vs agent)?
 - Is there a `requirements.txt` already? If not, prompt for one before cloning —
-  a clone with nothing to install is wasted minutes.
+  a clone with nothing to install is wasted time.
+- **Ambiguous PyPI names.** Confirm the distribution name before installing when
+  the import name and the PyPI name differ — e.g. Ibis is `ibis-framework` (plain
+  `ibis` is an unrelated legacy package), and backends are extras
+  (`ibis-framework[duckdb]`). Same class of trap: `sklearn` → `scikit-learn`,
+  `cv2` → `opencv-python`, `PIL` → `pillow`.
 - **Before deleting** — `env.delete()` is irreversible; confirm with the user, and
   never delete an environment a job, app, or deployment still references.
 
 ## Caveats
-- **Clone and install each block for minutes.** Use `await_creation=False` /
+- **The requirements path is a project path for BOTH the SDK and the CLI.** The
+  CLI does not upload; it only adds a local-existence check on top. `cd /hopsfs`
+  first and pass a project-relative path. This is the single most common failure
+  mode — see *Requirements-file paths*.
+- **Clone and install block.** Use `await_creation=False` /
   `await_installation=False` to fire-and-forget, but then you must poll before the
   workload can use the env.
 - **Install into the clone, never the base** — bases are managed/read-only.
-- The requirements path is a **project (Hopsworks) path**, not a local one, for the
-  SDK. The CLI `-f` flag uploads a local file for you.
 - **MLOps:** prefer code (SDK/CLI) over the UI so env setup is reproducible across
   dev/staging/prod, and name the clone after the pipeline version it serves (e.g.
   `spark-feature-pipeline-v1`) so a pinned env travels with the code version.
 
 ## Toolset
-- **CLI:** `hops env list`, `hops env clone <new> --from <base> [--description]`, `hops env install <env> -f <requirements.txt>`.
+- **CLI:** `hops env list`, `hops env clone <new> --from <base> [--description]`, `hops env install <env> -f <project-relative-requirements.txt>` (run from `/hopsfs`).
 - **SDK:** `project.get_environment_api()` → `create_environment(base_environment_name=, await_creation=)`, `env.install_requirements()`, `env.install_wheel()`, `env.uninstall()`, `env.delete()`.
-- **Source:** `python/hopsworks_common/core/environment_api.py`, `python/hopsworks_common/environment.py`, `python/hopsworks/cli/commands/env.py`.
+- **Source:** `python/hopsworks_common/core/environment_api.py`, `python/hopsworks_common/environment.py`, `python/hopsworks/cli/commands/env.py` (see `env_install` — it forwards the path unchanged, confirming the no-upload behaviour).
 
 ## Next steps
 - [hops-job](../hops-job/SKILL.md) — run a job in the cloned environment.

--- a/skills/hops/hops-environments/SKILL.md
+++ b/skills/hops/hops-environments/SKILL.md
@@ -15,19 +15,34 @@ workload at the clone.
 ## Contract
 - **Input:** a base environment name + a `requirements.txt` (or a `.whl`).
 - **Output:** a cloned environment with the dependencies installed.
-- **Pre-condition:** the requirements file / wheel **already exists inside the
-  project filesystem** at a project-relative path such as
-  `Users/<username>/app-requirements.txt`. Neither the SDK nor the CLI uploads
-  it for you — see *Requirements-file paths* below. Writing the file into the
-  project FUSE mount (`/hopsfs/...`) is how you put it there.
+- **Pre-condition (SDK only):** the requirements file / wheel **already exists
+  inside the project filesystem** at a project-relative path such as
+  `Users/<username>/app-requirements.txt`. The SDK does not upload it for you —
+  see *Requirements-file paths* below. The CLI does: `hops env install -f` takes
+  a local file and uploads it before installing.
 
 ## Requirements-file paths (read this before running `install`)
 
-**The path is always a project path, for both the SDK and the CLI.** The CLI's
-`-f/--file` flag does **not** upload a local file; `hops env install` passes the
-string straight to `env.install_requirements()`, and the backend resolves it
-against the project root `/Projects/<project>/`. Getting this wrong is the most
-common failure:
+**The CLI uploads; the SDK does not.** `hops env install <env> -f <file>`
+accepts either a local file, which it uploads to
+`Resources/environments/<env>/` first (`--upload-dir` overrides the
+destination), or a path that already exists in the project:
+
+```bash
+printf 'ibis-framework\n' > requirements.txt
+hops env install my_env -f requirements.txt          # local file: uploaded, then installed
+hops env install my_env -f Users/me/requirements.txt # no such local file: passed through as a project path
+```
+
+The passthrough rule is `os.path.isfile`: a string that names a local file is
+uploaded, anything else is handed to the backend as a project path. So run the
+CLI from a directory where the string means what you intend — a local
+`Users/me/requirements.txt` relative to the cwd would be uploaded rather than
+treated as the project path of the same name.
+
+**The SDK takes project paths only.** `env.install_requirements()` forwards the
+string to the backend, which resolves it against the project root
+`/Projects/<project>/`. A local-only path fails with:
 
 ```
 Error: Install failed: ... HTTP code: 404 ...
@@ -36,36 +51,8 @@ Error: Install failed: ... HTTP code: 404 ...
 ```
 
 That means the backend looked at the project root and found nothing — the file
-existed only on the local disk.
-
-There is a second trap layered on top: the CLI declares `-f` as
-`click.Path(exists=True)`, so the path must **also** resolve locally from the
-current working directory. A bare project path fails Click's check before any
-request is sent:
-
-```
-Error: Invalid value for '-f' / '--file': File 'Users/me/requirements.txt' does not exist.
-```
-
-**Both constraints are satisfied at once by writing the file into the project
-FUSE mount and invoking the CLI from the project root**, so that one relative
-path is simultaneously a valid local path and the correct project path:
-
-```bash
-# /hopsfs is the FUSE mount of the project root (/Projects/<project>).
-# Confirm with: ls /hopsfs   ->   Users/ Models/ Resources/ Jupyter/ Logs/ ...
-printf 'ibis-framework\n' > /hopsfs/Users/<username>/requirements.txt
-
-cd /hopsfs                                    # cwd == project root
-hops env install my_env -f Users/<username>/requirements.txt
-```
-
-Rule of thumb: **`cd` to the project root mount first, then pass a
-project-relative path.** Absolute local paths (`/tmp/...`, or even
-`/hopsfs/Users/...`) pass Click's check and then 404 on the backend, because the
-backend prepends the project root to whatever string it receives.
-
-With the SDK there is no local-existence check, so only the project path matters:
+existed only on the local disk. Writing the file into the project FUSE mount
+(`/hopsfs/...`, where mounted) is one way to put it there:
 
 ```python
 env.install_requirements("Users/<username>/requirements.txt", await_installation=True)
@@ -84,7 +71,7 @@ env.install_requirements("Users/<username>/requirements.txt", await_installation
 ```bash
 hops env list                                          # base + cloned environments
 hops env clone my_env --from pandas-training-pipeline  # provisions the clone
-cd /hopsfs && hops env install my_env -f Users/<username>/requirements.txt
+hops env install my_env -f requirements.txt            # uploads the local file, then installs
 ```
 
 ## Base environments (pick by workload)
@@ -160,10 +147,11 @@ env.delete()                               # remove the environment
   never delete an environment a job, app, or deployment still references.
 
 ## Caveats
-- **The requirements path is a project path for BOTH the SDK and the CLI.** The
-  CLI does not upload; it only adds a local-existence check on top. `cd /hopsfs`
-  first and pass a project-relative path. This is the single most common failure
-  mode — see *Requirements-file paths*.
+- **The SDK takes project paths only; the CLI uploads local files.** With the
+  SDK, put the file in the project first (FUSE mount or `dataset.upload`) and
+  pass the project path. With the CLI, a local `-f` is uploaded to
+  `Resources/environments/<env>/` and anything that is not a local file is
+  passed through as a project path — see *Requirements-file paths*.
 - **Clone and install block.** Use `await_creation=False` /
   `await_installation=False` to fire-and-forget, but then you must poll before the
   workload can use the env.
@@ -173,9 +161,9 @@ env.delete()                               # remove the environment
   `spark-feature-pipeline-v1`) so a pinned env travels with the code version.
 
 ## Toolset
-- **CLI:** `hops env list`, `hops env clone <new> --from <base> [--description]`, `hops env install <env> -f <project-relative-requirements.txt>` (run from `/hopsfs`).
+- **CLI:** `hops env list`, `hops env clone <new> --from <base> [--description]`, `hops env install <env> -f <local-file-or-project-path> [--upload-dir] [--no-overwrite]`.
 - **SDK:** `project.get_environment_api()` → `create_environment(base_environment_name=, await_creation=)`, `env.install_requirements()`, `env.install_wheel()`, `env.uninstall()`, `env.delete()`.
-- **Source:** `python/hopsworks_common/core/environment_api.py`, `python/hopsworks_common/environment.py`, `python/hopsworks/cli/commands/env.py` (see `env_install` — it forwards the path unchanged, confirming the no-upload behaviour).
+- **Source:** `python/hopsworks_common/core/environment_api.py`, `python/hopsworks_common/environment.py`, `python/hopsworks/cli/commands/env.py` (see `env_install` — a local `-f` is uploaded, any other string is passed through as a project path).
 
 ## Next steps
 - [hops-job](../hops-job/SKILL.md) — run a job in the cloned environment.


### PR DESCRIPTION
Part of the HWORKS-2991 set: logicalclocks/hopsworks-ee#3190, logicalclocks/hopsworks-helm#2163, logicalclocks/hopsworks-front#2026, logicalclocks/docker-images#904 and #908.

## The bug

`hops env install -f <file>` was the only path-taking command in the CLI that did not upload a local file. It declared `-f` as `click.Path(exists=True)`, forcing the path to exist locally, and then forwarded the same string to `install_requirements()`, which the backend resolves against `/Projects/<project>/`. The two constraints contradict each other:

| Invocation | Result |
|---|---|
| `-f requirements.txt` (local file) | Click passes; backend 404s (`errorCode 110008`) |
| `-f Users/me/requirements.txt` (project path) | Click rejects it before any request is sent |
| `-f /hopsfs/Users/me/requirements.txt` | Click passes; backend 404s on `/Projects/<project>/hopsfs/...` |

The only working call was `cd /hopsfs && hops env install <env> -f Users/me/requirements.txt`, making one relative string valid both locally and project-side. The command's own docstring promised the upload it never performed.

## The fix

`-f` now takes either a local file, uploaded to `Resources/environments/<env>/` before installing, or a string that is not a local file, passed through as a project path. Same resolution `hops job deploy` and `hops deployment create` already apply to their script arguments, same messages, same staging convention. `--upload-dir` overrides the destination; `--overwrite` defaults to on (unlike `job deploy`) because re-installing an edited requirements file is the common loop here.

The `hops-environments` skill is corrected in two steps that mirror reality: the first commit documents what the CLI actually did (the skill claimed an upload that never happened), the second updates it to the fixed contract. The SDK section is unchanged; `install_requirements()` still takes project paths only.

## Testing

- `python/tests/cli/test_env.py`, 5 tests: local file uploaded with the right destination and overwrite flag, non-local string passed through untouched, `--upload-dir`/`--no-overwrite` honored, upload failure reported without attempting the install, unknown environment named in the error. All pass.
- `ruff check` and `ruff format --check` clean at the pinned 0.15.6.
- End-to-end on `jim-dup-features` with the built package: `hops env clone cli-fix-check --from minimal-inference-pipeline`, then from an arbitrary cwd `hops env install cli-fix-check -f my-reqs.txt` uploaded to `Resources/environments/cli-fix-check/my-reqs.txt` and installed `humanize==4.12.1`, blocking until the backend finished. This is the exact invocation that failed with 110008 before.

## Recorded, not done

`install_wheel` and `delete` exist in the SDK but have no CLI commands; the backend's `110008` File-not-found could be wrapped with an actionable hint when the user-supplied path is at fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
