### PR TITLE
[HOPSFS-390] Bump HopsFS to 3.2.0.19-EE-RC2

### DIFF
--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -169,7 +169,7 @@
                 <dependency>
                     <groupId>io.hops</groupId>
                     <artifactId>hadoop-client</artifactId>
-                    <version>3.2.0.19-EE-RC0</version>
+                    <version>3.2.0.19-EE-RC2</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -8,7 +8,7 @@
     <version>4.8.4</version>
 
     <properties>
-        <hops.version>3.2.0.19-EE-RC0</hops.version>
+        <hops.version>3.2.0.19-EE-RC2</hops.version>
         <hsfs.version>${project.version}</hsfs.version>
         <slf4j.version>2.0.17</slf4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Bumps HopsFS to 3.2.0.19-EE-RC2.
Tracked by HOPSFS-390.
