### PR TITLE
[FSTORE-2091] Say what the UDF source-extraction fix is proven to do

### DIFF
--- a/python/hsfs/hopsworks_udf.py
+++ b/python/hsfs/hopsworks_udf.py
@@ -422,21 +422,32 @@ class HopsworksUdf:
 
         `inspect.getsource` locates a function by scanning backwards from its
         first line for something that opens a block, and returns whatever block
-        it lands on. Where several same-shaped UDFs are defined in a loop inside
-        an enclosing function, that scan can land on the *enclosing* function and
-        return its entire body.
+        it lands on, so in principle it can return more than the function asked
+        for.
 
-        The consequence is not a bad error message, it is a broken UDF. The
+        What that costs is not a bad error message, it is a broken UDF. The
         returned source is later split on its first "@" to recover the module
-        imports, so an enclosing body contributes everything up to the first
-        decorator, which ends part-way through the enclosing `for` statement.
-        The generated wrapper then fails to compile with
+        imports, so any text ahead of the first decorator is carried into them.
+        Where that text is a fragment of an enclosing block, the generated
+        wrapper fails to compile with
 
             IndentationError: expected an indented block after 'for' statement
 
-        naming a line in a string nobody can see. A run hit this 42 times across
-        four modules while three hand-written reproductions compiled cleanly,
-        because each of those defined a single UDF per loop.
+        naming a line in a string nobody can see. A cluster run hit this 42 times
+        across four modules.
+
+        The route by which enclosing text reached the extracted source in that
+        run has not been identified. A decorated function's co_firstlineno is its
+        first decorator line, so the backwards scan matches on its first look and
+        does not walk up to an enclosing def; UDFs defined in a loop, multi-line
+        decorators and udf(...)(fn) registration were all tried and none
+        reproduce it. A stale linecache against a file rewritten during the run,
+        or line-number shifts from an import hook that rewrites the AST, are the
+        remaining candidates and are untested.
+
+        Parsing the file and selecting the definition by name, nearest to the
+        function's own first line, cannot return an enclosing scope whatever the
+        route was, which is why the fix stands independently of the diagnosis.
 
         Parsing the file and selecting the definition by name, nearest to the
         function's own first line, cannot land on the enclosing scope. The result

--- a/python/tests/test_hopswork_udf.py
+++ b/python/tests/test_hopswork_udf.py
@@ -1644,12 +1644,18 @@ def test_function():
 class TestUdfSourceExtraction:
     """Source extraction for UDFs defined inside another function.
 
-    `inspect.getsource` locates a function by scanning backwards from its first
-    line for something that opens a block, and returns the block it lands on.
-    With several same-shaped UDFs defined in a loop inside an enclosing
-    function, that scan could land on the enclosing function and return its
-    whole body, which then broke wrapper generation with an IndentationError
-    naming a line in a string nobody could see.
+    These pin the property the fix guarantees: the extracted source is the UDF
+    and nothing above it, so the imports derived from it cannot carry a fragment
+    of an enclosing block into the generated wrapper.
+
+    They are not a reproduction of the original failure. A decorated function's
+    co_firstlineno is its first decorator line, so `inspect.getsource`'s
+    backwards scan matches immediately and does not reach an enclosing def; the
+    loop shape below does not fail on the old code. What reached the imports in
+    the run that hit this 42 times is still unidentified. The consequence chain
+    is exercised directly by
+    test_imports_never_carry_a_fragment_of_an_enclosing_scope, which feeds the
+    malformed source in rather than relying on the extractor to produce it.
     """
 
     def test_udf_defined_in_a_loop_extracts_only_itself(self):


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2091

Docs only. No behaviour change.

The docstrings that landed with #1095 assert a mechanism that does not reproduce: that `inspect.getsource`'s backwards scan lands on an enclosing function when several same-shaped UDFs are defined in a loop. A decorated function's `co_firstlineno` is its first decorator line, so the scan matches on its first look and never walks up to an enclosing `def`. The loop shape, a multi-line decorator, one UDF per loop, and `udf(...)(fn)` registration were all tried, and none fail on the pre-fix code.

Credit to @robzor92 for catching it — I reasoned from `split("@")[0]` plus the traceback and wrote the loop shape as though it were established.

**What is still established, and stays:**

- Text ahead of the first `@` is carried into `_module_imports` by the split.
- A fragment of an enclosing block there breaks wrapper generation with `IndentationError: expected an indented block after 'for' statement`, naming a line in a string nobody can see.
- `test_imports_never_carry_a_fragment_of_an_enclosing_scope` demonstrates that chain directly, by supplying the malformed source rather than relying on the extractor to produce it.
- A cluster run hit this 42 times across four modules.

**What changes:** the route by which enclosing text reached the extracted source in that run is now recorded as unidentified, with the two untested candidates named (a stale `linecache` against a file rewritten during the run, and line-number shifts from an AST-rewriting import hook). Parsing the file and selecting the definition by name cannot return an enclosing scope whatever the route was, so the fix stands independently of the diagnosis.

The point is that the next person reading this does not stop looking, having been told the cause was found.

`python/tests/test_hopswork_udf.py`: 99 passed.