### PR TITLE
[FSTORE-2068] Backport online delete on remove_rows to 5.0

### DIFF
--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/engine/FeatureGroupUtils.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/engine/FeatureGroupUtils.java
@@ -258,11 +258,16 @@ public class FeatureGroupUtils {
 
   public static Map<String, byte[]> getHeaders(FeatureGroupBase featureGroup, Long numEntries)
       throws FeatureStoreException, IOException {
-    return getHeaders(featureGroup, numEntries, null);
+    return getHeaders(featureGroup, numEntries, null, null);
   }
 
   public static Map<String, byte[]> getHeaders(FeatureGroupBase featureGroup, Long numEntries,
       Map<String, String> options) throws FeatureStoreException, IOException {
+    return getHeaders(featureGroup, numEntries, options, null);
+  }
+
+  public static Map<String, byte[]> getHeaders(FeatureGroupBase featureGroup, Long numEntries,
+      Map<String, String> options, String operation) throws FeatureStoreException, IOException {
     Map<String, byte[]> headerMap = new HashMap<>();
 
     headerMap.put("projectId",
@@ -270,6 +275,12 @@ public class FeatureGroupUtils {
     headerMap.put("featureGroupId", String.valueOf(featureGroup.getId()).getBytes(StandardCharsets.UTF_8));
     headerMap.put("subjectId",
         String.valueOf(featureGroup.getSubject().getId()).getBytes(StandardCharsets.UTF_8));
+
+    // operation header tells OnlineFS whether the message is an upsert (absent) or a
+    // delete tombstone ("delete"); OnlineFS deletes the row by primary key on "delete".
+    if (operation != null) {
+      headerMap.put("operation", operation.getBytes(StandardCharsets.UTF_8));
+    }
 
     if (options != null
         && Boolean.parseBoolean(options.get("online_ingestion_options.upsert_if_newer"))) {

--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/metadata/VariablesApi.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/metadata/VariablesApi.java
@@ -49,4 +49,5 @@ public class VariablesApi {
       return Optional.empty();
     }
   }
+
 }

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/FeatureGroup.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/FeatureGroup.java
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FeatureGroup extends FeatureGroupBase<Dataset<Row>> {
 
-  private final FeatureGroupEngine featureGroupEngine = new FeatureGroupEngine();
+  protected FeatureGroupEngine featureGroupEngine = new FeatureGroupEngine();
   protected StatisticsEngine statisticsEngine = new StatisticsEngine(EntityEndpointType.FEATURE_GROUP);
 
   @Builder
@@ -883,9 +883,12 @@ public class FeatureGroup extends FeatureGroupBase<Dataset<Row>> {
    *        // get feature group handle
    *        FeatureGroup fg = fs.getFeatureGroup("electricity_prices", 1);
    *        // Drops records of feature data and commit
-   *        fg.commitDeleteRecord(featureData);
+   *        fg.removeRows(featureData);
    * }
    * </pre>
+   *
+   * <p>When the feature group is online-enabled the records are deleted from the online store as
+   * well. Use {@link #removeRows(Dataset, Storage)} with {@link Storage#OFFLINE} to delete offline only.
    *
    * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
    * @throws FeatureStoreException If Client is not connected to Hopsworks and/or no commit information was found for
@@ -893,9 +896,11 @@ public class FeatureGroup extends FeatureGroupBase<Dataset<Row>> {
    * @throws IOException Generic IO exception.
    * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
    */
-  public void commitDeleteRecord(Dataset<Row> featureData)
+  public void removeRows(Dataset<Row> featureData)
       throws FeatureStoreException, IOException, ParseException {
-    featureGroupEngine.commitDelete(this, featureData, null);
+    // Null storage follows the feature group, so this overload works on one without an
+    // online store instead of throwing.
+    featureGroupEngine.commitDelete(this, featureData, null, null);
   }
 
   /**
@@ -915,9 +920,12 @@ public class FeatureGroup extends FeatureGroupBase<Dataset<Row>> {
    *                           put("hoodie.upsert.shuffle.parallelism", "5");}
    *                           };
    *        // Drops records of feature data and commit
-   *        fg.commitDeleteRecord(featureData, writeOptions);
+   *        fg.removeRows(featureData, writeOptions);
    * }
    * </pre>
+   *
+   * <p>When the feature group is online-enabled the records are deleted from the online store as
+   * well. Use {@link #removeRows(Dataset, Map, Storage)} with {@link Storage#OFFLINE} to delete offline only.
    *
    * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
    * @param writeOptions Additional write options as key-value pairs.
@@ -926,9 +934,97 @@ public class FeatureGroup extends FeatureGroupBase<Dataset<Row>> {
    * @throws IOException Generic IO exception.
    * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
    */
+  public void removeRows(Dataset<Row> featureData, Map<String, String> writeOptions)
+      throws FeatureStoreException, IOException, ParseException {
+    // Follows the feature group, as above.
+    featureGroupEngine.commitDelete(this, featureData, writeOptions, null);
+  }
+
+  /**
+   * Drops records present in the provided DataFrame from the offline table, and optionally from the online
+   * store of an online-enabled feature group. This method can only be used on time travel enabled feature
+   * groups.
+   *
+   * <p>{@code featureData} needs to carry the key columns the offline delete matches on: the primary key,
+   * plus the event time and any partition columns when the feature group has them. The online delete
+   * matches on the primary key alone and ignores every other column, so a value passed for a non-key
+   * feature has no effect on it.
+   *
+   * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
+   * @param storage The storage to delete from. Null follows the feature group: both stores when it is
+   *                online-enabled, offline alone when it is not. {@link Storage#OFFLINE} deletes from the
+   *                offline table only and {@link Storage#ONLINE} from the online store only, as on insert.
+   *                A single-store delete is not reconciled later: the rows stay in the other store until
+   *                they are deleted there too.
+   * @throws FeatureStoreException If storage is {@link Storage#ONLINE} and the feature group is not
+   *                               online-enabled; or on other client/commit errors.
+   * @throws IOException Generic IO exception.
+   * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
+   */
+  public void removeRows(Dataset<Row> featureData, Storage storage)
+      throws FeatureStoreException, IOException, ParseException {
+    featureGroupEngine.commitDelete(this, featureData, null, storage);
+  }
+
+  /**
+   * Drops records present in the provided DataFrame from the offline table, and optionally from the online
+   * store of an online-enabled feature group. This method can only be used on time travel enabled feature
+   * groups.
+   *
+   * <p>{@code featureData} needs to carry the key columns the offline delete matches on: the primary key,
+   * plus the event time and any partition columns when the feature group has them. The online delete
+   * matches on the primary key alone and ignores every other column, so a value passed for a non-key
+   * feature has no effect on it.
+   *
+   * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
+   * @param writeOptions Additional write options as key-value pairs.
+   * @param storage The storage to delete from. Null follows the feature group: both stores when it is
+   *                online-enabled, offline alone when it is not. {@link Storage#OFFLINE} deletes from the
+   *                offline table only and {@link Storage#ONLINE} from the online store only, as on insert.
+   *                A single-store delete is not reconciled later: the rows stay in the other store until
+   *                they are deleted there too.
+   * @throws FeatureStoreException If storage is {@link Storage#ONLINE} and the feature group is not
+   *                               online-enabled; or on other client/commit errors.
+   * @throws IOException Generic IO exception.
+   * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
+   */
+  public void removeRows(Dataset<Row> featureData, Map<String, String> writeOptions, Storage storage)
+      throws FeatureStoreException, IOException, ParseException {
+    featureGroupEngine.commitDelete(this, featureData, writeOptions, storage);
+  }
+
+  /**
+   * Drops records present in the provided DataFrame.
+   *
+   * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
+   * @throws FeatureStoreException on client/commit errors.
+   * @throws IOException Generic IO exception.
+   * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
+   * @deprecated use {@link #removeRows(Dataset)} instead.
+   */
+  @Deprecated
+  public void commitDeleteRecord(Dataset<Row> featureData)
+      throws FeatureStoreException, IOException, ParseException {
+    // Offline only: removeRows deletes from the online store too, this signature keeps the
+    // behaviour it had before the online delete existed.
+    removeRows(featureData, Storage.OFFLINE);
+  }
+
+  /**
+   * Drops records present in the provided DataFrame.
+   *
+   * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
+   * @param writeOptions Additional write options as key-value pairs.
+   * @throws FeatureStoreException on client/commit errors.
+   * @throws IOException Generic IO exception.
+   * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
+   * @deprecated use {@link #removeRows(Dataset, Map)} instead.
+   */
+  @Deprecated
   public void commitDeleteRecord(Dataset<Row> featureData, Map<String, String> writeOptions)
       throws FeatureStoreException, IOException, ParseException {
-    featureGroupEngine.commitDelete(this, featureData, writeOptions);
+    // Offline only, as above.
+    removeRows(featureData, writeOptions, Storage.OFFLINE);
   }
 
   /**

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/StreamFeatureGroup.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/StreamFeatureGroup.java
@@ -1107,9 +1107,12 @@ public class StreamFeatureGroup extends FeatureGroupBase<Dataset<Row>> {
    *        // get feature group handle
    *        StreamFeatureGroup fg = fs.getStreamFeatureGroup("electricity_prices", 1);
    *        // drop records of feature data and commit
-   *        fg.commitDeleteRecord(featureData);
+   *        fg.removeRows(featureData);
    * }
    * </pre>
+   *
+   * <p>When the feature group is online-enabled the records are deleted from the online store as
+   * well. Use {@link #removeRows(Dataset, Storage)} with {@link Storage#OFFLINE} to delete offline only.
    *
    * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
    * @throws FeatureStoreException If Client is not connected to Hopsworks and/or no commit information was found for
@@ -1117,9 +1120,11 @@ public class StreamFeatureGroup extends FeatureGroupBase<Dataset<Row>> {
    * @throws IOException Generic IO exception.
    * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
    */
-  public void commitDeleteRecord(Dataset<Row>  featureData)
+  public void removeRows(Dataset<Row>  featureData)
       throws FeatureStoreException, IOException, ParseException {
-    featureGroupEngine.commitDelete(this, featureData, null);
+    // Null storage follows the feature group, so this overload works on one without an
+    // online store instead of throwing.
+    featureGroupEngine.commitDelete(this, featureData, null, null);
   }
 
   /**
@@ -1138,9 +1143,12 @@ public class StreamFeatureGroup extends FeatureGroupBase<Dataset<Row>> {
    *                           put("hoodie.upsert.shuffle.parallelism", "5");}
    *                           };
    *        // drop records of feature data and commit
-   *        fg.commitDeleteRecord(featureData, writeOptions);
+   *        fg.removeRows(featureData, writeOptions);
    * }
    * </pre>
+   *
+   * <p>When the feature group is online-enabled the records are deleted from the online store as
+   * well. Use {@link #removeRows(Dataset, Map, Storage)} with {@link Storage#OFFLINE} to delete offline only.
    *
    * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
    * @param writeOptions Additional write options as key-value pairs.
@@ -1149,9 +1157,105 @@ public class StreamFeatureGroup extends FeatureGroupBase<Dataset<Row>> {
    * @throws IOException Generic IO exception.
    * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
    */
-  public void commitDeleteRecord(Dataset<Row>  featureData, Map<String, String> writeOptions)
+  public void removeRows(Dataset<Row>  featureData, Map<String, String> writeOptions)
       throws FeatureStoreException, IOException, ParseException {
-    featureGroupEngine.commitDelete(this, featureData, writeOptions);
+    // Follows the feature group, as above.
+    featureGroupEngine.commitDelete(this, featureData, writeOptions, null);
+  }
+
+  /**
+   * Drops records present in the provided DataFrame from the offline table, and optionally from the online
+   * store of an online-enabled feature group.
+   *
+   * <p>{@code featureData} needs to carry the key columns the offline delete matches on: the primary key,
+   * plus the event time and any partition columns when the feature group has them. The online delete
+   * matches on the primary key alone and ignores every other column, so a value passed for a non-key
+   * feature has no effect on it.
+   *
+   * <p>A stream feature group's inserts reach the offline table through the materialization job. Deleting a
+   * row whose insert has not been materialized yet deletes nothing offline, and the materialization job then
+   * writes the row, so it stays in the offline table while the online store has it deleted. Re-run the delete
+   * after the materialization job to reconcile the two stores.
+   *
+   * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
+   * @param storage The storage to delete from. Null follows the feature group: both stores when it is
+   *                online-enabled, offline alone when it is not. {@link Storage#OFFLINE} deletes from the
+   *                offline table only and {@link Storage#ONLINE} from the online store only, as on insert.
+   *                A single-store delete is not reconciled later: the rows stay in the other store until
+   *                they are deleted there too.
+   * @throws FeatureStoreException If storage is {@link Storage#ONLINE} and the feature group is not
+   *                               online-enabled; or on other client/commit errors.
+   * @throws IOException Generic IO exception.
+   * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
+   */
+  public void removeRows(Dataset<Row> featureData, Storage storage)
+      throws FeatureStoreException, IOException, ParseException {
+    featureGroupEngine.commitDelete(this, featureData, null, storage);
+  }
+
+  /**
+   * Drops records present in the provided DataFrame from the offline table, and optionally from the online
+   * store of an online-enabled feature group.
+   *
+   * <p>{@code featureData} needs to carry the key columns the offline delete matches on: the primary key,
+   * plus the event time and any partition columns when the feature group has them. The online delete
+   * matches on the primary key alone and ignores every other column, so a value passed for a non-key
+   * feature has no effect on it.
+   *
+   * <p>A stream feature group's inserts reach the offline table through the materialization job. Deleting a
+   * row whose insert has not been materialized yet deletes nothing offline, and the materialization job then
+   * writes the row, so it stays in the offline table while the online store has it deleted. Re-run the delete
+   * after the materialization job to reconcile the two stores.
+   *
+   * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
+   * @param writeOptions Additional write options as key-value pairs.
+   * @param storage The storage to delete from. Null follows the feature group: both stores when it is
+   *                online-enabled, offline alone when it is not. {@link Storage#OFFLINE} deletes from the
+   *                offline table only and {@link Storage#ONLINE} from the online store only, as on insert.
+   *                A single-store delete is not reconciled later: the rows stay in the other store until
+   *                they are deleted there too.
+   * @throws FeatureStoreException If storage is {@link Storage#ONLINE} and the feature group is not
+   *                               online-enabled; or on other client/commit errors.
+   * @throws IOException Generic IO exception.
+   * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
+   */
+  public void removeRows(Dataset<Row> featureData, Map<String, String> writeOptions, Storage storage)
+      throws FeatureStoreException, IOException, ParseException {
+    featureGroupEngine.commitDelete(this, featureData, writeOptions, storage);
+  }
+
+  /**
+   * Drops records present in the provided DataFrame.
+   *
+   * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
+   * @throws FeatureStoreException on client/commit errors.
+   * @throws IOException Generic IO exception.
+   * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
+   * @deprecated use {@link #removeRows(Dataset)} instead.
+   */
+  @Deprecated
+  public void commitDeleteRecord(Dataset<Row> featureData)
+      throws FeatureStoreException, IOException, ParseException {
+    // Offline only: removeRows deletes from the online store too, this signature keeps the
+    // behaviour it had before the online delete existed.
+    removeRows(featureData, Storage.OFFLINE);
+  }
+
+  /**
+   * Drops records present in the provided DataFrame.
+   *
+   * @param featureData Spark DataFrame, RDD. Feature data to be deleted.
+   * @param writeOptions Additional write options as key-value pairs.
+   * @throws FeatureStoreException on client/commit errors.
+   * @throws IOException Generic IO exception.
+   * @throws ParseException In case it's unable to parse HUDI commit date string to date type.
+   * @deprecated use {@link #removeRows(Dataset, Map)} instead.
+   */
+  @Deprecated
+  public void commitDeleteRecord(Dataset<Row> featureData, Map<String, String> writeOptions)
+      throws FeatureStoreException, IOException, ParseException {
+    // Offline only, as above.
+    removeRows(featureData, writeOptions, Storage.OFFLINE);
   }
 
   /**

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/FeatureGroupEngine.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/FeatureGroupEngine.java
@@ -468,14 +468,54 @@ public class FeatureGroupEngine  extends FeatureGroupEngineBase {
   public FeatureGroupCommit commitDelete(FeatureGroupBase featureGroupBase, Dataset<Row> genericDataset,
                                          Map<String, String> writeOptions)
       throws IOException, FeatureStoreException, ParseException {
+    return commitDelete(featureGroupBase, genericDataset, writeOptions, Storage.OFFLINE);
+  }
+
+  /**
+   * Deletes the records in {@code genericDataset} from the storage named by {@code storage}.
+   *
+   * <p>{@code null} follows the feature group: both stores when it is online-enabled, offline alone
+   * when it is not. {@link Storage#OFFLINE} deletes from the offline table only. {@link
+   * Storage#ONLINE} keeps the meaning it has on insert, online alone, and is not supported yet:
+   * it would leave the offline table holding rows the caller asked to remove.
+   */
+  public FeatureGroupCommit commitDelete(FeatureGroupBase featureGroupBase, Dataset<Row> genericDataset,
+                                         Map<String, String> writeOptions, Storage storage)
+      throws IOException, FeatureStoreException, ParseException {
     if (!((featureGroupBase instanceof FeatureGroup && featureGroupBase.getTimeTravelFormat() == TimeTravelFormat.HUDI)
         || featureGroupBase instanceof StreamFeatureGroup)) {
       // operation is only valid for time travel enabled feature group
       throw new FeatureStoreException("delete function is only valid for "
           + "time travel enabled feature group");
     }
-    return HudiEngine.getInstance().deleteRecord(SparkEngine.getInstance().getSparkSession(), featureGroupBase,
-        genericDataset, writeOptions);
+    // Validate before either leg runs, so an unsupported request fails without mutating a
+    // store. Online-only on a feature group with no online store would delete nothing.
+    if (storage == Storage.ONLINE && !Boolean.TRUE.equals(featureGroupBase.getOnlineEnabled())) {
+      throw new FeatureStoreException("Storage.ONLINE was set but this feature group is not online-enabled.");
+    }
+    boolean deleteOffline = storage != Storage.ONLINE;
+    boolean deleteOnline = storage != Storage.OFFLINE && Boolean.TRUE.equals(featureGroupBase.getOnlineEnabled());
+
+    // The online delete is routed as a Kafka tombstone consumed by OnlineFS, which deletes
+    // the row from RonDB by primary key. Null on an online-only delete: there is no offline
+    // commit to describe.
+    FeatureGroupCommit commit = null;
+    if (deleteOffline) {
+      commit = HudiEngine.getInstance().deleteRecord(
+          SparkEngine.getInstance().getSparkSession(), featureGroupBase, genericDataset, writeOptions);
+    }
+
+    if (deleteOnline) {
+      // Requires an OnlineFS (clusterj-onlinefs) that understands the operation: delete header
+      // (the release shipping the OnlineFS delete branch onward). Not runtime-gated: OnlineFS is
+      // not reachable from the client, and the backend version is not its proxy since backend, SDK
+      // and OnlineFS can be versioned/backported independently. A controlled deployment (helm bumps
+      // the SDK images and OnlineFS together) keeps them in sync; pair a delete-capable OnlineFS
+      // with this SDK, as an OnlineFS without the delete branch mishandles the tombstone.
+      SparkEngine.getInstance().deleteOnlineDataframe(featureGroupBase, genericDataset,
+          writeOptions != null ? writeOptions : new HashMap<>());
+    }
+    return commit;
   }
 
   public ExternalFeatureGroup saveExternalFeatureGroup(ExternalFeatureGroup externalFeatureGroup)

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/SparkEngine.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/SparkEngine.java
@@ -41,8 +41,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -59,6 +61,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.avro.SchemaConverters;
 import org.apache.spark.sql.functions;
 import org.apache.spark.sql.streaming.DataStreamReader;
 import org.apache.spark.sql.streaming.DataStreamWriter;
@@ -578,10 +581,78 @@ public class SparkEngine extends EngineBase {
     return query;
   }
 
+  /**
+   * Produces an online delete tombstone for every row in the dataset.
+   *
+   * <p>Each message carries the row encoded against the feature group Avro schema plus an
+   * {@code operation: delete} header; OnlineFS deletes the row by primary key and ignores the values.
+   * The dataset needs to carry only the primary key: non-key columns are filled with null so the Avro
+   * schema serializes.
+   *
+   * <p>The deletes are tracked by the same online ingestion record as an insert, and reported under
+   * its {@code DELETED} status, so the removed rows are counted apart from written ones.
+   *
+   * @param featureGroupBase the online-enabled feature group
+   * @param dataset the rows to delete
+   * @param writeOptions kafka write options
+   */
+  public void deleteOnlineDataframe(FeatureGroupBase featureGroupBase, Dataset<Row> dataset,
+                                    Map<String, String> writeOptions)
+      throws FeatureStoreException, IOException {
+    Map<String, String> kafkaConfig = SparkEngine.getInstance().getKafkaConfig(featureGroupBase, writeOptions);
+    Dataset<Row> padded = padOnlineDeleteDataset(featureGroupBase, dataset);
+    Long numEntries = Boolean.parseBoolean(
+        writeOptions.getOrDefault("online_ingestion_options.disable_online_ingestion_count", "false"))
+        ? null : padded.count();
+    onlineFeatureGroupToAvro(featureGroupBase, encodeComplexFeatures(featureGroupBase, padded))
+        .withColumn("headers", getHeader(featureGroupBase, numEntries, writeOptions, "delete"))
+        .write()
+        .format(Constants.KAFKA_FORMAT)
+        .options(kafkaConfig)
+        .option("topic", featureGroupBase.getOnlineTopicName())
+        .save();
+  }
+
+  /**
+   * Builds the delete tombstone from the primary key only: keeps the caller's primary-key columns
+   * and forces every other feature group column to a typed null.
+   *
+   * <p>Non-key columns are ignored for the online delete (OnlineFS deletes by primary key and
+   * discards the values), so overriding them here honors the removeRows contract and prevents a
+   * stale or type-incompatible caller value from failing Avro serialization after the offline
+   * delete has already committed. Feature group schemas wrap every field in a
+   * {@code ["null", <type>]} union, so a null fill always serializes.
+   */
+  private Dataset<Row> padOnlineDeleteDataset(FeatureGroupBase featureGroupBase, Dataset<Row> dataset)
+      throws FeatureStoreException, IOException {
+    // LinkedHashSet, not HashSet: the set is what the projection is built from, so keep the
+    // declared key order rather than a hash order. FeatureGroupBase is used raw here, which
+    // erases getPrimaryKeys() to a raw List, so read the keys back off the typed set.
+    Set<String> primaryKeys = new LinkedHashSet<>(featureGroupBase.getPrimaryKeys());
+    List<Column> columns = new ArrayList<>();
+    for (String primaryKey : primaryKeys) {
+      columns.add(col(primaryKey));
+    }
+    for (Schema.Field field : featureGroupBase.getDeserializedAvroSchema().getFields()) {
+      if (primaryKeys.contains(field.name())) {
+        continue;
+      }
+      DataType sparkType = SchemaConverters.toSqlType(field.schema()).dataType();
+      columns.add(lit(null).cast(sparkType).as(field.name()));
+    }
+    return dataset.select(columns.toArray(new Column[0]));
+  }
+
   private Column getHeader(FeatureGroupBase featureGroup, Long numEntries, Map<String, String> options)
       throws FeatureStoreException, IOException {
+    return getHeader(featureGroup, numEntries, options, null);
+  }
+
+  private Column getHeader(FeatureGroupBase featureGroup, Long numEntries, Map<String, String> options,
+                           String operation)
+      throws FeatureStoreException, IOException {
     return array(
-      FeatureGroupUtils.getHeaders(featureGroup, numEntries, options).entrySet().stream()
+      FeatureGroupUtils.getHeaders(featureGroup, numEntries, options, operation).entrySet().stream()
       .map(entry -> struct(
         lit(entry.getKey()).as("key"),
         lit(entry.getValue()).as("value")

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/DeltaStreamerAvroDeserializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/DeltaStreamerAvroDeserializer.java
@@ -106,6 +106,9 @@ public class DeltaStreamerAvroDeserializer implements Deserializer<GenericRecord
   public GenericRecord deserialize(String topic, Headers headers, byte[] data) {
     if (subjectId.equals(getHeader(headers, "subjectId"))
         && featureGroupId.equals(getHeader(headers, "featureGroupId"))) {
+      if (skipOfflineMaterialization(headers)) {
+        return null;
+      }
       return deserialize(topic, data);
     }
     return null; // this job doesn't care about this entry, no point in deserializing
@@ -157,6 +160,22 @@ public class DeltaStreamerAvroDeserializer implements Deserializer<GenericRecord
       }
     }
     return finalResult;
+  }
+
+  /**
+   * Whether this record belongs in the offline table at all.
+   *
+   * <p>A delete tombstone does not. It is on the topic for OnlineFS, while removeRows has already
+   * applied the offline delete directly to the table, so materializing the tombstone would
+   * re-insert the key it deleted. The operation header is a proxy for the destination here: it is
+   * the only header that distinguishes a tombstone, and dropping the record is the whole of what
+   * this job does with one today. When the offline delete moves onto the topic, this becomes a
+   * branch that emits a Hudi delete rather than dropping the record.
+   *
+   * <p>Exact match, as in OnlineFsHandler.getRow. Any other value is an upsert.
+   */
+  private boolean skipOfflineMaterialization(Headers headers) {
+    return "delete".equals(getHeader(headers, "operation"));
   }
 
   private static String getHeader(Headers headers, String headerKey) {

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/TestFeatureGroup.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/TestFeatureGroup.java
@@ -20,6 +20,7 @@ package com.logicalclocks.hsfs.spark;
 import com.logicalclocks.hsfs.Feature;
 import com.logicalclocks.hsfs.FeatureStoreException;
 import com.logicalclocks.hsfs.Project;
+import com.logicalclocks.hsfs.Storage;
 import com.logicalclocks.hsfs.TimeTravelFormat;
 import com.logicalclocks.hsfs.metadata.FeatureGroupApi;
 import com.logicalclocks.hsfs.FeatureGroupBase;
@@ -28,6 +29,8 @@ import com.logicalclocks.hsfs.metadata.HopsworksHttpClient;
 import com.logicalclocks.hsfs.spark.constructor.Query;
 import com.logicalclocks.hsfs.spark.engine.FeatureGroupEngine;
 
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -37,7 +40,9 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -173,5 +178,81 @@ public class TestFeatureGroup {
 
     // Assert
     Assertions.assertNull(featureGroup.getSubject());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testCommitDeleteRecordDelegatesToRemoveRowsOfflineOnly() throws Exception {
+    // The deprecated commitDeleteRecord overloads must delegate to removeRows and delete from
+    // the offline table only. They exist for callers written before the online delete, so
+    // neither may reach the online store; removeRows(Storage) is where that choice lives.
+    FeatureGroup featureGroup = Mockito.spy(new FeatureGroup(null, 1));
+    Dataset<Row> df = Mockito.mock(Dataset.class);
+    Map<String, String> writeOptions = new HashMap<>();
+
+    Mockito.doNothing().when(featureGroup).removeRows(Mockito.eq(df), Mockito.any(Storage.class));
+    Mockito.doNothing().when(featureGroup)
+        .removeRows(Mockito.eq(df), Mockito.eq(writeOptions), Mockito.any(Storage.class));
+
+    featureGroup.commitDeleteRecord(df);
+    featureGroup.commitDeleteRecord(df, writeOptions);
+
+    Mockito.verify(featureGroup).removeRows(df, Storage.OFFLINE);
+    Mockito.verify(featureGroup).removeRows(df, writeOptions, Storage.OFFLINE);
+  }
+
+  @Test
+  public void testRemoveRowsPassesNullStorage() throws Exception {
+    // The overloads without a storage argument must pass null rather than resolving the
+    // feature group themselves: null is what tells commitDelete to follow the feature group,
+    // and the resolution lives there so both feature group classes share one copy of it.
+    FeatureGroupEngine featureGroupEngine = Mockito.mock(FeatureGroupEngine.class);
+    Dataset<Row> df = Mockito.mock(Dataset.class);
+    Map<String, String> writeOptions = new HashMap<>();
+
+    FeatureGroup offlineOnly = new FeatureGroup(null, 1);
+    offlineOnly.featureGroupEngine = featureGroupEngine;
+    offlineOnly.setOnlineEnabled(false);
+
+    offlineOnly.removeRows(df);
+    offlineOnly.removeRows(df, writeOptions);
+
+    Mockito.verify(featureGroupEngine).commitDelete(offlineOnly, df, null, null);
+    Mockito.verify(featureGroupEngine).commitDelete(offlineOnly, df, writeOptions, null);
+
+    FeatureGroup onlineEnabled = new FeatureGroup(null, 2);
+    onlineEnabled.featureGroupEngine = featureGroupEngine;
+    onlineEnabled.setOnlineEnabled(true);
+
+    onlineEnabled.removeRows(df);
+
+    Mockito.verify(featureGroupEngine).commitDelete(onlineEnabled, df, null, null);
+  }
+
+  @Test
+  public void testStreamFeatureGroupRemoveRowsPassesNullStorage() throws Exception {
+    // Same contract on the stream feature group, whose overloads carry their own copy of the
+    // call into commitDelete.
+    FeatureGroupEngine featureGroupEngine = Mockito.mock(FeatureGroupEngine.class);
+    Dataset<Row> df = Mockito.mock(Dataset.class);
+    Map<String, String> writeOptions = new HashMap<>();
+
+    StreamFeatureGroup offlineOnly = new StreamFeatureGroup(null, 1);
+    offlineOnly.featureGroupEngine = featureGroupEngine;
+    offlineOnly.setOnlineEnabled(false);
+
+    offlineOnly.removeRows(df);
+    offlineOnly.removeRows(df, writeOptions);
+
+    Mockito.verify(featureGroupEngine).commitDelete(offlineOnly, df, null, null);
+    Mockito.verify(featureGroupEngine).commitDelete(offlineOnly, df, writeOptions, null);
+
+    StreamFeatureGroup onlineEnabled = new StreamFeatureGroup(null, 2);
+    onlineEnabled.featureGroupEngine = featureGroupEngine;
+    onlineEnabled.setOnlineEnabled(true);
+
+    onlineEnabled.removeRows(df);
+
+    Mockito.verify(featureGroupEngine).commitDelete(onlineEnabled, df, null, null);
   }
 }

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/hudi/TestDeltaStreamerAvroDeserializer.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/hudi/TestDeltaStreamerAvroDeserializer.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2026-2026. Hopsworks AB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.logicalclocks.hsfs.spark.engine.hudi;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestDeltaStreamerAvroDeserializer {
+
+  private static final String TOPIC = "test_topic";
+  private static final String SUBJECT = "7";
+  private static final String FEATURE_GROUP = "10";
+  private static final String SCHEMA_STRING =
+      "{\"type\":\"record\",\"name\":\"test_fg\",\"namespace\":\"test_featurestore.db\",\"fields\":"
+      + "[{\"name\":\"id\",\"type\":[\"null\",\"long\"]}]}";
+
+  private DeltaStreamerAvroDeserializer deserializer() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(HudiEngine.SUBJECT_ID, SUBJECT);
+    configs.put(HudiEngine.FEATURE_GROUP_ID, FEATURE_GROUP);
+    configs.put(HudiEngine.FEATURE_GROUP_SCHEMA, SCHEMA_STRING);
+    configs.put(HudiEngine.FEATURE_GROUP_ENCODED_SCHEMA, SCHEMA_STRING);
+    configs.put(HudiEngine.FEATURE_GROUP_COMPLEX_FEATURES, "[]");
+
+    DeltaStreamerAvroDeserializer deserializer = new DeltaStreamerAvroDeserializer();
+    deserializer.configure(configs, false);
+    return deserializer;
+  }
+
+  private byte[] encodedRow(long id) throws IOException {
+    Schema schema = new Schema.Parser().parse(SCHEMA_STRING);
+    GenericRecord record = new GenericData.Record(schema);
+    record.put("id", id);
+
+    DatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+    writer.write(record, encoder);
+    encoder.flush();
+    return out.toByteArray();
+  }
+
+  private Headers headers(String subjectId, String featureGroupId, String operation) {
+    RecordHeaders headers = new RecordHeaders();
+    headers.add("subjectId", subjectId.getBytes(StandardCharsets.UTF_8));
+    headers.add("featureGroupId", featureGroupId.getBytes(StandardCharsets.UTF_8));
+    if (operation != null) {
+      headers.add("operation", operation.getBytes(StandardCharsets.UTF_8));
+    }
+    return headers;
+  }
+
+  @Test
+  void testDeleteTombstoneIsDropped() throws IOException {
+    Headers headers = headers(SUBJECT, FEATURE_GROUP, "delete");
+
+    Assertions.assertNull(deserializer().deserialize(TOPIC, headers, encodedRow(2L)));
+  }
+
+  @Test
+  void testOperationHeaderMatchesDeleteExactly() throws IOException {
+    for (String operation : new String[] {"Delete", "DELETE", " delete", "deleted", "upsert"}) {
+      Headers headers = headers(SUBJECT, FEATURE_GROUP, operation);
+
+      GenericRecord record = deserializer().deserialize(TOPIC, headers, encodedRow(2L));
+
+      Assertions.assertNotNull(record, "operation header " + operation + " must not delete");
+      Assertions.assertEquals(2L, record.get("id"));
+    }
+  }
+
+  @Test
+  void testMissingOperationHeaderIsAnUpsert() throws IOException {
+    Headers headers = headers(SUBJECT, FEATURE_GROUP, null);
+
+    GenericRecord record = deserializer().deserialize(TOPIC, headers, encodedRow(2L));
+
+    Assertions.assertNotNull(record);
+    Assertions.assertEquals(2L, record.get("id"));
+  }
+
+  @Test
+  void testOtherFeatureGroupIsDropped() throws IOException {
+    Headers otherSubject = headers("8", FEATURE_GROUP, null);
+    Headers otherFeatureGroup = headers(SUBJECT, "11", null);
+
+    Assertions.assertNull(deserializer().deserialize(TOPIC, otherSubject, encodedRow(2L)));
+    Assertions.assertNull(deserializer().deserialize(TOPIC, otherFeatureGroup, encodedRow(2L)));
+  }
+}

--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -377,6 +377,21 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
         return None, None
 
     @staticmethod
+    def _delete_online_records(feature_group, delete_df, write_options):
+        # Produce online delete tombstones to the feature group topic; OnlineFS
+        # applies a RonDB delete by primary key. The offline delete is handled
+        # separately by `_commit_delete`.
+        online_engine = engine._get_instance()
+        if isinstance(online_engine, engine.spark.Engine):
+            online_engine._delete_online_dataframe(
+                feature_group, delete_df, write_options
+            )
+        else:
+            online_engine._delete_dataframe_kafka(
+                feature_group, delete_df, write_options
+            )
+
+    @staticmethod
     def _commit_delete(feature_group, delete_df, write_options):
         spark_session, spark_context = (
             FeatureGroupEngine._get_spark_session_and_context()

--- a/python/hsfs/core/kafka_engine.py
+++ b/python/hsfs/core/kafka_engine.py
@@ -128,10 +128,29 @@ def _get_writer_function(
     return (feature_writers, writer)
 
 
+def _online_delete_fill_values(
+    feature_group: FeatureGroup | ExternalFeatureGroup,
+) -> dict[str, Any]:
+    """Null fill values for every non-primary-key field in the feature group schema.
+
+    An online delete tombstone is serialized against the full feature group Avro
+    schema, but the caller only needs to pass the primary key (the offline delete
+    contract).
+    Non-key fields are filled with null so the record serializes; OnlineFS deletes
+    by primary key and discards the values.
+    Online feature group schemas make every non-key field a nullable union, so null
+    always serializes.
+    """
+    primary_key = set(feature_group.primary_key)
+    fields = json.loads(feature_group.avro_schema)["fields"]
+    return {field["name"]: None for field in fields if field["name"] not in primary_key}
+
+
 def _get_headers(
     feature_group: FeatureGroup | ExternalFeatureGroup,
     num_entries: int | None = None,
     options: dict[str, Any] | None = None,
+    operation: str | None = None,
 ) -> dict[str, bytes]:
     # custom headers for hopsworks onlineFS
     headers = {
@@ -139,6 +158,11 @@ def _get_headers(
         "featureGroupId": str(feature_group._id).encode("utf8"),
         "subjectId": str(feature_group.subject["id"]).encode("utf8"),
     }
+
+    # operation header tells OnlineFS whether the message is an upsert (absent) or a
+    # delete tombstone ("delete"); OnlineFS deletes the row by primary key on "delete".
+    if operation is not None:
+        headers["operation"] = operation.encode("utf8")
 
     online_ingestion_options = (
         options.get("online_ingestion_options") if options else None

--- a/python/hsfs/core/online_ingestion_result.py
+++ b/python/hsfs/core/online_ingestion_result.py
@@ -42,7 +42,7 @@ class OnlineIngestionResult:
 
         Parameters:
             online_ingestion_id: The unique identifier for the online ingestion batch.
-            status: The status of the ingestion batch (e.g., "UPSERTED", "FAILED").
+            status: The status of the ingestion batch: "UPSERTED", "DELETED", "IGNORED" or "FAILED".
             rows: The number of rows processed in this batch.
         """
         self._online_ingestion_id = online_ingestion_id
@@ -103,7 +103,11 @@ class OnlineIngestionResult:
     @public
     @property
     def status(self) -> str:
-        """Get the status of the ingestion batch (e.g., "UPSERTED", "FAILED")."""
+        """Get the status of the ingestion batch.
+
+        One of "UPSERTED" for rows written, "DELETED" for rows removed by a delete,
+        "IGNORED" for rows the online store skipped, or "FAILED".
+        """
         return self._status
 
     @public

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -43,6 +43,8 @@ from hsfs.core.type_systems import (
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     import great_expectations
     from hsfs.constructor.filter import Filter, Logic
     from hsfs.training_dataset import TrainingDataset
@@ -1823,6 +1825,52 @@ class Engine:
     ) -> np.ndarray:
         return feature_dataframe[feature_name].unique()
 
+    @staticmethod
+    def _iter_dataframe_rows(
+        dataframe: pd.DataFrame | pl.DataFrame,
+    ) -> Iterator[dict[str, Any]]:
+        if isinstance(dataframe, pd.DataFrame):
+            # itertuples returns Python NamedTuple; convert to dict to serialize via Avro
+            for row in dataframe.itertuples(index=False):
+                yield row._asdict()
+        else:
+            yield from dataframe.iter_rows(named=True)
+
+    @staticmethod
+    def _produce_row_kafka(
+        feature_group: FeatureGroup | ExternalFeatureGroup,
+        producer: Any,
+        row: dict[str, Any],
+        headers: dict[str, bytes],
+        feature_writers: dict[str, Any],
+        writer: Any,
+        acked: Any,
+        offline_write_options: dict[str, Any],
+    ) -> None:
+        encoded_row = kafka_engine._encode_row(feature_writers, writer, row)
+        key = "".join([str(row[pk]) for pk in sorted(feature_group.primary_key)])
+        kafka_engine._kafka_produce(
+            producer=producer,
+            key=key,
+            encoded_row=encoded_row,
+            topic_name=feature_group._online_topic_name,
+            headers=headers,
+            acked=acked,
+            debug_kafka=offline_write_options.get("debug_kafka", False),
+        )
+
+    @staticmethod
+    def _wait_for_online_ingestion(
+        feature_group: FeatureGroup | ExternalFeatureGroup,
+        offline_write_options: dict[str, Any],
+    ) -> None:
+        if feature_group.online_enabled and offline_write_options.get(
+            "wait_for_online_ingestion", False
+        ):
+            feature_group.get_latest_online_ingestion().wait_for_completion(
+                options=offline_write_options.get("online_ingestion_options", {})
+            )
+
     def _write_dataframe_kafka(
         self,
         feature_group: FeatureGroup | ExternalFeatureGroup,
@@ -1867,21 +1915,12 @@ class Engine:
             )
         )
 
-        if isinstance(dataframe, pd.DataFrame):
-            row_iterator = dataframe.itertuples(index=False)
-        else:
-            row_iterator = dataframe.iter_rows(named=True)
-
         # loop over rows
         for row, online_flag in zip(
-            row_iterator,
+            self._iter_dataframe_rows(dataframe),
             online_flags if online_flags is not None else itertools.repeat(None),
             strict=False,
         ):
-            if isinstance(dataframe, pd.DataFrame):
-                # itertuples returns Python NamedTuple; _convert to dict to serialize via Avro
-                row = row._asdict()
-
             # Set per-row storage header based on the online flag when present.
             row_headers = headers
             if online_flag is not None:
@@ -1894,19 +1933,15 @@ class Engine:
                     "storage": b"1" if online_flag else b"0",
                 }
 
-            encoded_row = kafka_engine._encode_row(feature_writers, writer, row)
-
-            # assemble key
-            key = "".join([str(row[pk]) for pk in sorted(feature_group.primary_key)])
-
-            kafka_engine._kafka_produce(
-                producer=producer,
-                key=key,
-                encoded_row=encoded_row,
-                topic_name=feature_group._online_topic_name,
-                headers=row_headers,
-                acked=acked,
-                debug_kafka=offline_write_options.get("debug_kafka", False),
+            self._produce_row_kafka(
+                feature_group,
+                producer,
+                row,
+                row_headers,
+                feature_writers,
+                writer,
+                acked,
+                offline_write_options,
             )
 
         # make sure producer blocks and everything is delivered
@@ -1915,13 +1950,77 @@ class Engine:
             del producer
             progress_bar.close()
 
-        # wait for online _ingestion
-        if feature_group.online_enabled and offline_write_options.get(
-            "wait_for_online_ingestion", False
-        ):
-            feature_group.get_latest_online_ingestion().wait_for_completion(
-                options=offline_write_options.get("online_ingestion_options", {})
+        self._wait_for_online_ingestion(feature_group, offline_write_options)
+
+    def _delete_dataframe_kafka(
+        self,
+        feature_group: FeatureGroup | ExternalFeatureGroup,
+        dataframe: pd.DataFrame | pl.DataFrame,
+        offline_write_options: dict[str, Any],
+    ) -> None:
+        # Produce an online delete tombstone for every row in `dataframe`.
+        # Each message carries the row encoded against the feature group Avro
+        # schema plus an `operation: delete` header; OnlineFS deletes the row by
+        # primary key and ignores the values. `dataframe` needs to carry only the
+        # primary key: non-key fields are filled with null so the record serializes.
+        fill_values = kafka_engine._online_delete_fill_values(feature_group)
+        n_rows = (
+            None
+            if offline_write_options.get("online_ingestion_options", {}).get(
+                "disable_online_ingestion_count", False
             )
+            else len(dataframe)
+        )
+        producer, headers, feature_writers, writer = kafka_engine._get_kafka_resources(
+            feature_group,
+            offline_write_options,
+            num_entries=n_rows,
+        )
+
+        acked, progress_bar = (
+            kafka_engine._build_ack_callback_and_optional_progress_bar(
+                n_rows=n_rows,
+                is_multi_part_insert=feature_group._multi_part_insert,
+                offline_write_options=offline_write_options,
+            )
+        )
+
+        # `operation` is the only header the delete needs, and it is what both consumers
+        # read: OnlineFsHandler.getRow turns it into Row.delete, and the offline
+        # materialization drops the record so it does not re-insert the deleted key.
+        # No `storage` header: it gates the online leg alone ("0" makes OnlineFS skip the
+        # row, anything else or absent ingests it), so it cannot express "online only" and
+        # setting it to b"1" here only restated the default. The Spark and Java delete
+        # paths never set it either.
+        row_headers = {**headers, "operation": b"delete"}
+
+        for row in self._iter_dataframe_rows(dataframe):
+            # Build the tombstone from the primary key only: null every non-key
+            # field and keep just the caller's primary-key values. Any other columns
+            # in `delete_df` are ignored for the online delete (OnlineFS deletes by
+            # primary key and discards the values), so a stale or unserializable
+            # non-key value cannot fail the tombstone after the offline delete has
+            # already committed.
+            row = {**fill_values, **{pk: row[pk] for pk in feature_group.primary_key}}
+            self._produce_row_kafka(
+                feature_group,
+                producer,
+                row,
+                row_headers,
+                feature_writers,
+                writer,
+                acked,
+                offline_write_options,
+            )
+
+        producer.flush()
+        del producer
+        if progress_bar is not None:
+            progress_bar.close()
+
+        # wait for online ingestion so callers that set wait_for_online_ingestion do not
+        # return before OnlineFS has applied the deletes (matches the insert path).
+        self._wait_for_online_ingestion(feature_group, offline_write_options)
 
     def _run_materialization_job(
         self,

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -762,12 +762,19 @@ class Engine:
 
         return dataframe
 
-    def _save_online_dataframe(self, feature_group, dataframe, write_options):
+    def _save_online_dataframe(
+        self, feature_group, dataframe, write_options, operation=None
+    ):
         write_options = kafka_engine._get_kafka_config(
             feature_group.feature_store_id, write_options, engine="spark"
         )
 
-        if write_options.get("online_ingestion_options", {}).get(
+        if operation == "delete":
+            # `dataframe` needs to carry only the primary key: non-key columns are filled
+            # with null so the record serializes against the feature group schema. OnlineFS
+            # deletes by primary key and ignores the values.
+            dataframe = self._pad_online_delete_dataframe(feature_group, dataframe)
+        elif write_options.get("online_ingestion_options", {}).get(
             "mark_online_rows", True
         ):
             dataframe = self._filter_online_dataframe(feature_group, dataframe)
@@ -784,6 +791,7 @@ class Engine:
                     )
                     else dataframe.count(),
                     write_options,
+                    operation=operation,
                 ),
             )
             .write.format(self.KAFKA_FORMAT)
@@ -792,7 +800,8 @@ class Engine:
             .save()
         )
 
-        # wait for online ingestion
+        # wait for online ingestion. On a delete this keeps callers that set
+        # wait_for_online_ingestion from returning before OnlineFS has applied it.
         if feature_group.online_enabled and write_options.get(
             "wait_for_online_ingestion", False
         ):
@@ -800,17 +809,45 @@ class Engine:
                 options=write_options.get("online_ingestion_options", {})
             )
 
+    def _delete_online_dataframe(self, feature_group, dataframe, write_options):
+        # Produce an online delete tombstone for every row in `dataframe`. Each message
+        # carries the row encoded against the feature group Avro schema plus an
+        # `operation: delete` header, which is what makes OnlineFS delete rather than upsert.
+        return self._save_online_dataframe(
+            feature_group, dataframe, write_options, operation="delete"
+        )
+
+    def _pad_online_delete_dataframe(self, feature_group, dataframe):
+        # Build the tombstone from the primary key only: keep the caller's primary-key
+        # columns and force every other feature group column to a typed null. Non-key
+        # columns are ignored for the online delete (OnlineFS deletes by primary key
+        # and discards the values), so overriding them here honors the remove_rows
+        # contract and prevents a stale or type-incompatible caller value from failing
+        # Avro serialization after the offline delete has already committed.
+        # The nulls have to be typed because _serialize_to_avro encodes complex
+        # features against their Avro schema, which an untyped null cannot satisfy.
+        primary_key = set(feature_group.primary_key)
+        return dataframe.select(
+            *[col(name) for name in feature_group.primary_key],
+            *[
+                lit(None).cast(_feature.type).alias(_feature.name)
+                for _feature in feature_group.columns
+                if _feature.name not in primary_key
+            ],
+        )
+
     def _get_headers(
         self,
         feature_group: fg_mod.FeatureGroup | fg_mod.ExternalFeatureGroup,
         num_entries: int | None = None,
         options: dict | None = None,
+        operation: str | None = None,
     ) -> array:
         return array(
             *[
                 struct(lit(key).alias("key"), lit(value).alias("value"))
                 for key, value in kafka_engine._get_headers(
-                    feature_group, num_entries, options
+                    feature_group, num_entries, options, operation
                 ).items()
             ]
         )

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -32,7 +32,7 @@ from urllib.parse import urlparse
 import avro.schema
 import hsfs.expectation_suite
 import humps
-from hopsworks_apigen import deprecation, public
+from hopsworks_apigen import deprecated, deprecation, public
 from hopsworks_common import job
 from hopsworks_common.client.exceptions import FeatureStoreException, RestAPIError
 from hopsworks_common.core import alerts_api
@@ -3692,6 +3692,7 @@ class FeatureGroup(FeatureGroupBase):
                     - `mark_online_rows`: `True` or `False` to filter rows for online ingestion based on event time and primary key deduplication, defaults to `True`.
                     - `disable_online_ingestion_count`: `True` or `False` to disable sending the total number of entries to the online ingestion tracking system, defaults to `False`.
                       When `True`, no batch size is known to the ingestion tracker so `wait_for_online_ingestion` will wait until `timeout` is reached.
+                      Combining it with `timeout` `0` waits forever, since neither the entry count nor the timeout can end the wait.
                 - key `start_offline_backfill` and value `True` or `False` to configure whether or not to start the materialization job to write data to the offline storage. `start_offline_backfill` is deprecated.
                   Use `start_offline_materialization` instead.
                 - key `start_offline_materialization` and value `True` or `False` to configure whether or not to start the materialization job to write data to the offline storage.
@@ -3933,6 +3934,7 @@ class FeatureGroup(FeatureGroupBase):
                     - `mark_online_rows`: `True` or `False` to filter rows for online ingestion based on event time and primary key deduplication, defaults to `True`.
                     - `disable_online_ingestion_count`: `True` or `False` to disable sending the total number of entries to the online ingestion tracking system, defaults to `False`.
                       When `True`, no batch size is known to the ingestion tracker so `wait_for_online_ingestion` will wait until `timeout` is reached.
+                      Combining it with `timeout` `0` waits forever, since neither the entry count nor the timeout can end the wait.
                 - key `start_offline_backfill` and value `True` or `False` to configure whether or not to start the materialization job to write data to the offline storage.
                   `start_offline_backfill` is deprecated.
                   Use `start_offline_materialization` instead.
@@ -4336,29 +4338,147 @@ class FeatureGroup(FeatureGroupBase):
         return self._feature_group_engine._commit_details(self, wallclock_time, limit)
 
     @public
-    def commit_delete_record(
+    def remove_rows(
         self,
         delete_df: TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
         write_options: dict[Any, Any] | None = None,
+        storage: str | None = None,
     ) -> None:
         """Drops records present in the provided DataFrame and commits it as update to this Feature group.
 
         This method can only be used on feature groups stored as HUDI or DELTA.
 
+        Both stores of an online-enabled feature group are affected, mirroring [`insert`][hsfs.feature_group.FeatureGroup.insert], which writes to both.
+        A feature group without an online store is deleted from offline only.
+        Set `storage` to `"offline"` or `"online"` to delete from one store alone.
+
+        Danger: A single-store delete leaves the two stores disagreeing
+            Deleting from one store only is not reconciled by anything later: the rows stay in the other store until they are deleted there too.
+            Reads served from the two stores return different results for those keys from then on.
+        `delete_df` needs to carry the key columns the offline delete matches on: the primary key, plus `event_time` and any partition columns when the feature group has them.
+        The online delete matches on the primary key alone and ignores every other column, so a value passed for a non-key feature has no effect on it.
+        The online delete is tracked by the same online-ingestion record as an insert, and reported under its `DELETED` status, so the removed rows are counted apart from written ones.
+
+        Warning: Deleting a row a stream feature group has not materialized yet
+            The offline delete is applied to the offline table directly, while a stream feature group's inserts reach that table through the materialization job.
+            Deleting a row whose insert has not been materialized yet deletes nothing offline, and the materialization job then writes the row, so it stays in the offline table while the online store has it deleted.
+            Re-run the delete after the materialization job to reconcile the two stores.
+
         Parameters:
-            delete_df: dataFrame containing records to be deleted.
+            delete_df: DataFrame containing records to be deleted.
             write_options: User provided write options.
+                - key `wait_for_online_ingestion` and value `True` or `False` to configure whether or not the call should return only after the online delete has been applied.
+                  By default it does not wait.
+                  Applies only when the online store is deleted from.
+                - key `online_ingestion_options` and value a dict to configure online ingestion behaviour.
+                  Supported keys:
+                    - `timeout`: seconds to wait for the online delete to complete, default `60`, set to `0` for indefinite.
+                      Applies only when `wait_for_online_ingestion` is `True`.
+                    - `period`: polling interval in seconds, default `1`.
+                      Applies only when `wait_for_online_ingestion` is `True`.
+                    - `disable_online_ingestion_count`: `True` or `False` to disable sending the total number of entries to the online ingestion tracking system, defaults to `False`.
+                      Use it to skip counting a large `delete_df` on the Spark engine, where the count is a separate pass over the data.
+                      When `True`, no batch size is known to the ingestion tracker so `wait_for_online_ingestion` will wait until `timeout` is reached.
+                      Combining it with `timeout` `0` waits forever, since neither the entry count nor the timeout can end the wait.
+                - key `internal_kafka` and value `True` or `False` in case you established connectivity from your Python environment to the internal advertised listeners of the Hopsworks Kafka Cluster.
+            storage: The storage to delete from, `"offline"` or `"online"`, mirroring [`insert`][hsfs.feature_group.FeatureGroup.insert].
+                Left unset it follows the feature group: both stores when it is online-enabled, offline alone when it is not or when its online data lives in the vector database behind an embedding index.
+                Set it to `"offline"` to delete from the offline table only, or `"online"` to delete from the online store only.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+            hopsworks.client.exceptions.FeatureStoreException: If `storage` is not one of `"offline"`, `"online"` or unset; or is `"online"` on a feature group that is not online-enabled or has an embedding index.
         """
-        if self.time_travel_format == "HUDI" and not engine._get_type().startswith(
-            "spark"
-        ):
-            raise NotImplementedError(
-                "commit_delete_record is only supported for HUDI feature groups when using the Spark engine."
+        # Validate before either leg runs, so an unsupported request fails without
+        # mutating a store.
+        storage = storage.lower() if storage is not None else None
+        if storage is not None and storage not in ("offline", "online"):
+            raise FeatureStoreException(
+                f"Invalid storage: {storage}. Use 'offline', 'online', or leave it unset."
             )
-        self._feature_group_engine._commit_delete(self, delete_df, write_options or {})
+
+        # Unset follows the feature group, so a plain remove_rows works on every feature
+        # group: it deletes online where there is an online store this release can delete
+        # from, and offline-only everywhere else.
+        delete_offline = storage != "online"
+        delete_online = storage != "offline" and bool(self.online_enabled)
+
+        if storage == "online":
+            # Online-only, so a feature group this release cannot delete online from would
+            # delete nothing at all. Refuse rather than no-op, unlike the unset case below
+            # where the offline delete still happens.
+            if not self.online_enabled:
+                raise FeatureStoreException(
+                    "storage='online' was set but this feature group is not online-enabled."
+                )
+            if self.embedding_index is not None:
+                raise FeatureStoreException(
+                    "storage='online' is not supported for feature groups with an embedding index; "
+                    "their online data lives in the vector database, which this release does not "
+                    "delete from, so nothing would be deleted."
+                )
+        elif delete_online and self.embedding_index is not None:
+            # An embedding index keeps its online data in the vector database, which this
+            # release cannot delete from. Skip the online leg rather than refuse the whole
+            # call, since the offline delete is still what the caller asked for, but say so:
+            # the two stores are left diverged.
+            warnings.warn(
+                "The online store was not deleted from: this feature group's online data lives in the "
+                "vector database behind an embedding index, which this release does not delete from. "
+                "The offline delete was applied, so the two stores now differ for the removed rows.",
+                stacklevel=2,
+            )
+            delete_online = False
+
+        if delete_offline:
+            # The guard is a property of the offline delete: a HUDI delete needs Spark.
+            # An online-only delete goes to Kafka and does not, so it stays available on
+            # those feature groups.
+            if self.time_travel_format == "HUDI" and not engine._get_type().startswith(
+                "spark"
+            ):
+                raise NotImplementedError(
+                    "Deleting rows is only supported for HUDI feature groups when using the Spark engine."
+                )
+
+            self._feature_group_engine._commit_delete(
+                self, delete_df, write_options or {}
+            )
+
+        if delete_online:
+            # Requires an OnlineFS (clusterj-onlinefs) that understands the
+            # `operation: delete` header (the release shipping the OnlineFS delete
+            # branch onward). Not runtime-gated: OnlineFS is not reachable from the
+            # client, and the backend version is not its proxy since backend, SDK and
+            # OnlineFS can be versioned/backported independently. A controlled
+            # deployment (helm bumps SDK images and OnlineFS together) keeps them in
+            # sync; against an OnlineFS without the delete branch the tombstone is a
+            # no-op-to-corrupting write, so pair a delete-capable OnlineFS with this SDK.
+            self._feature_group_engine._delete_online_records(
+                self, delete_df, write_options or {}
+            )
+
+    @deprecated("hsfs.feature_group.FeatureGroup.remove_rows")
+    @public
+    def commit_delete_record(
+        self,
+        delete_df: TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
+        write_options: dict[Any, Any] | None = None,
+    ) -> None:
+        """**Deprecated**, use [`remove_rows`][hsfs.feature_group.FeatureGroup.remove_rows] instead.
+
+        Unlike `remove_rows`, this method leaves the online store untouched, keeping the behaviour it
+        had before the online delete existed.
+        Pass `storage` to [`remove_rows`][hsfs.feature_group.FeatureGroup.remove_rows] to choose which
+        stores a delete affects.
+
+        Parameters:
+            delete_df: DataFrame containing records to be deleted.
+            write_options: User provided write options.
+        """
+        # Offline only, whatever the feature group: this exists for callers written before
+        # the online delete, and remove_rows is where the choice lives now.
+        return self.remove_rows(delete_df, write_options, "offline")
 
     @public
     def delta_vacuum(
@@ -5241,6 +5361,7 @@ class ExternalFeatureGroup(FeatureGroupBase):
                     - `mark_online_rows`: `True` or `False` to filter rows for online ingestion based on event time and primary key deduplication, defaults to `True`.
                     - `disable_online_ingestion_count`: `True` or `False` to disable sending the total number of entries to the online ingestion tracking system, defaults to `False`.
                       When `True`, no batch size is known to the ingestion tracker so `wait_for_online_ingestion` will wait until `timeout` is reached.
+                      Combining it with `timeout` `0` waits forever, since neither the entry count nor the timeout can end the wait.
                 - key `kafka_producer_config` and value an object of type [properties](https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.htmln) used to configure the Kafka client.
                   To optimize for throughput in high latency connection consider changing [producer properties](https://docs.confluent.io/cloud/current/client-apps/optimizing/throughput.html#producer).
                 - key `internal_kafka` and value `True` or `False` in case you established connectivity from you Python environment to the internal advertised listeners of the Hopsworks Kafka Cluster.

--- a/python/tests/engine/test_python_delete.py
+++ b/python/tests/engine/test_python_delete.py
@@ -1,0 +1,342 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+import warnings
+from io import BytesIO
+
+import fastavro
+import pandas as pd
+import pytest
+from hsfs import feature_group
+from hsfs.core import kafka_engine
+from hsfs.core.feature_group_engine import FeatureGroupEngine
+from hsfs.engine import python
+
+
+AVRO_SCHEMA = (
+    '{"type":"record","name":"test_fg","namespace":"test_featurestore.db","fields":'
+    '[{"name":"id","type":["null","long"]},'
+    '{"name":"state","type":["null","string"]},'
+    '{"name":"measurement","type":["null","double"]}]}'
+)
+
+
+class TestOnlineDeleteFillValues:
+    def test_fills_non_primary_key_fields_with_null(self, mocker):
+        fg = mocker.Mock()
+        fg.primary_key = ["id"]
+        fg.avro_schema = AVRO_SCHEMA
+
+        assert kafka_engine._online_delete_fill_values(fg) == {
+            "state": None,
+            "measurement": None,
+        }
+
+    def test_composite_primary_key_excluded(self, mocker):
+        fg = mocker.Mock()
+        fg.primary_key = ["id", "state"]
+        fg.avro_schema = AVRO_SCHEMA
+
+        assert kafka_engine._online_delete_fill_values(fg) == {"measurement": None}
+
+
+def _stream_online_fg(mocker):
+    mocker.patch("hopsworks_common.client._get_instance")
+    fg = feature_group.FeatureGroup(
+        name="test",
+        version=1,
+        featurestore_id=99,
+        primary_key=["id"],
+        partition_key=[],
+        id=10,
+        stream=True,
+        online_enabled=True,
+        time_travel_format="DELTA",
+    )
+    fg.primary_key = ["id"]
+    return fg
+
+
+class TestRemoveRowsStreamFeatureGroup:
+    def test_online_delete_by_default(self, mocker):
+        # remove_rows deletes from both stores by default, mirroring insert.
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        offline = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        online = mocker.patch.object(FeatureGroupEngine, "_delete_online_records")
+        fg = _stream_online_fg(mocker)
+
+        fg.remove_rows(pd.DataFrame({"id": [2]}))
+
+        offline.assert_called_once()
+        online.assert_called_once()
+
+    def test_offline_delete_only_when_storage_is_offline(self, mocker):
+        offline = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        online = mocker.patch.object(FeatureGroupEngine, "_delete_online_records")
+        fg = _stream_online_fg(mocker)
+
+        fg.remove_rows(pd.DataFrame({"id": [2]}), storage="offline")
+
+        offline.assert_called_once()
+        online.assert_not_called()
+
+    def test_deprecated_commit_delete_record_stays_offline_only(self, mocker):
+        # The deprecated alias keeps the offline-only behaviour it had before the online
+        # delete existed, so an existing caller does not start deleting online rows.
+        offline = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        online = mocker.patch.object(FeatureGroupEngine, "_delete_online_records")
+        fg = _stream_online_fg(mocker)
+
+        fg.commit_delete_record(pd.DataFrame({"id": [2]}))
+
+        offline.assert_called_once()
+        online.assert_not_called()
+
+
+def _offline_only_fg(mocker):
+    mocker.patch("hopsworks_common.client._get_instance")
+    fg = feature_group.FeatureGroup(
+        name="test",
+        version=1,
+        featurestore_id=99,
+        primary_key=["id"],
+        partition_key=[],
+        id=10,
+        stream=False,
+        online_enabled=False,
+        time_travel_format="DELTA",
+    )
+    fg.primary_key = ["id"]
+    return fg
+
+
+class TestRemoveRowsValidation:
+    def test_online_only_storage_skips_the_offline_commit(self, mocker):
+        # storage="online" keeps insert's meaning of online alone, so the offline table is
+        # left holding the rows and only the tombstone is produced.
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        offline = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        online = mocker.patch.object(FeatureGroupEngine, "_delete_online_records")
+        fg = _stream_online_fg(mocker)
+
+        fg.remove_rows(pd.DataFrame({"id": [2]}), storage="online")
+
+        offline.assert_not_called()
+        online.assert_called_once()
+
+    def test_online_only_storage_on_non_online_fg_is_rejected(self, mocker):
+        # Online-only on a feature group with no online store would delete nothing at all,
+        # so it raises rather than silently doing nothing.
+        from hopsworks_common.client.exceptions import FeatureStoreException
+
+        commit = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        fg = _offline_only_fg(mocker)
+
+        with pytest.raises(FeatureStoreException, match="not online-enabled"):
+            fg.remove_rows(pd.DataFrame({"id": [2]}), storage="online")
+
+        commit.assert_not_called()
+
+    def test_online_only_storage_on_embedding_fg_is_rejected(self, mocker):
+        # Same reasoning: the vector database is not deletable here, and with the offline
+        # leg skipped the call would be a complete no-op.
+        from hopsworks_common.client.exceptions import FeatureStoreException
+
+        commit = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        fg = _stream_online_fg(mocker)
+        fg._embedding_index = mocker.Mock()
+
+        with pytest.raises(FeatureStoreException, match="embedding index"):
+            fg.remove_rows(pd.DataFrame({"id": [2]}), storage="online")
+
+        commit.assert_not_called()
+
+    def test_online_only_storage_skips_the_offline_engine_guard(self, mocker):
+        # The HUDI guard is a property of the offline delete, which an online-only delete
+        # does not run, so it must not block one on the Python engine.
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        offline = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        online = mocker.patch.object(FeatureGroupEngine, "_delete_online_records")
+        fg = _stream_online_fg(mocker)
+        fg.time_travel_format = "HUDI"
+
+        fg.remove_rows(pd.DataFrame({"id": [2]}), storage="online")
+
+        offline.assert_not_called()
+        online.assert_called_once()
+
+    def test_unknown_storage_is_rejected_before_offline_commit(self, mocker):
+        from hopsworks_common.client.exceptions import FeatureStoreException
+
+        commit = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        fg = _stream_online_fg(mocker)
+
+        with pytest.raises(FeatureStoreException, match="Invalid storage"):
+            fg.remove_rows(pd.DataFrame({"id": [2]}), storage="both")
+
+        commit.assert_not_called()
+
+    def test_unset_storage_deletes_offline_only_on_non_online_fg(self, mocker):
+        # Unset storage follows the feature group, so a plain remove_rows must work on a
+        # feature group that has no online store rather than raising.
+        offline = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        online = mocker.patch.object(FeatureGroupEngine, "_delete_online_records")
+        fg = _offline_only_fg(mocker)
+
+        fg.remove_rows(pd.DataFrame({"id": [2]}))
+
+        offline.assert_called_once()
+        online.assert_not_called()
+
+    def test_embedding_fg_skips_the_online_leg_and_warns(self, mocker):
+        # The embedding index puts the online data in the vector database, which this release
+        # does not delete from. The online leg is skipped rather than failing the whole call,
+        # and the caller is warned that the two stores are left diverged.
+        offline = mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        online = mocker.patch.object(FeatureGroupEngine, "_delete_online_records")
+        fg = _stream_online_fg(mocker)
+        fg._embedding_index = mocker.Mock()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fg.remove_rows(pd.DataFrame({"id": [2]}))
+
+        assert any("vector database" in str(w.message) for w in caught)
+        offline.assert_called_once()
+        online.assert_not_called()
+
+
+class TestCommitDeleteRecordDeprecated:
+    def test_commit_delete_record_warns_and_delegates(self, mocker):
+        mocker.patch.object(FeatureGroupEngine, "_commit_delete")
+        online = mocker.patch.object(FeatureGroupEngine, "_delete_online_records")
+        remove_rows = mocker.spy(feature_group.FeatureGroup, "remove_rows")
+        fg = _stream_online_fg(mocker)
+        delete_df = pd.DataFrame({"id": [2]})
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fg.commit_delete_record(delete_df)
+
+        # the deprecation warning fired
+        assert any(
+            "commit_delete_record is deprecated" in str(w.message) for w in caught
+        )
+        # and it delegated to remove_rows, which deleted offline only: this alias exists for
+        # callers written before the online delete and must never reach the online store
+        remove_rows.assert_called_once()
+        online.assert_not_called()
+
+
+class TestDeleteDataframeKafka:
+    def _make_feature_group(self, mocker):
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.core.kafka_engine._get_kafka_config", return_value={})
+        mocker.patch("hsfs.core.kafka_engine.Producer")
+        # bypass the online-ingestion round trip in header setup; the delete leg
+        # adds the operation header itself.
+        mocker.patch("hsfs.core.kafka_engine._get_headers", return_value={})
+        mocker.patch(
+            "hsfs.feature_group.FeatureGroup.get_complex_features", return_value=[]
+        )
+
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=["id"],
+            partition_key=[],
+            id=10,
+            stream=False,
+        )
+        # id=10 makes the constructor derive the key from (absent) features, so
+        # set it explicitly to model a backend-initialized online feature group.
+        fg.primary_key = ["id"]
+        fg.feature_store = mocker.Mock()
+        fg.feature_store.project_id = 234
+        fg._subject = {"id": 1, "schema": AVRO_SCHEMA}
+        fg._online_topic_name = "test_topic"
+        return fg
+
+    def test_primary_key_only_dataframe_serializes_with_null_fields(self, mocker):
+        produced = {}
+
+        def fake_produce(**kwargs):
+            produced.update(kwargs)
+
+        mocker.patch("hsfs.core.kafka_engine._kafka_produce", side_effect=fake_produce)
+        fg = self._make_feature_group(mocker)
+
+        python.Engine()._delete_dataframe_kafka(fg, pd.DataFrame({"id": [7]}), {})
+
+        assert produced["key"] == "7"
+        assert produced["headers"]["operation"] == b"delete"
+        # No storage header. It gates the online leg alone ("0" makes OnlineFS skip the
+        # row), so it cannot mark a record online-only, and absent already ingests.
+        assert "storage" not in produced["headers"]
+
+        with BytesIO(produced["encoded_row"]) as outf:
+            record = fastavro.schemaless_reader(
+                outf, fastavro.parse_schema(json.loads(AVRO_SCHEMA))
+            )
+        assert record == {"id": 7, "state": None, "measurement": None}
+
+    def test_extra_non_key_columns_are_ignored(self, mocker):
+        produced = {}
+        mocker.patch(
+            "hsfs.core.kafka_engine._kafka_produce",
+            side_effect=lambda **kwargs: produced.update(kwargs),
+        )
+        fg = self._make_feature_group(mocker)
+
+        python.Engine()._delete_dataframe_kafka(
+            fg, pd.DataFrame({"id": [7], "state": ["nevada"]}), {}
+        )
+
+        # The online delete is by primary key, so a non-key column the caller passes
+        # is ignored and serialized as null rather than overriding the tombstone fill.
+        with BytesIO(produced["encoded_row"]) as outf:
+            record = fastavro.schemaless_reader(
+                outf, fastavro.parse_schema(json.loads(AVRO_SCHEMA))
+            )
+        assert record == {"id": 7, "state": None, "measurement": None}
+
+    def test_entry_count_is_sent_by_default(self, mocker):
+        fg = self._make_feature_group(mocker)
+        mocker.patch("hsfs.core.kafka_engine._kafka_produce")
+        get_headers = mocker.patch(
+            "hsfs.core.kafka_engine._get_headers", return_value={}
+        )
+
+        python.Engine()._delete_dataframe_kafka(fg, pd.DataFrame({"id": [7, 8]}), {})
+
+        assert get_headers.call_args[0][1] == 2
+
+    def test_disable_online_ingestion_count_skips_the_entry_count(self, mocker):
+        fg = self._make_feature_group(mocker)
+        mocker.patch("hsfs.core.kafka_engine._kafka_produce")
+        get_headers = mocker.patch(
+            "hsfs.core.kafka_engine._get_headers", return_value={}
+        )
+
+        python.Engine()._delete_dataframe_kafka(
+            fg,
+            pd.DataFrame({"id": [7, 8]}),
+            {"online_ingestion_options": {"disable_online_ingestion_count": True}},
+        )
+
+        assert get_headers.call_args[0][1] is None

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -2041,6 +2041,7 @@ class TestSpark:
                 "kafka.ssl.keystore.password": "test_ssl_keystore_password",
                 "kafka.ssl.key.password": "test_ssl_key_password",
             },
+            operation=None,
         )
         mock_spark_engine_serialize_to_avro.assert_called_once()
 
@@ -2115,8 +2116,144 @@ class TestSpark:
                 "kafka.ssl.key.password": "test_ssl_key_password",
                 "online_ingestion_options": {"disable_online_ingestion_count": True},
             },
+            operation=None,
         )
         mock_spark_engine_serialize_to_avro.assert_called_once()
+
+    def test_pad_online_delete_dataframe(self):
+        # Arrange
+        spark_engine = spark.Engine()
+
+        features = [
+            feature.Feature(name="id", type="bigint", primary=True),
+            feature.Feature(name="name", type="string"),
+            feature.Feature(name="scores", type="array<bigint>"),
+            feature.Feature(name="created", type="timestamp"),
+        ]
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=["id"],
+            partition_key=[],
+            id=10,
+            features=features,
+        )
+
+        delete_df = spark_engine._spark_session.createDataFrame(
+            pd.DataFrame(data={"id": [1, 2], "ignored": ["a", "b"]})
+        )
+
+        # Act
+        padded = spark_engine._pad_online_delete_dataframe(fg, delete_df)
+
+        # Assert - every feature is present with its declared type, non-key values are
+        # null, and a column the feature group does not have is dropped
+        assert padded.columns == ["id", "name", "scores", "created"]
+        assert {
+            field.name: field.dataType.simpleString() for field in padded.schema
+        } == {
+            "id": "bigint",
+            "name": "string",
+            "scores": "array<bigint>",
+            "created": "timestamp",
+        }
+        assert [row.asDict() for row in padded.orderBy("id").collect()] == [
+            {"id": 1, "name": None, "scores": None, "created": None},
+            {"id": 2, "name": None, "scores": None, "created": None},
+        ]
+
+    def test_pad_online_delete_dataframe_keeps_composite_primary_key(self):
+        # Arrange
+        spark_engine = spark.Engine()
+
+        features = [
+            feature.Feature(name="id", type="bigint", primary=True),
+            feature.Feature(name="region", type="string", primary=True),
+            feature.Feature(name="measurement", type="double"),
+        ]
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=["id", "region"],
+            partition_key=[],
+            id=10,
+            features=features,
+        )
+
+        delete_df = spark_engine._spark_session.createDataFrame(
+            pd.DataFrame(data={"id": [1], "region": ["eu"], "measurement": [3.5]})
+        )
+
+        # Act
+        padded = spark_engine._pad_online_delete_dataframe(fg, delete_df)
+
+        # Assert - both key columns keep the caller's values, and a value the caller
+        # passed for a non-key feature is overridden with null
+        assert padded.collect()[0].asDict() == {
+            "id": 1,
+            "region": "eu",
+            "measurement": None,
+        }
+
+    def test_delete_online_dataframe_disable_online_ingestion_count(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hopsworks_common.client._is_external", return_value=False)
+        mocker.patch("hsfs.engine.spark.Engine._serialize_to_avro")
+        mock_get_headers = mocker.patch("hsfs.engine.spark.Engine._get_headers")
+
+        mock_engine_get_instance = mocker.patch("hsfs.engine._get_instance")
+        mock_engine_get_instance.return_value._get_spark_version.return_value = "3.1.0"
+        mock_engine_get_instance.return_value._add_file.return_value = (
+            "result_from_add_file"
+        )
+
+        mock_storage_connector_api = mocker.patch(
+            "hsfs.core.storage_connector_api.StorageConnectorApi"
+        )
+        json_data = backend_fixtures["storage_connector"]["get_kafka_external"][
+            "response"
+        ]
+        sc = storage_connector.StorageConnector.from_response_json(json_data)
+        mock_storage_connector_api.return_value._get_kafka_connector.return_value = sc
+
+        spark_engine = spark.Engine()
+
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            id=10,
+            online_topic_name="test_online_topic_name",
+        )
+        fg.feature_store = mocker.Mock()
+
+        df = pd.DataFrame(data={"col_0": [1, 2], "col_1": ["test_1", "test_2"]})
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+        # the padding is covered by its own tests; keep the frame countable here
+        mocker.patch(
+            "hsfs.engine.spark.Engine._pad_online_delete_dataframe",
+            return_value=spark_df,
+        )
+
+        # Act
+        spark_engine._delete_online_dataframe(
+            feature_group=fg,
+            dataframe=spark_df,
+            write_options={
+                "online_ingestion_options": {"disable_online_ingestion_count": True}
+            },
+        )
+
+        # Assert - num_entries should be None when disable_online_ingestion_count is True
+        assert mock_get_headers.call_args[0][1] is None
+        assert mock_get_headers.call_args[1]["operation"] == "delete"
 
     def test_serialize_to_avro(self, mocker):
         # Arrange

--- a/skills/hops/hops-fg/SKILL.md
+++ b/skills/hops/hops-fg/SKILL.md
@@ -467,7 +467,11 @@ results = fg.find_neighbors(
 
 ## Deleting Rows from a Feature Group
 
-Pass a DataFrame identifying the rows to remove. For an **offline (Delta) FG with an `event_time`**, the merge key is the primary key **plus** the `event_time` column (plus any partition columns) — a primary-key-only DataFrame fails with `DeltaError: No field named <event_time>`. Include every key column:
+Pass a DataFrame identifying the rows to remove.
+Both stores of an online-enabled FG are affected by default; an FG without an online store is deleted from offline only.
+
+For an **offline (Delta) FG with an `event_time`**, the merge key is the primary key **plus** the `event_time` column (plus any partition columns).
+A primary-key-only DataFrame fails with `DeltaError: No field named <event_time>`, so include every key column:
 
 ```python
 import polars as pl
@@ -478,10 +482,33 @@ rows_to_delete = pl.DataFrame({
     "event_ts": ["2026-01-01", "2026-01-02", "2026-01-03"],
 })
 
-fg.commit_delete_record(rows_to_delete)
+fg.remove_rows(rows_to_delete)
 ```
 
 Only rows matching on all key columns are deleted.
+
+`fg.commit_delete_record(...)` is the deprecated name for the same method, and it deletes offline only unless you pass `delete_online=True`.
+
+### The online leg
+
+An online-enabled FG has its rows removed from the online store as well, with no argument needed:
+
+```python
+fg.remove_rows(rows_to_delete)
+```
+
+Pass `delete_online=False` to leave the online store untouched and delete offline only.
+
+The online delete matches on the primary key alone, so every non-key column in the DataFrame is ignored for the online leg, `event_time` included.
+The key columns the offline merge requires are still required; they just do not affect which online rows are removed.
+
+Stream FGs are included: the online delete works for both DELTA and HUDI.
+The one thing to know is that a stream FG's inserts reach the offline table through its materialization job, while the delete is applied to that table directly.
+Deleting a row whose insert has not been materialized yet removes it online but finds nothing offline, and the materialization job then writes the row.
+Run the materialization job before the delete, or re-run the delete after it, to keep the two stores in step.
+
+Deleting online is not supported on an FG with an embedding index, whose online data lives in the vector database.
+Such an FG is deleted from offline only, and passing `delete_online=True` on one raises.
 
 ---
 
@@ -587,7 +614,8 @@ derived_fg.materialization_job.run(await_termination=True)
 | Read (filtered) | `fg.filter(fg.col > X).read(dataframe_type="polars")` |
 | Preview rows | `print(fg.show(n=10))` (returns a DataFrame) |
 | Similarity search | `fg.find_neighbors(vector, k=5, filter=...)` |
-| Delete rows | `fg.commit_delete_record(df)` (df = primary_key cols + event_time) |
+| Delete rows | `fg.remove_rows(df)` (df = primary_key cols + event_time) |
+| Delete rows online too | `fg.remove_rows(df, delete_online=True)` (matches on primary key only) |
 | Add a column (same version) | `fg.append_features([Feature("c", "double")])` / `hops fg append-features <name> --features "c:double"` |
 | Drop/retype a column | not in place: create a new FG version |
 | Disable statistics | `statistics_config=False` |

--- a/skills/hops/hops-fg/SKILL.md
+++ b/skills/hops/hops-fg/SKILL.md
@@ -487,7 +487,7 @@ fg.remove_rows(rows_to_delete)
 
 Only rows matching on all key columns are deleted.
 
-`fg.commit_delete_record(...)` is the deprecated name for the same method, and it deletes offline only unless you pass `delete_online=True`.
+`fg.commit_delete_record(...)` is the deprecated name for the same method, and it always deletes offline only.
 
 ### The online leg
 
@@ -497,7 +497,8 @@ An online-enabled FG has its rows removed from the online store as well, with no
 fg.remove_rows(rows_to_delete)
 ```
 
-Pass `delete_online=False` to leave the online store untouched and delete offline only.
+Pass `storage="offline"` to leave the online store untouched, or `storage="online"` to delete from the online store alone and skip the offline commit.
+A single-store delete is not reconciled later: the rows stay in the other store until they are deleted there too.
 
 The online delete matches on the primary key alone, so every non-key column in the DataFrame is ignored for the online leg, `event_time` included.
 The key columns the offline merge requires are still required; they just do not affect which online rows are removed.
@@ -508,7 +509,7 @@ Deleting a row whose insert has not been materialized yet removes it online but 
 Run the materialization job before the delete, or re-run the delete after it, to keep the two stores in step.
 
 Deleting online is not supported on an FG with an embedding index, whose online data lives in the vector database.
-Such an FG is deleted from offline only, and passing `delete_online=True` on one raises.
+Such an FG is deleted from offline only, with a warning that the two stores now differ, and passing `storage="online"` on one raises.
 
 ---
 
@@ -614,8 +615,8 @@ derived_fg.materialization_job.run(await_termination=True)
 | Read (filtered) | `fg.filter(fg.col > X).read(dataframe_type="polars")` |
 | Preview rows | `print(fg.show(n=10))` (returns a DataFrame) |
 | Similarity search | `fg.find_neighbors(vector, k=5, filter=...)` |
-| Delete rows | `fg.remove_rows(df)` (df = primary_key cols + event_time) |
-| Delete rows online too | `fg.remove_rows(df, delete_online=True)` (matches on primary key only) |
+| Delete rows (both stores) | `fg.remove_rows(df)` (df = primary_key cols + event_time; online matches on primary key only) |
+| Delete rows from one store | `fg.remove_rows(df, storage="offline")` or `storage="online"` |
 | Add a column (same version) | `fg.append_features([Feature("c", "double")])` / `hops fg append-features <name> --features "c:double"` |
 | Drop/retype a column | not in place: create a new FG version |
 | Disable statistics | `statistics_config=False` |

--- a/utils/python/hsfs_utils.py
+++ b/utils/python/hsfs_utils.py
@@ -361,6 +361,18 @@ def offline_fg_materialization(
         == str(entity.subject["id"])
     )
 
+    # A delete tombstone is on the topic for OnlineFS only: remove_rows has already applied the
+    # offline delete directly to the table, so materializing the tombstone re-inserts the key it
+    # deleted.
+    # The header is absent on inserts, so null means keep.
+    # Exact match on the value, as in OnlineFsHandler.getRow.
+    operation_header = expr(
+        "CAST(filter(headers, header -> header.key = 'operation')[0].value AS STRING)"
+    )
+    filtered_df = filtered_df.filter(
+        operation_header.isNull() | (operation_header != "delete")
+    )
+
     # limit the number of records ingested
     # default limit is 5M
     limit = 5000000


### PR DESCRIPTION
Backport of #1069 to `branch-5.0`: cherry-pick of `03f5c6fba`, plus the doc fix from #1100 picked from main (`f8b31da77`).

## Deliberate differences from main

All three because `branch-5.0` has no ICEBERG feature groups (the backend enum is `NONE, HUDI, DELTA`):

- the ICEBERG guard in `remove_rows` is dropped, since `HAS_PYICEBERG` does not exist here and the branch would be unreachable
- the ICEBERG param on the stream delete test is dropped; that left the test identical to `test_online_delete_by_default`, so the duplicate went too
- the `hops-fg` skill's "DELTA, ICEBERG, and HUDI" line now reads "both DELTA and HUDI"

The HUDI guard is unchanged.

## Conflicts

Two, both in `python/hsfs/feature_group.py`: the apigen import line gained `deprecated`, and `commit_delete_record`'s body is replaced by the new implementation. Everything else auto-merged.

## Verification

`ruff check` and `ruff format --check` clean. `pytest python/tests`: 3459 passed, 13 skipped, 5 failed. The 5 failures are `TypeError: 'JavaPackage' object is not callable` in `test_spark.py` avro tests and fail identically on a pristine `branch-5.0` worktree (missing local spark-avro jar), so they are the baseline, not a regression.

No cluster validation: the dev cluster runs 5.1-line images, so it would prove nothing about the 5.0 artifacts.

## Companion backports

clusterj-onlinefs #182, hopsworks-ee #3208, hopsworks-front #2031, loadtest #972 (merges last, needs a 5.0.x SDK release first).

[FSTORE-2068]: https://hopsworks.atlassian.net/browse/FSTORE-2068
