### PR TITLE
[FSTORE-2068][APPEND] Document the storage argument in the hops-fg skill

### DIFF
--- a/skills/hops/hops-fg/SKILL.md
+++ b/skills/hops/hops-fg/SKILL.md
@@ -545,7 +545,7 @@ fg.remove_rows(rows_to_delete)
 
 Only rows matching on all key columns are deleted.
 
-`fg.commit_delete_record(...)` is the deprecated name for the same method, and it deletes offline only unless you pass `delete_online=True`.
+`fg.commit_delete_record(...)` is the deprecated name for the same method, and it always deletes offline only.
 
 ### The online leg
 
@@ -555,7 +555,8 @@ An online-enabled FG has its rows removed from the online store as well, with no
 fg.remove_rows(rows_to_delete)
 ```
 
-Pass `delete_online=False` to leave the online store untouched and delete offline only.
+Pass `storage="offline"` to leave the online store untouched, or `storage="online"` to delete from the online store alone and skip the offline commit.
+A single-store delete is not reconciled later: the rows stay in the other store until they are deleted there too.
 
 The online delete matches on the primary key alone, so every non-key column in the DataFrame is ignored for the online leg, `event_time` included.
 The key columns the offline merge requires are still required; they just do not affect which online rows are removed.
@@ -566,7 +567,7 @@ Deleting a row whose insert has not been materialized yet removes it online but 
 Run the materialization job before the delete, or re-run the delete after it, to keep the two stores in step.
 
 Deleting online is not supported on an FG with an embedding index, whose online data lives in the vector database.
-Such an FG is deleted from offline only, and passing `delete_online=True` on one raises.
+Such an FG is deleted from offline only, with a warning that the two stores now differ, and passing `storage="online"` on one raises.
 
 ---
 
@@ -674,8 +675,8 @@ derived_fg.materialization_job.run(await_termination=True)
 | Read (filtered) | `fg.filter(fg.col > X).read(dataframe_type="polars")` |
 | Preview rows | `print(fg.show(n=10))` (returns a DataFrame) |
 | Similarity search | `fg.find_neighbors(vector, k=5, filter=...)` |
-| Delete rows | `fg.remove_rows(df)` (df = primary_key cols + event_time) |
-| Delete rows online too | `fg.remove_rows(df, delete_online=True)` (matches on primary key only) |
+| Delete rows (both stores) | `fg.remove_rows(df)` (df = primary_key cols + event_time; online matches on primary key only) |
+| Delete rows from one store | `fg.remove_rows(df, storage="offline")` or `storage="online"` |
 | Add a column (same version) | `fg.append_features([Feature("c", "double")])` / `hops fg append-features <name> --features "c:double"` |
 | Drop/retype a column | not in place: create a new FG version |
 | Disable statistics | `statistics_config=False` |


### PR DESCRIPTION
The `hops-fg` skill documents a `delete_online` keyword on `remove_rows` that does not exist.

`remove_rows` takes `storage`:

```python
def remove_rows(self, delete_df, write_options=None, storage=None) -> None:
```

so `fg.remove_rows(df, delete_online=True)` raises `TypeError`. That exact call is in the skill's cheatsheet, ready to be copy-pasted. #1069 replaced the `delete_online` boolean with `storage` during review; the skill kept the original spelling.

## What changed

Four sites, all in `skills/hops/hops-fg/SKILL.md`:

| line | was | now |
|---|---|---|
| 548 | `commit_delete_record` deletes offline only "unless you pass `delete_online=True`" | it always deletes offline only |
| 558 | "Pass `delete_online=False`" | `storage="offline"`, plus `storage="online"` which the skill did not mention |
| 569 | embedding index: "passing `delete_online=True` on one raises" | default delete warns and skips the online leg; only `storage="online"` raises |
| 678 | `fg.remove_rows(df, delete_online=True)` | `fg.remove_rows(df, storage="offline")` / `storage="online"` |

The two corrections beyond the rename come from the same source. `commit_delete_record(delete_df, write_options)` has no parameter that reaches the online store, and `remove_rows` raises for an embedding index only under `storage="online"`, warning and continuing offline otherwise.

## Verification

Docs-only; no code changed. Each statement was checked against `python/hsfs/feature_group.py` on this branch: the `remove_rows` signature, `commit_delete_record`'s signature and docstring, and the `storage == "online"` / `elif delete_online and self.embedding_index is not None` branches.

Found while backporting #1069 to 5.0 (#1090), where the same four lines came across in the cherry-pick. Fixing main first so 5.0 can take it as a cherry-pick rather than diverging.

[FSTORE-2068]: https://hopsworks.atlassian.net/browse/FSTORE-2068
