### PR TITLE
[HOPSFS-392][APPEND] Use HopsFS client 3.4.3.1-EE-RC4

### DIFF
--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -161,7 +161,7 @@
                 <dependency>
                     <groupId>io.hops</groupId>
                     <artifactId>hadoop-client</artifactId>
-                    <version>3.4.3.2-EE-RC2</version>
+                    <version>3.4.3.1-EE-RC4</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -8,7 +8,7 @@
     <version>5.1.0-SNAPSHOT</version>
 
     <properties>
-        <hops.version>3.4.3.2-EE-RC2</hops.version>
+        <hops.version>3.4.3.1-EE-RC4</hops.version>
         <hsfs.version>${project.version}</hsfs.version>
         <slf4j.version>2.0.17</slf4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Follow-up to #1093, which bumped the HopsFS client to `3.4.3.2-EE-RC2`. Moves both pins to `3.4.3.1-EE-RC4` instead — 2 lines.

| file | pin |
|---|---|
| `utils/java/pom.xml:11` | `hops.version` property |
| `java/spark/pom.xml:164` | literal `hadoop-client` version in the `with-hops-ee` profile |

Companion to docker-images#918, which puts the base images back on the same version.

## Why

**The 3.4.3.2 line is built with JDK 17 (class file version 61), and the images that consume these jars run Java 8.**

`utils/java/pom.xml` compiles `hsfs-utils` with:

```xml
<maven.compiler.source>1.8</maven.compiler.source>
<maven.compiler.target>1.8</maven.compiler.target>
```

and the resulting jar runs inside the spark base image, whose only JVM is `openjdk 1.8.0_492` (`JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64`, no JDK 17 present). So a `3.4.3.2-EE-RC2` `hadoop-client` mismatches both the compiler target and the runtime it is `provided` by.

What that looks like at runtime, in the image built from the RC2 pins:

```
$ docker run --rm docker.hops.works/hopsworks/hopsworks-base:spark-feature-pipeline-5.1.0-SNAPSHOT \
    /srv/hops/hadoop/bin/hadoop version

Exception in thread "main" java.lang.UnsupportedClassVersionError:
  org/apache/hadoop/util/VersionInfo has been compiled by a more recent version of the
  Java Runtime (class file version 61.0), this version of the Java Runtime only
  recognizes class file versions up to 52.0
```

That broke every Spark job on 5.1 — see docker-images#918 for the full RCA.

## Why RC4

`3.4.3.1-EE-RC4` is the newest RC on the Java 8 line, and **`branch-5.0` already pins exactly this version at these same two lines**, so this is a return to a shipping configuration rather than a new combination. Confirmed working on the released 5.0.4 image, same Java 8, same command:

```
$ ... hopsworks-base:spark-feature-pipeline-5.0.4  /srv/hops/hadoop/bin/hadoop version
Hadoop 3.4.3.1-EE-RC4
```

`io.hops:hadoop-client:3.4.3.1-EE-RC4` resolves from the `HopsEE` nexus repo (verified with `mvn dependency:get`). After this change no `3.4.3.2-EE-RC2` reference remains in the repo.

I did not run a full local build — `hsfs-utils` needs the sibling `hsfs-spark-spark3.5:5.1.0-SNAPSHOT` snapshot built first, so compilation is left to CI here.

## Note

The alternative fix is moving the base images to JDK 17, which is where the 3.4.3.2 line eventually wants to go; that is a bigger change and deserves its own ticket. `testconnector` is already on `temurin-17-jdk` and deliberately stays on `3.4.3.2-EE-RC2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRi7xCvfg3GRmZLqJ5Gegi