### PR TITLE
[HWORKS-3074] Importing the Python SDK executes great_expectations and takes ~9 seconds

### DIFF
--- a/python/hopsworks_common/core/constants.py
+++ b/python/hopsworks_common/core/constants.py
@@ -46,14 +46,20 @@ GE_MAJOR: int | None = None
 if HAS_GREAT_EXPECTATIONS:
     # GE 1.x's _docs_decorators logs an INFO line for every closure it scans
     # during module init (DataSourceManager._register_* / _bind_asset_factory_*),
-    # producing hundreds of useless lines on every SDK import. Suppress before
-    # the great_expectations import so module-init chatter never fires.
+    # producing hundreds of useless lines whenever GE loads. Suppress here so it
+    # is in place before the validation modules import great_expectations.
+    import importlib.metadata
     import logging
 
     logging.getLogger("great_expectations._docs_decorators").setLevel(logging.WARNING)
-    import great_expectations as _ge
-
-    GE_MAJOR = int(_ge.__version__.split(".")[0])
+    # The version comes from package metadata, never from importing the package:
+    # this module sits on the SDK's import spine, and executing GE's module init
+    # here (it pulls altair, scipy and jsonschema) put ~8 seconds on every
+    # `import hopsworks` for a value the dist-info already carries.
+    try:
+        GE_MAJOR = int(importlib.metadata.version("great_expectations").split(".")[0])
+    except (importlib.metadata.PackageNotFoundError, ValueError):
+        GE_MAJOR = None
 great_expectations_not_installed_message = (
     "Great Expectations package not found. "
     "If you want to use data validation with Hopsworks you can install the corresponding extras via "

--- a/python/tests/test_hopsworks_lazy_alias.py
+++ b/python/tests/test_hopsworks_lazy_alias.py
@@ -26,19 +26,27 @@ import sys
 import textwrap
 
 
-def _run_isolated(snippet: str) -> tuple[int, str]:
-    """Execute ``snippet`` in a fresh interpreter for clean ``sys.modules``."""
+def _run_isolated(snippet: str) -> tuple[int, str, str]:
+    """Execute ``snippet`` in a fresh interpreter for clean ``sys.modules``.
+
+    The sentinel is asserted against stdout alone: optional dependencies log
+    to stderr on import (great_expectations prints "Multiple declarations of
+    metric ..." whenever it loads), and concatenating the streams put that
+    noise after the sentinel, failing every test on environments that have
+    the extras installed. The merged output is returned for failure messages.
+    """
     proc = subprocess.run(
         [sys.executable, "-c", textwrap.dedent(snippet)],
         capture_output=True,
         text=True,
     )
-    return proc.returncode, (proc.stdout + proc.stderr).strip()
+    merged = (proc.stdout + proc.stderr).strip()
+    return proc.returncode, proc.stdout.strip(), merged
 
 
 def test_import_hopsworks_does_not_load_hsfs():
     """``import hopsworks`` must not eagerly load ``hsfs`` or ``hsml``."""
-    rc, out = _run_isolated(
+    rc, out, log = _run_isolated(
         """
         import sys
         import hopsworks  # noqa: F401
@@ -49,24 +57,24 @@ def test_import_hopsworks_does_not_load_hsfs():
         print('OK')
         """
     )
-    assert rc == 0 and out.endswith("OK"), out
+    assert rc == 0 and out.endswith("OK"), log
 
 
 def test_dotted_submodule_import_works():
     """``from hopsworks.hsfs.X import Y`` resolves via the meta-path finder."""
-    rc, out = _run_isolated(
+    rc, out, log = _run_isolated(
         """
         from hopsworks.hsfs.builtin_transformations import one_hot_encoder
         assert one_hot_encoder is not None
         print('OK')
         """
     )
-    assert rc == 0 and out.endswith("OK"), out
+    assert rc == 0 and out.endswith("OK"), log
 
 
 def test_dotted_submodule_import_lazily_loads_hsfs():
     """The dotted import is what triggers the real ``hsfs`` load, not ``import hopsworks``."""
-    rc, out = _run_isolated(
+    rc, out, log = _run_isolated(
         """
         import sys
         import hopsworks  # noqa: F401
@@ -77,12 +85,12 @@ def test_dotted_submodule_import_lazily_loads_hsfs():
         print('OK')
         """
     )
-    assert rc == 0 and out.endswith("OK"), out
+    assert rc == 0 and out.endswith("OK"), log
 
 
 def test_attribute_access_still_works():
     """The PEP 562 ``__getattr__`` path is unaffected by the finder."""
-    rc, out = _run_isolated(
+    rc, out, log = _run_isolated(
         """
         import hopsworks
         _ = hopsworks.hsfs
@@ -91,12 +99,12 @@ def test_attribute_access_still_works():
         print('OK')
         """
     )
-    assert rc == 0 and out.endswith("OK"), out
+    assert rc == 0 and out.endswith("OK"), log
 
 
 def test_alias_and_real_module_are_identical():
     """``hopsworks.hsfs`` and ``hsfs`` must be the same module object."""
-    rc, out = _run_isolated(
+    rc, out, log = _run_isolated(
         """
         import hopsworks.hsfs
         import hsfs
@@ -107,12 +115,12 @@ def test_alias_and_real_module_are_identical():
         print('OK')
         """
     )
-    assert rc == 0 and out.endswith("OK"), out
+    assert rc == 0 and out.endswith("OK"), log
 
 
 def test_repeated_dotted_imports_are_idempotent():
     """Re-importing a dotted submodule must hand back the same object."""
-    rc, out = _run_isolated(
+    rc, out, log = _run_isolated(
         """
         from hopsworks.hsfs.builtin_transformations import one_hot_encoder as a
         from hopsworks.hsfs.builtin_transformations import one_hot_encoder as b
@@ -120,4 +128,4 @@ def test_repeated_dotted_imports_are_idempotent():
         print('OK')
         """
     )
-    assert rc == 0 and out.endswith("OK"), out
+    assert rc == 0 and out.endswith("OK"), log

--- a/python/tests/test_import_side_effects.py
+++ b/python/tests/test_import_side_effects.py
@@ -1,0 +1,40 @@
+#
+#   Copyright 2026 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+import subprocess
+import sys
+
+
+def test_importing_the_sdk_does_not_execute_great_expectations():
+    # constants.py sits on the SDK's import spine; executing great_expectations there put
+    # ~8 seconds of altair/scipy/jsonschema module init on every `import hopsworks`. The
+    # GE version must come from package metadata, so GE stays out of sys.modules until a
+    # validation module actually needs it. Run in a subprocess so this test's verdict
+    # cannot be poisoned by whatever earlier tests already imported.
+    code = (
+        "import json, sys\n"
+        "import hopsworks_common.core.constants as c\n"
+        "print(json.dumps({'ge_loaded': 'great_expectations' in sys.modules,"
+        " 'has_ge': c.HAS_GREAT_EXPECTATIONS, 'ge_major': c.GE_MAJOR}))\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    result = json.loads(out.stdout.strip().splitlines()[-1])
+    assert result["ge_loaded"] is False
+    if result["has_ge"]:
+        assert isinstance(result["ge_major"], int)


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-3074

`constants.py` imported `great_expectations` at module load only to read `_ge.__version__` for `GE_MAJOR` (FSTORE-1892). The module sits on the SDK's import spine (`hopsworks` → `client` → `decorators` → `core.constants`), so every `import hopsworks` executed GE's module init, which transitively pulls altair, scipy.stats, jsonschema and pandas.

**Measured inside a serving pod on jim-skills**: `import hopsworks` is **8.8s with the eager import, 0.8s without it** (`python -X importtime` attributes the cost to the GE subtree). The same tax was the dominant cost of the HWORKS-2954 in-pod log archiver (~10.5s of a ~13s archive upload was the import), and it lands on every job, app, and deployment start that imports the SDK.

The fix reads the major version from package metadata (`importlib.metadata.version("great_expectations")`) — the dist-info carries it without executing the package. `HAS_GREAT_EXPECTATIONS` was already a `find_spec` check, and the `_docs_decorators` logging suppression stays in place for whenever the validation modules import GE later. `GE_MAJOR` verified identical (1) on the live pod.

**Testing**: new subprocess-isolated test pins that importing `hopsworks_common.core.constants` leaves `great_expectations` out of `sys.modules` (and that `GE_MAJOR` still resolves when GE is installed); ruff check/format clean. Live-pod verification: after applying the same patch to a running pod's site-packages, `import hopsworks` dropped 8.8s → 0.8s and the log archiver's upload phase shrank accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HYcrd31o5o4LwZfAvDEt7
