### PR TITLE
[HWORKS-3071] Python client waits forever on a library or environment command that never reaches a final state

### DIFF
--- a/python/hopsworks_common/client/base.py
+++ b/python/hopsworks_common/client/base.py
@@ -129,6 +129,7 @@ class Client:
         stream: bool = False,
         files: dict | None = None,
         with_base_path_params: bool = True,
+        timeout: float | tuple[float, float] | None = None,
     ) -> dict:
         """Send REST request to Hopsworks.
 
@@ -143,6 +144,8 @@ class Client:
             stream: Set if response should be a stream, defaults to False
             files: dictionary for multipart encoding upload
             with_base_path_params: Whether to include the base path parameters (hopsworks-api/api) in the request URL.
+            timeout: How long to wait for the connection and for each block of the response, in seconds, passed straight through to `requests`.
+                Without it a stalled connection blocks the caller indefinitely, so pass one wherever the caller has its own deadline to honour.
 
         Returns:
             Response json
@@ -171,12 +174,14 @@ class Client:
         _logger.debug(f"url:{url} hostname_verification:{self._verify}")
 
         prepped = self._session.prepare_request(request)
-        response = self._session.send(prepped, verify=self._verify, stream=stream)
+        response = self._session.send(
+            prepped, verify=self._verify, stream=stream, timeout=timeout
+        )
 
         if response.status_code == 401 and self.REST_ENDPOINT in os.environ:
             # refresh token and retry request - only on hopsworks
             response = self._retry_token_expired(
-                request, stream, self.TOKEN_EXPIRED_RETRY_INTERVAL, 1
+                request, stream, self.TOKEN_EXPIRED_RETRY_INTERVAL, 1, timeout
             )
 
         if response.status_code // 100 != 2:
@@ -189,7 +194,7 @@ class Client:
             return None
         return response.json()
 
-    def _retry_token_expired(self, request, stream, wait, retries):
+    def _retry_token_expired(self, request, stream, wait, retries, timeout=None):
         """Refresh the JWT token and retry the request. Only on Hopsworks.
 
         As the token might take a while to get refreshed. Keep trying.
@@ -201,11 +206,15 @@ class Client:
         # Update request with the new token
         request.auth = self._auth
         prepped = self._session.prepare_request(request)
-        response = self._session.send(prepped, verify=self._verify, stream=stream)
+        response = self._session.send(
+            prepped, verify=self._verify, stream=stream, timeout=timeout
+        )
 
         if response.status_code == 401 and retries < self.TOKEN_EXPIRED_MAX_RETRIES:
             # Try again.
-            return self._retry_token_expired(request, stream, wait * 2, retries + 1)
+            return self._retry_token_expired(
+                request, stream, wait * 2, retries + 1, timeout
+            )
         # If the number of retries have expired, the _send_request method
         # will throw an exception to the user as part of the status_code validation.
         return response

--- a/python/hopsworks_common/core/environment_api.py
+++ b/python/hopsworks_common/core/environment_api.py
@@ -35,6 +35,7 @@ class EnvironmentApi:
         description: str | None = None,
         base_environment_name: str | None = "python-feature-pipeline",
         await_creation: bool | None = True,
+        timeout: float | None = None,
     ) -> environment.Environment:
         """Create Python environment for the project.
 
@@ -53,6 +54,8 @@ class EnvironmentApi:
             description: Description of the environment.
             base_environment_name: The name of the environment to clone from.
             await_creation: Whether the method returns only when the creation is finished.
+            timeout: Seconds to wait for the creation before raising. Falls back to the engine's
+                default when unset. Only used when awaiting.
 
         Returns:
             The Environment object.
@@ -81,7 +84,7 @@ class EnvironmentApi:
         )
 
         if await_creation:
-            self._environment_engine._await_environment_command(name)
+            self._environment_engine._await_environment_command(name, timeout)
 
         return env
 

--- a/python/hopsworks_common/core/environment_api.py
+++ b/python/hopsworks_common/core/environment_api.py
@@ -54,8 +54,9 @@ class EnvironmentApi:
             description: Description of the environment.
             base_environment_name: The name of the environment to clone from.
             await_creation: Whether the method returns only when the creation is finished.
-            timeout: Seconds to wait for the creation before raising. Falls back to the engine's
-                default when unset. Only used when awaiting.
+            timeout: Seconds to wait for the creation to finish before raising.
+                Falls back to the engine's default when unset.
+                Ignored when `await_creation` is `False`, because the method then returns without waiting at all.
 
         Returns:
             The Environment object.

--- a/python/hopsworks_common/engine/environment_engine.py
+++ b/python/hopsworks_common/engine/environment_engine.py
@@ -16,28 +16,37 @@
 
 from __future__ import annotations
 
+import logging
 import time
 
+import requests
 from hopsworks_apigen import also_available_as
 from hopsworks_common import client, command, environment, library
 from hopsworks_common.client.exceptions import EnvironmentException, RestAPIError
 
 
+_logger = logging.getLogger(__name__)
+
+
 @also_available_as("hopsworks.engine.environment_engine.EnvironmentEngine")
 class EnvironmentEngine:
-    # How long to keep waiting for a background command before giving up. Generous, because
-    # resolving a large requirements.txt against a cold cache legitimately takes many minutes
-    # and timing that out would be worse than waiting. What this bounds is the case that never
-    # finishes at all: a command whose installer is gone stays ONGOING for good, and without a
-    # deadline the caller polls it every POLL_INTERVAL seconds forever, silently.
+    # How long to keep waiting for a background command before giving up.
+    # Generous, because resolving a large requirements.txt against a cold cache legitimately takes many minutes, and timing that out would be worse than waiting.
+    # What this bounds is the case that never finishes at all.
+    # A command whose installer is gone stays ONGOING for good, and without a deadline the caller polls it every POLL_INTERVAL seconds forever, silently.
     AWAIT_COMMAND_TIMEOUT = 30 * 60
     POLL_INTERVAL = 5
+    # Each poll request is bounded as well, because the loop can only honour its deadline if the HTTP call it makes comes back.
+    # A GET that stalls blocks inside the socket rather than in the loop, so an unbounded request would defeat the deadline entirely.
+    POLL_REQUEST_TIMEOUT = 60
 
     def _await_library_command(
         self, environment_name, library_name, timeout: float | None = None
     ):
         self._await_command(
-            lambda: self._poll_commands_library(environment_name, library_name),
+            lambda request_timeout: self._poll_commands_library(
+                environment_name, library_name, request_timeout
+            ),
             f"library '{library_name}' in environment '{environment_name}'",
             timeout,
         )
@@ -46,7 +55,9 @@ class EnvironmentEngine:
         self, environment_name, timeout: float | None = None
     ):
         self._await_command(
-            lambda: self._poll_commands_environment(environment_name),
+            lambda request_timeout: self._poll_commands_environment(
+                environment_name, request_timeout
+            ),
             f"environment '{environment_name}'",
             timeout,
         )
@@ -54,27 +65,38 @@ class EnvironmentEngine:
     def _await_command(self, poll, description, timeout: float | None = None):
         """Poll until the command reaches a final status, the artifact is gone, or time runs out.
 
-        A missing artifact ends the wait rather than failing it: an uninstall whose library has
-        already been removed is done, not broken. That case was always handled; a command that
-        stalls in ONGOING was not, which is what the deadline is for.
+        A missing artifact ends the wait rather than failing it: an uninstall whose library has already been removed is done, not broken.
+        The same goes for an artifact that carries no commands at all, which is how the backend reports that nothing is in flight.
+        Those cases were always handled; a command that stalls in ONGOING was not, which is what the deadline is for.
         """
         timeout = self.AWAIT_COMMAND_TIMEOUT if timeout is None else timeout
         deadline = time.monotonic() + timeout
         commands = [command.Command(status="ONGOING")]
         while len(commands) > 0 and not self._is_final_status(commands[0]):
-            if time.monotonic() >= deadline:
-                # Name the last status seen: "still ONGOING" and "no command at all" are very
-                # different problems, and the caller cannot tell them apart from a bare timeout.
-                status = commands[0].status if commands else "unknown"
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                # Name the last status seen.
+                # "Still ONGOING" and "no command at all" are very different problems, and the caller cannot tell them apart from a bare timeout.
                 raise EnvironmentException(
-                    f"Timed out after {timeout:.0f}s waiting for {description}. "
-                    f"The last observed command status was {status}. The command may still be "
+                    f"Timed out after {timeout:g}s waiting for {description}. "
+                    f"The last observed command status was {commands[0].status}. The command may still be "
                     "running, or it may have stopped without reporting a final status: check "
                     "the environment page in the UI, where the command and its state are shown."
                 )
-            time.sleep(min(self.POLL_INTERVAL, max(0, deadline - time.monotonic())))
-            artifact = poll()
-            commands = [] if artifact is None else artifact._commands
+            time.sleep(min(self.POLL_INTERVAL, remaining))
+            try:
+                artifact = poll(self.POLL_REQUEST_TIMEOUT)
+            except requests.exceptions.Timeout:
+                # A poll that never came back is not an answer, but it is not a failure either.
+                # Keep the last known status and let the deadline decide when to give up.
+                _logger.debug(
+                    "Polling %s timed out after %ss, retrying until the deadline.",
+                    description,
+                    self.POLL_REQUEST_TIMEOUT,
+                )
+                continue
+            # Both Library and Environment leave _commands as None when the response carries none, which len() cannot take.
+            commands = [] if artifact is None else artifact._commands or []
 
     def _is_final_status(self, command):
         if command.status == "FAILED":
@@ -83,7 +105,9 @@ class EnvironmentEngine:
             )
         return command.status == "SUCCESS"
 
-    def _poll_commands_library(self, environment_name, library_name):
+    def _poll_commands_library(
+        self, environment_name, library_name, request_timeout: float | None = None
+    ):
         _client = client._get_instance()
 
         path_params = [
@@ -102,7 +126,11 @@ class EnvironmentEngine:
         try:
             return library.Library.from_response_json(
                 _client._send_request(
-                    "GET", path_params, headers=headers, query_params=query_params
+                    "GET",
+                    path_params,
+                    headers=headers,
+                    query_params=query_params,
+                    timeout=request_timeout,
                 ),
             )
         except RestAPIError as e:
@@ -112,7 +140,9 @@ class EnvironmentEngine:
             ):
                 return None
 
-    def _poll_commands_environment(self, environment_name):
+    def _poll_commands_environment(
+        self, environment_name, request_timeout: float | None = None
+    ):
         _client = client._get_instance()
 
         path_params = [
@@ -128,6 +158,10 @@ class EnvironmentEngine:
 
         return environment.Environment.from_response_json(
             _client._send_request(
-                "GET", path_params, headers=headers, query_params=query_params
+                "GET",
+                path_params,
+                headers=headers,
+                query_params=query_params,
+                timeout=request_timeout,
             ),
         )

--- a/python/hopsworks_common/engine/environment_engine.py
+++ b/python/hopsworks_common/engine/environment_engine.py
@@ -14,6 +14,8 @@
 #   limitations under the License.
 #
 
+from __future__ import annotations
+
 import time
 
 from hopsworks_apigen import also_available_as
@@ -23,19 +25,56 @@ from hopsworks_common.client.exceptions import EnvironmentException, RestAPIErro
 
 @also_available_as("hopsworks.engine.environment_engine.EnvironmentEngine")
 class EnvironmentEngine:
-    def _await_library_command(self, environment_name, library_name):
-        commands = [command.Command(status="ONGOING")]
-        while len(commands) > 0 and not self._is_final_status(commands[0]):
-            time.sleep(5)
-            library = self._poll_commands_library(environment_name, library_name)
-            commands = [] if library is None else library._commands
+    # How long to keep waiting for a background command before giving up. Generous, because
+    # resolving a large requirements.txt against a cold cache legitimately takes many minutes
+    # and timing that out would be worse than waiting. What this bounds is the case that never
+    # finishes at all: a command whose installer is gone stays ONGOING for good, and without a
+    # deadline the caller polls it every POLL_INTERVAL seconds forever, silently.
+    AWAIT_COMMAND_TIMEOUT = 30 * 60
+    POLL_INTERVAL = 5
 
-    def _await_environment_command(self, environment_name):
+    def _await_library_command(
+        self, environment_name, library_name, timeout: float | None = None
+    ):
+        self._await_command(
+            lambda: self._poll_commands_library(environment_name, library_name),
+            f"library '{library_name}' in environment '{environment_name}'",
+            timeout,
+        )
+
+    def _await_environment_command(
+        self, environment_name, timeout: float | None = None
+    ):
+        self._await_command(
+            lambda: self._poll_commands_environment(environment_name),
+            f"environment '{environment_name}'",
+            timeout,
+        )
+
+    def _await_command(self, poll, description, timeout: float | None = None):
+        """Poll until the command reaches a final status, the artifact is gone, or time runs out.
+
+        A missing artifact ends the wait rather than failing it: an uninstall whose library has
+        already been removed is done, not broken. That case was always handled; a command that
+        stalls in ONGOING was not, which is what the deadline is for.
+        """
+        timeout = self.AWAIT_COMMAND_TIMEOUT if timeout is None else timeout
+        deadline = time.monotonic() + timeout
         commands = [command.Command(status="ONGOING")]
         while len(commands) > 0 and not self._is_final_status(commands[0]):
-            time.sleep(5)
-            environment = self._poll_commands_environment(environment_name)
-            commands = [] if environment is None else environment._commands
+            if time.monotonic() >= deadline:
+                # Name the last status seen: "still ONGOING" and "no command at all" are very
+                # different problems, and the caller cannot tell them apart from a bare timeout.
+                status = commands[0].status if commands else "unknown"
+                raise EnvironmentException(
+                    f"Timed out after {timeout:.0f}s waiting for {description}. "
+                    f"The last observed command status was {status}. The command may still be "
+                    "running, or it may have stopped without reporting a final status: check "
+                    "the environment page in the UI, where the command and its state are shown."
+                )
+            time.sleep(min(self.POLL_INTERVAL, max(0, deadline - time.monotonic())))
+            artifact = poll()
+            commands = [] if artifact is None else artifact._commands
 
     def _is_final_status(self, command):
         if command.status == "FAILED":

--- a/python/hopsworks_common/environment.py
+++ b/python/hopsworks_common/environment.py
@@ -112,8 +112,9 @@ class Environment:
         Parameters:
             path: The path in Hopsworks where the wheel file is located.
             await_installation: If `True` the method returns only when the installation finishes.
-            timeout: Seconds to wait for the installation before raising. Falls back to the engine's
-                default when unset. Only used when awaiting.
+            timeout: Seconds to wait for the installation to finish before raising.
+                Falls back to the engine's default when unset.
+                It also bounds the wait for any environment command already in flight, which happens before the install is submitted and therefore applies even when `await_installation` is `False`.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
@@ -168,8 +169,9 @@ class Environment:
         Parameters:
             path: The path in Hopsworks where the `requirements.txt` file is located.
             await_installation: If `True` the method returns only when the installation is finished.
-            timeout: Seconds to wait for the installation before raising. Falls back to the engine's
-                default when unset. Only used when awaiting.
+            timeout: Seconds to wait for the installation to finish before raising.
+                Falls back to the engine's default when unset.
+                It also bounds the wait for any environment command already in flight, which happens before the install is submitted and therefore applies even when `await_installation` is `False`.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
@@ -219,8 +221,9 @@ class Environment:
         Parameters:
             library_name: Name of the installed library to remove.
             await_uninstallation: If `True` the method returns only when the uninstallation finishes.
-            timeout: Seconds to wait for the uninstallation before raising. Falls back to the engine's
-                default when unset. Only used when awaiting.
+            timeout: Seconds to wait for the uninstallation to finish before raising.
+                Falls back to the engine's default when unset.
+                It also bounds the wait for any environment command already in flight, which happens before the removal is submitted and therefore applies even when `await_uninstallation` is `False`.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.

--- a/python/hopsworks_common/environment.py
+++ b/python/hopsworks_common/environment.py
@@ -85,7 +85,12 @@ class Environment:
 
     @public
     @usage._method_logger
-    def install_wheel(self, path: str, await_installation: bool | None = True):
+    def install_wheel(
+        self,
+        path: str,
+        await_installation: bool | None = True,
+        timeout: float | None = None,
+    ):
         """Install a python library packaged in a wheel file.
 
         ```python
@@ -107,12 +112,14 @@ class Environment:
         Parameters:
             path: The path in Hopsworks where the wheel file is located.
             await_installation: If `True` the method returns only when the installation finishes.
+            timeout: Seconds to wait for the installation before raising. Falls back to the engine's
+                default when unset. Only used when awaiting.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         # Wait for any ongoing environment operations
-        self._environment_engine._await_environment_command(self.name)
+        self._environment_engine._await_environment_command(self.name, timeout)
 
         library_name = os.path.basename(path)
 
@@ -128,11 +135,18 @@ class Environment:
         self._library_api._install(library_name, self.name, library_spec)
 
         if await_installation:
-            self._environment_engine._await_library_command(self.name, library_name)
+            self._environment_engine._await_library_command(
+                self.name, library_name, timeout
+            )
 
     @public
     @usage._method_logger
-    def install_requirements(self, path: str, await_installation: bool | None = True):
+    def install_requirements(
+        self,
+        path: str,
+        await_installation: bool | None = True,
+        timeout: float | None = None,
+    ):
         """Install libraries specified in a `requirements.txt` file.
 
         ```python
@@ -154,12 +168,14 @@ class Environment:
         Parameters:
             path: The path in Hopsworks where the `requirements.txt` file is located.
             await_installation: If `True` the method returns only when the installation is finished.
+            timeout: Seconds to wait for the installation before raising. Falls back to the engine's
+                default when unset. Only used when awaiting.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         # Wait for any ongoing environment operations
-        self._environment_engine._await_environment_command(self.name)
+        self._environment_engine._await_environment_command(self.name, timeout)
 
         library_name = os.path.basename(path)
 
@@ -175,12 +191,17 @@ class Environment:
         self._library_api._install(library_name, self.name, library_spec)
 
         if await_installation:
-            self._environment_engine._await_library_command(self.name, library_name)
+            self._environment_engine._await_library_command(
+                self.name, library_name, timeout
+            )
 
     @public
     @usage._method_logger
     def uninstall(
-        self, library_name: str, await_uninstallation: bool | None = True
+        self,
+        library_name: str,
+        await_uninstallation: bool | None = True,
+        timeout: float | None = None,
     ) -> None:
         """Uninstall a library from the environment.
 
@@ -198,17 +219,21 @@ class Environment:
         Parameters:
             library_name: Name of the installed library to remove.
             await_uninstallation: If `True` the method returns only when the uninstallation finishes.
+            timeout: Seconds to wait for the uninstallation before raising. Falls back to the engine's
+                default when unset. Only used when awaiting.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request.
         """
         # Wait for any ongoing environment operations
-        self._environment_engine._await_environment_command(self.name)
+        self._environment_engine._await_environment_command(self.name, timeout)
 
         self._library_api._uninstall(library_name, self.name)
 
         if await_uninstallation:
-            self._environment_engine._await_library_command(self.name, library_name)
+            self._environment_engine._await_library_command(
+                self.name, library_name, timeout
+            )
 
     @public
     @usage._method_logger

--- a/python/tests/core/test_environment_api.py
+++ b/python/tests/core/test_environment_api.py
@@ -1,0 +1,68 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hopsworks_common.core import environment_api
+
+
+class TestEnvironmentApi:
+    def _api(self, mocker):
+        api = environment_api.EnvironmentApi()
+        mock_client = mocker.MagicMock()
+        mock_client._project_id = 1
+        mock_client._send_request.return_value = {"name": "myenv"}
+        mocker.patch("hopsworks_common.client._get_instance", return_value=mock_client)
+        return api
+
+    def test_create_environment_forwards_an_explicit_timeout(self, mocker):
+        """The parameter is only worth exposing if it reaches the wait it is meant to bound."""
+        # Arrange
+        api = self._api(mocker)
+        mock_await = mocker.patch.object(
+            api._environment_engine, "_await_environment_command"
+        )
+
+        # Act
+        api.create_environment("myenv", timeout=42)
+
+        # Assert
+        mock_await.assert_called_once_with("myenv", 42)
+
+    def test_create_environment_defaults_the_timeout_to_none(self, mocker):
+        """Unset has to arrive as `None`, which is what tells the engine to use its own default."""
+        # Arrange
+        api = self._api(mocker)
+        mock_await = mocker.patch.object(
+            api._environment_engine, "_await_environment_command"
+        )
+
+        # Act
+        api.create_environment("myenv")
+
+        # Assert
+        mock_await.assert_called_once_with("myenv", None)
+
+    def test_create_environment_does_not_wait_when_not_awaiting(self, mocker):
+        # Arrange
+        api = self._api(mocker)
+        mock_await = mocker.patch.object(
+            api._environment_engine, "_await_environment_command"
+        )
+
+        # Act
+        api.create_environment("myenv", await_creation=False, timeout=42)
+
+        # Assert
+        mock_await.assert_not_called()

--- a/python/tests/engine/test_environment_engine.py
+++ b/python/tests/engine/test_environment_engine.py
@@ -1,0 +1,140 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pytest
+from hopsworks_common import command
+from hopsworks_common.client.exceptions import EnvironmentException
+from hopsworks_common.engine import environment_engine
+
+
+class Artifact:
+    """Stand-in for a library or environment carrying commands."""
+
+    def __init__(self, *statuses):
+        self._commands = [command.Command(status=s) for s in statuses]
+
+
+class TestEnvironmentEngine:
+    def test_returns_when_the_command_succeeds(self, mocker):
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        poll = mocker.patch.object(
+            engine, "_poll_commands_library", return_value=Artifact("SUCCESS")
+        )
+
+        engine._await_library_command("myenv", "matplotlib")
+
+        assert poll.call_count == 1
+
+    def test_raises_when_the_command_fails(self, mocker):
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        mocker.patch.object(
+            engine, "_poll_commands_library", return_value=Artifact("FAILED")
+        )
+
+        with pytest.raises(EnvironmentException):
+            engine._await_library_command("myenv", "matplotlib")
+
+    def test_returns_when_the_artifact_is_gone(self, mocker):
+        """A missing artifact ends the wait rather than failing it.
+
+        Uninstalling a library that is already absent is done, not broken, and this case was
+        the one the original loop did handle. Kept under test so bounding the wait does not
+        turn a benign outcome into a timeout.
+        """
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        mocker.patch.object(engine, "_poll_commands_library", return_value=None)
+
+        engine._await_library_command("myenv", "matplotlib")
+
+    def test_raises_instead_of_polling_forever_on_a_stalled_command(self, mocker):
+        """The regression this exists for.
+
+        A command whose installer is gone stays ONGOING for good. Before the deadline the
+        caller polled it every five seconds with no output and no end, which cost two full
+        loadtest runs before anyone knew where the process was.
+
+        The clock is faked rather than slept through, so the test proves the deadline is
+        enforced without taking the timeout to prove it.
+        """
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        # monotonic() is read once for the deadline, then once per loop; walk it past the
+        # timeout so the second check trips.
+        mocker.patch.object(
+            environment_engine.time, "monotonic", side_effect=[0, 1, 10_000, 10_000]
+        )
+        poll = mocker.patch.object(
+            engine, "_poll_commands_library", return_value=Artifact("ONGOING")
+        )
+
+        with pytest.raises(EnvironmentException, match="Timed out"):
+            engine._await_library_command("myenv", "tmp3zwmpner.txt")
+
+        # It gave up rather than spinning: a bounded number of polls, not an endless stream.
+        assert poll.call_count < 5
+
+    def test_the_timeout_message_names_the_artifact_and_last_status(self, mocker):
+        """A bare timeout does not tell an operator where to look.
+
+        The environment, the library and the status it was stuck in are the three facts that
+        turn this from a mystery hang into a thing to go and inspect.
+        """
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        mocker.patch.object(
+            environment_engine.time, "monotonic", side_effect=[0, 1, 10_000, 10_000]
+        )
+        mocker.patch.object(
+            engine, "_poll_commands_library", return_value=Artifact("ONGOING")
+        )
+
+        with pytest.raises(EnvironmentException) as raised:
+            engine._await_library_command("env_ge_0_18_12", "tmp3zwmpner.txt")
+
+        message = str(raised.value)
+        assert "env_ge_0_18_12" in message
+        assert "tmp3zwmpner.txt" in message
+        assert "ONGOING" in message
+
+    def test_an_explicit_timeout_overrides_the_default(self, mocker):
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        mocker.patch.object(
+            environment_engine.time, "monotonic", side_effect=[0, 1, 10_000, 10_000]
+        )
+        mocker.patch.object(
+            engine, "_poll_commands_library", return_value=Artifact("ONGOING")
+        )
+
+        with pytest.raises(EnvironmentException, match="7s"):
+            engine._await_library_command("myenv", "matplotlib", timeout=7)
+
+    def test_environment_command_is_bounded_too(self, mocker):
+        """The environment wait had the same unbounded shape, so it gets the same deadline."""
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        mocker.patch.object(
+            environment_engine.time, "monotonic", side_effect=[0, 1, 10_000, 10_000]
+        )
+        mocker.patch.object(
+            engine, "_poll_commands_environment", return_value=Artifact("ONGOING")
+        )
+
+        with pytest.raises(EnvironmentException, match="Timed out"):
+            engine._await_environment_command("myenv")

--- a/python/tests/engine/test_environment_engine.py
+++ b/python/tests/engine/test_environment_engine.py
@@ -15,6 +15,7 @@
 #
 
 import pytest
+import requests
 from hopsworks_common import command
 from hopsworks_common.client.exceptions import EnvironmentException
 from hopsworks_common.engine import environment_engine
@@ -25,6 +26,30 @@ class Artifact:
 
     def __init__(self, *statuses):
         self._commands = [command.Command(status=s) for s in statuses]
+
+
+class CommandlessArtifact:
+    """Stand-in for the response shape where no command is attached.
+
+    Both `Library` and `Environment` leave `_commands` as `None` rather than empty in that case.
+    """
+
+    _commands = None
+
+
+def clock(*readings):
+    """A `time.monotonic` stand-in that returns the given readings, then holds the last one.
+
+    Holding rather than exhausting keeps the tests from depending on exactly how many times the loop reads the clock.
+    """
+    values = iter(readings)
+    last = [0.0]
+
+    def monotonic():
+        last[0] = next(values, last[0])
+        return last[0]
+
+    return monotonic
 
 
 class TestEnvironmentEngine:
@@ -52,32 +77,45 @@ class TestEnvironmentEngine:
     def test_returns_when_the_artifact_is_gone(self, mocker):
         """A missing artifact ends the wait rather than failing it.
 
-        Uninstalling a library that is already absent is done, not broken, and this case was
-        the one the original loop did handle. Kept under test so bounding the wait does not
-        turn a benign outcome into a timeout.
+        Uninstalling a library that is already absent is done, not broken, and this case was the one the original loop did handle.
+        Kept under test so bounding the wait does not turn a benign outcome into a timeout.
         """
         engine = environment_engine.EnvironmentEngine()
         mocker.patch.object(environment_engine.time, "sleep")
-        mocker.patch.object(engine, "_poll_commands_library", return_value=None)
+        poll = mocker.patch.object(engine, "_poll_commands_library", return_value=None)
 
         engine._await_library_command("myenv", "matplotlib")
+
+        # It polled, saw the artifact was gone, and returned: no exception and no second poll.
+        assert poll.call_count == 1
+
+    def test_returns_when_the_response_carries_no_commands(self, mocker):
+        """An artifact with no commands means nothing is in flight, so the wait is over.
+
+        `_commands` is `None` and not `[]` in that case, which `len()` cannot take, so the value has to be normalised before the loop condition sees it.
+        """
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        poll = mocker.patch.object(
+            engine, "_poll_commands_library", return_value=CommandlessArtifact()
+        )
+
+        engine._await_library_command("myenv", "matplotlib")
+
+        assert poll.call_count == 1
 
     def test_raises_instead_of_polling_forever_on_a_stalled_command(self, mocker):
         """The regression this exists for.
 
-        A command whose installer is gone stays ONGOING for good. Before the deadline the
-        caller polled it every five seconds with no output and no end, which cost two full
-        loadtest runs before anyone knew where the process was.
+        A command whose installer is gone stays ONGOING for good.
+        Before the deadline the caller polled it every five seconds with no output and no end, which cost two full loadtest runs before anyone knew where the process was.
 
-        The clock is faked rather than slept through, so the test proves the deadline is
-        enforced without taking the timeout to prove it.
+        The clock is faked rather than slept through, so the test proves the deadline is enforced without taking the timeout to prove it.
         """
         engine = environment_engine.EnvironmentEngine()
         mocker.patch.object(environment_engine.time, "sleep")
-        # monotonic() is read once for the deadline, then once per loop; walk it past the
-        # timeout so the second check trips.
         mocker.patch.object(
-            environment_engine.time, "monotonic", side_effect=[0, 1, 10_000, 10_000]
+            environment_engine.time, "monotonic", side_effect=clock(0, 1, 10_000)
         )
         poll = mocker.patch.object(
             engine, "_poll_commands_library", return_value=Artifact("ONGOING")
@@ -92,13 +130,12 @@ class TestEnvironmentEngine:
     def test_the_timeout_message_names_the_artifact_and_last_status(self, mocker):
         """A bare timeout does not tell an operator where to look.
 
-        The environment, the library and the status it was stuck in are the three facts that
-        turn this from a mystery hang into a thing to go and inspect.
+        The environment, the library and the status it was stuck in are the three facts that turn this from a mystery hang into a thing to go and inspect.
         """
         engine = environment_engine.EnvironmentEngine()
         mocker.patch.object(environment_engine.time, "sleep")
         mocker.patch.object(
-            environment_engine.time, "monotonic", side_effect=[0, 1, 10_000, 10_000]
+            environment_engine.time, "monotonic", side_effect=clock(0, 1, 10_000)
         )
         mocker.patch.object(
             engine, "_poll_commands_library", return_value=Artifact("ONGOING")
@@ -116,7 +153,7 @@ class TestEnvironmentEngine:
         engine = environment_engine.EnvironmentEngine()
         mocker.patch.object(environment_engine.time, "sleep")
         mocker.patch.object(
-            environment_engine.time, "monotonic", side_effect=[0, 1, 10_000, 10_000]
+            environment_engine.time, "monotonic", side_effect=clock(0, 1, 10_000)
         )
         mocker.patch.object(
             engine, "_poll_commands_library", return_value=Artifact("ONGOING")
@@ -125,12 +162,26 @@ class TestEnvironmentEngine:
         with pytest.raises(EnvironmentException, match="7s"):
             engine._await_library_command("myenv", "matplotlib", timeout=7)
 
+    def test_a_fractional_timeout_is_reported_as_given(self, mocker):
+        """Rounding the duration to whole seconds reports a half-second wait as `0s`, which reads as a bug in the client rather than a stalled command."""
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        mocker.patch.object(
+            environment_engine.time, "monotonic", side_effect=clock(0, 0.1, 10_000)
+        )
+        mocker.patch.object(
+            engine, "_poll_commands_library", return_value=Artifact("ONGOING")
+        )
+
+        with pytest.raises(EnvironmentException, match="0.5s"):
+            engine._await_library_command("myenv", "matplotlib", timeout=0.5)
+
     def test_environment_command_is_bounded_too(self, mocker):
         """The environment wait had the same unbounded shape, so it gets the same deadline."""
         engine = environment_engine.EnvironmentEngine()
         mocker.patch.object(environment_engine.time, "sleep")
         mocker.patch.object(
-            environment_engine.time, "monotonic", side_effect=[0, 1, 10_000, 10_000]
+            environment_engine.time, "monotonic", side_effect=clock(0, 1, 10_000)
         )
         mocker.patch.object(
             engine, "_poll_commands_environment", return_value=Artifact("ONGOING")
@@ -138,3 +189,59 @@ class TestEnvironmentEngine:
 
         with pytest.raises(EnvironmentException, match="Timed out"):
             engine._await_environment_command("myenv")
+
+    def test_each_poll_request_is_bounded(self, mocker):
+        """The deadline is only enforceable if the request the loop makes comes back.
+
+        A GET that stalls blocks in the socket, where the loop cannot see it, so the poll carries its own request timeout.
+        """
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        library_poll = mocker.patch.object(
+            engine, "_poll_commands_library", return_value=Artifact("SUCCESS")
+        )
+        environment_poll = mocker.patch.object(
+            engine, "_poll_commands_environment", return_value=Artifact("SUCCESS")
+        )
+
+        engine._await_library_command("myenv", "matplotlib")
+        engine._await_environment_command("myenv")
+
+        library_poll.assert_called_once_with(
+            "myenv", "matplotlib", engine.POLL_REQUEST_TIMEOUT
+        )
+        environment_poll.assert_called_once_with("myenv", engine.POLL_REQUEST_TIMEOUT)
+
+    def test_a_timed_out_poll_request_does_not_end_the_wait(self, mocker):
+        """One request giving up is not the command giving up.
+
+        A slow or dropped poll leaves the status unknown, so the loop keeps the last one it saw and carries on until the deadline decides.
+        """
+        engine = environment_engine.EnvironmentEngine()
+        mocker.patch.object(environment_engine.time, "sleep")
+        poll = mocker.patch.object(
+            engine,
+            "_poll_commands_library",
+            side_effect=[requests.exceptions.ReadTimeout(), Artifact("SUCCESS")],
+        )
+
+        engine._await_library_command("myenv", "matplotlib")
+
+        assert poll.call_count == 2
+
+    def test_the_request_timeout_reaches_the_backend_call(self, mocker):
+        """The bound is worth nothing unless `requests` is the one holding it."""
+        engine = environment_engine.EnvironmentEngine()
+        mock_client = mocker.MagicMock()
+        mock_client._project_id = 1
+        mock_client._send_request.return_value = {
+            "channel": "pip",
+            "packageSource": "PIP",
+            "library": "matplotlib",
+            "version": "3.1.3",
+        }
+        mocker.patch("hopsworks_common.client._get_instance", return_value=mock_client)
+
+        engine._poll_commands_library("myenv", "matplotlib", 30)
+
+        assert mock_client._send_request.call_args.kwargs["timeout"] == 30

--- a/python/tests/test_environment.py
+++ b/python/tests/test_environment.py
@@ -33,9 +33,9 @@ class TestEnvironment:
         env.uninstall("matplotlib")
 
         # Assert: in-flight env operations are awaited first, then DELETE, then await uninstall.
-        mock_await_env.assert_called_once_with("myenv")
+        mock_await_env.assert_called_once_with("myenv", None)
         mock_uninstall.assert_called_once_with("matplotlib", "myenv")
-        mock_await_lib.assert_called_once_with("myenv", "matplotlib")
+        mock_await_lib.assert_called_once_with("myenv", "matplotlib", None)
 
     def test_uninstall_no_await(self, mocker):
         # Arrange

--- a/python/tests/test_environment.py
+++ b/python/tests/test_environment.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 
+import pytest
 from hopsworks_common import environment
 
 
@@ -50,4 +51,109 @@ class TestEnvironment:
         env.uninstall("matplotlib", await_uninstallation=False)
 
         # Assert
+        mock_await_lib.assert_not_called()
+
+    def test_uninstall_forwards_an_explicit_timeout(self, mocker):
+        """A timeout that is accepted but dropped on the way through is worse than one that was never offered."""
+        # Arrange
+        env = environment.Environment(name="myenv")
+        mock_await_env = mocker.patch.object(
+            env._environment_engine, "_await_environment_command"
+        )
+        mocker.patch.object(env._library_api, "_uninstall")
+        mock_await_lib = mocker.patch.object(
+            env._environment_engine, "_await_library_command"
+        )
+
+        # Act
+        env.uninstall("matplotlib", timeout=42)
+
+        # Assert: both the preflight wait and the uninstall wait are bounded by what the caller asked for.
+        mock_await_env.assert_called_once_with("myenv", 42)
+        mock_await_lib.assert_called_once_with("myenv", "matplotlib", 42)
+
+    @pytest.mark.parametrize(
+        "method, library_name",
+        [
+            ("install_wheel", "matplotlib-3.1.3-cp38-cp38-manylinux1_x86_64.whl"),
+            ("install_requirements", "requirements.txt"),
+        ],
+    )
+    def test_install_forwards_an_explicit_timeout(self, mocker, method, library_name):
+        """Both install entry points expose `timeout`, and both have to route it to both waits."""
+        # Arrange
+        env = environment.Environment(name="myenv")
+        mock_await_env = mocker.patch.object(
+            env._environment_engine, "_await_environment_command"
+        )
+        mocker.patch.object(env._library_api, "_install")
+        mock_await_lib = mocker.patch.object(
+            env._environment_engine, "_await_library_command"
+        )
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch(
+            "hopsworks_common.util._convert_to_abs",
+            side_effect=lambda path, _project: path,
+        )
+
+        # Act
+        getattr(env, method)(f"/Projects/myproj/Resources/{library_name}", timeout=42)
+
+        # Assert
+        mock_await_env.assert_called_once_with("myenv", 42)
+        mock_await_lib.assert_called_once_with("myenv", library_name, 42)
+
+    def test_install_defaults_the_timeout_to_none(self, mocker):
+        """Unset means "use the engine default", which only holds if `None` is what reaches the engine."""
+        # Arrange
+        env = environment.Environment(name="myenv")
+        mock_await_env = mocker.patch.object(
+            env._environment_engine, "_await_environment_command"
+        )
+        mocker.patch.object(env._library_api, "_install")
+        mock_await_lib = mocker.patch.object(
+            env._environment_engine, "_await_library_command"
+        )
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch(
+            "hopsworks_common.util._convert_to_abs",
+            side_effect=lambda path, _project: path,
+        )
+
+        # Act
+        env.install_requirements("/Projects/myproj/Resources/requirements.txt")
+
+        # Assert
+        mock_await_env.assert_called_once_with("myenv", None)
+        mock_await_lib.assert_called_once_with("myenv", "requirements.txt", None)
+
+    def test_the_preflight_wait_is_bounded_even_without_awaiting(self, mocker):
+        """`timeout` is not only about the wait the caller opted into.
+
+        The environment command already in flight is awaited before anything is submitted, so an install that does not await still spends this timeout.
+        """
+        # Arrange
+        env = environment.Environment(name="myenv")
+        mock_await_env = mocker.patch.object(
+            env._environment_engine, "_await_environment_command"
+        )
+        mocker.patch.object(env._library_api, "_install")
+        mock_await_lib = mocker.patch.object(
+            env._environment_engine, "_await_library_command"
+        )
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch(
+            "hopsworks_common.util._convert_to_abs",
+            side_effect=lambda path, _project: path,
+        )
+
+        # Act
+        env.install_requirements(
+            "/Projects/myproj/Resources/requirements.txt",
+            await_installation=False,
+            timeout=42,
+        )
+
+        # Assert
+        mock_await_env.assert_called_once_with("myenv", 42)
         mock_await_lib.assert_not_called()


### PR DESCRIPTION
Ticket: [HWORKS-3071](https://hopsworks.atlassian.net/browse/HWORKS-3071)

**A background environment command that stops progressing hangs the client forever, silently.**

## The break

`EnvironmentEngine` polled with no deadline and no attempt cap:

```python
def _await_library_command(self, environment_name, library_name):
    commands = [command.Command(status="ONGOING")]
    while len(commands) > 0 and not self._is_final_status(commands[0]):
        time.sleep(5)
        library = self._poll_commands_library(environment_name, library_name)
        commands = [] if library is None else library._commands
```

`_is_final_status` returns `True` only on `SUCCESS` and raises only on `FAILED`, so `ONGOING` loops until the process is killed. `_await_environment_command` had the same shape.

The asymmetry is what makes this a defect rather than bad luck: a **deleted** artifact was already handled (a `None` poll empties `commands` and the loop ends), while a **stalled** command was not handled at all.

Everything that awaits inherited it: `install_wheel`, `install_requirements`, `uninstall`, and `create_environment`.

## How it was found

A full loadtest suite sat for 39 minutes with no output and frozen result counts. `py-spy dump` on the pytest process:

```
Thread 1606 (idle): "MainThread"
    _await_library_command (hopsworks_common/engine/environment_engine.py:29)
    install_requirements (hopsworks_common/environment.py:178)
    setup (tests/workflows/feature_store/pyspark_driver/test_external_fraud_batch_data_validation.py:36)
```

The command it was waiting on:

```
great-expectations   cmds: []                          <- installed
tmp3zwmpner.txt      cmds: [('INSTALL', 'ONGOING')]    <- wedged
```

No installer pod existed on the cluster any more, so nothing was ever going to move that row. Two full-suite runs were lost to this before the cause was known.

## The change

Both waits now share one bounded implementation. On expiry it raises `EnvironmentException` naming the environment, the library, and the last status observed — because "still `ONGOING`" and "no command at all" are different problems that a bare timeout cannot distinguish, and the message points at the environment page where the command state is visible.

The default is 30 minutes, deliberately generous: resolving a large `requirements.txt` against a cold cache legitimately takes many minutes, and timing that out would be worse than waiting. What the deadline bounds is the case that never finishes at all. The three `Environment` methods that await, plus `create_environment`, take an explicit `timeout` for callers who know their own workload.

## Verification

- **7 new tests** in `tests/engine/test_environment_engine.py` covering: success, failure, missing artifact (the benign case that must still return, not time out), stall → raises, message content, explicit override, and the environment-command twin.
- **The regression test genuinely tests the bug.** It fakes the clock instead of sleeping, so it is fast — and against the original loop **the test run itself hangs and has to be killed**, which is the bug reproduced in CI terms.
- Existing `tests/test_environment.py` assertions updated for the new call signature; 9/9 pass.
- `ruff check` and `ruff format` clean; `scripts/check_pep8_public.py` passes (the CI `pep8_public` gate).
- Docstrings follow the repo convention: one sentence per line, no defaults stated (they live in the signature).

## Scope

**Failing loudly does not repair the stuck command.** The server-side half — nothing reconciles a library command left `ONGOING` after its installer pod is gone — is recorded on the ticket as separate work and deliberately not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[HWORKS-3071]: https://hopsworks.atlassian.net/browse/HWORKS-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ