### PR TITLE
[HWORKS-3055] Inference requests are addressed by project name instead of project namespace

### DIFF
--- a/python/hsml/core/serving_api.py
+++ b/python/hsml/core/serving_api.py
@@ -423,7 +423,7 @@ class ServingApi:
     def _create_grpc_channel(self, deployment_instance):
         _client = client.istio._get_instance()
         path_prefix = (
-            f"/v1/{deployment_instance.project_name}/{deployment_instance.name}"
+            f"/v1/{deployment_instance.project_namespace}/{deployment_instance.name}"
         )
         return _client._create_grpc_channel(path_prefix)
 
@@ -559,7 +559,11 @@ class ServingApi:
         Returns:
             List of path segments.
         """
-        base_path = ["v1", deployment_instance.project_name, deployment_instance.name]
+        base_path = [
+            "v1",
+            deployment_instance.project_namespace,
+            deployment_instance.name,
+        ]
         if base_only:
             return base_path
         return base_path + ["v1", "models", deployment_instance.name + ":predict"]

--- a/python/tests/core/test_serving_api.py
+++ b/python/tests/core/test_serving_api.py
@@ -115,3 +115,39 @@ class TestServingApi:
 
         # Assert
         assert result == {"t": bad_value}
+
+    # Regression: Istio routes on the namespace the deployment runs in, and the
+    # backend reports it on every deployment the client parses. Addressing by
+    # project name instead only reaches the deployment on a cluster where the
+    # backend derives one name from the other, so it worked everywhere except
+    # the pre-created-namespace clusters it was silently broken on.
+    def test_istio_inference_path_addresses_the_namespace(self):
+        api = ServingApi()
+        deployment = SimpleNamespace(
+            name="skdepl",
+            project_name="my_project",
+            project_namespace="pre-created-ns",
+        )
+
+        assert api._get_istio_inference_path(deployment) == [
+            "v1",
+            "pre-created-ns",
+            "skdepl",
+            "v1",
+            "models",
+            "skdepl:predict",
+        ]
+
+    def test_istio_inference_base_path_addresses_the_namespace(self):
+        api = ServingApi()
+        deployment = SimpleNamespace(
+            name="vllmdepl",
+            project_name="my_project",
+            project_namespace="pre-created-ns",
+        )
+
+        assert api._get_istio_inference_path(deployment, base_only=True) == [
+            "v1",
+            "pre-created-ns",
+            "vllmdepl",
+        ]

--- a/python/tests/core/test_serving_api.py
+++ b/python/tests/core/test_serving_api.py
@@ -15,11 +15,14 @@
 #
 
 import json
+import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from hopsworks_common.client.exceptions import RestAPIError
+from hsml.client.istio.utils.infer_type import InferInput
+from hsml.constants import INFERENCE_ENDPOINTS as IE
 from hsml.core.serving_api import ServingApi
 
 
@@ -46,6 +49,58 @@ def _patch_client(mocker, send_request_return) -> MagicMock:
 
 def _deployment() -> SimpleNamespace:
     return SimpleNamespace(id=12)
+
+
+# The relation between a project's name and the Kubernetes namespace its
+# deployments run in, over the cluster configurations that exist. Istio routes
+# inference on the namespace, so every one of these has to be addressed by it.
+#
+#   identical   the backend created the namespace from a project name that was
+#               already a legal namespace, so the two strings coincide
+#   derived     the backend created the namespace from a project name that was
+#               not, lowercasing it and replacing the characters it had to
+#   unrelated   an administrator pre-created the namespace, which is how
+#               Hopsworks is deployed on OpenShift, and it bears no relation to
+#               the project name
+#   unstamped   the deployment carries no project name at all, which is its
+#               state between `from_response_json` and the client stamping one
+NAMESPACE_CASES = [
+    pytest.param("myproject", "myproject", id="identical"),
+    pytest.param("my_project", "my-project", id="derived"),
+    pytest.param(
+        "model_serving_int_MhGJP", "loadtest-kserve-0-main-000", id="unrelated"
+    ),
+    pytest.param(None, "pre-created-ns", id="unstamped"),
+]
+
+# The two cases a cluster that names its own namespaces can produce.
+BACKEND_DERIVED_NAMESPACE_CASES = NAMESPACE_CASES[:2]
+
+
+def _inference_deployment(
+    project_name: str | None,
+    project_namespace: str,
+    name: str = "skdepl",
+    api_protocol: str = IE.API_PROTOCOL_REST,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        project_name=project_name,
+        project_namespace=project_namespace,
+        api_protocol=api_protocol,
+        _grpc_channel=None,
+    )
+
+
+def _as_gateway_authority(segment: str) -> str:
+    """Normalize a path segment the way the istio gateway does.
+
+    The gateway turns `/v1/<segment>/<deployment>/...` into the authority it
+    routes on, lowercasing the segment and replacing every character outside
+    `[a-z0-9-]` with a hyphen. See `charts/kserve/files/envoyfilter.yaml` in
+    hopsworks-helm.
+    """
+    return re.sub(r"[^a-z0-9-]", "-", segment.lower())
 
 
 class TestServingApi:
@@ -116,38 +171,220 @@ class TestServingApi:
         # Assert
         assert result == {"t": bad_value}
 
-    # Regression: Istio routes on the namespace the deployment runs in, and the
-    # backend reports it on every deployment the client parses. Addressing by
-    # project name instead only reaches the deployment on a cluster where the
-    # backend derives one name from the other, so it worked everywhere except
-    # the pre-created-namespace clusters it was silently broken on.
-    def test_istio_inference_path_addresses_the_namespace(self):
-        api = ServingApi()
-        deployment = SimpleNamespace(
-            name="skdepl",
-            project_name="my_project",
-            project_namespace="pre-created-ns",
-        )
+    # inference addressing
 
-        assert api._get_istio_inference_path(deployment) == [
+    # Regression: Istio routes on the namespace a deployment runs in, and the
+    # backend reports that namespace on every deployment the client parses.
+    # Addressing by project name still reached the deployment on a cluster that
+    # derives one from the other, so this was invisible everywhere except the
+    # pre-created-namespace clusters where it broke every prediction.
+
+    @pytest.mark.parametrize(("project_name", "project_namespace"), NAMESPACE_CASES)
+    def test_istio_inference_path_addresses_the_namespace(
+        self, project_name, project_namespace
+    ):
+        # Arrange
+        api = ServingApi()
+        deployment = _inference_deployment(project_name, project_namespace)
+
+        # Act
+        path = api._get_istio_inference_path(deployment)
+
+        # Assert
+        assert path == [
             "v1",
-            "pre-created-ns",
+            project_namespace,
             "skdepl",
             "v1",
             "models",
             "skdepl:predict",
         ]
 
-    def test_istio_inference_base_path_addresses_the_namespace(self):
+    @pytest.mark.parametrize(("project_name", "project_namespace"), NAMESPACE_CASES)
+    def test_istio_inference_base_path_addresses_the_namespace(
+        self, project_name, project_namespace
+    ):
+        # Arrange: vLLM deployments and Python deployments without a model
+        # address the base path and append their own suffix.
         api = ServingApi()
-        deployment = SimpleNamespace(
-            name="vllmdepl",
-            project_name="my_project",
-            project_namespace="pre-created-ns",
+        deployment = _inference_deployment(
+            project_name, project_namespace, name="vllmdepl"
         )
 
-        assert api._get_istio_inference_path(deployment, base_only=True) == [
+        # Act
+        path = api._get_istio_inference_path(deployment, base_only=True)
+
+        # Assert
+        assert path == ["v1", project_namespace, "vllmdepl"]
+
+    @pytest.mark.parametrize("project_namespace", ["myproject", "pre-created-ns"])
+    @pytest.mark.parametrize("base_only", [False, True])
+    def test_istio_inference_path_ignores_the_project_name(
+        self, base_only, project_namespace
+    ):
+        # Arrange
+        api = ServingApi()
+
+        # Act: every project name a deployment in this namespace could carry,
+        # including one equal to the namespace, where asserting on the path
+        # cannot tell which of the two it was built from.
+        paths = {
+            tuple(
+                api._get_istio_inference_path(
+                    _inference_deployment(project_name, project_namespace),
+                    base_only=base_only,
+                )
+            )
+            for project_name in (
+                None,
+                "myproject",
+                "my_project",
+                "model_serving_int_MhGJP",
+            )
+        }
+
+        # Assert
+        assert len(paths) == 1
+
+    @pytest.mark.parametrize(
+        ("project_name", "project_namespace"), BACKEND_DERIVED_NAMESPACE_CASES
+    )
+    def test_namespace_addressing_is_inert_on_backend_created_namespaces(
+        self, project_name, project_namespace
+    ):
+        # Arrange
+        api = ServingApi()
+
+        # Act
+        segment = api._get_istio_inference_path(
+            _inference_deployment(project_name, project_namespace)
+        )[1]
+
+        # Assert: the gateway normalizes whichever of the two it is handed, and
+        # the namespace is what that normalization produces from the project
+        # name, so on a cluster that names its own namespaces the request this
+        # builds is the one the gateway already routed.
+        assert _as_gateway_authority(project_name) == project_namespace
+        assert _as_gateway_authority(project_namespace) == project_namespace
+        assert _as_gateway_authority(segment) == _as_gateway_authority(project_name)
+
+    @pytest.mark.parametrize(("project_name", "project_namespace"), NAMESPACE_CASES)
+    def test_rest_inference_request_posts_to_the_namespace_path(
+        self, mocker, project_name, project_namespace
+    ):
+        # Arrange
+        api = ServingApi()
+        istio_client = MagicMock()
+        istio_client._send_request.return_value = {"predictions": [1]}
+        mocker.patch(
+            "hsml.core.serving_api.client.istio._get_instance",
+            return_value=istio_client,
+        )
+        deployment = _inference_deployment(project_name, project_namespace)
+
+        # Act
+        response = api._send_inference_request(deployment, {"inputs": [[1]]})
+
+        # Assert
+        assert response == {"predictions": [1]}
+        args, kwargs = istio_client._send_request.call_args
+        assert args[0] == "POST"
+        assert args[1] == [
             "v1",
-            "pre-created-ns",
-            "vllmdepl",
+            project_namespace,
+            "skdepl",
+            "v1",
+            "models",
+            "skdepl:predict",
         ]
+        assert kwargs["with_base_path_params"] is False
+        # Inference moved from host-based to path-based routing in 4.8: the
+        # gateway derives the authority from the path it is given, so a host
+        # header here would be a return to the scheme this path replaced.
+        assert "host" not in {header.lower() for header in kwargs["headers"]}
+
+    @pytest.mark.parametrize(("project_name", "project_namespace"), NAMESPACE_CASES)
+    def test_grpc_channel_prefixes_the_namespace(
+        self, mocker, project_name, project_namespace
+    ):
+        # Arrange
+        api = ServingApi()
+        istio_client = MagicMock()
+        mocker.patch(
+            "hsml.core.serving_api.client.istio._get_instance",
+            return_value=istio_client,
+        )
+
+        # Act
+        api._create_grpc_channel(_inference_deployment(project_name, project_namespace))
+
+        # Assert
+        istio_client._create_grpc_channel.assert_called_once_with(
+            f"/v1/{project_namespace}/skdepl"
+        )
+
+    @pytest.mark.parametrize(("project_name", "project_namespace"), NAMESPACE_CASES)
+    def test_grpc_inference_request_addresses_the_namespace(
+        self, mocker, project_name, project_namespace
+    ):
+        # Arrange
+        api = ServingApi()
+        istio_client = MagicMock()
+        mocker.patch(
+            "hsml.core.serving_api.client.istio._get_instance",
+            return_value=istio_client,
+        )
+        deployment = _inference_deployment(
+            project_name, project_namespace, api_protocol=IE.API_PROTOCOL_GRPC
+        )
+        infer_input = InferInput(name="input", shape=[1], datatype="FP32", data=[1.0])
+
+        # Act
+        api._send_inference_request(deployment, [infer_input])
+
+        # Assert
+        istio_client._create_grpc_channel.assert_called_once_with(
+            f"/v1/{project_namespace}/skdepl"
+        )
+        # The channel is built once and kept on the deployment, so an address
+        # built here outlives the call that built it.
+        assert (
+            deployment._grpc_channel is istio_client._create_grpc_channel.return_value
+        )
+
+    def test_rest_inference_request_through_hopsworks_addresses_neither(self, mocker):
+        # Arrange
+        api = ServingApi()
+        hopsworks_client = _patch_client(mocker, {"predictions": [1]})
+        deployment = _inference_deployment(
+            "model_serving_int_MhGJP", "loadtest-kserve-0-main-000"
+        )
+
+        # Act
+        api._send_inference_request(
+            deployment, {"inputs": [[1]]}, through_hopsworks=True
+        )
+
+        # Assert: Hopsworks proxies by deployment name under the project id and
+        # resolves the namespace itself, so neither name belongs in this path.
+        args, kwargs = hopsworks_client._send_request.call_args
+        assert args[1] == ["project", 1, "inference", "models", "skdepl:predict"]
+        assert kwargs["with_base_path_params"] is True
+
+    def test_rest_inference_request_without_istio_falls_back_to_hopsworks(self, mocker):
+        # Arrange
+        api = ServingApi()
+        hopsworks_client = _patch_client(mocker, {"predictions": [1]})
+        mocker.patch(
+            "hsml.core.serving_api.client.istio._get_instance", return_value=None
+        )
+        deployment = _inference_deployment(
+            "model_serving_int_MhGJP", "loadtest-kserve-0-main-000"
+        )
+
+        # Act
+        api._send_inference_request(deployment, {"inputs": [[1]]})
+
+        # Assert
+        args, _ = hopsworks_client._send_request.call_args
+        assert args[1] == ["project", 1, "inference", "models", "skdepl:predict"]

--- a/python/tests/test_deployment.py
+++ b/python/tests/test_deployment.py
@@ -1403,6 +1403,77 @@ class TestDeployment:
         d.get_model.assert_called_once()
         mock_model.get_monitoring_configs.assert_called_once()
 
+    # inference addressing
+
+    def test_project_namespace_from_the_wire_reaches_the_inference_path(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange: the backend reports the namespace it created the deployment
+        # in, and never reports a project name. The client stamps that on
+        # afterwards, which is why a deployment parsed on its own has none.
+        self._mock_deployment_deserialization(mocker)
+        serving_json = self._serving_json(
+            backend_fixtures, "loadtest-kserve-0-main-000"
+        )
+
+        # Act
+        d = deployment.Deployment.from_response_json(serving_json)
+
+        # Assert
+        assert d.project_namespace == "loadtest-kserve-0-main-000"
+        assert d.project_name is None
+        assert serving_api.ServingApi()._get_istio_inference_path(d) == [
+            "v1",
+            "loadtest-kserve-0-main-000",
+            d.name,
+            "v1",
+            "models",
+            f"{d.name}:predict",
+        ]
+
+    def test_update_from_response_json_follows_the_namespace(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        self._mock_deployment_deserialization(mocker)
+        d = deployment.Deployment.from_response_json(
+            self._serving_json(backend_fixtures, "old-ns")
+        )
+        d.project_name = "my_project"  # what ServingApi stamps on
+
+        # Act
+        d.update_from_response_json(self._serving_json(backend_fixtures, "new-ns"))
+
+        # Assert
+        assert d.project_namespace == "new-ns"
+        assert serving_api.ServingApi()._get_istio_inference_path(d)[1] == "new-ns"
+        # The refresh re-initializes the predictor, which drops the stamped
+        # project name. That is why every ServingApi call that refreshes a
+        # deployment stamps it again, and a reason not to address by it.
+        assert d.project_name is None
+
+    def test_project_namespace_delegates_to_the_predictor(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange: the path builders read the namespace off a Deployment, while
+        # the tests covering them pass a stand-in, so the delegation to the
+        # predictor that holds it needs a check of its own.
+        p = self._get_dummy_predictor(mocker, backend_fixtures)
+        p.project_namespace = "pre-created-ns"
+        d = deployment.Deployment(predictor=p)
+
+        # Assert
+        assert d.project_namespace == "pre-created-ns"
+
+        # Act
+        d.project_namespace = "another-ns"
+
+        # Assert
+        assert p.project_namespace == "another-ns"
+        assert serving_api.ServingApi()._get_istio_inference_path(
+            d, base_only=True
+        ) == ["v1", "another-ns", p.name]
+
     # auxiliary methods
 
     def _get_dummy_predictor(self, mocker, backend_fixtures):
@@ -1424,3 +1495,27 @@ class TestDeployment:
             model_framework=p_json["model_framework"],
             model_server=p_json["model_server"],
         )
+
+    def _mock_deployment_deserialization(self, mocker):
+        mocker.patch(
+            "hopsworks_common.client._get_serving_num_instances_limits",
+            return_value=[-1],
+        )
+        mocker.patch(
+            "hopsworks_common.client._is_scale_to_zero_required", return_value=False
+        )
+        mocker.patch("hopsworks_common.client._is_saas_connection", return_value=False)
+        mocker.patch("hopsworks_common.client._is_kserve_installed", return_value=True)
+
+    def _serving_json(self, backend_fixtures, project_namespace):
+        # camelCase, as the backend sends it: `projectNamespace` is the key that
+        # has to survive decamelization to reach `project_namespace`.
+        serving_json = humps.camelize(
+            copy.deepcopy(
+                backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+                    "items"
+                ][0]
+            )
+        )
+        serving_json["projectNamespace"] = project_namespace
+        return serving_json

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -34,6 +34,20 @@ SERVING_NUM_INSTANCES_NO_LIMIT = [-1]
 SERVING_NUM_INSTANCES_SCALE_TO_ZERO = [0]
 SERVING_NUM_INSTANCES_ONE = [0]
 
+# The relation between a project's name and the Kubernetes namespace its
+# deployments run in: coinciding, derived from the name, pre-created and
+# unrelated to it, or reported before the client has stamped a name on. The URL
+# these getters render is the one users paste into an external client, so it has
+# to address the namespace in all four. See tests/core/test_serving_api.py.
+NAMESPACE_CASES = [
+    pytest.param("myproject", "myproject", id="identical"),
+    pytest.param("my_project", "my-project", id="derived"),
+    pytest.param(
+        "model_serving_int_MhGJP", "loadtest-kserve-0-main-000", id="unrelated"
+    ),
+    pytest.param(None, "pre-created-ns", id="unstamped"),
+]
+
 
 class TestPredictor:
     # from response json
@@ -743,7 +757,8 @@ class TestPredictor:
 
     # get_endpoint_url
 
-    def test_get_endpoint_url_with_istio(self, mocker):
+    @pytest.mark.parametrize(("project_name", "project_namespace"), NAMESPACE_CASES)
+    def test_get_endpoint_url_with_istio(self, mocker, project_name, project_namespace):
         # Arrange
         self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
         mock_istio_client = mocker.MagicMock()
@@ -760,14 +775,14 @@ class TestPredictor:
             model_version=1,
             model_framework=MODEL.FRAMEWORK_SKLEARN,
         )
-        p._project_name = "my_project"
-        p._project_namespace = "my-project-ns"
+        p._project_name = project_name
+        p._project_namespace = project_namespace
 
         # Act
         url = p.get_endpoint_url()
 
         # Assert
-        assert url == "https://istio.example.com/v1/my-project-ns/my_model"
+        assert url == f"https://istio.example.com/v1/{project_namespace}/my_model"
 
     def test_get_endpoint_url_no_istio_returns_none(self, mocker):
         # Arrange
@@ -794,7 +809,10 @@ class TestPredictor:
 
     # get_openai_url
 
-    def test_get_openai_url_vllm_with_istio(self, mocker):
+    @pytest.mark.parametrize(("project_name", "project_namespace"), NAMESPACE_CASES)
+    def test_get_openai_url_vllm_with_istio(
+        self, mocker, project_name, project_namespace
+    ):
         # Arrange
         self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
         mock_istio_client = mocker.MagicMock()
@@ -811,14 +829,14 @@ class TestPredictor:
             model_version=1,
             model_framework=MODEL.FRAMEWORK_LLM,
         )
-        p._project_name = "my_project"
-        p._project_namespace = "my-project-ns"
+        p._project_name = project_name
+        p._project_namespace = project_namespace
 
         # Act
         url = p.get_openai_url()
 
         # Assert
-        assert url == "https://istio.example.com/v1/my-project-ns/my_llm/v1"
+        assert url == f"https://istio.example.com/v1/{project_namespace}/my_llm/v1"
 
     def test_get_openai_url_non_vllm_returns_none(self, mocker):
         # Arrange
@@ -893,7 +911,10 @@ class TestPredictor:
 
     # get_inference_url
 
-    def test_get_inference_url_standard_model_with_istio(self, mocker):
+    @pytest.mark.parametrize(("project_name", "project_namespace"), NAMESPACE_CASES)
+    def test_get_inference_url_standard_model_with_istio(
+        self, mocker, project_name, project_namespace
+    ):
         # Arrange
         self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
         mock_istio_client = mocker.MagicMock()
@@ -910,16 +931,16 @@ class TestPredictor:
             model_version=1,
             model_framework=MODEL.FRAMEWORK_SKLEARN,
         )
-        p._project_name = "my_project"
-        p._project_namespace = "my-project-ns"
+        p._project_name = project_name
+        p._project_namespace = project_namespace
 
         # Act
         url = p.get_inference_url()
 
         # Assert
-        assert (
-            url
-            == "https://istio.example.com/v1/my-project-ns/my_model/v1/models/my_model:predict"
+        assert url == (
+            f"https://istio.example.com/v1/{project_namespace}"
+            "/my_model/v1/models/my_model:predict"
         )
 
     def test_get_inference_url_standard_model_fallback_hopsworks(self, mocker):

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -761,12 +761,13 @@ class TestPredictor:
             model_framework=MODEL.FRAMEWORK_SKLEARN,
         )
         p._project_name = "my_project"
+        p._project_namespace = "my-project-ns"
 
         # Act
         url = p.get_endpoint_url()
 
         # Assert
-        assert url == "https://istio.example.com/v1/my_project/my_model"
+        assert url == "https://istio.example.com/v1/my-project-ns/my_model"
 
     def test_get_endpoint_url_no_istio_returns_none(self, mocker):
         # Arrange
@@ -811,12 +812,13 @@ class TestPredictor:
             model_framework=MODEL.FRAMEWORK_LLM,
         )
         p._project_name = "my_project"
+        p._project_namespace = "my-project-ns"
 
         # Act
         url = p.get_openai_url()
 
         # Assert
-        assert url == "https://istio.example.com/v1/my_project/my_llm/v1"
+        assert url == "https://istio.example.com/v1/my-project-ns/my_llm/v1"
 
     def test_get_openai_url_non_vllm_returns_none(self, mocker):
         # Arrange
@@ -909,6 +911,7 @@ class TestPredictor:
             model_framework=MODEL.FRAMEWORK_SKLEARN,
         )
         p._project_name = "my_project"
+        p._project_namespace = "my-project-ns"
 
         # Act
         url = p.get_inference_url()
@@ -916,7 +919,7 @@ class TestPredictor:
         # Assert
         assert (
             url
-            == "https://istio.example.com/v1/my_project/my_model/v1/models/my_model:predict"
+            == "https://istio.example.com/v1/my-project-ns/my_model/v1/models/my_model:predict"
         )
 
     def test_get_inference_url_standard_model_fallback_hopsworks(self, mocker):


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-3055

On a cluster configured for pre-created namespaces, every prediction against a KServe deployment returns 404, while the deployment itself reports Ready with 100% traffic and its pods running.

Istio routes inference traffic by the namespace a deployment runs in. The client addresses deployments by the project's *name*:

```python
# hsml/core/serving_api.py
base_path = ["v1", deployment_instance.project_name, deployment_instance.name]      # REST
path_prefix = f"/v1/{deployment_instance.project_name}/{deployment_instance.name}"  # gRPC
```

Where the platform creates namespaces itself, it derives them as `name.toLowerCase().replaceAll("[^a-z0-9-]", "-")`, so the two strings are equal and the wrong one still arrives. Where namespaces are pre-created, which is how Hopsworks is deployed on OpenShift, they are unrelated.

## Fix

Address deployments by the namespace, at both sites.

The client is already given it. All five places that stamp `project_name` onto a deployment sit immediately after a `from_response_json`, and the payload being parsed in that same moment carries `projectNamespace`, which lands on the predictor. The correct value was on the object and unused.

This also covers the three public URL getters that share the path builder: `get_endpoint_url()`, `get_openai_url()` and `get_inference_url()`.

### The one behaviour change beyond the fix

A predictor built locally via `ms.create_predictor(...)` and not yet saved has no namespace, so those three getters now render `None` in the path where they previously rendered a project name. Both are wrong, because the deployment does not exist yet; the new one is wrong loudly.

Saving repairs it. `save()` goes through `_create()` to `_serving_api._put()`, whose response is fed to `update_from_response_json()`, and that response carries the namespace. So every deployment that can actually be predicted against has one, including the object `model.deploy()` hands back.

There is deliberately **no** fallback to `project_name`. It would restore the broken address silently on exactly the objects whose namespace is unknown, which is the failure this PR exists to remove.

## Regression, not a gap

| Releases | Addressed by | Pre-created-namespace clusters |
|---|---|---|
| 4.5.0 – 4.7.0 | namespace (Host header) | work |
| 4.8.0, 5.0.0 – 5.0.4, main | project name (URL path) | 404 |

HWORKS-1421 (#336, Sep 2024) deliberately moved inference addressing off the project name. HWORKS-2609 (#833, Feb 2026) rewrote host-based routing into path-based routing and reintroduced it at both sites.

**This needs backporting to 4.8 and 5.0.**

## Verification

On a live OKD cluster with pre-created namespaces. Project `model_serving_int_MhGJP` runs in namespace `loadtest-kserve-0-main-000`, and the deployment `skdepl` is Ready.

The two candidate paths, sent to that cluster's Istio ingress gateway:

```
POST /v1/model_serving_int_MhGJP/skdepl/v1/models/skdepl:predict     -> 404   no route
POST /v1/loadtest-kserve-0-main-000/skdepl/v1/models/skdepl:predict  -> 401   route found, auth required
```

The path each version of the client builds, from that cluster's actual serving payload (`projectNamespace: 'loadtest-kserve-0-main-000'`):

```
[before] /v1/model_serving_int_MhGJP/skdepl/v1/models/skdepl:predict
[after]  /v1/loadtest-kserve-0-main-000/skdepl/v1/models/skdepl:predict
```

So the fix produces the address the gateway actually routes.

The three URL-getter tests in `tests/test_predictor.py` set only the project name; they now set a namespace that differs from it, so they discriminate between the two. The added tests in `tests/core/test_serving_api.py` fail without the change and pass with it.

Full suite against this venv, compared with pristine `main` (the failures and errors are missing optional dependencies locally, identical on both):

```
pristine main   72 failed, 1492 passed, 86 errors
this branch     72 failed, 1494 passed, 86 errors
``` Two of the cluster's five worker nodes were lost to host memory exhaustion during this work, so a full green `deployment.predict()` against a live predictor is not part of this evidence; the earlier manual experiment on the same cluster, which reached a namespace-correct URL by renaming the namespace instead, turned `test_deploy_and_predict_sklearn_model_with_kserve` from a 404 failure into `1 passed`.

## Follow-up, deliberately not in this PR

After this change `Deployment.project_name` is assigned in five places and read in none. Whether the attribute and its stamping should go is a wider call than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
