### PR TITLE
[HWORKS-3054] Project.project_namespace always returns None

### DIFF
--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -71,7 +71,7 @@ class Project:
         services=None,
         datasets=None,
         creation_status=None,
-        project_namespace=None,
+        namespace=None,
         **kwargs,
     ):
         self._id = project_id
@@ -91,7 +91,7 @@ class Project:
         self._alerts_api = alerts_api.AlertsApi()
         self._project_members_api = project_members_api.ProjectMembersApi()
         self._search_api = search_api.SearchApi()
-        self._project_namespace = project_namespace
+        self._project_namespace = namespace
         self._trino_api = None
         self._superset_api = None
 

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -130,3 +130,14 @@ class TestProject:
         project = Project(project_name="my_project")
 
         assert project.get_members_api() is project._project_members_api
+
+    # Regression: the backend serializes this field as "namespace" (ProjectDTO),
+    # and from_response_json splats the decamelized payload straight into
+    # __init__, so a parameter under any other name is swallowed by **kwargs and
+    # the property silently reads None.
+    def test_project_namespace_deserialized_from_response(self):
+        project = Project.from_response_json(
+            {"projectName": "my_project", "namespace": "my-project-ns"}
+        )
+
+        assert project.project_namespace == "my-project-ns"


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-3054

`Project.project_namespace` is a documented public property that returns `None` for every project on every cluster. It has never returned a value since it was added by HWORKS-1421 (#336, September 2024).

## Cause

The backend serializes the field as `namespace`:

```java
// ProjectDTO.java:66, returned by GET /project/getProjectInfo/{name}
private String namespace;          // plain getter, no @XmlElement rename
```

`Project.from_response_json` deserializes with `cls(**humps.decamelize(json_dict))`, and `Project.__init__` accepted `project_namespace`, so the key landed in `**kwargs` and was discarded. Nothing else in `hopsworks_common/` assigns the backing attribute.

The only reference to the property in our own code is a `@pytest.mark.skip`ped loadtest assertion, which is why the breakage went unnoticed.

## Fix

Name the constructor parameter after the wire key. The public property keeps its name, so this is not a change to the client's API.

Renaming the backend field instead is not viable. `namespace` is also the request key the client sends when creating a project (`project_api.py:151`, read by `ProjectController` on clusters configured for pre-created namespaces), so a rename would break project creation for every released client.

## Why it matters

On a default cluster the namespace is `project.name.toLowerCase().replaceAll("[^a-z0-9-]", "-")`, so a caller can derive it and never notice the property is broken. On a cluster configured for pre-created namespaces (`kube_skip_namespace_creation`, the OpenShift deployment mode) the namespace is whatever was provisioned, and the backend is the only source of truth.

## Verification

Against a live OKD cluster with pre-created namespaces.

The payload the backend actually returns, for a project whose namespace is not derivable from its name:

```
GET /project/getProjectInfo/model_serving_int_MhGJP
keys: [created, creationStatus, datasets, inodeid, namespace, owner,
       projectId, projectName, projectTeam, services]
namespace        = 'loadtest-kserve-0-main-000'
projectNamespace = None
```

That exact payload through the patched client:

```
project.name              = model_serving_int_MhGJP
project.project_namespace = 'loadtest-kserve-0-main-000'
derived-from-name would be = 'model-serving-int-mhgjp'
```

Also checked inside a pod running the loadtest image, patching the client as installed by `pip install -r requirements.txt`: the property went from `None` to the expected value.

The added regression test fails without the fix (`assert None == 'my-project-ns'`) and passes with it. Full file: 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
