### PR TITLE
[FSTORE-2096] Attachment timestamps, the keyword API, and tags for jobs, apps and deployments

### DIFF
--- a/python/hopsworks/cli/commands/fg.py
+++ b/python/hopsworks/cli/commands/fg.py
@@ -3,7 +3,8 @@
 Covers the full feature-group surface: ``list``, ``info``, ``preview``,
 ``features`` (reads) plus ``create``, ``create-external``, ``insert``,
 ``derive``, ``append-features``, ``delete``, ``stats``, ``search``,
-``keywords``/``add-keyword``/``remove-keyword`` (writes). All operations go
+``keywords``/``add-keyword``/``remove-keyword`` (plain labels) and
+``tags``/``add-tag``/``remove-tag`` (name/value pairs). All operations go
 through the SDK in-process so Hopsworks domain logic is invoked directly, with
 no subprocess hop.
 """
@@ -917,52 +918,77 @@ def fg_search(
     output.print_table(["SCORE", "ROW"], rows)
 
 
+# Printed to stderr rather than raised as a DeprecationWarning: Python's default filters hide
+# DeprecationWarning outside __main__, and these commands run from click, so the one audience that
+# needs to read this would never see it.
+_KEYWORD_SEMANTICS_CHANGED = (
+    "The *-keyword commands now operate on keywords (plain labels without "
+    "values); tag name/value pairs moved to 'hops fg tags/add-tag/remove-tag'."
+)
+
+
 @fg_group.command("keywords")
 @click.argument("name")
 @click.option("--version", type=int, help="Feature group version.")
 @click.pass_context
 def fg_keywords(ctx: click.Context, name: str, version: int | None) -> None:
-    """Show all tags attached to a feature group (aka keywords).
+    """Show all keywords attached to a feature group.
 
     Args:
         ctx: Click context.
         name: Feature group name.
         version: Feature group version.
     """
+    output.warn(_KEYWORD_SEMANTICS_CHANGED)
     fg = _get_fg(ctx, name, version)
     try:
-        tags = fg.get_tags()
+        keywords = fg.get_keywords_metadata()
     except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Could not read tags: {exc}") from exc
+        raise click.ClickException(f"Could not read keywords: {exc}") from exc
 
     if output.JSON_MODE:
-        output.print_json({k: _tag_value(v) for k, v in (tags or {}).items()})
+        output.print_json(
+            {k: output.format_ts(v, empty=None) for k, v in (keywords or {}).items()}
+        )
         return
-    rows = [[k, _tag_value(v)] for k, v in (tags or {}).items()]
-    output.print_table(["KEYWORD", "VALUE"], rows)
+    rows = [[k, output.format_ts(v)] for k, v in (keywords or {}).items()]
+    output.print_table(["KEYWORD", "ADDED"], rows)
 
 
 @fg_group.command("add-keyword")
 @click.argument("name")
 @click.argument("keyword")
-@click.option("--value", default="true", help="Tag value; defaults to 'true'.")
+@click.option(
+    "--value",
+    default=None,
+    help="Retired. Keywords carry no value; use 'hops fg add-tag' for name/value tags.",
+)
 @click.option("--version", type=int, help="Feature group version.")
 @click.pass_context
 def fg_add_keyword(
-    ctx: click.Context, name: str, keyword: str, value: str, version: int | None
+    ctx: click.Context, name: str, keyword: str, value: str | None, version: int | None
 ) -> None:
-    """Attach a keyword (tag) to a feature group.
+    """Attach a keyword to a feature group.
 
     Args:
         ctx: Click context.
         name: Feature group name.
-        keyword: Tag name.
-        value: Tag value.
+        keyword: The keyword.
+        value: Retired; fails loudly when supplied.
         version: Feature group version.
     """
+    output.warn(_KEYWORD_SEMANTICS_CHANGED)
+    # Failing beats both alternatives: dropping the option outright would make
+    # scripts that passed it die on "no such option", while accepting it would
+    # silently turn their tag write into a keyword write.
+    if value is not None:
+        raise click.UsageError(
+            "--value is retired: keywords carry no value. To write a "
+            f"name/value tag use: hops fg add-tag {name} {keyword} --value ..."
+        )
     fg = _get_fg(ctx, name, version)
     try:
-        fg.add_tag(name=keyword, value=value)
+        fg.add_keywords([keyword])
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Could not add keyword: {exc}") from exc
     output.success("✓ Added keyword '%s' to %s", keyword, name)
@@ -976,20 +1002,89 @@ def fg_add_keyword(
 def fg_remove_keyword(
     ctx: click.Context, name: str, keyword: str, version: int | None
 ) -> None:
-    """Remove a keyword (tag) from a feature group.
+    """Remove a keyword from a feature group.
 
     Args:
         ctx: Click context.
         name: Feature group name.
-        keyword: Tag name.
+        keyword: The keyword.
+        version: Feature group version.
+    """
+    output.warn(_KEYWORD_SEMANTICS_CHANGED)
+    fg = _get_fg(ctx, name, version)
+    try:
+        fg.delete_keyword(keyword)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove keyword: {exc}") from exc
+    output.success("✓ Removed keyword '%s' from %s", keyword, name)
+
+
+@fg_group.command("tags")
+@click.argument("name")
+@click.option("--version", type=int, help="Feature group version.")
+@click.pass_context
+def fg_tags(ctx: click.Context, name: str, version: int | None) -> None:
+    """Show all tags attached to a feature group.
+
+    Args:
+        ctx: Click context.
+        name: Feature group name.
         version: Feature group version.
     """
     fg = _get_fg(ctx, name, version)
     try:
-        fg.delete_tag(keyword)
+        tags = fg.get_tags_metadata()
     except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Could not remove keyword: {exc}") from exc
-    output.success("✓ Removed keyword '%s' from %s", keyword, name)
+        raise click.ClickException(f"Could not read tags: {exc}") from exc
+    output.render_tags(tags)
+
+
+@fg_group.command("add-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--value", required=True, help="Tag value, JSON or a plain string.")
+@click.option("--version", type=int, help="Feature group version.")
+@click.pass_context
+def fg_add_tag(
+    ctx: click.Context, name: str, tag: str, value: str, version: int | None
+) -> None:
+    """Attach a tag (name/value pair) to a feature group.
+
+    Args:
+        ctx: Click context.
+        name: Feature group name.
+        tag: Tag name (a registered tag schema).
+        value: Tag value, JSON or a plain string.
+        version: Feature group version.
+    """
+    fg = _get_fg(ctx, name, version)
+    try:
+        fg.add_tag(name=tag, value=output.parse_tag_value(value))
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add tag: {exc}") from exc
+    output.success("✓ Added tag '%s' to %s", tag, name)
+
+
+@fg_group.command("remove-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--version", type=int, help="Feature group version.")
+@click.pass_context
+def fg_remove_tag(ctx: click.Context, name: str, tag: str, version: int | None) -> None:
+    """Remove a tag from a feature group.
+
+    Args:
+        ctx: Click context.
+        name: Feature group name.
+        tag: Tag name.
+        version: Feature group version.
+    """
+    fg = _get_fg(ctx, name, version)
+    try:
+        fg.delete_tag(tag)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove tag: {exc}") from exc
+    output.success("✓ Removed tag '%s' from %s", tag, name)
 
 
 # region Helpers
@@ -1135,13 +1230,6 @@ def _synth_value(dtype: str, i: int) -> Any:
 
         return pd.Timestamp("2026-01-01") + pd.Timedelta(days=i)
     return f"val_{i}"
-
-
-def _tag_value(tag: Any) -> Any:
-    """Normalize an SDK ``Tag`` object (or primitive) to a JSON-friendly value."""
-    if hasattr(tag, "value"):
-        return tag.value
-    return tag
 
 
 def _parse_join(raw: str) -> joinspec.JoinSpec:

--- a/python/hopsworks/cli/commands/fv.py
+++ b/python/hopsworks/cli/commands/fv.py
@@ -49,6 +49,15 @@ def fv_list(ctx: click.Context) -> None:
     output.print_table(["ID", "NAME", "VERSION", "LABELS", "DESCRIPTION"], rows)
 
 
+def _get_fv(ctx: click.Context, name: str, version: int | None) -> Any:
+    """Resolve a feature view or fail with a clean CLI error."""
+    fs = session.get_feature_store(ctx)
+    try:
+        return fs.get_feature_view(name, version=version)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+
+
 @fv_group.command("info")
 @click.argument("name")
 @click.option("--version", type=int, help="Feature view version; defaults to latest.")
@@ -61,11 +70,7 @@ def fv_info(ctx: click.Context, name: str, version: int | None) -> None:
         name: Feature view name.
         version: Specific version to inspect.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
 
     if output.JSON_MODE:
         output.print_json(_fv_to_dict(fv))
@@ -137,11 +142,7 @@ def fv_lineage(ctx: click.Context, name: str, version: int | None) -> None:
         name: Feature view name.
         version: Specific version; latest if omitted.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
     label = f"feature view {getattr(fv, 'name', name)} v{getattr(fv, 'version', '?')}"
     sections = [
         (
@@ -343,11 +344,7 @@ def fv_get(ctx: click.Context, name: str, version: int | None, entry: str) -> No
         version: Feature view version.
         entry: Comma-separated ``key=value`` pairs for the primary keys.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
 
     entry_dict = _parse_entry(entry)
     try:
@@ -396,11 +393,7 @@ def fv_read(
         start_time: ISO timestamp lower bound.
         end_time: ISO timestamp upper bound.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
 
     try:
         df = fv.get_batch_data(
@@ -447,11 +440,7 @@ def fv_delete(
         yes: Skip confirmation when True.
         force: Pass ``force=True`` to the SDK.
     """
-    fs = session.get_feature_store(ctx)
-    try:
-        fv = fs.get_feature_view(name, version=version)
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"Feature view '{name}' not found: {exc}") from exc
+    fv = _get_fv(ctx, name, version)
 
     if not yes and not output.JSON_MODE:
         click.confirm(
@@ -463,6 +452,149 @@ def fv_delete(
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Delete failed: {exc}") from exc
     output.success("✓ Deleted feature view %s", name)
+
+
+@fv_group.command("tags")
+@click.argument("name")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_tags(ctx: click.Context, name: str, version: int | None) -> None:
+    """Show all tags attached to a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        tags = fv.get_tags_metadata()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read tags: {exc}") from exc
+    output.render_tags(tags)
+
+
+@fv_group.command("add-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--value", required=True, help="Tag value, JSON or a plain string.")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_add_tag(
+    ctx: click.Context, name: str, tag: str, value: str, version: int | None
+) -> None:
+    """Attach a tag (name/value pair) to a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        tag: Tag name (a registered tag schema).
+        value: Tag value, JSON or a plain string.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        fv.add_tag(name=tag, value=output.parse_tag_value(value))
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add tag: {exc}") from exc
+    output.success("✓ Added tag '%s' to %s", tag, name)
+
+
+@fv_group.command("remove-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_remove_tag(ctx: click.Context, name: str, tag: str, version: int | None) -> None:
+    """Remove a tag from a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        tag: Tag name.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        fv.delete_tag(tag)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove tag: {exc}") from exc
+    output.success("✓ Removed tag '%s' from %s", tag, name)
+
+
+@fv_group.command("keywords")
+@click.argument("name")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_keywords(ctx: click.Context, name: str, version: int | None) -> None:
+    """Show all keywords attached to a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        keywords = fv.get_keywords_metadata()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read keywords: {exc}") from exc
+
+    if output.JSON_MODE:
+        output.print_json(
+            {k: output.format_ts(v, empty=None) for k, v in (keywords or {}).items()}
+        )
+        return
+    rows = [[k, output.format_ts(v)] for k, v in (keywords or {}).items()]
+    output.print_table(["KEYWORD", "ADDED"], rows)
+
+
+@fv_group.command("add-keyword")
+@click.argument("name")
+@click.argument("keyword")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_add_keyword(
+    ctx: click.Context, name: str, keyword: str, version: int | None
+) -> None:
+    """Attach a keyword to a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        keyword: The keyword.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        fv.add_keywords([keyword])
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add keyword: {exc}") from exc
+    output.success("✓ Added keyword '%s' to %s", keyword, name)
+
+
+@fv_group.command("remove-keyword")
+@click.argument("name")
+@click.argument("keyword")
+@click.option("--version", type=int, help="Feature view version.")
+@click.pass_context
+def fv_remove_keyword(
+    ctx: click.Context, name: str, keyword: str, version: int | None
+) -> None:
+    """Remove a keyword from a feature view.
+
+    Args:
+        ctx: Click context.
+        name: Feature view name.
+        keyword: The keyword.
+        version: Feature view version.
+    """
+    fv = _get_fv(ctx, name, version)
+    try:
+        fv.delete_keyword(keyword)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove keyword: {exc}") from exc
+    output.success("✓ Removed keyword '%s' from %s", keyword, name)
 
 
 # region Helpers

--- a/python/hopsworks/cli/commands/job.py
+++ b/python/hopsworks/cli/commands/job.py
@@ -120,6 +120,8 @@ def job_info(ctx: click.Context, name: str) -> None:
         ["Type", getattr(job, "job_type", "-")],
         ["Creator", _user_label(getattr(job, "creator", None))],
         ["Created", _ts_label(getattr(job, "creation_time", None))],
+        ["Description", output.first_line(getattr(job, "description", None))],
+        ["Tags", output.format_mapping(output.read_tags(job))],
     ]
     output.print_table(["FIELD", "VALUE"], rows)
 
@@ -144,6 +146,8 @@ def _job_to_dict(job: Any) -> dict[str, Any]:
         "type": getattr(job, "job_type", None),
         "creator": creator,
         "creation_time": getattr(job, "creation_time", None),
+        "description": getattr(job, "description", None),
+        "tags": output.read_tags(job),
         "config": config.to_dict() if hasattr(config, "to_dict") else config,
     }
 
@@ -164,6 +168,7 @@ def _job_to_dict(job: Any) -> dict[str, Any]:
     "--app-path", "app_path", required=True, help="HDFS/HopsFS path to the main file."
 )
 @click.option("--args", "app_args", help="Arguments passed to the program.")
+@click.option("--description", help="Free-form description of the job.")
 @click.pass_context
 def job_create(
     ctx: click.Context,
@@ -171,6 +176,7 @@ def job_create(
     job_type: str,
     app_path: str,
     app_args: str | None,
+    description: str | None,
 ) -> None:
     """Create a new job from a ``type`` + ``--app-path``.
 
@@ -180,6 +186,7 @@ def job_create(
         job_type: One of ``PYTHON``/``PYSPARK``/``SPARK``/``DOCKER``.
         app_path: HopsFS path to the script or JAR.
         app_args: Optional argument string passed to the job.
+        description: Optional free-form description.
     """
     project = session.get_project(ctx)
     api = project.get_job_api()
@@ -190,6 +197,8 @@ def job_create(
     config["appPath"] = app_path
     if app_args:
         config["defaultArgs"] = app_args
+    if description:
+        config["description"] = description
     try:
         job = api.create_job(name=name, config=config)
     except Exception as exc:  # noqa: BLE001
@@ -780,6 +789,87 @@ def job_delete(ctx: click.Context, name: str, yes: bool) -> None:
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Delete failed: {exc}") from exc
     output.success("✓ Deleted job %s", name)
+
+
+@job_group.command("tags")
+@click.argument("name")
+@click.pass_context
+def job_tags(ctx: click.Context, name: str) -> None:
+    """Show all tags attached to a job.
+
+    Args:
+        ctx: Click context.
+        name: Job name.
+    """
+    job = _get_job(ctx, name)
+    try:
+        tags = job.get_tags_metadata()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read tags: {exc}") from exc
+    output.render_tags(tags)
+
+
+@job_group.command("add-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.option("--value", required=True, help="Tag value, JSON or a plain string.")
+@click.pass_context
+def job_add_tag(ctx: click.Context, name: str, tag: str, value: str) -> None:
+    """Attach a tag (name/value pair) to a job.
+
+    Args:
+        ctx: Click context.
+        name: Job name.
+        tag: Tag name (a registered tag schema).
+        value: Tag value, JSON or a plain string.
+    """
+    job = _get_job(ctx, name)
+    try:
+        job.add_tag(name=tag, value=output.parse_tag_value(value))
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add tag: {exc}") from exc
+    output.success("✓ Added tag '%s' to %s", tag, name)
+
+
+@job_group.command("remove-tag")
+@click.argument("name")
+@click.argument("tag")
+@click.pass_context
+def job_remove_tag(ctx: click.Context, name: str, tag: str) -> None:
+    """Remove a tag from a job.
+
+    Args:
+        ctx: Click context.
+        name: Job name.
+        tag: Tag name.
+    """
+    job = _get_job(ctx, name)
+    try:
+        job.delete_tag(tag)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove tag: {exc}") from exc
+    output.success("✓ Removed tag '%s' from %s", tag, name)
+
+
+@job_group.command("describe")
+@click.argument("name")
+@click.option("--description", required=True, help="New description of the job.")
+@click.pass_context
+def job_describe(ctx: click.Context, name: str, description: str) -> None:
+    """Set the description of a job.
+
+    Args:
+        ctx: Click context.
+        name: Job name.
+        description: New description.
+    """
+    job = _get_job(ctx, name)
+    try:
+        job.description = description
+        job.save()
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not update description: {exc}") from exc
+    output.success("✓ Updated description of %s", name)
 
 
 def _read_log(path: str | None, tail: int | None) -> str:

--- a/python/hopsworks/cli/commands/td.py
+++ b/python/hopsworks/cli/commands/td.py
@@ -313,6 +313,101 @@ def td_lineage(
     lineage.render(label, sections)
 
 
+@td_group.command("keywords")
+@click.argument("feature_view")
+@click.argument("td_version", type=int)
+@click.option("--fv-version", "fv_version", type=int, help="Feature view version.")
+@click.pass_context
+def td_keywords(
+    ctx: click.Context, feature_view: str, td_version: int, fv_version: int | None
+) -> None:
+    """Show all keywords attached to a training dataset.
+
+    Args:
+        ctx: Click context.
+        feature_view: Feature view name.
+        td_version: Training dataset version.
+        fv_version: Feature view version; latest if omitted.
+    """
+    fv = _get_fv(ctx, feature_view, fv_version)
+    try:
+        keywords = fv.get_training_dataset_keywords_metadata(td_version)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read keywords: {exc}") from exc
+
+    if output.JSON_MODE:
+        output.print_json(
+            {k: output.format_ts(v, empty=None) for k, v in (keywords or {}).items()}
+        )
+        return
+    rows = [[k, output.format_ts(v)] for k, v in (keywords or {}).items()]
+    output.print_table(["KEYWORD", "ADDED"], rows)
+
+
+@td_group.command("add-keyword")
+@click.argument("feature_view")
+@click.argument("td_version", type=int)
+@click.argument("keyword")
+@click.option("--fv-version", "fv_version", type=int, help="Feature view version.")
+@click.pass_context
+def td_add_keyword(
+    ctx: click.Context,
+    feature_view: str,
+    td_version: int,
+    keyword: str,
+    fv_version: int | None,
+) -> None:
+    """Attach a keyword to a training dataset.
+
+    Args:
+        ctx: Click context.
+        feature_view: Feature view name.
+        td_version: Training dataset version.
+        keyword: The keyword.
+        fv_version: Feature view version; latest if omitted.
+    """
+    fv = _get_fv(ctx, feature_view, fv_version)
+    try:
+        fv.add_training_dataset_keywords(td_version, [keyword])
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not add keyword: {exc}") from exc
+    output.success(
+        "✓ Added keyword '%s' to %s td v%s", keyword, feature_view, td_version
+    )
+
+
+@td_group.command("remove-keyword")
+@click.argument("feature_view")
+@click.argument("td_version", type=int)
+@click.argument("keyword")
+@click.option("--fv-version", "fv_version", type=int, help="Feature view version.")
+@click.pass_context
+def td_remove_keyword(
+    ctx: click.Context,
+    feature_view: str,
+    td_version: int,
+    keyword: str,
+    fv_version: int | None,
+) -> None:
+    """Remove a keyword from a training dataset.
+
+    Args:
+        ctx: Click context.
+        feature_view: Feature view name.
+        td_version: Training dataset version.
+        keyword: The keyword.
+        fv_version: Feature view version; latest if omitted.
+    """
+    fv = _get_fv(ctx, feature_view, fv_version)
+    try:
+        fv.delete_training_dataset_keyword(td_version, keyword)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not remove keyword: {exc}") from exc
+    output.success(
+        "✓ Removed keyword '%s' from %s td v%s", keyword, feature_view, td_version
+    )
+
+
 def _get_fv(ctx: click.Context, name: str, version: int | None) -> Any:
     fs = session.get_feature_store(ctx)
     try:

--- a/python/hopsworks/cli/output.py
+++ b/python/hopsworks/cli/output.py
@@ -78,6 +78,70 @@ def read_tags(obj: Any) -> dict[str, Any]:
     return {name: getattr(t, "value", t) for name, t in (raw or {}).items()}
 
 
+def format_ts(value: Any, empty: str = "-") -> str:
+    """Render a datetime (or None) as an ISO-8601 table cell.
+
+    Args:
+        value: A datetime, or None when the timestamp is unknown.
+        empty: Fallback returned for None.
+
+    Returns:
+        An ISO-8601 string, or the ``empty`` placeholder.
+    """
+    if value is None:
+        return empty
+    if hasattr(value, "isoformat"):
+        return value.isoformat(sep=" ", timespec="seconds")
+    return str(value)
+
+
+def parse_tag_value(raw: str) -> Any:
+    """Parse a ``--value`` option as JSON, falling back to the raw string.
+
+    Tag values are arbitrary JSON; a bare word like ``prod`` is accepted as a
+    plain string rather than rejected for not being valid JSON.
+
+    Args:
+        raw: The option value as typed.
+
+    Returns:
+        The decoded JSON value, or ``raw`` unchanged.
+    """
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def render_tags(tags: Any) -> None:
+    """Render a ``{name: Tag}`` mapping as a NAME/VALUE/ADDED table or JSON.
+
+    Args:
+        tags: Mapping of tag name to SDK ``Tag`` objects (with ``value`` and
+            ``created_on``), as returned by the ``get_tags_metadata`` methods.
+    """
+    if JSON_MODE:
+        print_json(
+            {
+                k: {
+                    "value": getattr(t, "value", t),
+                    "added": format_ts(getattr(t, "created_on", None), empty=None),
+                }
+                for k, t in (tags or {}).items()
+            }
+        )
+        return
+    rows = [
+        [
+            k,
+            json.dumps(getattr(t, "value", t), default=str),
+            format_ts(getattr(t, "created_on", None)),
+        ]
+        for k, t in (tags or {}).items()
+    ]
+    print_table(["NAME", "VALUE", "ADDED"], rows)
+
+
 def format_mapping(values: Any, empty: str = "-") -> str:
     """Render a small mapping as ``key=value`` pairs for a one-line cell.
 

--- a/python/hopsworks_common/core/job_api.py
+++ b/python/hopsworks_common/core/job_api.py
@@ -25,6 +25,7 @@ from hopsworks_common import (
     execution,
     job,
     job_schedule,
+    tag,
     usage,
     util,
 )
@@ -333,3 +334,131 @@ class JobApi:
             "DELETE",
             path_params,
         )
+
+    def _add_tag(self, job: job.Job, name: str, value: Any) -> None:
+        """Attach a name/value tag to a job.
+
+        A tag consists of a name/value pair. Tag names are unique identifiers.
+        The value of a tag can be any valid json - primitives, arrays or json objects.
+
+        Parameters:
+            job: The job to attach the tag to.
+            name: Name of the tag to be added.
+            value: Value of the tag to be added.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "jobs",
+            job.name,
+            "tags",
+            name,
+        ]
+        headers = {"content-type": "application/json"}
+        json_value = json.dumps(value)
+        _client._send_request("PUT", path_params, headers=headers, data=json_value)
+
+    def _delete_tag(self, job: job.Job, name: str) -> None:
+        """Delete a tag from a job.
+
+        Tag names are unique identifiers.
+
+        Parameters:
+            job: The job to remove the tag from.
+            name: Name of the tag to be removed.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "jobs",
+            job.name,
+            "tags",
+            name,
+        ]
+        _client._send_request("DELETE", path_params)
+
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_tags(self, job: job.Job) -> dict[str, Any]:
+        """Get all tags attached to a job.
+
+        Parameters:
+            job: The job to get the tags from.
+
+        Returns:
+            Dict of tag name/values.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "jobs",
+            job.name,
+            "tags",
+        ]
+        # from_response_json already returns deserialized values.
+        return {
+            t._name: t._value
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return=None)
+    def _get_tag(self, job: job.Job, name: str) -> Any | None:
+        """Get the value of a tag attached to a job.
+
+        Parameters:
+            job: The job to get the tag from.
+            name: Tag name.
+
+        Returns:
+            The value of the tag with the specified name, or `None` if it does not exist.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "jobs",
+            job.name,
+            "tags",
+            name,
+        ]
+        tags = {
+            t._name: t._value
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+        return tags.get(name)
+
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_tags_metadata(
+        self, job: job.Job, name: str | None = None
+    ) -> dict[str, tag.Tag]:
+        """Get the tags of a job as Tag objects, keeping metadata such as created_on.
+
+        Parameters:
+            job: The job to get the tags from.
+            name: Tag name; all tags if omitted.
+
+        Returns:
+            Dict of tag name to Tag object.
+        """
+        _client = client._get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "jobs",
+            job.name,
+            "tags",
+        ]
+        if name is not None:
+            path_params.append(name)
+        return {
+            t._name: t
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }

--- a/python/hopsworks_common/core/keywords_api.py
+++ b/python/hopsworks_common/core/keywords_api.py
@@ -1,0 +1,195 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from hopsworks_apigen import also_available_as
+from hopsworks_common import client, tag, usage
+
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from hsfs.feature_group import FeatureGroup
+    from hsfs.training_dataset import TrainingDataset
+
+
+@also_available_as(
+    "hopsworks.core.keywords_api.KeywordsApi", "hsfs.core.keywords_api.KeywordsApi"
+)
+class KeywordsApi:
+    def __init__(
+        self, feature_store_id: int | None = None, entity_type: str | None = None
+    ):
+        """Keywords endpoint for `trainingdatasets`, `featuregroups`, and `featureview` resources.
+
+        Parameters:
+            feature_store_id: id of the respective featurestore
+            entity_type: "trainingdatasets" or "featuregroups"
+
+        Both may be omitted when the instance is only used for `_get_all`, which is not scoped to an artifact.
+        """
+        self._feature_store_id = feature_store_id
+        self._entity_type = entity_type
+
+    @usage._method_logger
+    def _get(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        training_dataset_version=None,
+    ) -> list[str]:
+        """Get the keywords of a feature group, feature view, or training dataset.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to get the keywords for.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            List of keywords.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+        return _client._send_request("GET", path_params).get("keywords") or []
+
+    @usage._method_logger
+    def _get_with_metadata(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        training_dataset_version=None,
+    ) -> dict[str, datetime | None]:
+        """Get the keywords with the time each was attached.
+
+        An old server sends only the plain keyword list, without the `items` carrying the timestamps; every keyword then maps to `None`.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to get the keywords for.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            Dict of keyword to attachment time, `None` when the time is unknown.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+        response = _client._send_request("GET", path_params)
+        created_on = {
+            item["name"]: tag.Tag._parse_created_on(item.get("createdOn"))
+            for item in response.get("items") or []
+            if item.get("name")
+        }
+        return {name: created_on.get(name) for name in response.get("keywords") or []}
+
+    @usage._method_logger
+    def _replace(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        keywords: list[str],
+        training_dataset_version=None,
+    ) -> list[str]:
+        """Replace the whole keyword set of the artifact.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to set the keywords for.
+            keywords: The new keyword set.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            The updated list of keywords.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+        headers = {"content-type": "application/json"}
+        return (
+            _client._send_request(
+                "POST",
+                path_params,
+                headers=headers,
+                data=json.dumps({"keywords": keywords}),
+            ).get("keywords")
+            or []
+        )
+
+    @usage._method_logger
+    def _delete(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        keyword: str,
+        training_dataset_version=None,
+    ) -> list[str]:
+        """Delete a single keyword from the artifact.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to delete the keyword for.
+            keyword: The keyword to remove.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            The updated list of keywords.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+        response = _client._send_request(
+            "DELETE", path_params, query_params={"keyword": keyword}
+        )
+        return (response or {}).get("keywords") or []
+
+    @usage._method_logger
+    def _get_all(self) -> list[str]:
+        """Get the keyword vocabulary in use across the whole cluster.
+
+        Cluster-wide despite the project-scoped path: the backend serves the same vocabulary to every project.
+
+        Returns:
+            List of keywords.
+        """
+        _client = client._get_instance()
+        path_params = ["project", _client._project_id, "featurestores", "keywords"]
+        return _client._send_request("GET", path_params).get("keywords") or []
+
+    @usage._method_logger
+    def _get_path(self, metadata_instance, training_dataset_version=None):
+        _client = client._get_instance()
+        if hasattr(metadata_instance, "training_data"):
+            # Only FeatureView has training_data method
+            path = [
+                "project",
+                _client._project_id,
+                "featurestores",
+                self._feature_store_id,
+                "featureview",
+                metadata_instance.name,
+                "version",
+                metadata_instance.version,
+            ]
+            if training_dataset_version:
+                return path + [
+                    "trainingdatasets",
+                    "version",
+                    training_dataset_version,
+                    "keywords",
+                ]
+            return path + ["keywords"]
+        return [
+            "project",
+            _client._project_id,
+            "featurestores",
+            self._feature_store_id,
+            self._entity_type,
+            metadata_instance.id,
+            "keywords",
+        ]

--- a/python/hopsworks_common/core/tag_schemas_api.py
+++ b/python/hopsworks_common/core/tag_schemas_api.py
@@ -83,7 +83,9 @@ class TagSchemasApi:
         return _client._send_request("GET", self._path() + [name])
 
     @public
-    def create(self, name: str, schema: dict | str) -> dict[str, Any]:
+    def create(
+        self, name: str, schema: dict | str, archive: bool = False
+    ) -> dict[str, Any]:
         """Register a new schematized tag.
 
         Tag schemas are JSON-Schema definitions that constrain the value
@@ -107,6 +109,9 @@ class TagSchemasApi:
                 "required": ["owner"],
             }
             TagSchemasApi().create("ownership", schema)
+
+            # keep deleted attachments of this tag for analytics
+            TagSchemasApi().create("ownership", schema, archive=True)
             ```
 
         Parameters:
@@ -114,6 +119,9 @@ class TagSchemasApi:
                 tag instances to entities).
             schema: JSON-Schema definition. May be a Python dict (the
                 preferred form) or a JSON string already serialized.
+            archive: Whether attachments of this tag are kept once they
+                are deleted, for later analytics. Defaults to `False`,
+                which discards them with the attachment.
 
         Returns:
             The created schema payload as returned by the backend.
@@ -144,7 +152,7 @@ class TagSchemasApi:
             return _client._send_request(
                 "POST",
                 self._path(),
-                query_params={"name": name},
+                query_params={"name": name, "archive": archive},
                 headers={"content-type": "application/json"},
                 data=body,
             )

--- a/python/hopsworks_common/core/tags_api.py
+++ b/python/hopsworks_common/core/tags_api.py
@@ -125,6 +125,39 @@ class TagsApi:
         }
 
     @usage._method_logger
+    @decorators._catch_not_found("hopsworks_common.tag.Tag", fallback_return={})
+    def _get_metadata(
+        self,
+        metadata_instance: TrainingDataset | FeatureGroup,
+        name: str | None = None,
+        training_dataset_version=None,
+    ) -> dict[str, tag.Tag]:
+        """Get the tags of a training dataset or feature group as Tag objects.
+
+        Unlike `_get`, keeps the `Tag` objects so callers can read metadata such as `created_on`.
+
+        Parameters:
+            metadata_instance: Metadata object of the instance to get the tags for.
+            name: Tag name.
+            training_dataset_version: Version of the training dataset.
+
+        Returns:
+            Dict of tag name to Tag object.
+        """
+        _client = client._get_instance()
+        path_params = self._get_path(metadata_instance, training_dataset_version)
+
+        if name is not None:
+            path_params.append(name)
+
+        return {
+            t._name: t
+            for t in tag.Tag.from_response_json(
+                _client._send_request("GET", path_params)
+            )
+        }
+
+    @usage._method_logger
     def _get_path(self, metadata_instance, training_dataset_version=None):
         _client = client._get_instance()
         if hasattr(metadata_instance, "training_data"):

--- a/python/hopsworks_common/job.py
+++ b/python/hopsworks_common/job.py
@@ -19,11 +19,11 @@ from __future__ import annotations
 import json
 import warnings
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import humps
 from hopsworks_apigen import public
-from hopsworks_common import alert, client, usage, util
+from hopsworks_common import alert, client, tag, usage, util
 from hopsworks_common.client.exceptions import JobException
 from hopsworks_common.core import alerts_api, execution_api, job_api
 from hopsworks_common.engine import execution_engine
@@ -53,12 +53,14 @@ class Job:
         items=None,
         count=None,
         job_schedule=None,
+        description=None,
         **kwargs,
     ):
         self._id = id
         self._name = name
         self._creation_time = creation_time
         self._config = config
+        self._description = description
         self._job_type = job_type
         self._creator = creator
         self._executions = executions
@@ -124,6 +126,27 @@ class Job:
 
     @public
     @property
+    def description(self):
+        """Description of the job.
+
+        An old server does not send the scalar field; the description then comes from the job configuration.
+        """
+        if self._description is not None:
+            return self._description
+        if isinstance(self._config, dict):
+            return self._config.get("description")
+        return None
+
+    @description.setter
+    def description(self, description: str):
+        # Written into the config too, so the existing save() persists it. Guarded like the getter:
+        # a config that did not deserialize to a dict should fail the save, not this assignment.
+        self._description = description
+        if isinstance(self._config, dict):
+            self._config["description"] = description
+
+    @public
+    @property
     def job_type(self):
         """Type of the job."""
         return self._job_type
@@ -151,12 +174,6 @@ class Job:
     def href(self):
         """The URL of the job in Hopsworks UI, use `get_url` instead."""
         return self._href
-
-    @public
-    @property
-    def config(self):
-        """Configuration for the job."""
-        return self._config
 
     @public
     @usage._method_logger
@@ -603,6 +620,99 @@ class Job:
             self._name, job_schedule.to_dict()
         )
         return self._job_schedule
+
+    @public
+    @usage._method_logger
+    def add_tag(self, name: str, value: Any) -> None:
+        """Attach a tag to the job.
+
+        A tag consists of a name-value pair.
+        Tag names are unique identifiers across the whole cluster.
+        The value of a tag can be any valid json - primitives, arrays or json objects.
+
+        ```python
+        job.add_tag(name="example_tag", value="42")
+        ```
+
+        Parameters:
+            name: Name of the tag to be added.
+            value: Value of the tag to be added.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        self._job_api._add_tag(self, name, value)
+
+    @public
+    @usage._method_logger
+    def delete_tag(self, name: str) -> None:
+        """Delete a tag attached to the job.
+
+        Parameters:
+            name: Name of the tag to be removed.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        self._job_api._delete_tag(self, name)
+
+    @public
+    def get_tag(self, name: str) -> Any | None:
+        """Get the value of a tag attached to the job.
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            Tag value or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._job_api._get_tag(self, name)
+
+    @public
+    def get_tags(self) -> dict[str, Any]:
+        """Retrieve all tags attached to the job.
+
+        Returns:
+            Dictionary of tag names and values.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._job_api._get_tags(self)
+
+    @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`Job.get_tag`][hopsworks.job.Job.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._job_api._get_tags_metadata(self, name).get(name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Retrieve all tags attached to the job, with their metadata.
+
+        Unlike [`Job.get_tags`][hopsworks.job.Job.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            Dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._job_api._get_tags_metadata(self)
 
     def json(self) -> str:
         return json.dumps(self, cls=util.Encoder)

--- a/python/hopsworks_common/tag.py
+++ b/python/hopsworks_common/tag.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from datetime import datetime, timezone
 from typing import Any
 
 import humps
@@ -39,6 +40,7 @@ class Tag:
         self,
         name: str,
         value: dict[str, Any] | str,
+        created_on: datetime | None = None,
         schema=None,
         href=None,
         expand=None,
@@ -53,10 +55,12 @@ class Tag:
             raise ValueError("Tag value cannot be None")
         self._name = name
         self._value = value
+        self._created_on = created_on
 
     def to_dict(self):
         # Backend expects value to always be a string
         # If value is a dict, serialize it to JSON string
+        # created_on is server-assigned, so it is deliberately not sent back
         value = self._value
         if isinstance(value, dict):
             value = json.dumps(value)
@@ -111,7 +115,14 @@ class Tag:
     @classmethod
     def from_response_json(cls, json_dict):
         json_decamelized = humps.decamelize(json_dict)
-        if "count" not in json_decamelized or json_decamelized["count"] == 0:
+        # A request naming one tag answers with that tag, not with a collection: the dataset tag
+        # endpoints do this, and reading it as an empty collection lost the tag entirely.
+        if "count" not in json_decamelized:
+            if "name" in json_decamelized and "value" in json_decamelized:
+                json_decamelized = {"count": 1, "items": [json_decamelized]}
+            else:
+                return []
+        if json_decamelized["count"] == 0:
             return []
         tags = []
         for tag_dict in json_decamelized["items"]:
@@ -124,9 +135,38 @@ class Tag:
                 with contextlib.suppress(json.JSONDecodeError, ValueError):
                     tag_dict["value"] = json.loads(tag_dict["value"])
 
-            # Only pass name and value to avoid issues with extra fields like schema
-            tags.append(cls(name=tag_dict["name"], value=tag_dict["value"]))
+            tags.append(
+                cls(
+                    name=tag_dict["name"],
+                    value=tag_dict["value"],
+                    created_on=cls._parse_created_on(tag_dict.get("created_on")),
+                )
+            )
         return tags
+
+    @staticmethod
+    def _parse_created_on(raw: Any) -> datetime | None:
+        """Parse the attachment time the backend sent, in whichever form it sent it.
+
+        Both epoch milliseconds and ISO-8601 are accepted because the backend's JSON date format
+        is not pinned across versions, and a client that only understood one of them would report
+        no attachment time at all against the other.
+        Anything unrecognized becomes None rather than raising: an unreadable timestamp must not
+        stop a tag from being read.
+        """
+        if raw is None:
+            return None
+        if isinstance(raw, datetime):
+            return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+        if isinstance(raw, (int, float)):
+            return datetime.fromtimestamp(raw / 1000, tz=timezone.utc)
+        if isinstance(raw, str):
+            with contextlib.suppress(ValueError):
+                return datetime.fromtimestamp(int(raw) / 1000, tz=timezone.utc)
+            with contextlib.suppress(ValueError):
+                parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+                return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        return None
 
     @public
     @property
@@ -151,6 +191,18 @@ class Tag:
         if value is None:
             raise ValueError("Tag value cannot be None")
         self._value = value
+
+    @public
+    @property
+    def created_on(self) -> datetime | None:
+        """When the tag was attached, as an aware UTC datetime.
+
+        `None` for a tag attached before Hopsworks recorded attachment times, and for legacy
+        per-file dataset tags, which are stored as HopsFS extended attributes and carry no
+        timestamp.
+        `None` therefore means the attachment time is unknown, not that the tag is new.
+        """
+        return self._created_on
 
     def __str__(self):
         return self.json()

--- a/python/hsfs/core/feature_group_base_engine.py
+++ b/python/hsfs/core/feature_group_base_engine.py
@@ -19,7 +19,13 @@ from typing import TYPE_CHECKING, Any
 
 from hopsworks_common.client.exceptions import FeatureStoreException
 from hsfs import util
-from hsfs.core import feature_group_api, kafka_api, storage_connector_api, tags_api
+from hsfs.core import (
+    feature_group_api,
+    kafka_api,
+    keywords_api,
+    storage_connector_api,
+    tags_api,
+)
 
 
 if TYPE_CHECKING:
@@ -34,6 +40,9 @@ class FeatureGroupBaseEngine:
     def __init__(self, feature_store_id):
         self._feature_store_id = feature_store_id
         self._tags_api = tags_api.TagsApi(feature_store_id, self.ENTITY_TYPE)
+        self._keywords_api = keywords_api.KeywordsApi(
+            feature_store_id, self.ENTITY_TYPE
+        )
         self._feature_group_api = feature_group_api.FeatureGroupApi()
         self._storage_connector_api = storage_connector_api.StorageConnectorApi()
         self._kafka_api = kafka_api.KafkaApi()
@@ -90,6 +99,37 @@ class FeatureGroupBaseEngine:
         if tags:
             return tags
         return {}
+
+    def _get_tag_metadata(self, feature_group: FeatureGroup, name: str):
+        """Get the tag with a certain name as a Tag object, or None if it does not exist."""
+        return self._tags_api._get_metadata(feature_group, name).get(name)
+
+    def _get_tags_metadata(self, feature_group: FeatureGroup):
+        """Get all tags for a feature group as Tag objects."""
+        return self._tags_api._get_metadata(feature_group)
+
+    def _get_keywords(self, feature_group: FeatureGroup):
+        """Get all keywords of a feature group."""
+        return self._keywords_api._get(feature_group)
+
+    def _get_keywords_metadata(self, feature_group: FeatureGroup):
+        """Get all keywords of a feature group with their attachment times."""
+        return self._keywords_api._get_with_metadata(feature_group)
+
+    def _set_keywords(self, feature_group: FeatureGroup, keywords: list[str]):
+        """Replace the whole keyword set of a feature group."""
+        return self._keywords_api._replace(feature_group, keywords)
+
+    def _add_keywords(self, feature_group: FeatureGroup, keywords: list[str]):
+        """Add keywords to a feature group, keeping the existing ones."""
+        current = self._keywords_api._get(feature_group)
+        return self._keywords_api._replace(
+            feature_group, list(dict.fromkeys(current + keywords))
+        )
+
+    def _delete_keyword(self, feature_group: FeatureGroup, keyword: str):
+        """Remove a single keyword from a feature group."""
+        return self._keywords_api._delete(feature_group, keyword)
 
     def _get_parent_feature_groups(
         self, feature_group: FeatureGroup

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -36,6 +36,7 @@ from hsfs.constructor.filter import Filter, Logic
 from hsfs.constructor.query import Query
 from hsfs.core import (
     feature_view_api,
+    keywords_api,
     query_constructor_api,
     statistics_engine,
     tags_api,
@@ -73,6 +74,9 @@ class FeatureViewEngine:
 
         self._feature_view_api = feature_view_api.FeatureViewApi(feature_store_id)
         self._tags_api = tags_api.TagsApi(feature_store_id, self.ENTITY_TYPE)
+        self._keywords_api = keywords_api.KeywordsApi(
+            feature_store_id, self.ENTITY_TYPE
+        )
         self._statistics_engine = statistics_engine.StatisticsEngine(
             feature_store_id, self._TRAINING_DATA_API_PATH
         )
@@ -1163,6 +1167,65 @@ class FeatureViewEngine:
     def _get_tags(self, feature_view_obj, training_dataset_version=None):
         return self._tags_api._get(
             feature_view_obj, training_dataset_version=training_dataset_version
+        )
+
+    def _get_tag_metadata(
+        self, feature_view_obj, name: str, training_dataset_version=None
+    ):
+        """Get the tag with a certain name as a Tag object, or None if it does not exist."""
+        return self._tags_api._get_metadata(
+            feature_view_obj, name, training_dataset_version=training_dataset_version
+        ).get(name)
+
+    def _get_tags_metadata(self, feature_view_obj, training_dataset_version=None):
+        """Get all tags for a feature view or training dataset as Tag objects."""
+        return self._tags_api._get_metadata(
+            feature_view_obj, training_dataset_version=training_dataset_version
+        )
+
+    def _get_keywords(self, feature_view_obj, training_dataset_version=None):
+        """Get all keywords of a feature view or one of its training datasets."""
+        return self._keywords_api._get(
+            feature_view_obj, training_dataset_version=training_dataset_version
+        )
+
+    def _get_keywords_metadata(self, feature_view_obj, training_dataset_version=None):
+        """Get all keywords of a feature view or one of its training datasets with their attachment times."""
+        return self._keywords_api._get_with_metadata(
+            feature_view_obj, training_dataset_version=training_dataset_version
+        )
+
+    def _set_keywords(
+        self, feature_view_obj, keywords: list[str], training_dataset_version=None
+    ):
+        """Replace the whole keyword set of a feature view or one of its training datasets."""
+        return self._keywords_api._replace(
+            feature_view_obj,
+            keywords,
+            training_dataset_version=training_dataset_version,
+        )
+
+    def _add_keywords(
+        self, feature_view_obj, keywords: list[str], training_dataset_version=None
+    ):
+        """Add keywords to a feature view or one of its training datasets, keeping the existing ones."""
+        current = self._keywords_api._get(
+            feature_view_obj, training_dataset_version=training_dataset_version
+        )
+        return self._keywords_api._replace(
+            feature_view_obj,
+            list(dict.fromkeys(current + keywords)),
+            training_dataset_version=training_dataset_version,
+        )
+
+    def _delete_keyword(
+        self, feature_view_obj, keyword: str, training_dataset_version=None
+    ):
+        """Remove a single keyword from a feature view or one of its training datasets."""
+        return self._keywords_api._delete(
+            feature_view_obj,
+            keyword,
+            training_dataset_version=training_dataset_version,
         )
 
     def _get_parent_feature_groups(

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -974,7 +974,7 @@ class FeatureGroupBase:
         self._feature_group_engine._delete_tag(self, name)
 
     @public
-    def get_tag(self, name: str) -> tag.Tag | None:
+    def get_tag(self, name: str) -> Any | None:
         """Get the tags of a feature group.
 
         Example:
@@ -1000,16 +1000,132 @@ class FeatureGroupBase:
         return self._feature_group_engine._get_tag(self, name)
 
     @public
-    def get_tags(self) -> dict[str, tag.Tag]:
+    def get_tags(self) -> dict[str, Any]:
         """Retrieves all tags attached to a feature group.
 
         Returns:
-            The dictionary of tags.
+            The dictionary of tag names and values.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         return self._feature_group_engine._get_tags(self)
+
+    @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`FeatureGroupBase.get_tag`][hsfs.feature_group.FeatureGroupBase.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
+
+        Example:
+            ```python
+            fg_tag = fg.get_tag_metadata("example_tag")
+            print(fg_tag.value, fg_tag.created_on)
+            ```
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._get_tag_metadata(self, name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Retrieves all tags attached to a feature group, with their metadata.
+
+        Unlike [`FeatureGroupBase.get_tags`][hsfs.feature_group.FeatureGroupBase.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            The dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._get_tags_metadata(self)
+
+    @public
+    def get_keywords(self) -> list[str]:
+        """Retrieve all keywords attached to a feature group.
+
+        A keyword is a plain label without a value, used to categorize and search for artifacts.
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._get_keywords(self)
+
+    @public
+    def get_keywords_metadata(self) -> dict[str, datetime | None]:
+        """Retrieve all keywords attached to a feature group, with the time each was attached.
+
+        Returns:
+            Dictionary of keyword to attachment time.
+            The time is `None` when it is unknown, for example for a keyword attached before Hopsworks recorded attachment times.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._get_keywords_metadata(self)
+
+    @public
+    def set_keywords(self, keywords: list[str]) -> list[str]:
+        """Replace the whole keyword set of a feature group.
+
+        Keywords not in `keywords` are removed.
+
+        Parameters:
+            keywords: The new keyword set.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._set_keywords(self, keywords)
+
+    @public
+    def add_keywords(self, keywords: str | list[str]) -> list[str]:
+        """Add keywords to a feature group, keeping the existing ones.
+
+        This reads the current keywords and writes back their union with `keywords`, so a concurrent `add_keywords` or [`FeatureGroupBase.set_keywords`][hsfs.feature_group.FeatureGroupBase.set_keywords] call can lose additions.
+        When the full keyword set is known, prefer [`FeatureGroupBase.set_keywords`][hsfs.feature_group.FeatureGroupBase.set_keywords].
+
+        Parameters:
+            keywords: A keyword or a list of keywords to add.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return self._feature_group_engine._add_keywords(self, keywords)
+
+    @public
+    def delete_keyword(self, keyword: str) -> list[str]:
+        """Remove a single keyword from a feature group.
+
+        Parameters:
+            keyword: The keyword to remove.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_group_engine._delete_keyword(self, keyword)
 
     @public
     def get_parent_feature_groups(self) -> explicit_provenance.Links | None:

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -40,6 +40,7 @@ from hsfs.core import (
     feature_group_api,
     feature_group_engine,
     feature_view_engine,
+    keywords_api,
     search_api,
     storage_connector_api,
     training_dataset_api,
@@ -3004,3 +3005,18 @@ class FeatureStore:
             limit=limit,
             global_search=global_search,
         )
+
+    @public
+    @usage._method_logger
+    def get_all_keywords(self) -> list[str]:
+        """Retrieve the keyword vocabulary in use across the whole cluster.
+
+        Despite being accessed through a feature store, the vocabulary is cluster-wide, not project-scoped: it contains every keyword attached to any artifact in any project.
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return keywords_api.KeywordsApi()._get_all()

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -1513,7 +1513,7 @@ class FeatureView:
         return self._feature_view_engine._add_tag(self, name, value)
 
     @public
-    def get_tag(self, name: str) -> tag.Tag | None:
+    def get_tag(self, name: str) -> Any | None:
         """Get the tags of a feature view.
 
         Example:
@@ -1540,7 +1540,7 @@ class FeatureView:
         return self._feature_view_engine._get_tag(self, name)
 
     @public
-    def get_tags(self) -> dict[str, tag.Tag]:
+    def get_tags(self) -> dict[str, Any]:
         """Returns all tags attached to a feature view.
 
         Example:
@@ -1556,12 +1556,128 @@ class FeatureView:
             ```
 
         Returns:
-            The dictionary of tags.
+            The dictionary of tag names and values.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         return self._feature_view_engine._get_tags(self)
+
+    @public
+    def get_tag_metadata(self, name: str) -> tag.Tag | None:
+        """Get a tag with its metadata, including the time it was attached.
+
+        Unlike [`FeatureView.get_tag`][hsfs.feature_view.FeatureView.get_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
+
+        Example:
+            ```python
+            fv_tag = feature_view.get_tag_metadata("example_tag")
+            print(fv_tag.value, fv_tag.created_on)
+            ```
+
+        Parameters:
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._get_tag_metadata(self, name)
+
+    @public
+    def get_tags_metadata(self) -> dict[str, tag.Tag]:
+        """Returns all tags attached to a feature view, with their metadata.
+
+        Unlike [`FeatureView.get_tags`][hsfs.feature_view.FeatureView.get_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
+
+        Returns:
+            The dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._get_tags_metadata(self)
+
+    @public
+    def get_keywords(self) -> list[str]:
+        """Retrieve all keywords attached to a feature view.
+
+        A keyword is a plain label without a value, used to categorize and search for artifacts.
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._get_keywords(self)
+
+    @public
+    def get_keywords_metadata(self) -> dict[str, datetime | None]:
+        """Retrieve all keywords attached to a feature view, with the time each was attached.
+
+        Returns:
+            Dictionary of keyword to attachment time.
+            The time is `None` when it is unknown, for example for a keyword attached before Hopsworks recorded attachment times.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._get_keywords_metadata(self)
+
+    @public
+    def set_keywords(self, keywords: list[str]) -> list[str]:
+        """Replace the whole keyword set of a feature view.
+
+        Keywords not in `keywords` are removed.
+
+        Parameters:
+            keywords: The new keyword set.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._set_keywords(self, keywords)
+
+    @public
+    def add_keywords(self, keywords: str | list[str]) -> list[str]:
+        """Add keywords to a feature view, keeping the existing ones.
+
+        This reads the current keywords and writes back their union with `keywords`, so a concurrent `add_keywords` or [`FeatureView.set_keywords`][hsfs.feature_view.FeatureView.set_keywords] call can lose additions.
+        When the full keyword set is known, prefer [`FeatureView.set_keywords`][hsfs.feature_view.FeatureView.set_keywords].
+
+        Parameters:
+            keywords: A keyword or a list of keywords to add.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return self._feature_view_engine._add_keywords(self, keywords)
+
+    @public
+    def delete_keyword(self, keyword: str) -> list[str]:
+        """Remove a single keyword from a feature view.
+
+        Parameters:
+            keyword: The keyword to remove.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        return self._feature_view_engine._delete_keyword(self, keyword)
 
     @public
     def get_parent_feature_groups(self) -> explicit_provenance.Links | None:
@@ -3609,7 +3725,7 @@ class FeatureView:
     @usage._method_logger
     def get_training_dataset_tag(
         self, training_dataset_version: int, name: str
-    ) -> tag.Tag | None:
+    ) -> Any | None:
         """Get the tags of a training dataset.
 
         Example:
@@ -3645,7 +3761,7 @@ class FeatureView:
     @usage._method_logger
     def get_training_dataset_tags(
         self, training_dataset_version: int
-    ) -> dict[str, tag.Tag]:
+    ) -> dict[str, Any]:
         """Returns all tags attached to a training dataset.
 
         Example:
@@ -3666,13 +3782,169 @@ class FeatureView:
             training_dataset_version: The training dataset version to get tags for.
 
         Returns:
-            Dictionary of tags.
+            Dictionary of tag names and values.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
         """
         return self._feature_view_engine._get_tags(
             self, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def get_training_dataset_tag_metadata(
+        self, training_dataset_version: int, name: str
+    ) -> tag.Tag | None:
+        """Get a training dataset tag with its metadata, including the time it was attached.
+
+        Unlike [`FeatureView.get_training_dataset_tag`][hsfs.feature_view.FeatureView.get_training_dataset_tag], which returns only the tag's value, this returns the [`Tag`][hopsworks.tag.Tag] object, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            training_dataset_version: training dataset version
+            name: Name of the tag to get.
+
+        Returns:
+            The tag object or `None` if it does not exist.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._get_tag_metadata(
+            self, name, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def get_training_dataset_tags_metadata(
+        self, training_dataset_version: int
+    ) -> dict[str, tag.Tag]:
+        """Returns all tags attached to a training dataset, with their metadata.
+
+        Unlike [`FeatureView.get_training_dataset_tags`][hsfs.feature_view.FeatureView.get_training_dataset_tags], which returns only the tag values, this keeps the [`Tag`][hopsworks.tag.Tag] objects, whose [`Tag.created_on`][hopsworks_common.tag.Tag.created_on] is the attachment time.
+
+        Parameters:
+            training_dataset_version: The training dataset version to get tags for.
+
+        Returns:
+            Dictionary of tag names to tag objects.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._get_tags_metadata(
+            self, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def get_training_dataset_keywords(self, training_dataset_version: int) -> list[str]:
+        """Retrieve all keywords attached to a training dataset.
+
+        A keyword is a plain label without a value, used to categorize and search for artifacts.
+
+        Parameters:
+            training_dataset_version: training dataset version
+
+        Returns:
+            List of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._get_keywords(
+            self, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def get_training_dataset_keywords_metadata(
+        self, training_dataset_version: int
+    ) -> dict[str, datetime | None]:
+        """Retrieve all keywords attached to a training dataset, with the time each was attached.
+
+        Parameters:
+            training_dataset_version: training dataset version
+
+        Returns:
+            Dictionary of keyword to attachment time.
+            The time is `None` when it is unknown, for example for a keyword attached before Hopsworks recorded attachment times.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._get_keywords_metadata(
+            self, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def set_training_dataset_keywords(
+        self, training_dataset_version: int, keywords: list[str]
+    ) -> list[str]:
+        """Replace the whole keyword set of a training dataset.
+
+        Keywords not in `keywords` are removed.
+
+        Parameters:
+            training_dataset_version: training dataset version
+            keywords: The new keyword set.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._set_keywords(
+            self, keywords, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def add_training_dataset_keywords(
+        self, training_dataset_version: int, keywords: str | list[str]
+    ) -> list[str]:
+        """Add keywords to a training dataset, keeping the existing ones.
+
+        This reads the current keywords and writes back their union with `keywords`, so a concurrent add or [`FeatureView.set_training_dataset_keywords`][hsfs.feature_view.FeatureView.set_training_dataset_keywords] call can lose additions.
+        When the full keyword set is known, prefer [`FeatureView.set_training_dataset_keywords`][hsfs.feature_view.FeatureView.set_training_dataset_keywords].
+
+        Parameters:
+            training_dataset_version: training dataset version
+            keywords: A keyword or a list of keywords to add.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return self._feature_view_engine._add_keywords(
+            self, keywords, training_dataset_version=training_dataset_version
+        )
+
+    @public
+    @usage._method_logger
+    def delete_training_dataset_keyword(
+        self, training_dataset_version: int, keyword: str
+    ) -> list[str]:
+        """Remove a single keyword from a training dataset.
+
+        Parameters:
+            training_dataset_version: training dataset version
+            keyword: The keyword to remove.
+
+        Returns:
+            The updated list of keywords.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request
+        """
+        return self._feature_view_engine._delete_keyword(
+            self, keyword, training_dataset_version=training_dataset_version
         )
 
     @public

--- a/python/tests/cli/test_writes.py
+++ b/python/tests/cli/test_writes.py
@@ -9,6 +9,7 @@ test.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -108,11 +109,15 @@ def test_fg_append_features_rejects_bad_spec(mock_project):
 def test_fg_keywords_table(mock_project):
     fs = mock_project.get_feature_store.return_value
     fg = mock.MagicMock()
-    fg.get_tags.return_value = {"prod": mock.Mock(value="true")}
+    fg.get_keywords_metadata.return_value = {"prod": datetime(2026, 3, 4, 5, 6, 7)}
     fs.get_feature_group.return_value = fg
     result = CliRunner().invoke(cli, ["fg", "keywords", "txn"])
     assert result.exit_code == 0, result.output
     assert "prod" in result.output
+    assert "2026-03-04" in result.output
+    # The semantics notice has to be visible, which is why it goes to stderr
+    # rather than through the warnings module.
+    assert "moved to 'hops fg tags/add-tag/remove-tag'" in result.output
 
 
 def test_fg_add_keyword(mock_project):
@@ -121,7 +126,21 @@ def test_fg_add_keyword(mock_project):
     fs.get_feature_group.return_value = fg
     result = CliRunner().invoke(cli, ["fg", "add-keyword", "txn", "prod"])
     assert result.exit_code == 0, result.output
-    fg.add_tag.assert_called_with(name="prod", value="true")
+    fg.add_keywords.assert_called_with(["prod"])
+    fg.add_tag.assert_not_called()
+
+
+def test_fg_add_keyword_value_is_retired(mock_project):
+    fs = mock_project.get_feature_store.return_value
+    fg = mock.MagicMock()
+    fs.get_feature_group.return_value = fg
+    result = CliRunner().invoke(
+        cli, ["fg", "add-keyword", "txn", "prod", "--value", "true"]
+    )
+    assert result.exit_code != 0
+    assert "hops fg add-tag txn prod" in result.output
+    fg.add_keywords.assert_not_called()
+    fg.add_tag.assert_not_called()
 
 
 def test_fg_remove_keyword(mock_project):
@@ -130,7 +149,43 @@ def test_fg_remove_keyword(mock_project):
     fs.get_feature_group.return_value = fg
     result = CliRunner().invoke(cli, ["fg", "remove-keyword", "txn", "prod"])
     assert result.exit_code == 0, result.output
-    fg.delete_tag.assert_called_with("prod")
+    fg.delete_keyword.assert_called_with("prod")
+    fg.delete_tag.assert_not_called()
+
+
+# --- fg tags / add-tag / remove-tag ---------------------------------------
+
+
+def test_fg_tags_table(mock_project):
+    fs = mock_project.get_feature_store.return_value
+    fg = mock.MagicMock()
+    fg.get_tags_metadata.return_value = {
+        "owner": {"value": {"team": "risk"}, "createdOn": datetime(2026, 3, 4)}
+    }
+    fs.get_feature_group.return_value = fg
+    result = CliRunner().invoke(cli, ["fg", "tags", "txn"])
+    assert result.exit_code == 0, result.output
+    assert "owner" in result.output
+
+
+def test_fg_add_tag_parses_json_value(mock_project):
+    fs = mock_project.get_feature_store.return_value
+    fg = mock.MagicMock()
+    fs.get_feature_group.return_value = fg
+    result = CliRunner().invoke(
+        cli, ["fg", "add-tag", "txn", "owner", "--value", '{"team": "risk"}']
+    )
+    assert result.exit_code == 0, result.output
+    fg.add_tag.assert_called_with(name="owner", value={"team": "risk"})
+
+
+def test_fg_remove_tag(mock_project):
+    fs = mock_project.get_feature_store.return_value
+    fg = mock.MagicMock()
+    fs.get_feature_group.return_value = fg
+    result = CliRunner().invoke(cli, ["fg", "remove-tag", "txn", "owner"])
+    assert result.exit_code == 0, result.output
+    fg.delete_tag.assert_called_with("owner")
 
 
 # --- fg stats --------------------------------------------------------------

--- a/python/tests/core/test_feature_group_base_engine.py
+++ b/python/tests/core/test_feature_group_base_engine.py
@@ -51,6 +51,54 @@ class TestFeatureGroupBaseEngine:
         # Assert
         assert mock_tags_api.return_value._add.call_count == 1
 
+    def test_get_tag_metadata(self, mocker):
+        # Arrange
+        mock_tags_api = mocker.patch("hsfs.core.tags_api.TagsApi")
+        tag_obj = mocker.Mock()
+        mock_tags_api.return_value._get_metadata.return_value = {"meta": tag_obj}
+
+        fg_base_engine = feature_group_base_engine.FeatureGroupBaseEngine(
+            feature_store_id=99
+        )
+
+        # Act & Assert
+        assert fg_base_engine._get_tag_metadata(None, "meta") is tag_obj
+        assert fg_base_engine._get_tag_metadata(None, "missing") is None
+
+    def test_add_keywords_unions_with_existing(self, mocker):
+        # A read-modify-write: the union must keep the existing keywords and
+        # not duplicate re-added ones.
+        # Arrange
+        mock_keywords_api = mocker.patch("hsfs.core.keywords_api.KeywordsApi")
+        mock_keywords_api.return_value._get.return_value = ["a", "b"]
+
+        fg_base_engine = feature_group_base_engine.FeatureGroupBaseEngine(
+            feature_store_id=99
+        )
+
+        # Act
+        fg_base_engine._add_keywords(None, ["b", "c"])
+
+        # Assert
+        mock_keywords_api.return_value._replace.assert_called_once_with(
+            None, ["a", "b", "c"]
+        )
+
+    def test_set_keywords_replaces(self, mocker):
+        # Arrange
+        mock_keywords_api = mocker.patch("hsfs.core.keywords_api.KeywordsApi")
+
+        fg_base_engine = feature_group_base_engine.FeatureGroupBaseEngine(
+            feature_store_id=99
+        )
+
+        # Act
+        fg_base_engine._set_keywords(None, ["a"])
+
+        # Assert
+        mock_keywords_api.return_value._replace.assert_called_once_with(None, ["a"])
+        mock_keywords_api.return_value._get.assert_not_called()
+
     def test_delete_tag(self, mocker):
         # Arrange
         feature_store_id = 99

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -607,3 +607,115 @@ class TestExecution:
 
         # Act + Assert
         assert ex.app_url is None
+
+
+class TestJobDescription:
+    def _job(self, mocker, **kwargs):
+        mocker.patch("hopsworks_common.client._get_instance")
+        return job.Job(
+            id=1,
+            name="test",
+            creation_time=None,
+            config={"appPath": "app.py"},
+            job_type="PYTHON",
+            creator=None,
+            **kwargs,
+        )
+
+    def test_description_from_constructor(self, mocker):
+        j = self._job(mocker, description="scalar description")
+
+        assert j.description == "scalar description"
+
+    def test_description_falls_back_to_config(self, mocker):
+        # An old server does not send the scalar field; the config carries it.
+        j = self._job(mocker)
+        j._config["description"] = "config description"
+
+        assert j.description == "config description"
+
+    def test_description_none_when_absent_everywhere(self, mocker):
+        j = self._job(mocker)
+
+        assert j.description is None
+
+    def test_description_setter_writes_config_too(self, mocker):
+        # save() persists the config, so the setter must write it there.
+        j = self._job(mocker)
+
+        j.description = "new description"
+
+        assert j._description == "new description"
+        assert j._config["description"] == "new description"
+
+    def test_config_setter_survives(self, mocker):
+        # A duplicate `config` property definition used to shadow this setter.
+        j = self._job(mocker)
+
+        j.config = {"appPath": "other.py"}
+
+        assert j.config == {"appPath": "other.py"}
+
+
+class TestJobTags:
+    def _job(self, mocker):
+        mocker.patch("hopsworks_common.client._get_instance")
+        mock_job_api = mocker.patch("hopsworks_common.core.job_api.JobApi")
+        j = job.Job(
+            id=1,
+            name="test",
+            creation_time=None,
+            config={},
+            job_type="PYTHON",
+            creator=None,
+        )
+        return j, mock_job_api.return_value
+
+    def test_add_tag_delegates(self, mocker):
+        j, api = self._job(mocker)
+
+        j.add_tag("meta", {"k": "v"})
+
+        api._add_tag.assert_called_once_with(j, "meta", {"k": "v"})
+
+    def test_delete_tag_delegates(self, mocker):
+        j, api = self._job(mocker)
+
+        j.delete_tag("meta")
+
+        api._delete_tag.assert_called_once_with(j, "meta")
+
+    def test_get_tag_delegates(self, mocker):
+        j, api = self._job(mocker)
+        api._get_tag.return_value = "v"
+
+        assert j.get_tag("meta") == "v"
+        api._get_tag.assert_called_once_with(j, "meta")
+
+    def test_get_tags_delegates(self, mocker):
+        j, api = self._job(mocker)
+        api._get_tags.return_value = {"meta": "v"}
+
+        assert j.get_tags() == {"meta": "v"}
+
+    def test_get_tag_metadata_delegates(self, mocker):
+        j, api = self._job(mocker)
+        tag_obj = mocker.Mock()
+        api._get_tags_metadata.return_value = {"meta": tag_obj}
+
+        assert j.get_tag_metadata("meta") is tag_obj
+        api._get_tags_metadata.assert_called_once_with(j, "meta")
+
+    def test_get_tag_metadata_missing_is_none(self, mocker):
+        j, api = self._job(mocker)
+        api._get_tags_metadata.return_value = {}
+
+        assert j.get_tag_metadata("meta") is None
+
+    def test_get_tags_metadata_delegates(self, mocker):
+        j, api = self._job(mocker)
+        tag_obj = mocker.Mock()
+        api._get_tags_metadata.return_value = {"meta": tag_obj}
+
+        assert j.get_tags_metadata() == {"meta": tag_obj}
+        api._get_tags_metadata.assert_called_once_with(j)

--- a/python/tests/core/test_keywords_api.py
+++ b/python/tests/core/test_keywords_api.py
@@ -1,0 +1,197 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hopsworks_common.core.keywords_api import KeywordsApi
+
+
+def _patch_client(mocker, send_request_return) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 1
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hopsworks_common.core.keywords_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+# A feature-group-like metadata object: an id and no `training_data` attribute,
+# so KeywordsApi._get_path takes the featuregroups/trainingdatasets branch.
+def _fg_metadata() -> SimpleNamespace:
+    return SimpleNamespace(id=14)
+
+
+def _fv_metadata() -> SimpleNamespace:
+    return SimpleNamespace(name="my_fv", version=1, training_data=lambda: None)
+
+
+class TestKeywordsApi:
+    def test_get_returns_keyword_list(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": ["pii", "prod"]})
+
+        # Act
+        result = api._get(_fg_metadata())
+
+        # Assert
+        assert result == ["pii", "prod"]
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == [
+            "project",
+            1,
+            "featurestores",
+            99,
+            "featuregroups",
+            14,
+            "keywords",
+        ]
+
+    def test_get_tolerates_missing_keywords(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, {})
+
+        # Act & Assert
+        assert api._get(_fg_metadata()) == []
+
+    def test_get_with_metadata_parses_created_on(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(
+            mocker,
+            {
+                "keywords": ["pii", "prod"],
+                "items": [
+                    {"name": "pii", "createdOn": 1785474813000},
+                    {"name": "prod", "createdOn": None},
+                ],
+            },
+        )
+
+        # Act
+        result = api._get_with_metadata(_fg_metadata())
+
+        # Assert
+        assert result == {
+            "pii": datetime(2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc),
+            "prod": None,
+        }
+
+    def test_get_with_metadata_old_server_without_items(self, mocker):
+        # An old server sends only the plain keyword list; every keyword maps to None.
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, {"keywords": ["pii", "prod"]})
+
+        # Act
+        result = api._get_with_metadata(_fg_metadata())
+
+        # Assert
+        assert result == {"pii": None, "prod": None}
+
+    def test_replace_posts_keyword_dto(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": ["a", "b"]})
+
+        # Act
+        result = api._replace(_fg_metadata(), ["a", "b"])
+
+        # Assert
+        assert result == ["a", "b"]
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "POST"
+        assert json.loads(call.kwargs["data"]) == {"keywords": ["a", "b"]}
+
+    def test_delete_sends_keyword_query_param(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": ["b"]})
+
+        # Act
+        result = api._delete(_fg_metadata(), "a")
+
+        # Assert
+        assert result == ["b"]
+        call = client_instance._send_request.call_args
+        assert call.args[0] == "DELETE"
+        assert call.kwargs["query_params"] == {"keyword": "a"}
+
+    def test_get_all_uses_featurestores_keywords_path(self, mocker):
+        # Arrange
+        api = KeywordsApi()
+        client_instance = _patch_client(mocker, {"keywords": ["pii"]})
+
+        # Act
+        result = api._get_all()
+
+        # Assert
+        assert result == ["pii"]
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == ["project", 1, "featurestores", "keywords"]
+
+    def test_feature_view_path(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": []})
+
+        # Act
+        api._get(_fv_metadata())
+
+        # Assert
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == [
+            "project",
+            1,
+            "featurestores",
+            99,
+            "featureview",
+            "my_fv",
+            "version",
+            1,
+            "keywords",
+        ]
+
+    def test_feature_view_training_dataset_path(self, mocker):
+        # Arrange
+        api = KeywordsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, {"keywords": []})
+
+        # Act
+        api._get(_fv_metadata(), training_dataset_version=7)
+
+        # Assert
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params == [
+            "project",
+            1,
+            "featurestores",
+            99,
+            "featureview",
+            "my_fv",
+            "version",
+            1,
+            "trainingdatasets",
+            "version",
+            7,
+            "keywords",
+        ]

--- a/python/tests/core/test_tag_schemas_api.py
+++ b/python/tests/core/test_tag_schemas_api.py
@@ -1,0 +1,97 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.core.tag_schemas_api import TagSchemasApi
+
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"owner": {"type": "string"}},
+    "required": ["owner"],
+}
+
+
+def _patch_client(mocker) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._send_request.return_value = {"name": "ownership"}
+    mocker.patch(
+        "hopsworks_common.core.tag_schemas_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
+
+
+class TestTagSchemasApiArchive:
+    def test_create_defaults_archive_to_false(self, mocker):
+        # Arrange
+        c = _patch_client(mocker)
+
+        # Act
+        TagSchemasApi().create("ownership", SCHEMA)
+
+        # Assert
+        assert c._send_request.call_args.kwargs["query_params"] == {
+            "name": "ownership",
+            "archive": False,
+        }
+
+    def test_create_sends_archive_when_requested(self, mocker):
+        # Arrange
+        c = _patch_client(mocker)
+
+        # Act
+        TagSchemasApi().create("ownership", SCHEMA, archive=True)
+
+        # Assert
+        assert c._send_request.call_args.kwargs["query_params"]["archive"] is True
+
+    # The flag rides beside the name; it must not disturb the body, which is the schema itself.
+    @pytest.mark.parametrize("archive", [True, False])
+    def test_archive_does_not_change_the_body(self, mocker, archive):
+        # Arrange
+        c = _patch_client(mocker)
+
+        # Act
+        TagSchemasApi().create("ownership", SCHEMA, archive=archive)
+
+        # Assert
+        assert json.loads(c._send_request.call_args.kwargs["data"]) == SCHEMA
+
+    def test_archive_accepted_with_a_json_string_schema_too(self, mocker):
+        # Arrange
+        c = _patch_client(mocker)
+
+        # Act
+        TagSchemasApi().create("ownership", json.dumps(SCHEMA), archive=True)
+
+        # Assert
+        assert c._send_request.call_args.kwargs["query_params"]["archive"] is True
+        assert json.loads(c._send_request.call_args.kwargs["data"]) == SCHEMA
+
+    # Validation runs before the request, so a bad call cannot reach the backend carrying archive.
+    @pytest.mark.parametrize("bad", ["", None])
+    def test_empty_name_still_refused_with_archive_set(self, mocker, bad):
+        # Arrange
+        c = _patch_client(mocker)
+
+        # Act / Assert
+        with pytest.raises(ValueError):
+            TagSchemasApi().create(bad, SCHEMA, archive=True)
+        c._send_request.assert_not_called()

--- a/python/tests/core/test_tags_api.py
+++ b/python/tests/core/test_tags_api.py
@@ -15,6 +15,7 @@
 #
 
 import json
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -137,3 +138,48 @@ class TestTagsApi:
 
         # Assert
         assert result == {"t": bad_value}
+
+    def test_get_metadata_keeps_tag_objects(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        response = {
+            "count": 1,
+            "items": [
+                {"name": "meta", "value": "v", "createdOn": 1785474813000},
+            ],
+        }
+        _patch_client(mocker, response)
+
+        # Act
+        result = api._get_metadata(_fg_metadata())
+
+        # Assert
+        assert set(result) == {"meta"}
+        assert result["meta"].value == "v"
+        assert result["meta"].created_on == datetime(
+            2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc
+        )
+
+    def test_get_metadata_by_name_appends_name_to_path(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        client_instance = _patch_client(mocker, _tags_response("meta", "v"))
+
+        # Act
+        result = api._get_metadata(_fg_metadata(), name="meta")
+
+        # Assert
+        assert result["meta"].name == "meta"
+        path_params = client_instance._send_request.call_args.args[1]
+        assert path_params[-1] == "meta"
+
+    def test_get_metadata_empty_returns_empty_dict(self, mocker):
+        # Arrange
+        api = TagsApi(feature_store_id=99, entity_type="featuregroups")
+        _patch_client(mocker, {"count": 0, "items": []})
+
+        # Act
+        result = api._get_metadata(_fg_metadata())
+
+        # Assert
+        assert result == {}

--- a/python/tests/test_tag.py
+++ b/python/tests/test_tag.py
@@ -15,6 +15,7 @@
 #
 
 import json as json_module
+from datetime import datetime, timezone
 
 import humps
 import pytest
@@ -134,3 +135,120 @@ class TestTag:
         # Act & Assert
         with pytest.raises(ValueError, match="Tag value cannot be None"):
             tag.Tag._normalize([{"name": "test_name", "value": None}])
+
+    def test_created_on_defaults_to_none(self):
+        # Arrange
+        t = tag.Tag(name="test_name", value="test_value")
+
+        # Assert
+        assert t.created_on is None
+
+    def test_from_response_json_parses_epoch_millis(self):
+        # Arrange
+        json_dict = {
+            "count": 1,
+            "items": [
+                {
+                    "name": "test_name",
+                    "value": "test_value",
+                    "createdOn": 1785474813000,
+                }
+            ],
+        }
+
+        # Act
+        tags = tag.Tag.from_response_json(json_dict)
+
+        # Assert
+        assert tags[0].created_on == datetime(
+            2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc
+        )
+
+    def test_from_response_json_parses_iso_8601(self):
+        # Arrange
+        json_dict = {
+            "count": 1,
+            "items": [
+                {
+                    "name": "test_name",
+                    "value": "test_value",
+                    "createdOn": "2026-07-31T05:13:33Z",
+                }
+            ],
+        }
+
+        # Act
+        tags = tag.Tag.from_response_json(json_dict)
+
+        # Assert
+        assert tags[0].created_on == datetime(
+            2026, 7, 31, 5, 13, 33, tzinfo=timezone.utc
+        )
+
+    def test_from_response_json_missing_created_on_is_none(self):
+        # Arrange
+        json_dict = {
+            "count": 1,
+            "items": [{"name": "test_name", "value": "test_value"}],
+        }
+
+        # Act
+        tags = tag.Tag.from_response_json(json_dict)
+
+        # Assert
+        assert tags[0].created_on is None
+
+    def test_from_response_json_unparseable_created_on_is_none(self):
+        # A timestamp we cannot read must not stop the tag from being read.
+        # Arrange
+        json_dict = {
+            "count": 1,
+            "items": [
+                {
+                    "name": "test_name",
+                    "value": "test_value",
+                    "createdOn": "not a date",
+                }
+            ],
+        }
+
+        # Act
+        tags = tag.Tag.from_response_json(json_dict)
+
+        # Assert
+        assert tags[0].name == "test_name"
+        assert tags[0].created_on is None
+
+    def test_to_dict_omits_created_on(self):
+        # It is server-assigned, so sending it back would be meaningless.
+        # Arrange
+        t = tag.Tag(
+            name="test_name",
+            value="test_value",
+            created_on=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        )
+
+        # Act
+        result = t.to_dict()
+
+        # Assert
+        assert result == {"name": "test_name", "value": "test_value"}
+
+
+class TestTagSingleObjectResponse:
+    def test_from_response_json_single_tag(self):
+        # A request naming one tag answers with that tag rather than a collection.
+        tags = tag.Tag.from_response_json(
+            {
+                "name": "owner",
+                "value": '{"team": "risk"}',
+                "createdOn": 1785736991000,
+            }
+        )
+        assert len(tags) == 1
+        assert tags[0].name == "owner"
+        assert tags[0].value == {"team": "risk"}
+        assert tags[0].created_on is not None
+
+    def test_from_response_json_single_without_value_is_empty(self):
+        assert tag.Tag.from_response_json({"name": "owner"}) == []


### PR DESCRIPTION
Ticket: [FSTORE-2096](https://hopsworks.atlassian.net/browse/FSTORE-2096) · Backend: logicalclocks/hopsworks-ee#3227 · Frontend: logicalclocks/hopsworks-front#2042 · Helm: logicalclocks/hopsworks-helm#2212 · Docs: logicalclocks/logicalclocks.github.io#635

The Python client half of the FSTORE-2075 split (api#1079): the low-risk, independently useful parts, landing first. 21 files, ~2,100 added lines.

## Attachment timestamps

`Tag` objects carry `created_on`, parsed tolerantly from epoch millis, ISO strings, or absence, because pre-existing rows report NULL by design. Feature groups, feature views, and training datasets gain `get_tag_metadata` / `get_tags_metadata` alongside the value-only reads, and keyword metadata reads report each keyword with its attachment time.

## The keyword API

A real `keywords_api` addressing the keyword endpoints, including the cluster-wide vocabulary read on the feature store. The CLI keyword commands on `fg`, `fv`, and `td` operate on keywords rather than on tags, which is what they were mislabelled as doing; the retired `add-keyword --value` option warns loudly on stderr, where a click command's user actually sees it.

## Job tags and a job description

`Job` objects gain tag reads and writes (`add_tag`, `get_tag(s)`, `get_tag(s)_metadata`, `delete_tag`) and a `description` property that answers config-first, so an older server that never sent the scalar field still reports the description its configuration carries. The setter writes both, guarded the same way the getter is.

## A pre-existing defect fixed on the way

`job.py` defined the `config` property **twice**, and the second definition shadowed the first's getter+setter pair, so `job.config = x` raised `AttributeError: property 'config' of 'Job' object has no setter`. Found by the moved tests; the duplicate is gone and a test pins the setter.

## What deliberately stays with FSTORE-2075 (api#1079)

The search API and its result types, the tag schema lifecycle client (`deprecate`/`restore`/`usage`/guarded delete and the `hops tags` CLI group), dataset tags, and the foreign-`Project` handle binding. After this merges, api#1079 rebases and shrinks by this amount.

## Verification

Full unit suite: **4145 passed, 13 skipped, 0 failed** (with `PYSPARK_SUBMIT_ARGS` per CI). ruff check and format clean, docsig clean under the project config, the `@public` gate passes. New coverage: `TestJobDescription` and `TestJobTags` (12 tests), keyword API tests, tag `created_on` parsing tests.

Synced with `upstream/main` (through `[FSTORE-2086]` #1105); no conflicts and no client change was needed for it.

**Cluster-verified on jim-tags** alongside ee#3227's EAR: job tag attach returns 201 with `createdOn`, keywords answer JSON with no `Accept` header and carry per-keyword `createdOn`, and feature-group / model / deployment tags report `created_on` with a re-attach preserving the original time. The search-side work this ticket added since (apps and agents as their own result classes, the tag-facets endpoint) is server plus UI only and adds no client surface, so nothing here changed for it.

## Loadtests

New coverage: **logicalclocks/loadtest#984**, 13 tests, **13/13 passing** on jim-tags against this EAR. Job tags (attach/read/delete, `createdOn` reported, re-attach preserving the original `createdOn`, cascade on job delete), the `JOB`/`APP` partition in both directions with `ALL` double-counting nothing, tag content matching a job document, tag facets reporting the attached values, and the `archive` flag defaulting false / settable / per schema.

Existing suite, the six files that cover what this touches (`hopsworks/test_search.py`, `hopsworks/test_opensearch.py`, `hopsworks/test_custom_apps.py`, `hopsworks/test_python_job_execution.py`, `feature_store/python_driver/test_tags.py`, `model_serving/python_driver/external/test_tags.py`): **21 collected, 15 passed, 1 failed, 5 skipped**.

The one failure is environmental, not a regression: `test_custom_app_lifecycle[fastapi]` timed out with `JobExecutionException: Timed out waiting for app to reach Serving state after 600.0s. Current state: RUNNING` — the app was created and reached RUNNING but never got the resources to serve. The 5 skips are its siblings, skipped after it failed. Nothing in this PR touches app startup or the serving state machine.

A full-suite run was attempted first and abandoned. On a two-worker cluster it was capacity-bound rather than slow: a Spark driver sat `Pending` for 78 minutes, and after freeing capacity the rate settled at ~12 min/test, a ~5-day projection for 935 tests. Its only failure was also environmental (`test_pyspark_batch[DELTA]`, executor starvation then a 600 s shuffle-service idle timeout, no application error). A run that manufactures failures at that rate cannot serve as evidence, which is why the targeted subset is what is reported here.

**Two real defects the runs found, both now fixed:**

- **A deployment-state gap.** `POST /tags` returned `500 {"errorCode":120005,"usrMsg":"Unknown column 'archive' in 'field list'"}` on a cluster where V92 had been applied *before* the `archive` column was appended to it. Flyway will not re-run a recorded migration, so the EAR had the entity field while the table did not. A fresh install is unaffected; anyone who ran a pre-release V92 is not. Applied on the cluster and verified: create without the flag reads back `archive=False`, with `archive=true` reads back `True`.
- **The kube runner ran only the first path given to it.** `run_tests_on_kube.sh` passed `${1:-workflows/*}` to pytest while `deploy_loadtest.sh` forwards any number of paths, so a six-file selection ran one file and exited 0 — reading as "your selection passed" when most of it never ran. Collection went from 4 items to 21 once fixed. Fixed in loadtest#984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FSTORE-2096]: https://hopsworks.atlassian.net/browse/FSTORE-2096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[FSTORE-2086]: https://hopsworks.atlassian.net/browse/FSTORE-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



