### PR TITLE
Pin maven-scala-plugin so the build does not depend on Central metadata

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -16,6 +16,7 @@
     </modules>
 
     <properties>
+        <maven-scala-plugin.version>2.15.2</maven-scala-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <guava.version>30.1.1-jre</guava.version>
@@ -157,6 +158,15 @@
             <plugin>
                 <groupId>org.scala-tools</groupId>
                 <artifactId>maven-scala-plugin</artifactId>
+                <!-- Pinned because an unversioned plugin is resolved from
+                     Central's metadata on every build, so the build depends on
+                     a network round trip it does not need. Central answered 429
+                     Too Many Requests and the whole reactor failed at
+                     hsfs-parent with "Plugin not found in any plugin
+                     repository", which reads as a missing plugin rather than a
+                     rate limit. 2.15.2 is the last release of this plugin, and
+                     it is what the unversioned resolution selected anyway. -->
+                <version>${maven-scala-plugin.version}</version>
                 <configuration>
                     <scalaVersion>${scala.version}</scalaVersion>
                 </configuration>


### PR DESCRIPTION
The only plugin in the Java tree without a `<version>`, so Maven resolves it from Central's `maven-metadata.xml` on every build.

When Central answered `429 Too Many Requests`, the reactor failed at `hsfs-parent` with

```
Plugin not found in any plugin repository: org.scala-tools:maven-scala-plugin
```

which reads as a missing or renamed plugin rather than rate limiting, and takes the whole build down before any module compiles. Maven already warned about it on every run: *"'build.plugins.plugin.version' for org.scala-tools:maven-scala-plugin is missing ... threaten the stability of your build"*.

`2.15.2` is the last release of this plugin, so it is what the unversioned resolution selected anyway. Pinning changes which artifact is used not at all, and removes a network round trip the build never needed.

Verified with `mvn -f java/pom.xml validate -Pspark-3.5 -Dspark.version=3.5.5 -Dhudi.version=1.0.2`.

Found while investigating a CI failure on #1095, which is Python-only and could not have caused it.