### PR TITLE
[HOPSFS-388] Bump Spark to 3.5.5.2 and Hudi to 1.0.2.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,8 +29,8 @@
         <lombok.plugin.version>1.18.20.0</lombok.plugin.version>
         <fasterxml.jackson.databind.version>2.10.0</fasterxml.jackson.databind.version>
         <datasketches.version>6.2.0</datasketches.version>
-        <spark.version>3.5.5.1</spark.version>
-        <hudi.version>1.0.2.1</hudi.version>
+        <spark.version>3.5.5.2</spark.version>
+        <hudi.version>1.0.2.2</hudi.version>
         <awssdk.version>2.10.40</awssdk.version>
         <scala.version>2.12.10</scala.version>
         <scala-short.version>2.12</scala-short.version>
@@ -311,7 +311,7 @@
         <profile>
             <id>spark-3.5</id>
             <properties>
-                <spark.version>3.5.5.1</spark.version>
+                <spark.version>3.5.5.2</spark.version>
                 <deequ.version>2.0.7-spark-3.5</deequ.version>
                 <artifact.spark.version>spark3.5</artifact.spark.version>
                 <fasterxml.jackson.databind.version>2.15.2</fasterxml.jackson.databind.version>


### PR DESCRIPTION
Ports the dependency bump from #1084 to `main`. Three lines, one file.

| Property | File | Before | After |
|---|---|---|---|
| `spark.version` | `java/pom.xml:31` | `3.5.5.1` | `3.5.5.2` |
| `hudi.version` | `java/pom.xml:32` | `1.0.2.1` | `1.0.2.2` |
| `spark.version` (`spark-3.5` profile) | `java/pom.xml:304` | `3.5.5.1` | `3.5.5.2` |

The profile override is the one that matters in practice: every build here runs `-Pspark-3.5`, so editing the top-level property alone would have no effect.

`git grep -E '3\.5\.5\.1|1\.0\.2\.1'` over the repo returns nothing after the change.

## Deliberately not ported

#1084 also carried the `Release 5.0.4` commit, bumping the project version across 7 files. `main` stays on `5.1.0-SNAPSHOT`, so that half does not apply.

`.github/workflows/java.yml` and `mkdocs-test.yml` keep `-Dspark.version=3.5.5 -Dhudi.version=1.0.2`. Those are the upstream base versions from Maven Central, not the Hops builds, so CI does not exercise this pin either before or after. Same as on `branch-5.0`.

## Why

Spark `3.5.5.2` is built from spark `branch-3.5.5.2` against HopsFS `3.4.3.1-EE-RC4` and hive `3.0.0.14.6`; `3.5.5.1` comes from `branch-3.5.5.1`, which is RC0 and hive `3.0.0.14.5`. `main` already pins the HopsFS client itself at `3.4.3.1-EE-RC4` (#1094), and docker-images#919 moves the Spark distribution in the base images to `3.5.5.2`, so this aligns the jars this repo compiles against with what the images ship.

This repo pins no Hive version of its own. The only Hive coordinate is `org.apache.spark:spark-hive_2.12` at `${spark.version}` (test scope, `java/spark/pom.xml`), and that pom pulls `io.hops.hive:*:3.0.0.14.6`.

## Artifacts verified

- `org.apache.spark:spark-core_2.12` on nexus `hops-artifacts`: `<release>3.5.5.2</release>`
- `io.hops.hudi:hudi-spark3.5-bundle_2.12` on archiva `Hops`: `<release>1.0.2.2</release>`

Both have been in use by `branch-5.0` since the released `5.0.4`.
