### PR TITLE
[HOPSFS-392] Bump HopsFS client to 3.4.3.2-EE-RC2

### DIFF
--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -161,7 +161,7 @@
                 <dependency>
                     <groupId>io.hops</groupId>
                     <artifactId>hadoop-client</artifactId>
-                    <version>3.4.3.1-EE-RC0</version>
+                    <version>3.4.3.2-EE-RC2</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -8,7 +8,7 @@
     <version>5.1.0-SNAPSHOT</version>
 
     <properties>
-        <hops.version>3.4.3.1-EE-RC0</hops.version>
+        <hops.version>3.4.3.2-EE-RC2</hops.version>
         <hsfs.version>${project.version}</hsfs.version>
         <slf4j.version>2.0.17</slf4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Bumps both `io.hops:hadoop-client` pins from `3.4.3.1-EE-RC0` to `3.4.3.2-EE-RC2` for Hopsworks 5.1.

- `utils/java/pom.xml:11` — `hops.version` property (hsfs-utils)
- `java/spark/pom.xml:168` — the `with-hops-ee` profile's `hadoop-client` dependency, which is pinned literally rather than via a property, so a properties-only edit would silently miss it

Both were still on the **3.4.3.1** line at RC0, a minor version behind the HopsFS server the 5.1 chart deploys.

Deliberately **not** touched: `spark.version` (3.5.5.1) and `hudi.version` (1.0.2.1). This PR is the HopsFS client rollout only.

`io.hops:hadoop-client:3.4.3.2-EE-RC2` is published in nexus `hops-artifacts`. Both pins are `<scope>provided</scope>`, so this changes what the build compiles against, not what ships in the artifact.

Part of the HOPSFS-392 rollout.