### PR TITLE
[HWORKS-2742][4.8] Fix hopsworks.login() when istio lb is not configured

### DIFF
--- a/python/hsml/core/model_serving_api.py
+++ b/python/hsml/core/model_serving_api.py
@@ -95,23 +95,19 @@ class ModelServingApi:
                     inference_endpoints, INFERENCE_ENDPOINTS.ENDPOINT_TYPE_LOAD_BALANCER
                 )
 
-                port = (
-                    endpoint.get_port(INFERENCE_ENDPOINTS.PORT_NAME_HTTPS)
-                    if endpoint.get_port(INFERENCE_ENDPOINTS.PORT_NAME_HTTPS)
-                    else endpoint.get_port(INFERENCE_ENDPOINTS.PORT_NAME_HTTP)
-                )
-
                 if endpoint is not None:
                     # if load balancer (external ip) available
+                    https_port = endpoint.get_port(INFERENCE_ENDPOINTS.PORT_NAME_HTTPS)
+                    port = https_port or endpoint.get_port(
+                        INFERENCE_ENDPOINTS.PORT_NAME_HTTP
+                    )
                     _client = client.get_instance()
                     client.istio.init(
                         endpoint.get_any_host(),
                         port.number,
                         _client._project_name,
                         _client._auth._token,  # reuse hopsworks client token
-                        scheme="https"
-                        if endpoint.get_port(INFERENCE_ENDPOINTS.PORT_NAME_HTTPS)
-                        else "http",
+                        scheme="https" if https_port else "http",
                     )
                     return
 

--- a/python/tests/core/test_model_serving_api.py
+++ b/python/tests/core/test_model_serving_api.py
@@ -1,0 +1,174 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+from hsml.constants import INFERENCE_ENDPOINTS
+from hsml.core.model_serving_api import ModelServingApi
+from hsml.inference_endpoint import InferenceEndpoint, InferenceEndpointPort
+
+
+def _endpoint(endpoint_type, ports):
+    return InferenceEndpoint(
+        type=endpoint_type,
+        hosts=["host.example"],
+        ports=[InferenceEndpointPort(name, number) for name, number in ports],
+    )
+
+
+class TestIstioInitIfAvailable:
+    # Regression tests for hsml.core.model_serving_api.ModelServingApi._istio_init_if_available.
+    # The external-LB branch used to dereference a None endpoint when the cluster had no
+    # load balancer configured; the fallback print path must be reachable.
+
+    @pytest.fixture
+    def api(self, mocker):
+        api = ModelServingApi()
+        mocker.patch.object(api, "_serving_api")
+        return api
+
+    @pytest.fixture(autouse=True)
+    def _istio_stubs(self, mocker):
+        mocker.patch(
+            "hsml.core.model_serving_api.client.is_kserve_installed", return_value=True
+        )
+        mocker.patch(
+            "hsml.core.model_serving_api.client.istio.get_instance", return_value=None
+        )
+        self.istio_init = mocker.patch("hsml.core.model_serving_api.client.istio.init")
+
+    def test_skips_when_kserve_not_installed(self, mocker, api):
+        mocker.patch(
+            "hsml.core.model_serving_api.client.is_kserve_installed", return_value=False
+        )
+
+        api._istio_init_if_available()
+
+        api._serving_api.get_inference_endpoints.assert_not_called()
+        self.istio_init.assert_not_called()
+
+    def test_skips_when_istio_already_initialized(self, mocker, api):
+        mocker.patch(
+            "hsml.core.model_serving_api.client.istio.get_instance",
+            return_value=object(),
+        )
+
+        api._istio_init_if_available()
+
+        api._serving_api.get_inference_endpoints.assert_not_called()
+        self.istio_init.assert_not_called()
+
+    # internal (non-external) client
+
+    def test_internal_uses_kube_cluster_http_port(self, mocker, api):
+        mocker.patch(
+            "hsml.core.model_serving_api.client._is_external", return_value=False
+        )
+        api._serving_api.get_inference_endpoints.return_value = [
+            _endpoint(
+                INFERENCE_ENDPOINTS.ENDPOINT_TYPE_KUBE_CLUSTER,
+                [(INFERENCE_ENDPOINTS.PORT_NAME_HTTP, 80)],
+            )
+        ]
+
+        api._istio_init_if_available()
+
+        self.istio_init.assert_called_once_with("host.example", 80)
+
+    def test_internal_raises_when_kube_cluster_missing(self, mocker, api):
+        mocker.patch(
+            "hsml.core.model_serving_api.client._is_external", return_value=False
+        )
+        api._serving_api.get_inference_endpoints.return_value = [
+            _endpoint(
+                INFERENCE_ENDPOINTS.ENDPOINT_TYPE_LOAD_BALANCER,
+                [(INFERENCE_ENDPOINTS.PORT_NAME_HTTP, 80)],
+            )
+        ]
+
+        with pytest.raises(ValueError, match="KUBE_CLUSTER"):
+            api._istio_init_if_available()
+        self.istio_init.assert_not_called()
+
+    # external client
+
+    def test_external_load_balancer_https_preferred(self, mocker, api):
+        mocker.patch(
+            "hsml.core.model_serving_api.client._is_external", return_value=True
+        )
+        fake_client = mocker.MagicMock()
+        fake_client._project_name = "proj"
+        fake_client._auth._token = "tok"
+        mocker.patch(
+            "hsml.core.model_serving_api.client.get_instance", return_value=fake_client
+        )
+        api._serving_api.get_inference_endpoints.return_value = [
+            _endpoint(
+                INFERENCE_ENDPOINTS.ENDPOINT_TYPE_LOAD_BALANCER,
+                [
+                    (INFERENCE_ENDPOINTS.PORT_NAME_HTTP, 80),
+                    (INFERENCE_ENDPOINTS.PORT_NAME_HTTPS, 443),
+                ],
+            )
+        ]
+
+        api._istio_init_if_available()
+
+        self.istio_init.assert_called_once_with(
+            "host.example", 443, "proj", "tok", scheme="https"
+        )
+
+    def test_external_load_balancer_falls_back_to_http(self, mocker, api):
+        mocker.patch(
+            "hsml.core.model_serving_api.client._is_external", return_value=True
+        )
+        fake_client = mocker.MagicMock()
+        fake_client._project_name = "proj"
+        fake_client._auth._token = "tok"
+        mocker.patch(
+            "hsml.core.model_serving_api.client.get_instance", return_value=fake_client
+        )
+        api._serving_api.get_inference_endpoints.return_value = [
+            _endpoint(
+                INFERENCE_ENDPOINTS.ENDPOINT_TYPE_LOAD_BALANCER,
+                [(INFERENCE_ENDPOINTS.PORT_NAME_HTTP, 80)],
+            )
+        ]
+
+        api._istio_init_if_available()
+
+        self.istio_init.assert_called_once_with(
+            "host.example", 80, "proj", "tok", scheme="http"
+        )
+
+    def test_external_no_load_balancer_falls_back_without_crashing(
+        self, mocker, capsys, api
+    ):
+        # Regression: previously raised AttributeError: 'NoneType' object has no attribute 'get_port'
+        # when the cluster had no LOAD_BALANCER inference endpoint configured.
+        mocker.patch(
+            "hsml.core.model_serving_api.client._is_external", return_value=True
+        )
+        api._serving_api.get_inference_endpoints.return_value = [
+            _endpoint(
+                INFERENCE_ENDPOINTS.ENDPOINT_TYPE_KUBE_CLUSTER,
+                [(INFERENCE_ENDPOINTS.PORT_NAME_HTTP, 80)],
+            )
+        ]
+
+        api._istio_init_if_available()
+
+        self.istio_init.assert_not_called()
+        assert "External IP not configured" in capsys.readouterr().out

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -14,6 +14,10 @@
 #   limitations under the License.
 #
 
+from unittest.mock import MagicMock
+
+import pytest
+from hopsworks_common.client.exceptions import RestAPIError
 from hsml.connection import (
     HOPSWORKS_PORT_DEFAULT,
     HOSTNAME_VERIFICATION_DEFAULT,
@@ -132,3 +136,116 @@ class TestConnection:
 
     def test_connection(self, mocker):
         pass
+
+
+class TestProvideProject:
+    # Tests for hopsworks_common.connection.Connection._provide_project, which runs
+    # during hopsworks.login() after the client is initialized and is responsible for
+    # loading the default model serving configuration.
+
+    @pytest.fixture
+    def conn(self):
+        conn = MagicMock(spec=Connection)
+        conn._connected = True
+        conn._project = None
+        conn._variable_api = MagicMock()
+        conn._model_serving_api = MagicMock()
+        # Bind the real method so the decorator can read _connected from our mock.
+        conn._provide_project = Connection._provide_project.__get__(conn, Connection)
+        return conn
+
+    @pytest.fixture
+    def client_instance(self, mocker):
+        hw_client = MagicMock()
+        hw_client._project_name = None
+        hw_client._is_external.return_value = True
+        hw_client.provide_project = MagicMock()
+        mocker.patch(
+            "hopsworks_common.connection.client.get_instance", return_value=hw_client
+        )
+        return hw_client
+
+    @pytest.fixture(autouse=True)
+    def _stub_hsfs_engine(self, mocker):
+        mocker.patch("hsfs.engine.get_instance")
+
+    def _make_rest_error(self, status_error_code, error_code):
+        err = RestAPIError.__new__(RestAPIError)
+        err.response = MagicMock()
+        err.response.error_code = status_error_code
+        err.error_code = error_code
+        return err
+
+    def test_name_delegates_to_external_client(self, conn, client_instance):
+        conn._variable_api.get_data_science_profile_enabled.return_value = False
+
+        conn._provide_project(name="proj")
+
+        assert conn._project == "proj"
+        client_instance.provide_project.assert_called_once_with("proj")
+
+    def test_name_is_not_forwarded_when_internal(self, conn, client_instance):
+        client_instance._is_external.return_value = False
+        conn._variable_api.get_data_science_profile_enabled.return_value = False
+
+        conn._provide_project(name="proj")
+
+        assert conn._project == "proj"
+        client_instance.provide_project.assert_not_called()
+
+    def test_uses_client_project_name_when_already_set(self, conn, client_instance):
+        client_instance._project_name = "already-set"
+        conn._variable_api.get_data_science_profile_enabled.return_value = False
+
+        conn._provide_project()
+
+        assert conn._project == "already-set"
+
+    def test_short_circuits_when_no_project(self, conn, client_instance):
+        conn._provide_project()
+
+        conn._variable_api.get_data_science_profile_enabled.assert_not_called()
+        conn._model_serving_api.load_default_configuration.assert_not_called()
+
+    def test_loads_default_configuration_when_profile_enabled(
+        self, conn, client_instance
+    ):
+        client_instance._project_name = "proj"
+        conn._variable_api.get_data_science_profile_enabled.return_value = True
+
+        conn._provide_project()
+
+        conn._model_serving_api.load_default_configuration.assert_called_once()
+
+    def test_skips_default_configuration_when_profile_disabled(
+        self, conn, client_instance
+    ):
+        client_instance._project_name = "proj"
+        conn._variable_api.get_data_science_profile_enabled.return_value = False
+
+        conn._provide_project()
+
+        conn._model_serving_api.load_default_configuration.assert_not_called()
+
+    def test_missing_serving_scope_is_swallowed(self, conn, client_instance, capsys):
+        # 403 + 320004 means the API key lacks the SERVING scope; model serving is disabled
+        # but login must still succeed.
+        client_instance._project_name = "proj"
+        conn._variable_api.get_data_science_profile_enabled.return_value = True
+        conn._model_serving_api.load_default_configuration.side_effect = (
+            self._make_rest_error(status_error_code=403, error_code=320004)
+        )
+
+        conn._provide_project()
+
+        assert "SERVING" in capsys.readouterr().out
+
+    def test_other_rest_api_errors_are_reraised(self, conn, client_instance):
+        client_instance._project_name = "proj"
+        conn._variable_api.get_data_science_profile_enabled.return_value = True
+        conn._model_serving_api.load_default_configuration.side_effect = (
+            self._make_rest_error(status_error_code=500, error_code=999999)
+        )
+
+        with pytest.raises(RestAPIError):
+            conn._provide_project()


### PR DESCRIPTION
Cherry pick changes done by PR : https://github.com/logicalclocks/hopsworks-api/pull/918

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
