### PR TITLE
[FSTORE-2073] Stop UDF source extraction carrying the enclosing scope

### DIFF
--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -19,8 +19,10 @@ import ast
 import copy
 import inspect
 import json
+import linecache
 import logging
 import re
+import textwrap
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -411,8 +413,68 @@ class HopsworksUdf:
                 stacklevel=2,
             )
 
-        function_code = inspect.getsource(udf_function)
+        function_code = HopsworksUdf._extract_function_block(udf_function)
         return "\n".join(module_imports) + "\n" + function_code
+
+    @staticmethod
+    def _extract_function_block(udf_function: Callable) -> str:
+        """The source of exactly this function, decorators included and dedented.
+
+        `inspect.getsource` locates a function by scanning backwards from its
+        first line for something that opens a block, and returns whatever block
+        it lands on. Where several same-shaped UDFs are defined in a loop inside
+        an enclosing function, that scan can land on the *enclosing* function and
+        return its entire body.
+
+        The consequence is not a bad error message, it is a broken UDF. The
+        returned source is later split on its first "@" to recover the module
+        imports, so an enclosing body contributes everything up to the first
+        decorator, which ends part-way through the enclosing `for` statement.
+        The generated wrapper then fails to compile with
+
+            IndentationError: expected an indented block after 'for' statement
+
+        naming a line in a string nobody can see. A run hit this 42 times across
+        four modules while three hand-written reproductions compiled cleanly,
+        because each of those defined a single UDF per loop.
+
+        Parsing the file and selecting the definition by name, nearest to the
+        function's own first line, cannot land on the enclosing scope. The result
+        is dedented so a UDF defined inside a function or a loop yields the same
+        source as one defined at module level.
+        """
+        try:
+            source_file = inspect.getsourcefile(udf_function)
+            source = "".join(linecache.getlines(source_file)) if source_file else ""
+            tree = ast.parse(source)
+        except (OSError, TypeError, SyntaxError, ValueError):
+            # Notebooks and exec'd code have no readable file. The old behaviour
+            # is still the best available answer there.
+            return inspect.getsource(udf_function)
+
+        name = getattr(udf_function, "__name__", None)
+        first_line = getattr(
+            getattr(udf_function, "__code__", None), "co_firstlineno", 0
+        )
+        best = None
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name != name:
+                continue
+            # Decorators come first in the source but not in node.lineno, and the
+            # generated wrapper needs them, so start from the earliest of the two.
+            start = min([d.lineno for d in node.decorator_list] + [node.lineno])
+            distance = abs(start - first_line)
+            if best is None or distance < best[0]:
+                best = (distance, start, node.end_lineno)
+
+        if best is None or best[2] is None:
+            return inspect.getsource(udf_function)
+
+        _, start, end = best
+        block = "".join(source.splitlines(keepends=True)[start - 1 : end])
+        return textwrap.dedent(block)
 
     @staticmethod
     def _parse_function_signature(source_code: str) -> tuple[list[str], str, int, int]:
@@ -505,6 +567,35 @@ class HopsworksUdf:
         return [TransformationFeature(arg, None) for arg in arg_list]
 
     @staticmethod
+    def _select_import_lines(source_code: str) -> str:
+        """The import statements at the top of `source_code`, and nothing else.
+
+        Parsed rather than string-split so a fragment of an enclosing function
+        can never be mistaken for an import. Falls back to a line scan when the
+        source does not parse on its own, which happens for the dedented body
+        of a nested function.
+        """
+        try:
+            tree = ast.parse(source_code)
+        except SyntaxError:
+            lines = []
+            for line in source_code.split("\n"):
+                stripped = line.strip()
+                if stripped.startswith(("import ", "from ")):
+                    lines.append(stripped)
+                elif stripped.startswith(("@", "def ", "async def ")):
+                    break
+            return "\n".join(lines) + ("\n" if lines else "")
+
+        lines = source_code.splitlines()
+        selected = [
+            "\n".join(lines[node.lineno - 1 : node.end_lineno])
+            for node in ast.iter_child_nodes(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+        ]
+        return "\n".join(selected) + ("\n" if selected else "")
+
+    @staticmethod
     def _format_source_code(source_code: str) -> tuple[str, str]:
         """Function that parses the existing source code to remove statistics parameter and remove all decorators and type hints from the function source code.
 
@@ -517,7 +608,21 @@ class HopsworksUdf:
         arg_list, signature, _, signature_end_line = (
             HopsworksUdf._parse_function_signature(source_code)
         )
-        module_imports = source_code.split("@")[0]
+        # Everything before the first "@" is not "the imports": it is whatever
+        # precedes the first decorator, which is only the imports when the
+        # source contains nothing else. When it contains more — an enclosing
+        # function, a loop — the split keeps a fragment of that too, cut off
+        # wherever the decorator happens to be. A UDF defined inside a `for`
+        # loop produced imports ending in
+        #
+        #     for udf_execution_mode in ["default", "pandas", "python"]:
+        #
+        # with no body, so the generated wrapper failed to compile with
+        # "IndentationError: expected an indented block after 'for' statement",
+        # naming a line in a string the caller never sees. Selecting the import
+        # statements by parsing keeps only what the name promises, and cannot
+        # carry a fragment of anything else.
+        module_imports = HopsworksUdf._select_import_lines(source_code)
 
         # Reconstruct the function signature
         new_signature = (

--- a/python/tests/test_hopswork_udf.py
+++ b/python/tests/test_hopswork_udf.py
@@ -1639,3 +1639,102 @@ def test_function():
         assert add_statistics_data.executor(
             statistics={"feature": {"mean": 100}}, context={"test_value": 10}
         ).execute(data).values.tolist() == [111, 112, 113]
+
+
+class TestUdfSourceExtraction:
+    """Source extraction for UDFs defined inside another function.
+
+    `inspect.getsource` locates a function by scanning backwards from its first
+    line for something that opens a block, and returns the block it lands on.
+    With several same-shaped UDFs defined in a loop inside an enclosing
+    function, that scan could land on the enclosing function and return its
+    whole body, which then broke wrapper generation with an IndentationError
+    naming a line in a string nobody could see.
+    """
+
+    def test_udf_defined_in_a_loop_extracts_only_itself(self):
+        # The shape that failed: several UDFs, same enclosing scope, in a loop.
+        # A single UDF per loop does not reproduce it.
+        udfs = []
+        for mode in ["default", "pandas", "python"]:
+
+            @udf(int, drop=["feature"], mode=mode)
+            def add_one(feature):
+                return feature + 1
+
+            @udf([int, int], drop=["feature"], mode=mode)
+            def add_two(feature):
+                return feature + 1, feature + 2
+
+            udfs.extend([add_one, add_two])
+
+        for extracted in udfs:
+            source = extracted._function_source
+            assert (
+                "def test_udf_defined_in_a_loop_extracts_only_itself" not in source
+            ), "extraction captured the enclosing test function, not the UDF"
+            assert "for mode in" not in source, (
+                "extraction captured the enclosing loop, whose body is then cut "
+                "off at the first decorator and cannot compile"
+            )
+
+    def test_udf_defined_in_a_loop_generates_compilable_source(self):
+        # The failure was not a bad message, it was a UDF that could not be
+        # built, so assert on the thing that actually broke.
+        for mode in ["default", "pandas"]:
+
+            @udf(int, drop=["feature"], mode=mode)
+            def add_one(feature):
+                return feature + 1
+
+            @udf([int, int], drop=["feature"], mode=mode)
+            def add_two(feature):
+                return feature + 1, feature + 2
+
+            for built in (add_one, add_two):
+                # One output name per declared return type; the wrapper renames
+                # its columns to these.
+                built._output_column_names = [
+                    f"out_{i}" for i in range(len(built.return_types))
+                ]
+                built._pandas_udf_wrapper()  # raised IndentationError before
+
+    def test_nested_udf_source_is_dedented(self):
+        # A UDF defined inside a function must yield the same source as one at
+        # module level, or the generated wrapper mixes indentation levels.
+        @udf(int, drop=["feature"])
+        def add_three(feature):
+            return feature + 3
+
+        first_line = add_three._function_source.split("\n")[-3]
+        assert not first_line.startswith(" "), (
+            f"nested UDF source kept its enclosing indentation: {first_line!r}"
+        )
+
+    def test_imports_never_carry_a_fragment_of_an_enclosing_scope(self):
+        """The shape captured from a real run that failed 42 nodes.
+
+        The source handed to the formatter contained an enclosing function, so
+        splitting it on the first "@" kept everything up to the decorator: the
+        imports *plus* a `for` statement with no body. The generated wrapper
+        then failed to compile with an IndentationError naming a line in a
+        string the caller never sees.
+        """
+        source = (
+            "import pandas as pd\n"
+            "from hsfs.transformation_statistics import TransformationStatistics\n"
+            "def enclosing_test(fs):\n"
+            "    df = pd.DataFrame()\n"
+            "    for mode in ['default', 'pandas', 'python']:\n"
+            "\n"
+            "        @udf(int, drop=['feature'], mode=mode)\n"
+            "        def add_one(feature):\n"
+            "            return feature + 1\n"
+        )
+        _, module_imports = HopsworksUdf._format_source_code(source)
+
+        assert "for mode in" not in module_imports, (
+            f"imports carried a fragment of the enclosing scope: {module_imports!r}"
+        )
+        # The real symptom: the imports block on its own must compile.
+        compile(module_imports + "\nimport pandas as pd\n", "<test>", "exec")


### PR DESCRIPTION
JIRA: https://hopsworks.atlassian.net/browse/FSTORE-2073

A UDF defined inside another function could be built from the wrong source, and the resulting transformation function then failed to compile at apply time with

```
IndentationError: expected an indented block after 'for' statement on line 32 (<string>, line 35)
```

naming a line in a generated string the caller never sees. A loadtest run hit this **42 times across four modules**.

## Two defects combined

**1. Module imports were derived by string-splitting on `@`.**

```python
module_imports = source_code.split("@")[0]
```

That is only the imports when the source contains nothing else. When it contains an enclosing function, the split keeps a fragment of that too, cut off wherever the first decorator happens to be. For a UDF defined inside a `for` loop the "imports" ended with

```
    for udf_execution_mode in ["default", "pandas", "python"]:
```

and no body, so the generated wrapper could not compile. Import statements are now selected by parsing, which cannot carry a fragment of anything else, with a line scan as a fallback for source that does not parse standalone.

**2. `inspect.getsource` could return the enclosing function.**

It locates a function by scanning backwards for something that opens a block and returns whatever block it lands on. With several same-shaped UDFs defined in a loop inside an enclosing function, that scan can land on the enclosing function and return its entire body. Selecting the definition by name, nearest to the function's own first line, cannot. The result is dedented, so a UDF defined inside a function yields the same source as one at module level.

## Why it took a captured artifact to find

Three hand-written reproductions compiled cleanly — a nested definition with a multi-line signature, a definition inside a `for` loop, and a full create-then-read-back round trip against a live cluster. Each defined a *single* UDF per loop; the failing test defines three. `hsfs/hopsworks_udf.py` is also byte-identical between 5.0.4, main and 5.1.0.dev1, so it is not a recent regression, which ruled out bisecting.

It was diagnosed by capturing the generated source at failure from a real run (loadtest side, `LOADTEST_UDF_CAPTURE_DIR`), then replaying the captured `_function_source` through `_format_source_code` offline, which reproduces the `IndentationError` deterministically with the same line numbers.

## Tests

Four, **two of which fail without this change**. The important one replays the exact shape captured from the failing run: given source containing an enclosing function, the imports must not carry the loop, and the imports block on its own must compile.

`test_hopswork_udf.py` is fully green with this change: **99 passed, 0 failed**. Against `main` with the same tests present, 2 fail; with the fix, none do.

An earlier revision of this description mentioned pre-existing errors in that file. That was wrong and is retracted: they were `pytest-mock` and `pyspark` missing from the environment I first ran in, both of which are declared dev dependencies. There are no pre-existing failures here.

