### PR TITLE
[FSTORE-2066] Fixes for stats computation / feature monitoring (#1054)

### DIFF
--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfile.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfile.java
@@ -34,11 +34,13 @@ class ColumnProfile {
   private final double completeness;
   private final long numRecordsNonNull;
   private final long numRecordsNull;
-  private final double distinctness;
-  private final double entropy;
-  private final double uniqueness;
+  // uniqueness-family stats are null when exactUniqueness is disabled, so the
+  // serializer omits their keys and consumers deserialize them as absent
+  private final Double distinctness;
+  private final Double entropy;
+  private final Double uniqueness;
   private final long approximateNumDistinctValues;
-  private final long exactNumDistinctValues;
+  private final Long exactNumDistinctValues;
 
   private final Double mean;
   private final Double maximum;
@@ -97,15 +99,15 @@ class ColumnProfile {
     return numRecordsNull;
   }
 
-  double getDistinctness() {
+  Double getDistinctness() {
     return distinctness;
   }
 
-  double getEntropy() {
+  Double getEntropy() {
     return entropy;
   }
 
-  double getUniqueness() {
+  Double getUniqueness() {
     return uniqueness;
   }
 
@@ -113,7 +115,7 @@ class ColumnProfile {
     return approximateNumDistinctValues;
   }
 
-  long getExactNumDistinctValues() {
+  Long getExactNumDistinctValues() {
     return exactNumDistinctValues;
   }
 
@@ -160,11 +162,11 @@ class ColumnProfile {
     private double completeness;
     private long numRecordsNonNull;
     private long numRecordsNull;
-    private double distinctness;
-    private double entropy;
-    private double uniqueness;
+    private Double distinctness;
+    private Double entropy;
+    private Double uniqueness;
     private long approximateNumDistinctValues;
-    private long exactNumDistinctValues;
+    private Long exactNumDistinctValues;
     private Double mean;
     private Double maximum;
     private Double minimum;
@@ -200,17 +202,17 @@ class ColumnProfile {
       return this;
     }
 
-    Builder distinctness(double value) {
+    Builder distinctness(Double value) {
       this.distinctness = value;
       return this;
     }
 
-    Builder entropy(double value) {
+    Builder entropy(Double value) {
       this.entropy = value;
       return this;
     }
 
-    Builder uniqueness(double value) {
+    Builder uniqueness(Double value) {
       this.uniqueness = value;
       return this;
     }
@@ -220,7 +222,7 @@ class ColumnProfile {
       return this;
     }
 
-    Builder exactNumDistinctValues(long value) {
+    Builder exactNumDistinctValues(Long value) {
       this.exactNumDistinctValues = value;
       return this;
     }

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -50,27 +50,33 @@ import java.util.Map;
  * <h3>KLL gating divergence from Deequ</h3>
  *
  * <p>Deequ always emits {@code kll} for numeric columns regardless of {@code withKLLProfiling()};
- * the toggle is a no-op in 2.0.7-spark-3.5. This implementation emits {@code kll} only when
- * {@code kll=true}, aligning with the Phase-1 API contract. The {@code kll=false} path produces
- * smaller profiles. The golden-parity test (task #6) accounts for this known divergence.
+ * the toggle is a no-op in 2.0.7-spark-3.5.
+ * This implementation emits {@code kll} only when {@code kll=true}, aligning with the Phase-1
+ * API contract.
+ * The {@code kll=false} path produces smaller profiles.
+ * The golden-parity test (task #6) accounts for this known divergence.
  *
  * <h3>Entropy computation</h3>
  *
  * <p>Shannon entropy is derived from the exact per-value frequency distribution via
- * {@code groupBy(col).count()} per column. For numeric columns where all values are unique
- * this equals {@code ln(exactNumDistinctValues)}, but the groupBy is required for correctness
- * when duplicates exist.
+ * {@code groupBy(col).count()} per column.
+ * For numeric columns where all values are unique this equals
+ * {@code ln(exactNumDistinctValues)}, but the groupBy is required for correctness when
+ * duplicates exist.
  *
  * <h3>Uniqueness formula</h3>
  *
- * <p>{@code uniqueness = max(0, (2 * exactDistinct - nonNull) / nonNull)} — verified against
- * the Deequ baseline. This formula holds because Deequ defines uniqueness as the fraction of
- * values appearing exactly once, and with random integers most duplicates appear exactly twice.
+ * <p>{@code uniqueness = singletons / nonNull}: Deequ's exact definition (fraction of values
+ * appearing exactly once).
+ * The singleton count comes from the same per-value frequency pass as entropy, so no
+ * additional Spark job is paid for it.
+ * (An earlier shortcut, {@code (2 * exactDistinct - nonNull) / nonNull}, is only equivalent
+ * when no value occurs more than twice and undercounts otherwise.)
  *
  * <h3>stdDev</h3>
  *
- * <p>Uses Spark's {@code stddev_pop()} (population standard deviation, dividing by n). Deequ's
- * StandardDeviation metric also uses population stddev — verified against the baseline.
+ * <p>Uses Spark's {@code stddev_pop()} (population standard deviation, dividing by n).
+ * Deequ's StandardDeviation metric also uses population stddev; verified against the baseline.
  */
 public class ColumnProfiler {
 
@@ -116,7 +122,12 @@ public class ColumnProfiler {
       }
 
       Row aggRow = computeScalars(df, columns, exactUniqueness);
-      Map<String, Double> entropyMap = computeEntropy(df, columns);
+      // entropy and the uniqueness singleton count are derived from exact per-value
+      // frequencies; only pay for the per-column groupBy when exact uniqueness
+      // stats were requested
+      Map<String, ValueFrequencyStats> frequencyStatsMap = exactUniqueness
+          ? computeValueFrequencyStats(df, columns)
+          : new LinkedHashMap<String, ValueFrequencyStats>();
 
       Map<String, Map<String, Double>> correlationMap =
           new LinkedHashMap<String, Map<String, Double>>();
@@ -126,7 +137,7 @@ public class ColumnProfiler {
 
       List<ColumnProfile> profiles = new ArrayList<ColumnProfile>(columns.size());
       for (ColumnInfo col : columns) {
-        ColumnProfile cp = buildProfile(df, col, aggRow, entropyMap, correlationMap,
+        ColumnProfile cp = buildProfile(df, col, aggRow, frequencyStatsMap, correlationMap,
             histogram, histogramBins, kll, exactUniqueness);
         profiles.add(cp);
       }
@@ -210,18 +221,31 @@ public class ColumnProfiler {
   }
 
   // ---------------------------------------------------------------------------
-  // Pass 2: entropy — one groupBy per column
+  // Pass 2: per-value frequencies (entropy + uniqueness singletons) — one groupBy per column
   // ---------------------------------------------------------------------------
 
-  private Map<String, Double> computeEntropy(Dataset<Row> df, List<ColumnInfo> columns) {
-    Map<String, Double> result = new LinkedHashMap<String, Double>();
+  /** Per-column stats derived from the exact per-value frequency distribution. */
+  private static final class ValueFrequencyStats {
+    private final double entropy;
+    private final long singletons;
+
+    private ValueFrequencyStats(double entropy, long singletons) {
+      this.entropy = entropy;
+      this.singletons = singletons;
+    }
+  }
+
+  private Map<String, ValueFrequencyStats> computeValueFrequencyStats(Dataset<Row> df,
+      List<ColumnInfo> columns) {
+    Map<String, ValueFrequencyStats> result = new LinkedHashMap<String, ValueFrequencyStats>();
     for (ColumnInfo col : columns) {
-      result.put(col.name, computeColumnEntropy(df, col.name));
+      result.put(col.name, computeColumnValueFrequencyStats(df, col.name));
     }
     return result;
   }
 
-  private double computeColumnEntropy(Dataset<Row> df, String columnName) {
+  private ValueFrequencyStats computeColumnValueFrequencyStats(Dataset<Row> df,
+      String columnName) {
     Column cc = functions.col(columnName);
     List<Row> rows = df.filter(cc.isNotNull())
         .groupBy(cc)
@@ -230,14 +254,19 @@ public class ColumnProfiler {
         .collectAsList();
 
     if (rows.isEmpty()) {
-      return 0.0;
+      return new ValueFrequencyStats(0.0, 0L);
     }
     long total = 0;
+    long singletons = 0;
     for (Row row : rows) {
-      total += row.getLong(0);
+      long count = row.getLong(0);
+      total += count;
+      if (count == 1) {
+        singletons++;
+      }
     }
     if (total == 0) {
-      return 0.0;
+      return new ValueFrequencyStats(0.0, 0L);
     }
     double entropy = 0.0;
     for (Row row : rows) {
@@ -247,7 +276,7 @@ public class ColumnProfiler {
         entropy -= pp * Math.log(pp);
       }
     }
-    return entropy;
+    return new ValueFrequencyStats(entropy, singletons);
   }
 
   // ---------------------------------------------------------------------------
@@ -282,7 +311,7 @@ public class ColumnProfiler {
   // ---------------------------------------------------------------------------
 
   private ColumnProfile buildProfile(Dataset<Row> df, ColumnInfo col, Row aggRow,
-      Map<String, Double> entropyMap,
+      Map<String, ValueFrequencyStats> frequencyStatsMap,
       Map<String, Map<String, Double>> correlationMap,
       boolean histogram, int histogramBins, boolean kll, boolean exactUniqueness) {
     String nn = col.name;
@@ -294,18 +323,19 @@ public class ColumnProfiler {
     long total = nonNull + nullCount;
     long approxDistinct = aggRow.getAs(nn + "__approx_distinct");
     // exactNumDistinctValues + derived stats (distinctness/uniqueness/entropy) are only
-    // meaningful when exactUniqueness=true. When false we leave them at 0; the serializer
-    // still emits the keys (matching Deequ's shape, which is always keys-present).
-    long exactDistinct = exactUniqueness ? (Long) aggRow.getAs(nn + "__exact_distinct") : 0L;
+    // meaningful when exactUniqueness=true. When false they stay null and the serializer
+    // omits their keys, so consumers deserialize them as absent instead of a bogus 0.
+    Long exactDistinct = exactUniqueness ? (Long) aggRow.getAs(nn + "__exact_distinct") : null;
+    ValueFrequencyStats freqStats = frequencyStatsMap.get(nn);
 
     double completeness = total > 0 ? (double) nonNull / total : 0.0;
-    double distinctness = exactUniqueness && nonNull > 0
-        ? (double) exactDistinct / nonNull : 0.0;
-    double uniqueness = exactUniqueness && nonNull > 0
-        ? Math.max(0.0, (double) (2L * exactDistinct - nonNull) / nonNull)
-        : 0.0;
-    double entropy = exactUniqueness && entropyMap.containsKey(nn)
-        ? entropyMap.get(nn) : 0.0;
+    Double distinctness = exactUniqueness
+        ? (nonNull > 0 ? (double) exactDistinct / nonNull : 0.0) : null;
+    Double uniqueness = exactUniqueness
+        ? (nonNull > 0 && freqStats != null ? (double) freqStats.singletons / nonNull : 0.0)
+        : null;
+    Double entropy = exactUniqueness
+        ? (freqStats != null ? freqStats.entropy : 0.0) : null;
 
     ColumnProfile.Builder builder = new ColumnProfile.Builder()
         .columnName(nn)

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -34,6 +34,9 @@ import java.util.Map;
  * {@code column, dataType, isDataTypeInferred, completeness, numRecordsNonNull, numRecordsNull,
  * distinctness, entropy, uniqueness, approximateNumDistinctValues, exactNumDistinctValues,
  * mean, maximum, minimum, sum, stdDev, correlations, histogram, kll, approxPercentiles}.
+ * The uniqueness-family keys ({@code distinctness, entropy, uniqueness, exactNumDistinctValues})
+ * are omitted when exactUniqueness is disabled — a deliberate divergence from Deequ's
+ * always-keys-present shape, so consumers see them as absent instead of a bogus 0.
  *
  * <p>Categorical/Boolean columns omit {@code mean, maximum, minimum, sum, stdDev, correlations,
  * kll, approxPercentiles}.
@@ -89,16 +92,17 @@ class ProfileJsonSerializer {
     map.put("completeness", profile.getCompleteness());
     map.put("numRecordsNonNull", profile.getNumRecordsNonNull());
     map.put("numRecordsNull", profile.getNumRecordsNull());
-    map.put("distinctness", profile.getDistinctness());
-    map.put("entropy", profile.getEntropy());
-    map.put("uniqueness", profile.getUniqueness());
-    map.put("approximateNumDistinctValues", profile.getApproximateNumDistinctValues());
-    map.put("exactNumDistinctValues", profile.getExactNumDistinctValues());
-    map.put("mean", profile.getMean());
-    map.put("maximum", profile.getMaximum());
-    map.put("minimum", profile.getMinimum());
-    map.put("sum", profile.getSum());
-    map.put("stdDev", profile.getStdDev());
+    putUniquenessFamily(map, profile);
+    // Spark's avg/min/max/sum/stddev_pop return null over an all-null column.
+    // Emitting "mean": null (etc.) would crash the has()->getDouble() parsers
+    // (org.json has() is true for JSON null, getDouble throws on it), so omit
+    // the key instead: "absent = not computed", the same contract as the
+    // uniqueness family above.
+    putIfNotNull(map, "mean", profile.getMean());
+    putIfNotNull(map, "maximum", profile.getMaximum());
+    putIfNotNull(map, "minimum", profile.getMinimum());
+    putIfNotNull(map, "sum", profile.getSum());
+    putIfNotNull(map, "stdDev", profile.getStdDev());
     if (profile.getCorrelations() != null) {
       map.put("correlations", buildCorrelationsList(profile.getCorrelations()));
     }
@@ -123,15 +127,39 @@ class ProfileJsonSerializer {
     map.put("completeness", profile.getCompleteness());
     map.put("numRecordsNonNull", profile.getNumRecordsNonNull());
     map.put("numRecordsNull", profile.getNumRecordsNull());
-    map.put("distinctness", profile.getDistinctness());
-    map.put("entropy", profile.getEntropy());
-    map.put("uniqueness", profile.getUniqueness());
-    map.put("approximateNumDistinctValues", profile.getApproximateNumDistinctValues());
-    map.put("exactNumDistinctValues", profile.getExactNumDistinctValues());
+    putUniquenessFamily(map, profile);
     if (profile.getHistogram() != null) {
       map.put("histogram", profile.getHistogram());
     }
     return map;
+  }
+
+  /**
+   * Emits the uniqueness-family stats, omitting the keys when they were not computed
+   * (exactUniqueness disabled) so consumers deserialize them as absent instead of a
+   * bogus 0.
+   * Divergence from Deequ's always-keys-present shape is deliberate.
+   */
+  private void putUniquenessFamily(Map<String, Object> map, ColumnProfile profile) {
+    if (profile.getDistinctness() != null) {
+      map.put("distinctness", profile.getDistinctness());
+    }
+    if (profile.getEntropy() != null) {
+      map.put("entropy", profile.getEntropy());
+    }
+    if (profile.getUniqueness() != null) {
+      map.put("uniqueness", profile.getUniqueness());
+    }
+    map.put("approximateNumDistinctValues", profile.getApproximateNumDistinctValues());
+    if (profile.getExactNumDistinctValues() != null) {
+      map.put("exactNumDistinctValues", profile.getExactNumDistinctValues());
+    }
+  }
+
+  private static void putIfNotNull(Map<String, Object> map, String key, Object value) {
+    if (value != null) {
+      map.put(key, value);
+    }
   }
 
   private List<Map<String, Object>> buildCorrelationsList(Map<String, Double> correlations) {

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -161,6 +161,73 @@ public class ColumnProfilerSmokeTest {
     Assertions.assertNull(cBool.get("kll"), "c_bool must NOT have kll field");
   }
 
+  @Test
+  void omitsUniquenessFamilyWhenExactUniquenessDisabled() throws Exception {
+    Dataset<Row> df = buildDataset();
+
+    String json = new ColumnProfiler().profile(df, null, false, false, 20, false, false);
+
+    JsonNode columns = new ObjectMapper().readTree(json).get("columns");
+    for (JsonNode col : columns) {
+      String name = col.get("column").asText();
+      Assertions.assertFalse(col.has("uniqueness"),
+          name + " must not emit 'uniqueness' when exactUniqueness is disabled");
+      Assertions.assertFalse(col.has("distinctness"),
+          name + " must not emit 'distinctness' when exactUniqueness is disabled");
+      Assertions.assertFalse(col.has("entropy"),
+          name + " must not emit 'entropy' when exactUniqueness is disabled");
+      Assertions.assertFalse(col.has("exactNumDistinctValues"),
+          name + " must not emit 'exactNumDistinctValues' when exactUniqueness is disabled");
+      Assertions.assertTrue(col.has("approximateNumDistinctValues"),
+          name + " must still emit 'approximateNumDistinctValues'");
+    }
+  }
+
+  @Test
+  void emitsUniquenessFamilyWhenExactUniquenessEnabled() throws Exception {
+    Dataset<Row> df = buildDataset();
+
+    String json = new ColumnProfiler().profile(df, null, false, false, 20, true, false);
+
+    JsonNode columns = new ObjectMapper().readTree(json).get("columns");
+    for (JsonNode col : columns) {
+      String name = col.get("column").asText();
+      Assertions.assertTrue(col.has("uniqueness"),
+          name + " must emit 'uniqueness' when exactUniqueness is enabled");
+      Assertions.assertTrue(col.has("distinctness"),
+          name + " must emit 'distinctness' when exactUniqueness is enabled");
+      Assertions.assertTrue(col.has("entropy"),
+          name + " must emit 'entropy' when exactUniqueness is enabled");
+      Assertions.assertTrue(col.has("exactNumDistinctValues"),
+          name + " must emit 'exactNumDistinctValues' when exactUniqueness is enabled");
+    }
+  }
+
+  @Test
+  void uniquenessCountsSingletonsWithHighMultiplicity() throws Exception {
+    // 15 values; 5 occurs three times, 4/3/2/1 twice, 9/8/7/6 once.
+    // Deequ uniqueness = singletons / nonNull = 4/15. The former shortcut
+    // (2*distinct - n)/n gave 3/15 whenever a value occurred more than twice.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("col_1", DataTypes.IntegerType, true),
+    });
+    int[] values = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1, 9, 8, 7, 6, 5};
+    List<Row> rows = new ArrayList<>(values.length);
+    for (int value : values) {
+      rows.add(RowFactory.create(value));
+    }
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, false, 20, true, false);
+
+    JsonNode col = findColumn(new ObjectMapper().readTree(json).get("columns"), "col_1");
+    Assertions.assertNotNull(col);
+    Assertions.assertEquals(4.0 / 15.0, col.get("uniqueness").asDouble(), 1e-9,
+        "uniqueness must be the exact singleton fraction");
+    Assertions.assertEquals(9.0 / 15.0, col.get("distinctness").asDouble(), 1e-9);
+    Assertions.assertEquals(9, col.get("exactNumDistinctValues").asLong());
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/python/hsfs/core/delta_engine.py
+++ b/python/hsfs/core/delta_engine.py
@@ -197,13 +197,15 @@ class DeltaEngine:
             # CDC query - remove duplicates for upserts and do not include deleted rows
             # to match behavior of other engines.
             #
-            # Why retry: Delta's CDF lower-bound check uses the commit file modification
-            # time, while DeltaTable.history() returns the in-commit creation timestamp.
-            # On a freshly-created table these can differ by tens of milliseconds, so a
-            # pre-flight comparison against history() cannot reliably predict whether
-            # Delta will accept the startingTimestamp. Instead we attempt the read with
-            # startingTimestamp and, if Delta rejects it with the "before the earliest
-            # version" error, retry from the earliest commit version (startingVersion).
+            # Why retry: Delta's CDF lower-bound check and DeltaTable.history()
+            # both report the commit-file modification time (without in-commit
+            # timestamps enabled), while the startingTimestamp we pass derives
+            # from the backend-recorded commit_time, which is ~200 ms earlier.
+            # A pre-flight comparison against history() therefore cannot reliably
+            # predict whether Delta will accept the startingTimestamp. Instead we
+            # attempt the read with startingTimestamp and, if Delta rejects it
+            # with the "before the earliest version" error, retry from the
+            # earliest commit version (startingVersion).
             def _do_cdf_read(opts):
                 return (
                     self._spark_session.read.format(self.DELTA_SPARK_FORMAT)
@@ -269,17 +271,35 @@ class DeltaEngine:
             delta_fg_alias.left_feature_group_end_timestamp is not None
             and delta_fg_alias.left_feature_group_start_timestamp is None
         ):
-            # snapshot query with end time
+            # snapshot query with end time; resolve the version against the Delta
+            # log's in-commit timestamps instead of passing timestampAsOf.
+            # Delta resolves timestamp bounds against commit-file modification
+            # times, while the backend-recorded commit_time carries the log's
+            # in-commit commitInfo timestamp, which is tens to hundreds of
+            # milliseconds earlier: enough for timestampAsOf to silently resolve
+            # to the previous version (or to be rejected outright when it
+            # predates the first commit, which happens when compute_statistics
+            # runs right after a fresh insert).
             end_ts = delta_fg_alias.left_feature_group_end_timestamp
-            earliest = self._get_delta_earliest_commit(location) if location else None
-            if earliest is not None and end_ts <= earliest[1]:
-                # Requested time predates the Delta log's first commit.
-                # Happens when compute_statistics runs immediately after a fresh
-                # insert: the backend-recorded commit_time can be a few ms before
-                # the Delta log's first commit, and Delta rejects timestampAsOf
-                # in that range. Fall back to versionAsOf on the earliest commit.
+            commits = self._get_delta_commits(location) if location else None
+            if commits:
+                # Highest version committed at or before end_ts.
+                # commitInfo timestamps are not guaranteed monotonic in version
+                # (concurrent writers / commit retries), so stop at the first
+                # commit past end_ts rather than letting a later out-of-order
+                # commit select too high a version.
+                # When end_ts predates every commit the earliest version is
+                # pinned; if the window genuinely ended before the first commit
+                # this reads post-window data instead of returning empty
+                # (indistinguishable here from clock skew, and mirrors the
+                # Iceberg earliest-snapshot fallback).
+                version = commits[0][0]
+                for commit_version, commit_ts in commits:
+                    if commit_ts > end_ts:
+                        break
+                    version = commit_version
                 delta_options = {
-                    self.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: earliest[0],
+                    self.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: version,
                 }
             else:
                 _delta_commit_end_time = util._get_delta_datestr_from_timestamp(end_ts)
@@ -315,42 +335,93 @@ class DeltaEngine:
 
         return delta_options
 
+    def _get_delta_commits(self, location: str):
+        """Get all commits from the Delta log.
+
+        Return a list of (version, timestamp_ms) tuples sorted by version
+        ascending, or None if the log cannot be read or is empty.
+
+        The timestamps are the log's in-commit ``commitInfo.timestamp`` values,
+        the same clock the backend-recorded commit times are derived from.
+        ``DeltaTable.history()`` is deliberately NOT used here: its timestamp
+        column carries the commit-file modification time, which lags the
+        in-commit timestamp (tens to hundreds of milliseconds on HopsFS), so
+        resolving a recorded commit time against it can silently land on the
+        previous version.
+        History's modtime clock diverges for tables written by classic Spark
+        (only delta-rs and the Spark Connect writer record the in-commit clock),
+        so reading ``commitInfo.timestamp`` from the log directly is what keeps
+        resolution correct for the pyspark-driver variants too.
+        """
+        try:
+            if self._spark_session is not None:
+                from pyspark.sql import functions as F  # noqa: PLC0415
+                from pyspark.sql.types import (  # noqa: PLC0415
+                    LongType,
+                    StructField,
+                    StructType,
+                )
+
+                # explicit schema: avoids inferring/parsing the large
+                # add/remove action payloads and tolerates commitInfo rows
+                # without a timestamp
+                log_schema = StructType(
+                    [
+                        StructField(
+                            "commitInfo",
+                            StructType([StructField("timestamp", LongType())]),
+                        )
+                    ]
+                )
+                rows = (
+                    self._spark_session.read.schema(log_schema)
+                    .json(location.rstrip("/") + "/_delta_log/*.json")
+                    .withColumn("_file", F.input_file_name())
+                    .filter(F.col("commitInfo.timestamp").isNotNull())
+                    .withColumn(
+                        # anchor on the 20-digit commit basename so V2 checkpoint
+                        # manifests (<v>.checkpoint.<uuid>.json) and log-compaction
+                        # files (<x>.<y>.compacted.json) do not match and yield a
+                        # bogus version
+                        "version",
+                        F.regexp_extract(F.col("_file"), r"(\d{20})\.json$", 1).cast(
+                            "long"
+                        ),
+                    )
+                    .filter(F.col("version").isNotNull())
+                    .select("version", F.col("commitInfo.timestamp").alias("timestamp"))
+                    .collect()
+                )
+                commits = [(int(row["version"]), int(row["timestamp"])) for row in rows]
+            else:
+                # delta-rs reads the commit timestamps from the log itself, so
+                # its history() is already on the in-commit clock
+                from deltalake import DeltaTable as DeltaRsTable
+
+                history = DeltaRsTable(location, storage_options={}).history()
+                commits = [
+                    (
+                        int(commit["version"]),
+                        int(util._convert_event_time_to_timestamp(commit["timestamp"])),
+                    )
+                    for commit in history
+                ]
+            if not commits:
+                return None
+            commits.sort(key=lambda commit: commit[0])
+            return commits
+        except Exception as e:
+            _logger.debug(f"Could not read Delta log at {location}: {e}")
+            return None
+
     def _get_delta_earliest_commit(self, location: str):
         """Get earliest commit from the Delta log.
 
         Return (version, timestamp_ms) of the earliest commit in the Delta
         log at `location`, or None if the history cannot be read.
         """
-        try:
-            if self._spark_session is not None:
-                from delta.tables import DeltaTable
-
-                rows = (
-                    DeltaTable.forPath(self._spark_session, location)
-                    .history()
-                    .select("version", "timestamp")
-                    .collect()
-                )
-                if not rows:
-                    return None
-                oldest = min(rows, key=lambda r: r["version"])
-                return int(oldest["version"]), int(
-                    oldest["timestamp"].timestamp() * 1000
-                )
-
-            from deltalake import DeltaTable as DeltaRsTable
-
-            history = DeltaRsTable(location, storage_options={}).history()
-            if not history:
-                return None
-            oldest = min(history, key=lambda c: c["version"])
-            return (
-                int(oldest["version"]),
-                int(util._convert_event_time_to_timestamp(oldest["timestamp"])),
-            )
-        except Exception as e:
-            _logger.debug(f"Could not read Delta history at {location}: {e}")
-            return None
+        commits = self._get_delta_commits(location)
+        return commits[0] if commits else None
 
     def _delete_record(self, delete_df):
         storage_options = None

--- a/python/hsfs/core/feature_descriptive_statistics.py
+++ b/python/hsfs/core/feature_descriptive_statistics.py
@@ -16,6 +16,8 @@
 from __future__ import annotations
 
 import json
+import math
+import numbers
 from typing import TYPE_CHECKING
 
 import humps
@@ -25,6 +27,17 @@ from hsfs import util
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+
+def _finite_or_none(value):
+    """Map non-finite numbers (NaN, Infinity) to None.
+
+    Non-finite values are not valid JSON and not valid SQL numerics: a single
+    one aborts the whole statistics registration on the backend.
+    """
+    if isinstance(value, numbers.Real) and not math.isfinite(value):
+        return None
+    return value
 
 
 @public
@@ -187,25 +200,30 @@ class FeatureDescriptiveStatistics:
         return cls(**stats_dict)
 
     def to_dict(self):
+        percentiles = self._percentiles
+        if isinstance(percentiles, dict):
+            percentiles = {k: _finite_or_none(v) for k, v in percentiles.items()}
+        elif isinstance(percentiles, list):
+            percentiles = [_finite_or_none(v) for v in percentiles]
         _dict = {
             "id": self._id,
             "featureName": self._feature_name,
             "count": self._count,
             "featureType": self._feature_type,
-            "min": self._min,
-            "max": self._max,
-            "sum": self._sum,
-            "mean": self._mean,
-            "stdDev": self._std_dev,
-            "completeness": self._completeness,
+            "min": _finite_or_none(self._min),
+            "max": _finite_or_none(self._max),
+            "sum": _finite_or_none(self._sum),
+            "mean": _finite_or_none(self._mean),
+            "stdDev": _finite_or_none(self._std_dev),
+            "completeness": _finite_or_none(self._completeness),
             "numNonNullValues": self._num_non_null_values,
             "numNullValues": self._num_null_values,
-            "distinctness": self._distinctness,
-            "entropy": self._entropy,
-            "uniqueness": self._uniqueness,
+            "distinctness": _finite_or_none(self._distinctness),
+            "entropy": _finite_or_none(self._entropy),
+            "uniqueness": _finite_or_none(self._uniqueness),
             "approxNumDistinctValues": self._approx_num_distinct_values,
             "exactNumDistinctValues": self._exact_num_distinct_values,
-            "percentiles": self._percentiles,
+            "percentiles": percentiles,
         }
         if self._extended_statistics is not None:
             _dict["extendedStatistics"] = json.dumps(self._extended_statistics)

--- a/python/hsfs/core/feature_monitoring_result_engine.py
+++ b/python/hsfs/core/feature_monitoring_result_engine.py
@@ -551,6 +551,10 @@ class FeatureMonitoringResultEngine:
             if specific_value is not None
             else reference_statistics.get_value(metric_lower)
         )
+        if detection_value is None or reference_value is None:
+            # the metric was not computed on one of the sides (e.g. uniqueness
+            # metrics when exact_uniqueness is disabled)
+            return None
         return self._compute_difference_between_specific_values(
             detection_value, reference_value, relative
         )

--- a/python/hsfs/core/statistics_engine.py
+++ b/python/hsfs/core/statistics_engine.py
@@ -94,7 +94,9 @@ class StatisticsEngine:
             stats_str = self._profile_statistics_with_config(
                 feature_dataframe, metadata_instance.statistics_config
             )
-            desc_stats = self._parse_deequ_statistics(stats_str)
+            desc_stats = self._parse_deequ_statistics(
+                stats_str, metadata_instance.statistics_config.exact_uniqueness
+            )
             if desc_stats:
                 stats = statistics.Statistics(
                     computation_time=computation_time,
@@ -185,7 +187,7 @@ class StatisticsEngine:
                 kll=kll,
                 histogram_bins=histogram_bins,
             )
-            desc_stats = self._parse_deequ_statistics(stats_str)
+            desc_stats = self._parse_deequ_statistics(stats_str, exact_uniqueness)
 
             stats = statistics.Statistics(
                 computation_time=commit_time,
@@ -298,7 +300,9 @@ class StatisticsEngine:
                 ),
                 td_metadata_instance.statistics_config,
             )
-            desc_stats = self._parse_deequ_statistics(stats_str)
+            desc_stats = self._parse_deequ_statistics(
+                stats_str, td_metadata_instance.statistics_config.exact_uniqueness
+            )
             statistics_of_splits.append(
                 split_statistics.SplitStatistics(
                     name=split_name,
@@ -365,7 +369,8 @@ class StatisticsEngine:
         stats_str = self._profile_transformation_fn_statistics(
             feature_dataframe, columns, label_encoder_features
         )
-        desc_stats = self._parse_deequ_statistics(stats_str)
+        # _profile_transformation_fn_statistics profiles with exact_uniqueness=False
+        desc_stats = self._parse_deequ_statistics(stats_str, False)
         return statistics.Statistics(
             computation_time=computation_time,
             feature_descriptive_statistics=desc_stats,
@@ -600,7 +605,9 @@ class StatisticsEngine:
             )
         return stats
 
-    def _parse_deequ_statistics(self, stats) -> list[FeatureDescriptiveStatistics]:
+    def _parse_deequ_statistics(
+        self, stats, exact_uniqueness: bool
+    ) -> list[FeatureDescriptiveStatistics] | None:
         if stats is None:
             warnings.warn(
                 "There is no Deequ statistics to deserialize. A possible cause might be that Deequ did not succeed in the statistics computation.",
@@ -610,6 +617,18 @@ class StatisticsEngine:
             return None
         if isinstance(stats, str):
             stats = json.loads(stats)
+        if not exact_uniqueness:
+            # The JVM deequ profiler emits uniqueness-family metrics even when
+            # the Uniqueness analyzer was not requested; drop them so they stay
+            # None instead of a spurious 0.0.
+            for col_stats in stats["columns"]:
+                for key in (
+                    "uniqueness",
+                    "distinctness",
+                    "entropy",
+                    "exactNumDistinctValues",
+                ):
+                    col_stats.pop(key, None)
         return [
             FeatureDescriptiveStatistics._from_deequ_json(col_stats)
             for col_stats in stats["columns"]

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -812,25 +812,24 @@ class Engine:
         if "count" in stat:
             content_dict["count"] = stat["count"]
         if dataType != "String":
-            if "25%" in stat:
+            # pandas emits NaN for the statistics of all-null or constant
+            # columns; skip those values so they are not serialized (NaN is
+            # not valid JSON and aborts the statistics registration)
+            if "25%" in stat and not pd.isna(stat["25%"]):
                 percentiles = [0] * 100
                 percentiles[24] = stat["25%"]
                 percentiles[49] = stat["50%"]
                 percentiles[74] = stat["75%"]
                 content_dict["approxPercentiles"] = percentiles
-            if "mean" in stat:
+            if "mean" in stat and not pd.isna(stat["mean"]):
                 content_dict["mean"] = stat["mean"]
-            if (
-                "mean" in stat
-                and "count" in stat
-                and isinstance(stat["mean"], numbers.Number)
-            ):
-                content_dict["sum"] = stat["mean"] * stat["count"]
-            if "max" in stat:
+                if "count" in stat and isinstance(stat["mean"], numbers.Number):
+                    content_dict["sum"] = stat["mean"] * stat["count"]
+            if "max" in stat and not pd.isna(stat["max"]):
                 content_dict["maximum"] = stat["max"]
             if "std" in stat and not pd.isna(stat["std"]):
                 content_dict["stdDev"] = stat["std"]
-            if "min" in stat:
+            if "min" in stat and not pd.isna(stat["min"]):
                 content_dict["minimum"] = stat["min"]
         if "unique" in stat:
             content_dict["approximateNumDistinctValues"] = stat["unique"]

--- a/python/tests/core/test_delta_engine.py
+++ b/python/tests/core/test_delta_engine.py
@@ -349,7 +349,7 @@ class TestDeltaEngine:
 
     def test_setup_delta_read_opts_end_before_earliest_uses_version(self, mocker):
         # Snapshot-with-end counterpart of the same skew: an end time before the
-        # Delta log's first commit falls back to versionAsOf on the earliest commit.
+        # Delta log's first commit pins versionAsOf on the earliest commit.
         # Arrange
         _patch_client(mocker, is_external=False)
         fg = _make_fg("hopsfs://nn:8020/p")
@@ -357,15 +357,54 @@ class TestDeltaEngine:
         alias = mock.Mock()
         alias.left_feature_group_start_timestamp = None
         alias.left_feature_group_end_timestamp = 1000
-        mocker.patch.object(
-            engine, "_get_delta_earliest_commit", return_value=(3, 2000)
-        )
+        mocker.patch.object(engine, "_get_delta_commits", return_value=[(3, 2000)])
 
         # Act
         result = engine._setup_delta_read_opts(alias, "hopsfs://nn:8020/p")
 
         # Assert
         assert result == {engine.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: 3}
+
+    def test_setup_delta_read_opts_end_resolves_version_between_commits(self, mocker):
+        # Delta resolves timestampAsOf against commit-file modification times,
+        # which can be tens of milliseconds after the history()'s in-commit
+        # timestamps the backend records: an end bound equal to commit N's
+        # recorded time could silently resolve to version N-1. The end-only read
+        # therefore resolves the version against history() itself.
+        # Arrange
+        _patch_client(mocker, is_external=False)
+        fg = _make_fg("hopsfs://nn:8020/p")
+        engine = DeltaEngine(1, "fs", fg, None, None)
+        alias = mock.Mock()
+        alias.left_feature_group_start_timestamp = None
+        alias.left_feature_group_end_timestamp = 2000
+        mocker.patch.object(
+            engine, "_get_delta_commits", return_value=[(0, 1000), (1, 2000), (2, 3000)]
+        )
+
+        # Act
+        result = engine._setup_delta_read_opts(alias, "hopsfs://nn:8020/p")
+
+        # Assert: end == commit 1's recorded time resolves to exactly version 1
+        assert result == {engine.DELTA_QUERY_TIME_TRAVEL_AS_OF_VERSION: 1}
+
+    def test_setup_delta_read_opts_end_unreadable_history_uses_timestamp(self, mocker):
+        # When the Delta history cannot be read the timestamp bound is kept.
+        # Arrange
+        _patch_client(mocker, is_external=False)
+        fg = _make_fg("hopsfs://nn:8020/p")
+        engine = DeltaEngine(1, "fs", fg, None, None)
+        alias = mock.Mock()
+        alias.left_feature_group_start_timestamp = None
+        alias.left_feature_group_end_timestamp = 2000
+        mocker.patch.object(engine, "_get_delta_commits", return_value=None)
+        mocker.patch("hsfs.util._get_delta_datestr_from_timestamp", return_value="t")
+
+        # Act
+        result = engine._setup_delta_read_opts(alias, "hopsfs://nn:8020/p")
+
+        # Assert
+        assert result == {engine.DELTA_QUERY_TIME_TRAVEL_AS_OF_INSTANT: "t"}
 
     def test_generate_merge_query_primary_key_only(self, mocker):
         # Arrange

--- a/python/tests/core/test_feature_descriptive_statistics.py
+++ b/python/tests/core/test_feature_descriptive_statistics.py
@@ -383,3 +383,45 @@ class TestFeatureDescriptiveStatistics:
         assert kll.get("kllFormat") == "datasketches-native-v1"
         assert kll.get("bytes") == "AgEAAIAAAAAAAAAAAAAAAA=="
         assert "buckets" in kll
+
+    def test_to_dict_scrubs_non_finite_values(self):
+        # NaN/Infinity are not valid JSON and abort the statistics
+        # registration on the backend
+        fds = FeatureDescriptiveStatistics(
+            feature_name="constant_col",
+            count=10,
+            min=1.0,
+            max=float("inf"),
+            sum=float("-inf"),
+            mean=float("nan"),
+            std_dev=float("nan"),
+            completeness=float("nan"),
+            distinctness=float("nan"),
+            entropy=float("inf"),
+            uniqueness=0.5,
+            percentiles=[1.0, float("nan"), 3.0],
+        )
+
+        result = fds.to_dict()
+
+        assert result["min"] == 1.0
+        assert result["max"] is None
+        assert result["sum"] is None
+        assert result["mean"] is None
+        assert result["stdDev"] is None
+        assert result["completeness"] is None
+        assert result["distinctness"] is None
+        assert result["entropy"] is None
+        assert result["uniqueness"] == 0.5
+        assert result["percentiles"] == [1.0, None, 3.0]
+
+    def test_to_dict_scrubs_non_finite_percentiles_mapping(self):
+        fds = FeatureDescriptiveStatistics(
+            feature_name="amount",
+            count=10,
+            percentiles={"25%": 0.4, "50%": float("nan"), "75%": 0.86},
+        )
+
+        result = fds.to_dict()
+
+        assert result["percentiles"] == {"25%": 0.4, "50%": None, "75%": 0.86}

--- a/python/tests/core/test_feature_monitoring_result_engine.py
+++ b/python/tests/core/test_feature_monitoring_result_engine.py
@@ -287,6 +287,31 @@ class TestFeatureMonitoringResultEngine:
         assert count_specific_difference == 2
         assert none_difference is None
 
+    def test_compute_difference_between_stats_missing_metric(self):
+        # Arrange
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        # uniqueness is not computed when exact_uniqueness is disabled
+        detection_statistics = FeatureDescriptiveStatistics(
+            feature_name="amount", count=10
+        )
+        reference_statistics = FeatureDescriptiveStatistics(
+            feature_name="amount", count=10, uniqueness=0.5
+        )
+
+        # Act
+        difference = result_engine._compute_difference_between_stats(
+            detection_statistics=detection_statistics,
+            reference_statistics=reference_statistics,
+            metric="uniqueness",
+            relative=False,
+        )
+
+        # Assert
+        assert difference is None
+
     def test_compute_difference_and_shift(self):
         # Arrange
         from hsfs.core.statistics_comparison_config import StatisticsComparisonConfig

--- a/python/tests/core/test_statistics_engine.py
+++ b/python/tests/core/test_statistics_engine.py
@@ -929,3 +929,46 @@ class TestStatisticsEngine:
         assert fds_by_name["loc_delta"].count == 0
         # Assert: a warning was logged
         assert mock_logger.warning.call_count == 1
+
+    def test_parse_deequ_statistics_exact_uniqueness(self, mocker):
+        # Arrange
+        feature_store_id = 99
+
+        mocker.patch("hopsworks_common.client._get_instance")
+
+        s_engine = statistics_engine.StatisticsEngine(feature_store_id, "featuregroup")
+
+        # the deequ profiler emits uniqueness-family metrics (as 0.0) even when
+        # the Uniqueness analyzer was not requested
+        stats_str = json.dumps(
+            {
+                "columns": [
+                    {
+                        "column": "col_1",
+                        "dataType": "Integral",
+                        "numRecordsNull": 0,
+                        "numRecordsNonNull": 4,
+                        "uniqueness": 0.0,
+                        "distinctness": 0.0,
+                        "entropy": 0.0,
+                        "exactNumDistinctValues": 0,
+                    }
+                ]
+            }
+        )
+
+        # Act
+        with_uniqueness = s_engine._parse_deequ_statistics(stats_str, True)
+        without_uniqueness = s_engine._parse_deequ_statistics(stats_str, False)
+
+        # Assert
+        assert with_uniqueness[0].uniqueness == 0.0
+        assert with_uniqueness[0].distinctness == 0.0
+        assert with_uniqueness[0].entropy == 0.0
+        assert with_uniqueness[0].exact_num_distinct_values == 0
+        assert without_uniqueness[0].uniqueness is None
+        assert without_uniqueness[0].distinctness is None
+        assert without_uniqueness[0].entropy is None
+        assert without_uniqueness[0].exact_num_distinct_values is None
+        # non-uniqueness metrics are untouched
+        assert without_uniqueness[0].num_non_null_values == 4

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -1750,6 +1750,31 @@ class TestPython:
             "count": 100,
         }
 
+    def test_convert_pandas_statistics_all_null_column(self):
+        # Arrange: pandas describe() emits NaN for every statistic of an
+        # all-null column
+        python_engine = python.Engine()
+
+        stat = {
+            "25%": float("nan"),
+            "50%": float("nan"),
+            "75%": float("nan"),
+            "mean": float("nan"),
+            "count": 0,
+            "max": float("nan"),
+            "std": float("nan"),
+            "min": float("nan"),
+        }
+
+        # Act
+        result = python_engine._convert_pandas_statistics(stat=stat, dataType="Float")
+
+        # Assert: NaN values are skipped entirely
+        assert result == {
+            "dataType": "Float",
+            "count": 0,
+        }
+
     def test_validate(self):
         # Arrange
         python_engine = python.Engine()


### PR DESCRIPTION
* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Strip uniqueness-family metrics from parsed deequ statistics when exact_uniqueness is disabled. The JVM deequ profiler emits uniqueness, distinctness, entropy and exactNumDistinctValues as 0.0 even when the Uniqueness analyzer was not requested, so clients received a spurious 0.0 where None is expected. _parse_deequ_statistics now takes the exact_uniqueness flag, already in scope at all four call sites, and drops those keys before deserialization.

Guard the feature monitoring difference computation against None metric values: previously the spurious 0.0 made abs(det - ref) always succeed; with the strip in place a config tracking a uniqueness metric while exact_uniqueness is off would raise TypeError. The difference is now None when either side is missing.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Fall back to the earliest Iceberg snapshot when an end-bounded time-travel read cannot resolve its timestamp. compute_statistics runs right after a fresh insert, and the backend-recorded commit time is ms-floored, so it can land just before the table's first snapshot; Iceberg then rejects the bare as-of-timestamp with "Cannot find a snapshot older than ..." and the compute_stats job dies. The end-only branch of _setup_iceberg_read_opts now resolves the timestamp against the snapshot log first and pins the read to the earliest snapshot by snapshot-id when nothing resolves, mirroring the versionAsOf fallback the Delta engine already has for this exact case. Tables with no snapshots keep the timestamp bound.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Scrub non-finite values from client-side statistics serialization, as defense-in-depth alongside the backend sanitization. json.dumps emits bare NaN literals (invalid JSON), and a single NaN column aborted the whole statistics registration on the backend.

FeatureDescriptiveStatistics.to_dict() now maps NaN/Infinity to None for all numeric fields and percentile entries. The pandas statistics conversion skips NaN values entirely (all-null or constant columns produce NaN for mean, std, min, max and percentiles; previously only std was guarded), matching how absent deequ keys are treated.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Address Copilot review on #1054. Read the Iceberg snapshot log once in the end-only time-travel branch instead of twice on the fallback path (each read is a Spark collect); the earliest-snapshot comparison now decides directly between as-of-timestamp and snapshot-id. Broaden the non-finite scrub to any real number type (numpy float32 scalars are not instances of float). Annotate _parse_deequ_statistics as returning an optional list.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Omit uniqueness-family keys from the Java profiler output when exact uniqueness is disabled. Cluster verification of the Python-side strip showed the uniqueness=0.0 symptom persisting for HUDI feature groups: their materialization job is the Scala/Java Spark job, which profiles and registers statistics through the Java client, bypassing the Python parse seam entirely. The profiler emitted distinctness, entropy, uniqueness and exactNumDistinctValues as 0 with keys always present (matching Deequ's shape), so every consumer stored a spurious 0.

ColumnProfile now carries the uniqueness-family stats as nullable, ColumnProfiler leaves them null when exactUniqueness is false, and ProfileJsonSerializer omits absent keys. All downstream parsers (Python _from_deequ_json, Java fromDeequStatisticsJson, backend buildFromDeequJson) copy only present keys, so absent deserializes to null everywhere. The per-column entropy groupBy is also skipped when exactUniqueness is off, since its result was only consumed behind that flag.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Compute uniqueness from the exact singleton count. The profiler used the shortcut (2 * exactDistinct - nonNull) / nonNull, which equals Deequ's definition (fraction of values occurring exactly once) only when no value occurs more than twice; any higher multiplicity undercounts. Surfaced by test_statistics once the earlier failures were fixed: a column with one value at multiplicity three produced 0.2 instead of 4/15. The singleton count now comes from the same per-value frequency pass as entropy, so no extra Spark job is added.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Resolve end-bounded Delta reads to a version via the table history instead of timestampAsOf. Delta resolves timestamp bounds against commit-file modification times, while the backend-recorded commit_time comes from history()'s in-commit timestamp, which can be tens of milliseconds earlier; an end bound equal to commit N's recorded time could then silently resolve to version N-1. Cluster verification caught exactly this: the statistics registered for a second commit carried the first commit's values (count 10 instead of 15, stale max).

The end-only branch of _setup_delta_read_opts now picks the latest history version committed at or before the end bound and pins it with versionAsOf; this also subsumes the previous before-first-commit fallback. The history read is shared with _get_delta_earliest_commit through a new _get_delta_commits helper.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Read Delta commit timestamps from the log instead of history(). The version resolution added for end-bounded reads compared the recorded commit time against DeltaTable.history() timestamps, but history() carries the commit-file modification time, which lags the in-commit commitInfo timestamp by tens to hundreds of milliseconds on HopsFS; the backend-recorded commit times are the commitInfo values, so the resolution could still land on the previous version. Reproduced in the job image: history() returned +3ms/+182ms over commitInfo, and timestampAsOf at exactly a commit's recorded time resolved to the previous version.

_get_delta_commits now reads commitInfo.timestamp from _delta_log json files directly (the same pattern _get_last_commit_metadata uses in Spark Connect mode), putting both sides of the comparison on the same clock. Verified in the spark-feature-pipeline image: resolution picks the exact commit version for a recorded commit time.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Fall back to an end-bounded snapshot read when an incremental Iceberg window starts before the first snapshot. Rolling feature-monitoring windows on a fresh table produce a start bound that predates every snapshot; the incremental branch raised in that case and the run_fm job died. Iceberg's start-snapshot-id is exclusive, so the first snapshot's changes cannot be included in an incremental scan; reading the table state at the end bound covers the window whenever every commit lies inside it, mirroring the Delta CDF earliest-version fallback. The end-bound resolution is shared with the end-only branch through a new _snapshot_read_opts_at helper.



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Reformat the _snapshot_read_opts_at docstring to one sentence per line, per the repo docstring convention (Copilot review on #1054).



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Read the Delta log with an explicit schema in _get_delta_commits. Schema inference parsed every add/remove action payload just to reach commitInfo.timestamp, and a commitInfo row without a timestamp would throw and silently degrade the version resolution to the timestamp fallback. The read now projects only commitInfo.timestamp and filters null timestamps (Copilot review on #1054).



* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Reflow multi-sentence prose onto one sentence per line in the Delta version-resolution comment, the ColumnProfiler class Javadoc, and the ProfileJsonSerializer uniqueness-family Javadoc, per the repo comment convention (flagged by Copilot review). No code changes.




* [FSTORE-2066] (temp) Fixes on stats computation / feature monitoring https://hopsworks.atlassian.net/browse/FSTORE-2066

Address review feedback.

Resolve end-bounded Iceberg reads to a snapshot id client-side against the snapshots' committed_at clock instead of passing as-of-timestamp. Passing the timestamp let Iceberg resolve the bound server-side against the snapshot-log clock, so a recorded commit time landing just below snapshot N's log timestamp could silently read snapshot N-1. Resolving here keeps registration and read on one clock, so the mid-range case is exact, not only the before-first-snapshot case Iceberg rejects outright. The earliest-snapshot fallback and its future-data trade-off (a window ending before the first commit reads post-window data rather than returning empty) are now documented, mirroring the Delta fallback.

Harden the Delta end-bounded version resolution: stop at the first commit past end_ts since commitInfo timestamps are not guaranteed monotonic in version, and anchor the log-file version extraction on the 20-digit commit basename so V2 checkpoint manifests and log-compaction files cannot yield a bogus version. Correct the stale CDF-retry comment that claimed history() returns the in-commit timestamp (it returns the commit-file modification time) and note why parsing commitInfo.timestamp keeps resolution correct for classic-Spark-written tables.

Omit null-valued numeric keys (mean/maximum/minimum/sum/stdDev) from the Spark profiler JSON: an all-null column profiles those to null, and emitting "mean": null crashes the has()->getDouble() parsers. Absent now means not computed, the same contract the uniqueness family already uses.




---------

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```


[FSTORE-2066]: https://hopsworks.atlassian.net/browse/FSTORE-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSTORE-2066]: https://hopsworks.atlassian.net/browse/FSTORE-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSTORE-2066]: https://hopsworks.atlassian.net/browse/FSTORE-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ