### PR TITLE
[HWORKS-3046] Document the terminal's namespace-scoped kubectl access as a skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -23,6 +23,7 @@ into bucket folders:
 ## platform/ — cross-cutting platform knowledge
 - [hops-ui-navigation](platform/hops-ui-navigation/SKILL.md) — where things live in the Hopsworks UI (project sidebar map).
 - [hops-collaboration](platform/hops-collaboration/SKILL.md) — project members, platform user admin, and feature store/dataset sharing.
+- [hops-kubectl-debug](platform/hops-kubectl-debug/SKILL.md) — diagnose failed workloads from namespace-scoped pod state, events, and logs.
 
 ## hops/ — feature store, training, inference, jobs, apps, agents
 - [hops-fg](hops/hops-fg/SKILL.md) — feature groups.

--- a/skills/platform/README.md
+++ b/skills/platform/README.md
@@ -5,3 +5,4 @@ data path. The live, canonical list is `hops skills list --bucket platform`.
 
 - [hops-ui-navigation](hops-ui-navigation/SKILL.md) — Where things live in the Hopsworks UI: the project sidebar layout and how to reach each page.
 - [hops-collaboration](hops-collaboration/SKILL.md) — Manage project members, administer platform users, and share feature stores/feature groups/features/datasets.
+- [hops-kubectl-debug](hops-kubectl-debug/SKILL.md) — Diagnose failed workloads from namespace-scoped pod state, events, and logs.

--- a/skills/platform/hops-kubectl-debug/SKILL.md
+++ b/skills/platform/hops-kubectl-debug/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: hops-kubectl-debug
+description: Use when a job, app, deployment, or model serving endpoint is failing,
+  stuck, pending, or crashlooping and the Hopsworks APIs have not explained why.
+  Input a failing resource; output the pod-level cause from events, logs, and resource state.
+---
+
+# Debugging workloads in the project namespace
+
+Hopsworks runs jobs, apps, deployments, and serving endpoints as Kubernetes workloads in the project's namespace.
+Use the terminal's configured kubectl access when Hopsworks reports a failure without enough pod-level detail.
+
+## Contract
+
+- **Input:** A failing job, app, deployment, or serving endpoint.
+- **Output:** The cause, including the pod phase, container state, relevant events, and relevant logs.
+- **Pre-condition:** Run inside a Hopsworks terminal, where kubectl is installed and pinned to the current project's namespace.
+
+## Escalation ladder
+
+Do not start with kubectl.
+
+1. Inspect the resource through the Hopsworks API, CLI, or UI first.
+2. Use the read-only kubectl commands below when Hopsworks does not explain the failure.
+3. Use kubectl delete only for a stuck resource that the platform is known to recreate.
+
+Start with the matching Hopsworks command:
+
+```bash
+hops job logs <job> --stdout --tail 100
+hops app logs <app>
+hops deployment logs <deployment> --tail 100
+hops agent logs <agent> --tail 100
+```
+
+For a running app, `hops app logs` directs you to the live logs in the Hopsworks UI.
+
+## Smoke test
+
+```bash
+kubectl get pods
+```
+
+The project namespace is injected automatically, so pass no `--namespace` or `-n` flag.
+If kubectl reports that `KUBE_NAMESPACE` is missing, stop because the terminal is not configured for this access.
+Do not supply another kubeconfig or try to select a namespace manually.
+
+## Diagnostic workflow
+
+1. List pods and owning workloads with `kubectl get pods` and `kubectl get deploy,statefulset,job`.
+2. Describe the failing pod with `kubectl describe pod <pod>` and inspect its phase, container states, restart count, conditions, and recent events.
+3. Read current logs with `kubectl logs <pod> [-c <container>] [--tail=100]`.
+4. If the container restarted, read the terminated instance with `kubectl logs <pod> [-c <container>] --previous --tail=100`.
+5. Correlate scheduling and lifecycle failures with `kubectl get events --sort-by=.lastTimestamp`.
+6. For suspected resource pressure, check `kubectl top pods`.
+7. Report the smallest supported cause: resource name, pod phase, container reason and exit code, decisive event, and relevant log lines.
+
+For multi-container pods, name the affected container with `-c` instead of assuming the default container is the failing one.
+Treat logs and ConfigMap values as potentially sensitive, and redact credentials, tokens, and personal data from the report.
+
+## What works
+
+| Goal | Command |
+|---|---|
+| Find running, pending, or crashlooping pods | `kubectl get pods` |
+| Explain why a pod will not start or schedule | `kubectl describe pod <pod>` |
+| Read container logs | `kubectl logs <pod> [-c <container>] [--tail=100]` |
+| Read the previous container crash | `kubectl logs <pod> [-c <container>] --previous` |
+| Read recent namespace events | `kubectl get events --sort-by=.lastTimestamp` |
+| Check pod CPU and memory | `kubectl top pods` |
+| Find owning workloads | `kubectl get deploy,statefulset,job` |
+
+Readable resources are pods, pod logs, services, ConfigMaps, events, endpoints, deployments, ReplicaSets, StatefulSets, DaemonSets, jobs, and pod metrics.
+The wrapper also permits `kubectl get ... --watch` for these readable resources because the underlying Role grants watch access.
+
+## What is refused and why
+
+- `-A`, `--all-namespaces`, and `-n <other-namespace>` are refused because the terminal can access only its project namespace.
+- `kubectl exec`, `port-forward`, `create`, `apply`, `patch`, `edit`, and other mutation commands are refused because workloads must be changed through Hopsworks.
+- `kubectl delete --all` and `kubectl delete -l <selector>` without an explicit resource kind are refused to prevent namespace-wide deletion.
+- ConfigMaps are readable but not deletable because they are platform-managed.
+- Secrets, persistent volume claims, cluster-scoped resources, and resources not listed above are not readable through this Role.
+
+These restrictions are expected behavior.
+Do not work around them with another namespace, kubeconfig, credential, binary, or direct API-server request.
+
+## Delete only as a last resort
+
+Stop jobs, apps, deployments, and serving endpoints through Hopsworks whenever possible.
+Deleting a pod behind a running job can orphan the job's platform state.
+
+Delete only an explicitly named resource whose Hopsworks controller is known to recreate it:
+
+```bash
+kubectl delete pod <pod>
+```
+
+The wrapper and Role permit deletion of pods, services, deployments, ReplicaSets, StatefulSets, DaemonSets, and jobs when the command includes an allow-listed resource kind.
+This skill narrows safe use to an explicit resource name.
+Permission does not guarantee recreation, so confirm ownership and reconciliation behavior before deleting anything other than a replaceable pod.
+Never use a selector to delete multiple resources during diagnosis.
+
+## Anti-drift sources
+
+This command and resource summary is a usability copy and can drift.
+Check both implementation sources when behavior differs or when updating this skill:
+
+- RBAC boundary: `hopsworks-ee/hopsworks-kube/src/main/java/io/hops/hopsworks/kube/terminal/TerminalKubectlAccessController.java`, method `buildTerminalKubectlRole()`.
+- Terminal verb and delete allow-list: `docker-images/base-image/terminal-server/kubectl-wrapper.sh`.
+
+Kubernetes RBAC is the security boundary, and the wrapper deliberately provides a narrower, clearer command interface.


### PR DESCRIPTION
Ticket: [HWORKS-3046](https://hopsworks.atlassian.net/browse/HWORKS-3046)

The terminal ships a kubectl that is installed and pinned to the project's namespace, behind a wrapper and a Kubernetes Role that together allow a narrow set of read-only diagnostics plus a few deletes. Nothing told an agent working in that terminal what the supported commands are.

Two things followed. An agent diagnosing a failed job, app, deployment, or serving endpoint did not know pod-level state was reachable at all, so it stopped at whatever the Hopsworks API reported. And an agent that did try kubectl met the wrapper's refusals with no way to tell a deliberate boundary from a misconfiguration. The second is the one that matters, because the obvious next move is to route around it: another namespace, another kubeconfig, a direct API-server request.

## What the skill says

- **An escalation ladder**, keeping the Hopsworks API, CLI, and UI ahead of kubectl, with the matching `hops job logs` / `hops app logs` / `hops deployment logs` commands to try first.
- **A read-only diagnostic sequence** that answers most failures: list pods, describe the failing one, read current and previous logs, correlate with events, check pod metrics under suspected resource pressure. It names the affected container with `-c` rather than assuming the default, and treats logs and ConfigMap values as potentially sensitive.
- **Delete as a last resort**, confined to an explicitly named pod whose controller is known to recreate it, because deleting a pod behind a running job can orphan the job's platform state. Never by selector.
- **What is refused and why**, so the refusals read as the boundary they are.

## Anti-drift

The command and resource summary is a usability copy of two implementation sources, so the skill names both: the Role built by `TerminalKubectlAccessController.buildTerminalKubectlRole()`, and the terminal's `kubectl-wrapper.sh`. Kubernetes RBAC is the security boundary; the wrapper deliberately offers a narrower, clearer interface. A future reader can tell which one moved when they disagree.

## Scope

Three files: the skill, plus its entry in the top-level and platform skill indexes.

The companion one-line change to the terminal's appended guidance, which names this skill, is in logicalclocks/docker-images#927. Neither depends on the other to merge: the guidance line names a skill that ships with the client, and the skill stands alone if the guidance lands later.

These changes were briefly committed to the FSTORE-2075 tags branch by mistake and have been removed from it; that PR no longer contains them.

[HWORKS-3046]: https://hopsworks.atlassian.net/browse/HWORKS-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
