### PR TITLE
[HWORKS-3045] Create a Trino catalog from a data source

### DIFF
--- a/python/hopsworks_common/core/trino_catalog_api.py
+++ b/python/hopsworks_common/core/trino_catalog_api.py
@@ -1,0 +1,265 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hopsworks_apigen import also_available_as
+from hopsworks_common import client
+
+
+@also_available_as(
+    "hopsworks.core.trino_catalog_api.TrinoCatalogApi",
+    "hsfs.core.trino_catalog_api.TrinoCatalogApi",
+)
+class TrinoCatalogApi:
+    """Trino catalogs of the current project, and the query engine restart that loads them.
+
+    A catalog makes an external source queryable from the query engine. Creating one records the
+    change; it becomes queryable once the query engine restarts, which happens on the cluster's
+    schedule or immediately when a cluster administrator asks for it.
+    """
+
+    def _project_path(self, *tail: Any) -> list[Any]:
+        _client = client._get_instance()
+        return ["project", _client._project_id, "trino", *tail]
+
+    def get_catalogs(self) -> list[dict[str, Any]]:
+        """The project's Trino catalogs, plus the cluster's shared default catalogs.
+
+        Returns:
+            One entry per catalog: its `name`, `connectorType`, `status`, pending `operation`,
+            `creator`, and `defaultCatalog` for a cluster-wide one. Properties are not included;
+            use `get_catalog` for those.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        return _client._send_request("GET", self._project_path("catalog"))
+
+    def get_catalog(self, name: str) -> dict[str, Any]:
+        """One catalog with its properties, for inspection or editing.
+
+        Secret-bearing property values come back masked (`********`). Submitting a masked value
+        unchanged through `update_catalog` keeps the stored secret, so a masked property does not
+        have to be retyped to change a different one.
+
+        Parameters:
+            name: The catalog's full name, including the `<project>__` prefix.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        return _client._send_request("GET", self._project_path("catalog", name))
+
+    def get_capabilities(self) -> dict[str, Any]:
+        """What this cluster's query engine supports, and when it next restarts.
+
+        Returns:
+            `connectors` a catalog may use, `testConnectionAvailable` for whether a live connection
+            test is possible, `restarting` while the engine is mid-restart, `nextScheduledRestart`
+            as the instant a pending catalog next goes live (null when no restart is scheduled), and
+            `mountableSecretsAvailable` for whether credential files can be delivered.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        return _client._send_request("GET", self._project_path("capabilities"))
+
+    def get_catalog_template(
+        self, data_source_name: str, featurestore_id: int
+    ) -> dict[str, Any]:
+        """A proposed catalog derived from a data source, to be reviewed and then created.
+
+        Nothing is created or written by asking for this. Credential properties come back as a
+        reference to a Hopsworks secret or credential-file bundle rather than a value: the value is
+        read from the data source when the catalog is created, so no credential is sent here.
+
+        Parameters:
+            data_source_name: Name of the data source (storage connector) to derive from.
+            featurestore_id: The feature store the data source belongs to.
+
+        Returns:
+            `supported` and, when false, `reason` saying why the source cannot be mapped. When true:
+            `suggestedName`, `connectorType`, `properties`, and `credentialKeys` naming the
+            properties that are credential-derived.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        return _client._send_request(
+            "GET",
+            self._project_path("catalog", "template"),
+            query_params={
+                "dataSourceName": data_source_name,
+                "featurestoreId": featurestore_id,
+            },
+        )
+
+    def _catalog_payload(
+        self,
+        name: str,
+        connector_type: str,
+        properties: dict[str, str],
+        data_source_name: str | None,
+        featurestore_id: int | None,
+    ) -> str:
+        payload: dict[str, Any] = {
+            "name": name,
+            "connectorType": connector_type,
+            "properties": properties,
+        }
+        # Sent only when creating from a data source. Their presence is what tells the backend to
+        # resolve credential references out of that source; without them the properties are used
+        # exactly as given, which is the hand-written case.
+        if data_source_name is not None:
+            payload["dataSourceName"] = data_source_name
+        if featurestore_id is not None:
+            payload["featurestoreId"] = featurestore_id
+        return json.dumps(payload)
+
+    def create_catalog(
+        self,
+        name: str,
+        connector_type: str,
+        properties: dict[str, str],
+        data_source_name: str | None = None,
+        featurestore_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Create a Trino catalog.
+
+        The catalog is recorded now and becomes queryable when the query engine restarts. Check
+        `get_capabilities()["nextScheduledRestart"]` for when that is, or call `restart()` as a
+        cluster administrator to do it immediately.
+
+        Parameters:
+            name: Full catalog name. It must start with `<project>__` in lowercase.
+            connector_type: A Trino connector from `get_capabilities()["connectors"]`.
+            properties: Connector properties, without `connector.name`. A value may reference a
+                Hopsworks secret as `${HOPSWORKS_SECRET:<name>}`, or a credential-file bundle as
+                `${HOPSWORKS_MOUNT:<bundle>}`, instead of holding the value itself.
+            data_source_name: Derive credential properties from this data source, for a catalog
+                built from `get_catalog_template`. Leave unset for a hand-written catalog.
+            featurestore_id: The data source's feature store. Required with `data_source_name`.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        return _client._send_request(
+            "POST",
+            self._project_path("catalog"),
+            headers={"content-type": "application/json"},
+            data=self._catalog_payload(
+                name, connector_type, properties, data_source_name, featurestore_id
+            ),
+        )
+
+    def update_catalog(
+        self,
+        name: str,
+        connector_type: str,
+        properties: dict[str, str],
+        data_source_name: str | None = None,
+        featurestore_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Change an existing catalog's connector or properties.
+
+        Like a create, the change takes effect at the next query engine restart. A property left at
+        its masked value keeps the secret already stored for it.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        return _client._send_request(
+            "PUT",
+            self._project_path("catalog", name),
+            headers={"content-type": "application/json"},
+            data=self._catalog_payload(
+                name, connector_type, properties, data_source_name, featurestore_id
+            ),
+        )
+
+    def delete_catalog(self, name: str) -> None:
+        """Delete a catalog.
+
+        The catalog stays queryable until the query engine restarts and unloads it.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        _client._send_request("DELETE", self._project_path("catalog", name))
+
+    def test_connection(
+        self,
+        name: str,
+        connector_type: str,
+        properties: dict[str, str],
+        data_source_name: str | None = None,
+        featurestore_id: int | None = None,
+    ) -> None:
+        """Check that a catalog definition can actually reach its source, without creating it.
+
+        Available only where `get_capabilities()["testConnectionAvailable"]` is true, which needs the
+        cluster's optional test coordinator. Returns nothing on success and raises with the engine's
+        own message on failure, so a bad host or credential is reported before the catalog exists.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the connection fails, or the backend
+                encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        _client._send_request(
+            "POST",
+            self._project_path("catalog", "test-connection"),
+            headers={"content-type": "application/json"},
+            data=self._catalog_payload(
+                name, connector_type, properties, data_source_name, featurestore_id
+            ),
+        )
+
+    def restart(self) -> dict[str, Any]:
+        """Apply every pending catalog change now, instead of waiting for the schedule.
+
+        Requires cluster administrator (`HOPS_ADMIN`) privileges; the backend refuses otherwise.
+        This interrupts queries running anywhere on the cluster, so prefer waiting for
+        `get_capabilities()["nextScheduledRestart"]` unless the change is needed sooner.
+
+        Pending changes are written and the query engine is then restarted, in that order: a restart
+        on its own would load nothing, because a newly created catalog is only a record until it is
+        written.
+
+        Returns:
+            `restarted` false when the restart was skipped as unnecessary, and `quarantined` naming
+            any catalog removed because the engine could not load it. A quarantined catalog is not
+            applied; its own page carries the load error.
+
+        Raises:
+            hopsworks.client.exceptions.RestAPIError: If the user is not a cluster administrator, or
+                the backend encounters an error when handling the request.
+        """
+        _client = client._get_instance()
+        return _client._send_request(
+            "POST", ["admin", "trino", "catalogs", "sync-and-restart"]
+        )

--- a/python/hopsworks_common/core/trino_catalog_api.py
+++ b/python/hopsworks_common/core/trino_catalog_api.py
@@ -19,14 +19,11 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from hopsworks_apigen import also_available_as
-from hopsworks_common import client
+from hopsworks_apigen import public
+from hopsworks_common import client, usage
 
 
-@also_available_as(
-    "hopsworks.core.trino_catalog_api.TrinoCatalogApi",
-    "hsfs.core.trino_catalog_api.TrinoCatalogApi",
-)
+@public("hopsworks.core.trino_catalog_api.TrinoCatalogApi")
 class TrinoCatalogApi:
     """Trino catalogs of the current project, and the query engine restart that loads them.
 
@@ -39,6 +36,42 @@ class TrinoCatalogApi:
         _client = client._get_instance()
         return ["project", _client._project_id, "trino", *tail]
 
+    def _send_catalog(
+        self,
+        method: str,
+        path: list[Any],
+        name: str,
+        connector_type: str,
+        properties: dict[str, str],
+        data_source_name: str | None = None,
+        featurestore_id: int | None = None,
+    ) -> Any:
+        payload: dict[str, Any] = {
+            "name": name,
+            "connectorType": connector_type,
+            "properties": properties,
+        }
+        # Sent only when deriving from a data source. Their joint presence is what tells the backend
+        # to resolve credential references out of that source; without them the properties are used
+        # exactly as given, which is the hand-written case.
+        if (data_source_name is None) != (featurestore_id is None):
+            raise ValueError(
+                "data_source_name and featurestore_id must be passed together: "
+                "they name the data source to resolve credentials from."
+            )
+        if data_source_name is not None:
+            payload["dataSourceName"] = data_source_name
+            payload["featurestoreId"] = featurestore_id
+        _client = client._get_instance()
+        return _client._send_request(
+            method,
+            path,
+            headers={"content-type": "application/json"},
+            data=json.dumps(payload),
+        )
+
+    @public
+    @usage._method_logger
     def get_catalogs(self) -> list[dict[str, Any]]:
         """The project's Trino catalogs, plus the cluster's shared default catalogs.
 
@@ -53,6 +86,8 @@ class TrinoCatalogApi:
         _client = client._get_instance()
         return _client._send_request("GET", self._project_path("catalog"))
 
+    @public
+    @usage._method_logger
     def get_catalog(self, name: str) -> dict[str, Any]:
         """One catalog with its properties, for inspection or editing.
 
@@ -63,12 +98,18 @@ class TrinoCatalogApi:
         Parameters:
             name: The catalog's full name, including the `<project>__` prefix.
 
+        Returns:
+            The catalog: its `name`, `connectorType`, `status`, pending `operation`, and
+            `properties` with secret-bearing values masked.
+
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         _client = client._get_instance()
         return _client._send_request("GET", self._project_path("catalog", name))
 
+    @public
+    @usage._method_logger
     def get_capabilities(self) -> dict[str, Any]:
         """What this cluster's query engine supports, and when it next restarts.
 
@@ -84,6 +125,8 @@ class TrinoCatalogApi:
         _client = client._get_instance()
         return _client._send_request("GET", self._project_path("capabilities"))
 
+    @public
+    @usage._method_logger
     def get_catalog_template(
         self, data_source_name: str, featurestore_id: int
     ) -> dict[str, Any]:
@@ -99,8 +142,7 @@ class TrinoCatalogApi:
 
         Returns:
             `supported` and, when false, `reason` saying why the source cannot be mapped. When true:
-            `suggestedName`, `connectorType`, `properties`, and `credentialKeys` naming the
-            properties that are credential-derived.
+            `suggestedName`, `connectorType`, and `properties`.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
@@ -115,28 +157,8 @@ class TrinoCatalogApi:
             },
         )
 
-    def _catalog_payload(
-        self,
-        name: str,
-        connector_type: str,
-        properties: dict[str, str],
-        data_source_name: str | None,
-        featurestore_id: int | None,
-    ) -> str:
-        payload: dict[str, Any] = {
-            "name": name,
-            "connectorType": connector_type,
-            "properties": properties,
-        }
-        # Sent only when creating from a data source. Their presence is what tells the backend to
-        # resolve credential references out of that source; without them the properties are used
-        # exactly as given, which is the hand-written case.
-        if data_source_name is not None:
-            payload["dataSourceName"] = data_source_name
-        if featurestore_id is not None:
-            payload["featurestoreId"] = featurestore_id
-        return json.dumps(payload)
-
+    @public
+    @usage._method_logger
     def create_catalog(
         self,
         name: str,
@@ -161,49 +183,65 @@ class TrinoCatalogApi:
                 built from `get_catalog_template`. Leave unset for a hand-written catalog.
             featurestore_id: The data source's feature store. Required with `data_source_name`.
 
+        Returns:
+            The created catalog, including the `status` it is waiting in.
+
         Raises:
+            ValueError: If only one of `data_source_name` and `featurestore_id` is passed.
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
-        _client = client._get_instance()
-        return _client._send_request(
+        return self._send_catalog(
             "POST",
             self._project_path("catalog"),
-            headers={"content-type": "application/json"},
-            data=self._catalog_payload(
-                name, connector_type, properties, data_source_name, featurestore_id
-            ),
+            name,
+            connector_type,
+            properties,
+            data_source_name,
+            featurestore_id,
         )
 
+    @public
+    @usage._method_logger
     def update_catalog(
         self,
         name: str,
         connector_type: str,
         properties: dict[str, str],
-        data_source_name: str | None = None,
-        featurestore_id: int | None = None,
     ) -> dict[str, Any]:
         """Change an existing catalog's connector or properties.
 
         Like a create, the change takes effect at the next query engine restart. A property left at
-        its masked value keeps the secret already stored for it.
+        its masked value keeps the secret already stored for it, which is how an update changes one
+        property without retyping the others' credentials.
+
+        Parameters:
+            name: The catalog's full name, including the `<project>__` prefix.
+            connector_type: The Trino connector the catalog uses.
+            properties: The full set of connector properties to store, as from `get_catalog`.
+
+        Returns:
+            The updated catalog, including the `status` it is waiting in.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
-        _client = client._get_instance()
-        return _client._send_request(
+        return self._send_catalog(
             "PUT",
             self._project_path("catalog", name),
-            headers={"content-type": "application/json"},
-            data=self._catalog_payload(
-                name, connector_type, properties, data_source_name, featurestore_id
-            ),
+            name,
+            connector_type,
+            properties,
         )
 
+    @public
+    @usage._method_logger
     def delete_catalog(self, name: str) -> None:
         """Delete a catalog.
 
         The catalog stays queryable until the query engine restarts and unloads it.
+
+        Parameters:
+            name: The catalog's full name, including the `<project>__` prefix.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
@@ -211,6 +249,8 @@ class TrinoCatalogApi:
         _client = client._get_instance()
         _client._send_request("DELETE", self._project_path("catalog", name))
 
+    @public
+    @usage._method_logger
     def test_connection(
         self,
         name: str,
@@ -225,20 +265,31 @@ class TrinoCatalogApi:
         cluster's optional test coordinator. Returns nothing on success and raises with the engine's
         own message on failure, so a bad host or credential is reported before the catalog exists.
 
+        Parameters:
+            name: Full catalog name, as it would be created.
+            connector_type: A Trino connector from `get_capabilities()["connectors"]`.
+            properties: The connector properties to test, as they would be stored.
+            data_source_name: Resolve credential properties from this data source, exactly as
+                `create_catalog` would. Leave unset for a hand-written catalog.
+            featurestore_id: The data source's feature store. Required with `data_source_name`.
+
         Raises:
+            ValueError: If only one of `data_source_name` and `featurestore_id` is passed.
             hopsworks.client.exceptions.RestAPIError: If the connection fails, or the backend
                 encounters an error when handling the request.
         """
-        _client = client._get_instance()
-        _client._send_request(
+        self._send_catalog(
             "POST",
             self._project_path("catalog", "test-connection"),
-            headers={"content-type": "application/json"},
-            data=self._catalog_payload(
-                name, connector_type, properties, data_source_name, featurestore_id
-            ),
+            name,
+            connector_type,
+            properties,
+            data_source_name,
+            featurestore_id,
         )
 
+    @public
+    @usage._method_logger
     def restart(self) -> dict[str, Any]:
         """Apply every pending catalog change now, instead of waiting for the schedule.
 

--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -436,9 +436,9 @@ class Project:
             import hopsworks
 
             project = hopsworks.login()
-            catalogs = project.get_trino_catalog_api()
+            catalog_api = project.get_trino_catalog_api()
 
-            for catalog in catalogs.get_catalogs():
+            for catalog in catalog_api.get_catalogs():
                 print(catalog["name"], catalog["status"])
             ```
 

--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -34,6 +34,7 @@ from hopsworks_common.core import (
     search_api,
     superset_api,
     trino_api,
+    trino_catalog_api,
 )
 
 
@@ -93,6 +94,7 @@ class Project:
         self._search_api = search_api.SearchApi()
         self._project_namespace = namespace
         self._trino_api = None
+        self._trino_catalog_api = None
         self._superset_api = None
 
     @classmethod
@@ -421,6 +423,31 @@ class Project:
         if self._trino_api is None:
             self._trino_api = trino_api.TrinoApi(project=self)
         return self._trino_api
+
+    @public
+    def get_trino_catalog_api(self) -> trino_catalog_api.TrinoCatalogApi:
+        """Get the Trino catalog API for the project.
+
+        Distinct from `get_trino_api`, which connects to the query engine and runs queries. This one
+        manages which sources the engine can query, and the restart that applies a change.
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            catalogs = project.get_trino_catalog_api()
+
+            for catalog in catalogs.get_catalogs():
+                print(catalog["name"], catalog["status"])
+            ```
+
+        Returns:
+            The Trino catalog API handle.
+        """
+        if self._trino_catalog_api is None:
+            self._trino_catalog_api = trino_catalog_api.TrinoCatalogApi()
+        return self._trino_catalog_api
 
     @public
     def get_superset_api(self) -> superset_api.SupersetApi:

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -246,10 +246,9 @@ class StorageConnector(ABC):
     def get_trino_catalog_template(self) -> dict[str, Any]:
         """A Trino catalog proposed from this data source, to review before creating it.
 
-        Nothing is created by asking for this. The connector type and properties are derived from
-        what this data source already holds, and credential properties come back as a reference to a
-        Hopsworks secret or credential-file bundle rather than a value, so no credential is sent to
-        the caller.
+        Nothing is created by asking for this.
+        The connector type and properties are derived from what this data source already holds.
+        Credential properties come back as a reference to a Hopsworks secret or credential-file bundle rather than a value, so no credential is sent to the caller.
 
         Example:
             ```python
@@ -283,10 +282,8 @@ class StorageConnector(ABC):
     ) -> dict[str, Any]:
         """Make this data source queryable from the query engine, as a Trino catalog.
 
-        The catalog is derived from this data source, so nothing has to be supplied: credentials are
-        read from the data source when the catalog is created and stored as a reference, never as a
-        plaintext copy. It becomes queryable once the query engine restarts, on the cluster's
-        schedule or immediately via `project.get_trino_catalog_api().restart()` as an administrator.
+        The catalog is derived from this data source, so nothing has to be supplied: credentials are read from the data source when the catalog is created and stored as a reference, never as a plaintext copy.
+        It becomes queryable once the query engine restarts, on the cluster's schedule or immediately via `project.get_trino_catalog_api().restart()` as an administrator.
 
         Example:
             ```python
@@ -303,11 +300,10 @@ class StorageConnector(ABC):
         Parameters:
             name: Catalog name, which must start with `<project>__` in lowercase. Defaults to the
                 name the template suggests, derived from this data source's own name.
-            properties: Replace the derived properties entirely; keys are not merged with the
-                template's. Start from the template's `properties` and apply your edits.
-            test_connection: Verify the definition can reach the source before creating it, where
-                the cluster supports it. On failure nothing is created and the engine's own error is
-                raised, so an unreachable source is caught now rather than after a restart.
+            properties: Replace the derived properties entirely; keys are not merged with the template's.
+                Start from the template's `properties` and apply your edits.
+            test_connection: Verify the definition can reach the source before creating it, where the cluster supports it.
+                On failure nothing is created and the engine's own error is raised, so an unreachable source is caught now rather than after a restart.
 
         Returns:
             The created catalog, including the `status` it is waiting in.

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -35,10 +35,10 @@ from hopsworks_common.client.exceptions import (
     DataSourceException,
     FeatureStoreException,
 )
+from hopsworks_common.core import trino_catalog_api
 from hopsworks_common.core.constants import HAS_NUMPY, HAS_POLARS
 from hopsworks_common.core.opensearch_api import OPENSEARCH_CONFIG
 from hopsworks_common.core.rest_endpoint import RestEndpointConfig
-from hopsworks_common.core import trino_catalog_api
 from hsfs import engine
 from hsfs.core import data_source as ds
 from hsfs.core import data_source_api, storage_connector_api
@@ -268,7 +268,7 @@ class StorageConnector(ABC):
 
         Returns:
             `supported`, and `reason` when it is false. Otherwise `suggestedName`,
-            `connectorType`, `properties` and `credentialKeys`.
+            `connectorType` and `properties`.
         """
         return self._trino_catalog_api.get_catalog_template(
             self._name, self._featurestore_id
@@ -303,9 +303,8 @@ class StorageConnector(ABC):
         Parameters:
             name: Catalog name, which must start with `<project>__` in lowercase. Defaults to the
                 name the template suggests, derived from this data source's own name.
-            properties: Override the derived properties. Any property left out of an override keeps
-                the derived value only if it is absent here entirely: pass the template's
-                `properties` with your edits applied rather than a partial dictionary.
+            properties: Replace the derived properties entirely; keys are not merged with the
+                template's. Start from the template's `properties` and apply your edits.
             test_connection: Verify the definition can reach the source before creating it, where
                 the cluster supports it. On failure nothing is created and the engine's own error is
                 raised, so an unreachable source is caught now rather than after a restart.
@@ -326,7 +325,7 @@ class StorageConnector(ABC):
                 f"{template.get('reason')}"
             )
 
-        catalog_name = name or template["suggestedName"]
+        catalog_name = name if name is not None else template["suggestedName"]
         catalog_properties = (
             properties if properties is not None else template["properties"]
         )

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -31,10 +31,14 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from hopsworks_apigen import public
 from hopsworks_common import client, util
-from hopsworks_common.client.exceptions import DataSourceException
+from hopsworks_common.client.exceptions import (
+    DataSourceException,
+    FeatureStoreException,
+)
 from hopsworks_common.core.constants import HAS_NUMPY, HAS_POLARS
 from hopsworks_common.core.opensearch_api import OPENSEARCH_CONFIG
 from hopsworks_common.core.rest_endpoint import RestEndpointConfig
+from hopsworks_common.core import trino_catalog_api
 from hsfs import engine
 from hsfs.core import data_source as ds
 from hsfs.core import data_source_api, storage_connector_api
@@ -118,6 +122,7 @@ class StorageConnector(ABC):
         self._featurestore_id = featurestore_id
 
         self._storage_connector_api = storage_connector_api.StorageConnectorApi()
+        self._trino_catalog_api = trino_catalog_api.TrinoCatalogApi()
         self._data_source_api = data_source_api.DataSourceApi()
 
     @classmethod
@@ -236,6 +241,115 @@ class StorageConnector(ABC):
             The updated storage connector.
         """
         return self._storage_connector_api._update(self)
+
+    @public
+    def get_trino_catalog_template(self) -> dict[str, Any]:
+        """A Trino catalog proposed from this data source, to review before creating it.
+
+        Nothing is created by asking for this. The connector type and properties are derived from
+        what this data source already holds, and credential properties come back as a reference to a
+        Hopsworks secret or credential-file bundle rather than a value, so no credential is sent to
+        the caller.
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            fs = project.get_feature_store()
+
+            sc = fs.get_data_source("my_snowflake_connector").storage_connector
+            template = sc.get_trino_catalog_template()
+            if template["supported"]:
+                print(template["connectorType"], template["properties"])
+            else:
+                print("cannot be mapped:", template["reason"])
+            ```
+
+        Returns:
+            `supported`, and `reason` when it is false. Otherwise `suggestedName`,
+            `connectorType`, `properties` and `credentialKeys`.
+        """
+        return self._trino_catalog_api.get_catalog_template(
+            self._name, self._featurestore_id
+        )
+
+    @public
+    def create_trino_catalog(
+        self,
+        name: str | None = None,
+        properties: dict[str, str] | None = None,
+        test_connection: bool = True,
+    ) -> dict[str, Any]:
+        """Make this data source queryable from the query engine, as a Trino catalog.
+
+        The catalog is derived from this data source, so nothing has to be supplied: credentials are
+        read from the data source when the catalog is created and stored as a reference, never as a
+        plaintext copy. It becomes queryable once the query engine restarts, on the cluster's
+        schedule or immediately via `project.get_trino_catalog_api().restart()` as an administrator.
+
+        Example:
+            ```python
+            import hopsworks
+
+            project = hopsworks.login()
+            fs = project.get_feature_store()
+
+            sc = fs.get_data_source("my_snowflake_connector").storage_connector
+            catalog = sc.create_trino_catalog()
+            print(catalog["name"], catalog["status"])
+            ```
+
+        Parameters:
+            name: Catalog name, which must start with `<project>__` in lowercase. Defaults to the
+                name the template suggests, derived from this data source's own name.
+            properties: Override the derived properties. Any property left out of an override keeps
+                the derived value only if it is absent here entirely: pass the template's
+                `properties` with your edits applied rather than a partial dictionary.
+            test_connection: Verify the definition can reach the source before creating it, where
+                the cluster supports it. On failure nothing is created and the engine's own error is
+                raised, so an unreachable source is caught now rather than after a restart.
+
+        Returns:
+            The created catalog, including the `status` it is waiting in.
+
+        Raises:
+            hopsworks.client.exceptions.FeatureStoreException: If this data source cannot be mapped
+                to a Trino catalog; the message says why.
+            hopsworks.client.exceptions.RestAPIError: If the connection test fails, or the backend
+                encounters an error when handling the request.
+        """
+        template = self.get_trino_catalog_template()
+        if not template.get("supported"):
+            raise FeatureStoreException(
+                f"Data source '{self._name}' cannot be mapped to a Trino catalog: "
+                f"{template.get('reason')}"
+            )
+
+        catalog_name = name or template["suggestedName"]
+        catalog_properties = (
+            properties if properties is not None else template["properties"]
+        )
+        connector_type = template["connectorType"]
+
+        if test_connection and self._trino_catalog_api.get_capabilities().get(
+            "testConnectionAvailable"
+        ):
+            self._trino_catalog_api.test_connection(
+                catalog_name,
+                connector_type,
+                catalog_properties,
+                data_source_name=self._name,
+                featurestore_id=self._featurestore_id,
+            )
+
+        return self._trino_catalog_api.create_catalog(
+            catalog_name,
+            connector_type,
+            catalog_properties,
+            data_source_name=self._name,
+            featurestore_id=self._featurestore_id,
+        )
 
     @public
     @property

--- a/python/tests/core/test_trino_catalog_api.py
+++ b/python/tests/core/test_trino_catalog_api.py
@@ -1,0 +1,123 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+from unittest.mock import Mock, patch
+
+from hopsworks_common.core.trino_catalog_api import TrinoCatalogApi
+
+
+class TestTrinoCatalogApi:
+    """The request each call makes, since the contract with the backend is the whole of this class."""
+
+    def _client(self, response=None):
+        client = Mock()
+        client._project_id = 119
+        client._send_request.return_value = response
+        return client
+
+    def _call(self, response, fn):
+        client = self._client(response)
+        with patch(
+            "hopsworks_common.core.trino_catalog_api.client._get_instance",
+            return_value=client,
+        ):
+            result = fn(TrinoCatalogApi())
+        return result, client._send_request.call_args
+
+    def test_get_catalogs_is_project_scoped(self):
+        result, call = self._call([{"name": "p__pg"}], lambda api: api.get_catalogs())
+        assert result == [{"name": "p__pg"}]
+        assert call.args[0] == "GET"
+        assert call.args[1] == ["project", 119, "trino", "catalog"]
+
+    def test_get_catalog_names_the_catalog_in_the_path(self):
+        _, call = self._call({}, lambda api: api.get_catalog("p__pg"))
+        assert call.args[1] == ["project", 119, "trino", "catalog", "p__pg"]
+
+    def test_get_catalog_template_passes_the_data_source_as_query_params(self):
+        # The template is a GET so that asking for it creates nothing; the source it derives from
+        # therefore travels as query params rather than a body.
+        _, call = self._call(
+            {"supported": True},
+            lambda api: api.get_catalog_template("snow", 67),
+        )
+        assert call.args[0] == "GET"
+        assert call.args[1] == ["project", 119, "trino", "catalog", "template"]
+        assert call.kwargs["query_params"] == {
+            "dataSourceName": "snow",
+            "featurestoreId": 67,
+        }
+
+    def test_create_omits_the_data_source_when_hand_written(self):
+        # Their absence is the signal that the properties are to be used exactly as given: sending
+        # them as nulls would make the backend try to resolve credentials from a source named null.
+        _, call = self._call(
+            {},
+            lambda api: api.create_catalog("p__pg", "postgresql", {"connection-url": "jdbc:x"}),
+        )
+        body = json.loads(call.kwargs["data"])
+        assert body == {
+            "name": "p__pg",
+            "connectorType": "postgresql",
+            "properties": {"connection-url": "jdbc:x"},
+        }
+
+    def test_create_carries_the_data_source_when_derived(self):
+        _, call = self._call(
+            {},
+            lambda api: api.create_catalog(
+                "p__snow",
+                "snowflake",
+                {"connection-url": "jdbc:snowflake://x"},
+                data_source_name="snow",
+                featurestore_id=67,
+            ),
+        )
+        body = json.loads(call.kwargs["data"])
+        assert body["dataSourceName"] == "snow"
+        assert body["featurestoreId"] == 67
+
+    def test_update_uses_put_on_the_named_catalog(self):
+        _, call = self._call({}, lambda api: api.update_catalog("p__pg", "postgresql", {}))
+        assert call.args[0] == "PUT"
+        assert call.args[1] == ["project", 119, "trino", "catalog", "p__pg"]
+
+    def test_delete_uses_delete_on_the_named_catalog(self):
+        _, call = self._call(None, lambda api: api.delete_catalog("p__pg"))
+        assert call.args[0] == "DELETE"
+        assert call.args[1] == ["project", 119, "trino", "catalog", "p__pg"]
+
+    def test_test_connection_posts_to_the_test_endpoint(self):
+        _, call = self._call(None, lambda api: api.test_connection("p__pg", "postgresql", {}))
+        assert call.args[0] == "POST"
+        assert call.args[1] == [
+            "project",
+            119,
+            "trino",
+            "catalog",
+            "test-connection",
+        ]
+
+    # Not project-scoped, and deliberately the sync-and-restart endpoint: a plain restart would load
+    # nothing, because a newly created catalog is only a record until it is written.
+    def test_restart_calls_the_admin_sync_and_restart_endpoint(self):
+        result, call = self._call(
+            {"restarted": True, "quarantined": []}, lambda api: api.restart()
+        )
+        assert result == {"restarted": True, "quarantined": []}
+        assert call.args[0] == "POST"
+        assert call.args[1] == ["admin", "trino", "catalogs", "sync-and-restart"]

--- a/python/tests/core/test_trino_catalog_api.py
+++ b/python/tests/core/test_trino_catalog_api.py
@@ -15,46 +15,52 @@
 #
 
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock
 
+import pytest
 from hopsworks_common.core.trino_catalog_api import TrinoCatalogApi
+
+
+def _patch_client(mocker, send_request_return=None) -> MagicMock:
+    client_instance = MagicMock()
+    client_instance._project_id = 119
+    client_instance._send_request.return_value = send_request_return
+    mocker.patch(
+        "hopsworks_common.core.trino_catalog_api.client._get_instance",
+        return_value=client_instance,
+    )
+    return client_instance
 
 
 class TestTrinoCatalogApi:
     """The request each call makes, since the contract with the backend is the whole of this class."""
 
-    def _client(self, response=None):
-        client = Mock()
-        client._project_id = 119
-        client._send_request.return_value = response
-        return client
+    def test_get_catalogs_is_project_scoped(self, mocker):
+        client = _patch_client(mocker, [{"name": "p__pg"}])
 
-    def _call(self, response, fn):
-        client = self._client(response)
-        with patch(
-            "hopsworks_common.core.trino_catalog_api.client._get_instance",
-            return_value=client,
-        ):
-            result = fn(TrinoCatalogApi())
-        return result, client._send_request.call_args
+        result = TrinoCatalogApi().get_catalogs()
 
-    def test_get_catalogs_is_project_scoped(self):
-        result, call = self._call([{"name": "p__pg"}], lambda api: api.get_catalogs())
         assert result == [{"name": "p__pg"}]
+        call = client._send_request.call_args
         assert call.args[0] == "GET"
         assert call.args[1] == ["project", 119, "trino", "catalog"]
 
-    def test_get_catalog_names_the_catalog_in_the_path(self):
-        _, call = self._call({}, lambda api: api.get_catalog("p__pg"))
+    def test_get_catalog_names_the_catalog_in_the_path(self, mocker):
+        client = _patch_client(mocker, {})
+
+        TrinoCatalogApi().get_catalog("p__pg")
+
+        call = client._send_request.call_args
         assert call.args[1] == ["project", 119, "trino", "catalog", "p__pg"]
 
-    def test_get_catalog_template_passes_the_data_source_as_query_params(self):
+    def test_get_catalog_template_passes_the_data_source_as_query_params(self, mocker):
         # The template is a GET so that asking for it creates nothing; the source it derives from
         # therefore travels as query params rather than a body.
-        _, call = self._call(
-            {"supported": True},
-            lambda api: api.get_catalog_template("snow", 67),
-        )
+        client = _patch_client(mocker, {"supported": True})
+
+        TrinoCatalogApi().get_catalog_template("snow", 67)
+
+        call = client._send_request.call_args
         assert call.args[0] == "GET"
         assert call.args[1] == ["project", 119, "trino", "catalog", "template"]
         assert call.kwargs["query_params"] == {
@@ -62,47 +68,81 @@ class TestTrinoCatalogApi:
             "featurestoreId": 67,
         }
 
-    def test_create_omits_the_data_source_when_hand_written(self):
+    def test_create_omits_the_data_source_when_hand_written(self, mocker):
         # Their absence is the signal that the properties are to be used exactly as given: sending
         # them as nulls would make the backend try to resolve credentials from a source named null.
-        _, call = self._call(
-            {},
-            lambda api: api.create_catalog("p__pg", "postgresql", {"connection-url": "jdbc:x"}),
+        client = _patch_client(mocker, {})
+
+        TrinoCatalogApi().create_catalog(
+            "p__pg", "postgresql", {"connection-url": "jdbc:x"}
         )
-        body = json.loads(call.kwargs["data"])
+
+        body = json.loads(client._send_request.call_args.kwargs["data"])
         assert body == {
             "name": "p__pg",
             "connectorType": "postgresql",
             "properties": {"connection-url": "jdbc:x"},
         }
 
-    def test_create_carries_the_data_source_when_derived(self):
-        _, call = self._call(
-            {},
-            lambda api: api.create_catalog(
-                "p__snow",
-                "snowflake",
-                {"connection-url": "jdbc:snowflake://x"},
-                data_source_name="snow",
-                featurestore_id=67,
-            ),
+    def test_create_carries_the_data_source_when_derived(self, mocker):
+        client = _patch_client(mocker, {})
+
+        TrinoCatalogApi().create_catalog(
+            "p__snow",
+            "snowflake",
+            {"connection-url": "jdbc:snowflake://x"},
+            data_source_name="snow",
+            featurestore_id=67,
         )
-        body = json.loads(call.kwargs["data"])
+
+        body = json.loads(client._send_request.call_args.kwargs["data"])
         assert body["dataSourceName"] == "snow"
         assert body["featurestoreId"] == 67
 
-    def test_update_uses_put_on_the_named_catalog(self):
-        _, call = self._call({}, lambda api: api.update_catalog("p__pg", "postgresql", {}))
+    def test_create_refuses_a_half_specified_data_source(self, mocker):
+        # One without the other cannot be resolved server-side; failing here beats an opaque
+        # backend error after the request is already sent.
+        client = _patch_client(mocker)
+
+        with pytest.raises(ValueError, match="passed together"):
+            TrinoCatalogApi().create_catalog(
+                "p__snow", "snowflake", {}, data_source_name="snow"
+            )
+        with pytest.raises(ValueError, match="passed together"):
+            TrinoCatalogApi().create_catalog(
+                "p__snow", "snowflake", {}, featurestore_id=67
+            )
+        client._send_request.assert_not_called()
+
+    def test_update_uses_put_on_the_named_catalog(self, mocker):
+        client = _patch_client(mocker, {})
+
+        TrinoCatalogApi().update_catalog("p__pg", "postgresql", {})
+
+        call = client._send_request.call_args
         assert call.args[0] == "PUT"
         assert call.args[1] == ["project", 119, "trino", "catalog", "p__pg"]
+        # The backend does not re-derive credentials on update (masked values keep the stored
+        # secret instead), so an update never carries a data source.
+        body = json.loads(call.kwargs["data"])
+        assert "dataSourceName" not in body
+        assert "featurestoreId" not in body
 
-    def test_delete_uses_delete_on_the_named_catalog(self):
-        _, call = self._call(None, lambda api: api.delete_catalog("p__pg"))
+    def test_delete_uses_delete_on_the_named_catalog(self, mocker):
+        client = _patch_client(mocker)
+
+        TrinoCatalogApi().delete_catalog("p__pg")
+
+        call = client._send_request.call_args
         assert call.args[0] == "DELETE"
         assert call.args[1] == ["project", 119, "trino", "catalog", "p__pg"]
 
-    def test_test_connection_posts_to_the_test_endpoint(self):
-        _, call = self._call(None, lambda api: api.test_connection("p__pg", "postgresql", {}))
+    def test_test_connection_posts_to_the_test_endpoint(self, mocker):
+        client = _patch_client(mocker)
+
+        TrinoCatalogApi().test_connection("p__pg", "postgresql", {})
+
+        call = client._send_request.call_args
         assert call.args[0] == "POST"
         assert call.args[1] == [
             "project",
@@ -114,10 +154,12 @@ class TestTrinoCatalogApi:
 
     # Not project-scoped, and deliberately the sync-and-restart endpoint: a plain restart would load
     # nothing, because a newly created catalog is only a record until it is written.
-    def test_restart_calls_the_admin_sync_and_restart_endpoint(self):
-        result, call = self._call(
-            {"restarted": True, "quarantined": []}, lambda api: api.restart()
-        )
+    def test_restart_calls_the_admin_sync_and_restart_endpoint(self, mocker):
+        client = _patch_client(mocker, {"restarted": True, "quarantined": []})
+
+        result = TrinoCatalogApi().restart()
+
         assert result == {"restarted": True, "quarantined": []}
+        call = client._send_request.call_args
         assert call.args[0] == "POST"
         assert call.args[1] == ["admin", "trino", "catalogs", "sync-and-restart"]


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-3045

Python client for the Trino catalog work in logicalclocks/hopsworks-ee#3222. The backend can propose, create and apply Trino catalogs from a data source, but only the UI could reach it, so making a configured data source queryable could not be scripted from a job or notebook. This PR exposes the same operations to the Python client.

**`TrinoCatalogApi`**, reached as `project.get_trino_catalog_api()`, covers the catalog lifecycle: list, get, create, update, delete, the connection test, the capabilities the cluster advertises (including `nextScheduledRestart` and whether the credential-file store is available), and the template proposed from a data source. It is kept separate from the existing `TrinoApi`, which connects and runs queries; this one manages what is connectable.

**Data-source methods live on the connector itself**, since that is the object a user already holds:

- `sc.get_trino_catalog_template()` returns the proposal: suggested name, connector type, and derived properties with credentials already resolved to references rather than values.
- `sc.create_trino_catalog()` needs no arguments. Name, connector type and properties are derived from the data source, credentials are resolved server-side into `${HOPSWORKS_SECRET:...}` references rather than copied into the request, and the connection is tested first where the cluster supports it, so an unreachable source fails before the catalog exists rather than after a restart.
- A data source that cannot be mapped raises `FeatureStoreException` carrying the backend's reason instead of returning an unusable template.

**`restart()`** applies pending catalog changes immediately for a cluster administrator. It calls sync-and-restart rather than a plain restart because a restart alone would load nothing: a newly created catalog is only a record until a sync writes it out. HOPS_ADMIN is enforced by the backend, so the client does not restate the rule; the docstring says the call needs it, warns that a restart interrupts queries cluster-wide, and points at the capabilities' `nextScheduledRestart` as the alternative to waiting.

One wire-format decision worth review: the data-source fields are omitted from the request rather than sent as nulls when a catalog is hand-written. Their absence is what tells the backend to use the properties exactly as given; a null source name would make it try to resolve credentials from a source called "null".

## Testing

9 new tests in `python/tests/core/test_trino_catalog_api.py` assert the request each call makes: paths, verbs, the template's query parameters, and that the data-source fields appear only when deriving from a source. That request contract is the whole of this client. The 11 pre-existing failures in `tests/test_storage_connector.py` are a missing pyspark in the local environment, confirmed identical with these changes stashed.

Not yet covered: the loadtest suite has no Trino catalog scenario, so no loadtest exercises the new calls, and the Python client has not itself been run end to end against a cluster. The endpoints it calls are the ones verified on `jim-trino-catalog` and `jim-af` through the UI in the backend PR, including a Snowflake catalog created from a data source with the connection test passing against real credentials.

Backend: logicalclocks/hopsworks-ee#3222. Frontend: logicalclocks/hopsworks-front#2040. Chart fix found during that verification: logicalclocks/hopsworks-helm#2209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — review round (`4512ead5e`)

A review pass against the backend contract and this repo's own CI checks, none of which had run when the PR opened, found and fixed:

- **None of the nine public methods carried `@public`**, which the `pep8_public` CI job rejects, and none carried the `usage._method_logger` telemetry every sibling api module puts on its public methods. Both added. The class-level `also_available_as` aliases are dropped instead: they preserve legacy import paths, and a new class has none, which is why `TrinoApi` and `SupersetApi` carry no aliases either.
- **docsig would have failed on five methods** missing Parameters or Returns sections; filled in.
- **Two claims the backend does not honour**: the template docstrings promised a `credentialKeys` entry that `TrinoCatalogTemplateDTO` never carried, and `update_catalog` offered `data_source_name`/`featurestore_id` although the backend PUT never resolves credentials. The phantom field is gone from the docs and the parameters are gone from `update_catalog`; masked-value retention is the real update story and is now said outright.
- A **half-specified derived create** (source name without its feature store, or the reverse) now raises `ValueError` before anything is sent, instead of an opaque backend error. The guard lives in the one `_send_catalog` helper that create, update and test-connection now share, replacing three copies of the header and serialization boilerplate.
- `create_trino_catalog`'s **name fallback tests identity rather than truthiness**, so an empty string reaches the backend's own name validation instead of silently becoming the suggested name.
- Tests moved to the pytest-mock `_patch_client` pattern the sibling test files use, gained the `ValueError` case, and pin that an update body never carries a data source. An import-sort ruff failure in `storage_connector.py` is fixed.

Verified locally with the CI's own tools: 10 tests pass; `ruff check`, `ruff format --check`, `docsig` and `check_pep8_public.py` all clean on the touched files.

**CI status:** all 19 checks pass on `4512ead5e`, including `PEP-8 / @public check`, `Lint and Stylecheck`, `test-docs-build`, and the unit-test matrix (3.10 through 3.13, Windows, no-optional-deps, pandas 1.x, legacy optional deps, typechecked).

---

## Update — docstring fixes from review (`92476a60d`)

Two review comments, both valid: the repo's convention is one sentence per line in a docstring and these paragraphs wrapped mid-sentence instead, so the prose in both data-source methods and the `properties` / `test_connection` parameter descriptions are re-broken on sentence boundaries; and the project example named an API handle `catalogs`, which reads like a list of them, now `catalog_api`. Both inline comments are answered and resolved.
