### PR TITLE
[HWORKS-2845][APPEND] Drop --system from the documented custom-app entrypoint

### DIFF
--- a/skills/hops/hops-app/SKILL.md
+++ b/skills/hops/hops-app/SKILL.md
@@ -250,7 +250,7 @@ fastapi_app = apps.create_app(
     git_provider="GitHub",
     git_branch="main",
     entrypoint_command=(
-        'bash -lc "python -m uv pip install --system --no-cache fastapi uvicorn && '
+        'bash -lc "python -m uv pip install --no-cache fastapi uvicorn && '
         'exec python -m uvicorn fastapiapp:app --host 0.0.0.0 --port \\"$APP_PORT\\""'
     ),
     app_port=8080,


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-2845

## The bug

The CUSTOM app example in `skills/hops/hops-app/SKILL.md` tells users to start their entrypoint with:

```
python -m uv pip install --system --no-cache fastapi uvicorn
```

That cannot work. `--system` means the *system* interpreter `/usr/bin/python3`, whose site-packages is root-owned `755`, while app containers run unprivileged:

```
Caused by: failed to create directory
  `/usr/local/lib/python3.10/dist-packages/...`: Permission denied (os error 13)
```

The container exits before the app serves, and the user sees only `App failed to start. State: FAILED`.

It is also the wrong interpreter. The next command in the same example is `python -m uvicorn`, and `python` resolves to the **project environment (3.12)**, which cannot see anything installed into the system **3.10**. PATH has put the project environment first since before the uv migration, so the two have never been the same interpreter — the example could not have worked as written.

## The fix

Drop the flag. uv runs as `python -m uv`, so it targets the interpreter running it. Verified inside `hopsworks-base:python-app-pipeline-5.1.0-SNAPSHOT`, from an app-like working directory rather than the image WORKDIR:

```
$ cd /tmp/app && python -m uv pip install --no-cache six
Using Python 3.12.13 environment at: /srv/hops/anaconda/envs/hopsworks_environment
```

## How it was found

Reproducing helm CI run 32053827229 on a live OKD cluster. All 14 python-app tests failed there for what looked like one bug; it is two. The STREAMLIT cases fail because the image installs `streamlit` into the system interpreter so `${ANACONDA_ENV}/bin/streamlit` is missing (docker-images#931). The CUSTOM cases fail because of this command, which the loadtest suite had copied verbatim from this doc — fixed in logicalclocks/loadtest#979.

Doc-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)