### PR TITLE
[FSTORE-2029] PushDown PIT queries to Snowflake when all feature groups in a feature view are created from same snowflake connector

### DIFF
--- a/python/hsfs/constructor/fs_query.py
+++ b/python/hsfs/constructor/fs_query.py
@@ -31,6 +31,7 @@ class FsQuery:
         query_online: str | None = None,
         pit_query: str | None = None,
         pit_query_asof: str | None = None,
+        pushdown_query: str | None = None,
         hqs_payload: str | None = None,
         hqs_payload_signature: str | None = None,
         href: str | None = None,
@@ -45,6 +46,7 @@ class FsQuery:
         self._query_online = query_online
         self._pit_query = pit_query
         self._pit_query_asof = pit_query_asof
+        self._pushdown_query = pushdown_query
 
         self._hqs_payload = hqs_payload
         self._hqs_payload_signature = hqs_payload_signature
@@ -103,6 +105,16 @@ class FsQuery:
     @property
     def pit_query_asof(self) -> str | None:
         return self._pit_query_asof
+
+    @property
+    def pushdown_query(self) -> str | None:
+        """The whole query as SQL the external source can execute itself.
+
+        Set by the backend only when every feature group in the query is backed by the same
+        pushdown-capable connector.
+        None means the engine reads each feature group separately and joins them locally.
+        """
+        return self._pushdown_query
 
     @property
     def on_demand_fg_aliases(

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -124,6 +124,18 @@ class Query:
                 sql_query = self._query_constructor_api._construct_query(self, hqs=True)
             else:
                 fs_query = self._query_constructor_api._construct_query(self)
+
+                if fs_query.pushdown_query is not None:
+                    if engine._get_instance()._is_source_pushdown_supported():
+                        return (
+                            engine._get_instance()._register_pushdown_query(fs_query),
+                            online_conn,
+                        )
+                    _logger.debug(
+                        "The query can be pushed down to its source, but the current engine "
+                        "cannot execute it. Reading each feature group separately instead."
+                    )
+
                 sql_query = self._to_string(fs_query, online)
                 # Register on demand feature groups as temporary tables
                 if isinstance(self._left_feature_group, fg_mod.SpineGroup):

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -126,9 +126,10 @@ class Query:
                 fs_query = self._query_constructor_api._construct_query(self)
 
                 if fs_query.pushdown_query is not None:
-                    if engine._get_instance()._is_source_pushdown_supported():
+                    engine_instance = engine._get_instance()
+                    if engine_instance._is_source_pushdown_supported():
                         return (
-                            engine._get_instance()._register_pushdown_query(fs_query),
+                            engine_instance._register_pushdown_query(fs_query),
                             online_conn,
                         )
                     _logger.debug(

--- a/python/hsfs/core/training_dataset_engine.py
+++ b/python/hsfs/core/training_dataset_engine.py
@@ -105,6 +105,12 @@ class TrainingDatasetEngine:
         if online:
             return fs_query.query_online
 
+        if (
+            fs_query.pushdown_query is not None
+            and engine._get_instance()._is_source_pushdown_supported()
+        ):
+            return engine._get_instance()._register_pushdown_query(fs_query)
+
         # The offline queries could be referencing temporary tables
         # like external feature groups/hudi feature groups
         # Here we register those tables before returning the query to the user

--- a/python/hsfs/core/training_dataset_engine.py
+++ b/python/hsfs/core/training_dataset_engine.py
@@ -105,11 +105,10 @@ class TrainingDatasetEngine:
         if online:
             return fs_query.query_online
 
-        if (
-            fs_query.pushdown_query is not None
-            and engine._get_instance()._is_source_pushdown_supported()
-        ):
-            return engine._get_instance()._register_pushdown_query(fs_query)
+        if fs_query.pushdown_query is not None:
+            engine_instance = engine._get_instance()
+            if engine_instance._is_source_pushdown_supported():
+                return engine_instance._register_pushdown_query(fs_query)
 
         # The offline queries could be referencing temporary tables
         # like external feature groups/hudi feature groups

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -613,6 +613,16 @@ class Engine:
             df = pd.DataFrame(results, columns=feature_names, index=None)
         return self._return_dataframe_type(df, dataframe_type)
 
+    def _is_source_pushdown_supported(self) -> bool:
+        # FlyingDuck fetches each feature group separately through its own connector entry, so a
+        # single pushed-down query has nowhere to go until that payload can carry one.
+        return False
+
+    def _register_pushdown_query(self, fs_query: FsQuery) -> str:
+        raise NotImplementedError(
+            "Source pushdown is not supported by the python engine."
+        )
+
     def _register_external_temporary_table(
         self, external_fg: ExternalFeatureGroup, alias: str
     ) -> None:

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -142,7 +142,9 @@ class Engine:
     APPEND = "append"
     OVERWRITE = "overwrite"
 
-    PUSHDOWN_RESULT_VIEW = "pushdown_result_hopsworks"
+    # Prefix only; each registration appends a unique suffix so two pushdown reads in one
+    # session cannot land on the same view.
+    PUSHDOWN_RESULT_VIEW_PREFIX = "pushdown_result_hopsworks"
 
     def _create_spark_session(self):
         """Create and return a SparkSession.
@@ -297,8 +299,11 @@ class Engine:
             if column != column.lower():
                 dataframe = dataframe.withColumnRenamed(column, column.lower())
 
-        dataframe.createOrReplaceTempView(self.PUSHDOWN_RESULT_VIEW)
-        return f"SELECT * FROM {self.PUSHDOWN_RESULT_VIEW}"
+        # A fixed name would let two concurrent reads in one session overwrite each other's
+        # result between registration and execution, and answer from the wrong one.
+        view = f"{self.PUSHDOWN_RESULT_VIEW_PREFIX}_{uuid.uuid4().hex}"
+        dataframe.createOrReplaceTempView(view)
+        return f"SELECT * FROM {view}"
 
     def _register_external_temporary_table(self, external_fg, alias):
         if not isinstance(external_fg, fg_mod.SpineGroup):

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -142,6 +142,8 @@ class Engine:
     APPEND = "append"
     OVERWRITE = "overwrite"
 
+    PUSHDOWN_RESULT_VIEW = "pushdown_result_hopsworks"
+
     def _create_spark_session(self):
         """Create and return a SparkSession.
 
@@ -277,6 +279,26 @@ class Engine:
         if self._is_connect:
             return
         self._spark_session.sparkContext.setJobGroup(group_id, description)
+
+    def _is_source_pushdown_supported(self):
+        return True
+
+    def _register_pushdown_query(self, fs_query):
+        external_fg = fs_query.on_demand_fg_aliases[0].on_demand_feature_group
+        dataframe = external_fg.data_source.storage_connector.read(
+            fs_query.pushdown_query
+        )
+
+        # Feature names in the feature store are always lower case, while a warehouse that folds
+        # unquoted identifiers returns them upper case. Lower casing can only move a returned
+        # column towards its feature name, so it stays correct for warehouses that fold the other
+        # way or not at all.
+        for column in dataframe.columns:
+            if column != column.lower():
+                dataframe = dataframe.withColumnRenamed(column, column.lower())
+
+        dataframe.createOrReplaceTempView(self.PUSHDOWN_RESULT_VIEW)
+        return f"SELECT * FROM {self.PUSHDOWN_RESULT_VIEW}"
 
     def _register_external_temporary_table(self, external_fg, alias):
         if not isinstance(external_fg, fg_mod.SpineGroup):

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -1788,7 +1788,12 @@ class SnowflakeConnector(StorageConnector):
     def connector_options(self) -> dict[str, Any] | None:
         """Prepare a Python dictionary with the needed arguments for you to connect to a Snowflake database.
 
-        It is useful for the `snowflake.connector` Python library.
+        It is useful for the `snowflake.connector` Python library, which this client does
+        not depend on and does not install. Install it yourself to use the example below:
+
+        ```bash
+        pip install snowflake-connector-python
+        ```
 
         ```python
         import snowflake.connector

--- a/python/tests/constructor/test_fs_query.py
+++ b/python/tests/constructor/test_fs_query.py
@@ -44,6 +44,7 @@ class TestFsQuery:
         )
         assert q.query_online == "test_query_online"
         assert q.pit_query == "test_pit_query"
+        assert q.pushdown_query == "test_pushdown_query"
 
     def test_from_response_json_basic_info(self, backend_fixtures):
         # Arrange
@@ -58,3 +59,4 @@ class TestFsQuery:
         assert len(q._hudi_cached_feature_groups) == 0
         assert q.query_online is None
         assert q.pit_query is None
+        assert q.pushdown_query is None

--- a/python/tests/constructor/test_query.py
+++ b/python/tests/constructor/test_query.py
@@ -698,6 +698,7 @@ class TestQuery:
         mocker.patch("hsfs.engine._get_type", return_value="spark")
 
         mock_fs_query = mocker.MagicMock(spec=FsQuery)
+        mock_fs_query.pushdown_query = None
         mock_fs_query.query = "SELECT * FROM test"
         mock_fs_query.on_demand_feature_groups = []
         mock_fs_query.hudi_cached_feature_groups = []
@@ -718,12 +719,61 @@ class TestQuery:
         mock_fs_query._register_delta_tables.assert_called()
         mock_fs_query._register_hudi_tables.assert_called()
 
+    def test_prep_read_source_pushdown(self, mocker):
+        mocker.patch("hsfs.engine._get_type", return_value="spark")
+        mock_engine = mocker.MagicMock()
+        mock_engine._is_flyingduck_query_supported.return_value = False
+        mock_engine._is_source_pushdown_supported.return_value = True
+        mock_engine._register_pushdown_query.return_value = "SELECT * FROM pushed_down"
+        mocker.patch("hsfs.engine._get_instance", return_value=mock_engine)
+
+        mock_fs_query = mocker.MagicMock(spec=FsQuery)
+        mock_fs_query.pushdown_query = "SELECT * FROM SALES_DB.PUBLIC.FG0 AS fg0"
+        mocker.patch(
+            "hsfs.core.query_constructor_api.QueryConstructorApi._construct_query",
+            return_value=mock_fs_query,
+        )
+
+        sql_query, _ = TestQuery.fg1.select_all()._prep_read(
+            online=False, read_options={}
+        )
+
+        assert sql_query == "SELECT * FROM pushed_down"
+        mock_engine._register_pushdown_query.assert_called_once_with(mock_fs_query)
+        mock_fs_query._register_external.assert_not_called()
+        mock_fs_query._register_hudi_tables.assert_not_called()
+
+    def test_prep_read_source_pushdown_unsupported_engine(self, mocker):
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        mock_engine = mocker.MagicMock()
+        mock_engine._is_flyingduck_query_supported.return_value = False
+        mock_engine._is_source_pushdown_supported.return_value = False
+        mocker.patch("hsfs.engine._get_instance", return_value=mock_engine)
+
+        mock_fs_query = mocker.MagicMock(spec=FsQuery)
+        mock_fs_query.pushdown_query = "SELECT * FROM SALES_DB.PUBLIC.FG0 AS fg0"
+        mock_fs_query.query = "SELECT * FROM test"
+        mock_fs_query.pit_query = None
+        mocker.patch(
+            "hsfs.core.query_constructor_api.QueryConstructorApi._construct_query",
+            return_value=mock_fs_query,
+        )
+
+        sql_query, _ = TestQuery.fg1.select_all()._prep_read(
+            online=False, read_options={}
+        )
+
+        assert sql_query == "SELECT * FROM test"
+        mock_engine._register_pushdown_query.assert_not_called()
+        mock_fs_query._register_external.assert_called()
+
     def test_prep_hudi_delta_fg_join(self, mocker):
         engine = spark.Engine()
         mocker.patch("hsfs.engine._get_instance", return_value=engine)
         mocker.patch("hsfs.engine._get_type", return_value="spark")
 
         mock_fs_query = mocker.MagicMock(spec=FsQuery)
+        mock_fs_query.pushdown_query = None
         mock_fs_query.query = "SELECT * FROM test"
         mock_fs_query.on_demand_feature_groups = []
         mock_fs_query.hudi_cached_feature_groups = []
@@ -779,6 +829,7 @@ class TestQuery:
         mocker.patch("hsfs.engine._get_instance", return_value=mock_engine)
 
         mock_fs_query = mocker.MagicMock(spec=FsQuery)
+        mock_fs_query.pushdown_query = None
         mock_fs_query.query = "SELECT * FROM test"
         mock_fs_query.on_demand_feature_groups = []
         mock_fs_query.hudi_cached_feature_groups = []
@@ -802,6 +853,7 @@ class TestQuery:
         mocker.patch("hsfs.engine._get_instance", return_value=mock_engine)
 
         mock_fs_query = mocker.MagicMock(spec=FsQuery)
+        mock_fs_query.pushdown_query = None
         mock_fs_query.query = "SELECT * FROM test"
         mock_fs_query.on_demand_feature_groups = []
         mock_fs_query.hudi_cached_feature_groups = []

--- a/python/tests/core/test_training_dataset_engine.py
+++ b/python/tests/core/test_training_dataset_engine.py
@@ -265,6 +265,9 @@ class TestTrainingDatasetEngine:
         td_engine = training_dataset_engine.TrainingDatasetEngine(feature_store_id)
 
         mock_td_api.return_value._get_query.return_value.pit_query = None
+        # Explicit: on a MagicMock this attribute is a truthy mock, which would send the
+        # call down the pushdown branch. This test is the per-feature-group path.
+        mock_td_api.return_value._get_query.return_value.pushdown_query = None
 
         # Act
         result = td_engine._query(
@@ -291,6 +294,9 @@ class TestTrainingDatasetEngine:
 
         td_engine = training_dataset_engine.TrainingDatasetEngine(feature_store_id)
 
+        # See test_query: without this the truthy mock takes the pushdown branch.
+        mock_td_api.return_value._get_query.return_value.pushdown_query = None
+
         # Act
         result = td_engine._query(
             training_dataset=None, online=None, with_label=None, is_hive_query=None
@@ -307,6 +313,56 @@ class TestTrainingDatasetEngine:
             == 1
         )
         assert result == mock_td_api.return_value._get_query.return_value.pit_query
+
+    def test_query_pushdown(self, mocker):
+        # Arrange
+        feature_store_id = 99
+
+        mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
+        mock_engine = mocker.patch("hsfs.engine._get_instance")
+        mock_engine.return_value._is_source_pushdown_supported.return_value = True
+
+        td_engine = training_dataset_engine.TrainingDatasetEngine(feature_store_id)
+
+        fs_query = mock_td_api.return_value._get_query.return_value
+        fs_query.pushdown_query = "SELECT 1"
+
+        # Act
+        result = td_engine._query(
+            training_dataset=None, online=None, with_label=None, is_hive_query=None
+        )
+
+        # Assert
+        assert result == mock_engine.return_value._register_pushdown_query.return_value
+        # The whole point of pushing down is that no feature group is read separately.
+        assert fs_query._register_external.call_count == 0
+        assert fs_query._register_hudi_tables.call_count == 0
+
+    def test_query_pushdown_declined_by_engine(self, mocker):
+        # Arrange
+        feature_store_id = 99
+
+        mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
+        mock_engine = mocker.patch("hsfs.engine._get_instance")
+        mock_engine.return_value._is_source_pushdown_supported.return_value = False
+
+        td_engine = training_dataset_engine.TrainingDatasetEngine(feature_store_id)
+
+        fs_query = mock_td_api.return_value._get_query.return_value
+        fs_query.pushdown_query = "SELECT 1"
+        fs_query.pit_query = None
+
+        # Act
+        result = td_engine._query(
+            training_dataset=None, online=None, with_label=None, is_hive_query=None
+        )
+
+        # Assert
+        # Declining has to leave the existing route intact, which is what makes the
+        # backend safe to populate the field for every engine.
+        assert mock_engine.return_value._register_pushdown_query.call_count == 0
+        assert fs_query._register_external.call_count == 1
+        assert result == fs_query.query
 
     def test_query_online(self, mocker):
         # Arrange

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -38,6 +38,7 @@ from hsfs import (
     util,
 )
 from hsfs.client import exceptions
+from hsfs.constructor import fs_query as fs_query_mod
 from hsfs.constructor import hudi_feature_group_alias, query
 from hsfs.core import data_source as ds
 from hsfs.core import online_ingestion, training_dataset_engine
@@ -617,6 +618,31 @@ class TestSpark:
 
         # Assert
         assert mock_sc_read.return_value.createOrReplaceTempView.call_count == 1
+
+    def test_register_pushdown_query(self, mocker, backend_fixtures):
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+
+        spark_engine = spark.Engine()
+
+        json = backend_fixtures["fs_query"]["get"]["response"]
+        fs_query = fs_query_mod.FsQuery.from_response_json(json)
+
+        # A warehouse that folds unquoted identifiers hands back upper-case columns, while
+        # feature names in the feature store are always lower case.
+        mocker.patch(
+            "hsfs.storage_connector.JdbcConnector.read",
+            return_value=spark_engine._spark_session.createDataFrame(
+                [("key", 1)], ["PK1", "Value_2"]
+            ),
+        )
+
+        # Act
+        result = spark_engine._register_pushdown_query(fs_query)
+
+        # Assert
+        assert result == "SELECT * FROM pushdown_result_hopsworks"
+        assert spark_engine._spark_session.sql(result).columns == ["pk1", "value_2"]
 
     def test_register_hudi_temporary_table(self, mocker):
         # Arrange

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -641,8 +641,38 @@ class TestSpark:
         result = spark_engine._register_pushdown_query(fs_query)
 
         # Assert
-        assert result == "SELECT * FROM pushdown_result_hopsworks"
+        # The view name carries a unique suffix, so match the prefix and read the view back.
+        assert result.startswith("SELECT * FROM pushdown_result_hopsworks_")
         assert spark_engine._spark_session.sql(result).columns == ["pk1", "value_2"]
+
+    def test_register_pushdown_query_uses_a_distinct_view_per_call(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+
+        spark_engine = spark.Engine()
+
+        json = backend_fixtures["fs_query"]["get"]["response"]
+        fs_query = fs_query_mod.FsQuery.from_response_json(json)
+
+        mocker.patch(
+            "hsfs.storage_connector.JdbcConnector.read",
+            side_effect=[
+                spark_engine._spark_session.createDataFrame([("a",)], ["PK1"]),
+                spark_engine._spark_session.createDataFrame([("b",)], ["PK1"]),
+            ],
+        )
+
+        # Act
+        first = spark_engine._register_pushdown_query(fs_query)
+        second = spark_engine._register_pushdown_query(fs_query)
+
+        # Assert
+        # Two reads in one session must not answer from each other's result.
+        assert first != second
+        assert spark_engine._spark_session.sql(first).collect()[0][0] == "a"
+        assert spark_engine._spark_session.sql(second).collect()[0][0] == "b"
 
     def test_register_hudi_temporary_table(self, mocker):
         # Arrange

--- a/python/tests/fixtures/fs_query_fixtures.json
+++ b/python/tests/fixtures/fs_query_fixtures.json
@@ -39,6 +39,7 @@
       ],
       "query_online": "test_query_online",
       "pit_query": "test_pit_query",
+      "pushdown_query": "test_pushdown_query",
       "href": "test_href",
       "expand": "test_expand",
       "items": "test_items",


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2029

Consume the pushdown query the backend now sets on the query response. When every feature group in a query comes from the same Snowflake data source, the backend sends back the whole query as SQL the warehouse can execute; the client reads it through the connector, registers the result as a single temporary view, and returns `SELECT * FROM <view>` so everything downstream is unchanged.

Two engine methods separate the decision from the work: one asks whether the engine can execute a pushed-down query, the other executes it. The Spark engine implements both. The python engine declines by design, which is also what makes the fallback safe: the per-feature-group aliases are still on the response, so declining costs no second round trip. Adding FlyingDuck later means implementing the same two methods.

That deferral is why acceptance criterion 6 is met for Spark only. A FlyingDuck read still fetches each feature group separately; the field is populated for it regardless, so closing the gap needs no backend or gate change.

Result columns are lower-cased on the way back. Feature names in the feature store are always lower case, while a warehouse that folds unquoted identifiers returns them upper case; lower-casing can only move a returned column towards its feature name, so it stays correct for a warehouse that folds the other way or not at all.

Requires the backend change in `logicalclocks/hopsworks-ee` (FSTORE-2029). Without it `pushdown_query` is never set and this code does not run.

### Verification

Exercised on a live cluster against Snowflake: a three-feature-group chain over `TPCH_SF10` returns 103,758 rows on both the pushed-down and the per-feature-group path, with `exceptAll` zero in both directions. Integration coverage lands in `logicalclocks/loadtest` (FSTORE-2029).

Unit tests cover both sides of the engine decision for a training-dataset read, and the lower-casing of returned columns is asserted through a real Spark dataframe rather than a mocked rename. Note that the branch that consults the engine is new to this method, so two existing tests that build the query response as a mock had to state explicitly that they exercise the per-feature-group path.

Note for anyone testing a dev build of this client: the version string is identical on this branch and on `main`, so it cannot tell them apart. Check `hasattr(FsQuery, "pushdown_query")` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
