### PR TITLE
[HWORKS-2883] Add KServe Standard mode support for LLM deployments

### DIFF
--- a/python/hopsworks/cli/commands/deployment.py
+++ b/python/hopsworks/cli/commands/deployment.py
@@ -275,6 +275,14 @@ def _deployment_to_dict(d: Any) -> dict[str, Any]:
     type=click.Choice(["KSERVE", "DEFAULT"], case_sensitive=False),
     help="Serving backend.",
 )
+@click.option(
+    "--knative/--standard",
+    "knative_mode",
+    default=None,
+    help="KServe mode: Knative (scale-to-zero) or Standard (no scale-to-zero, CPU/memory autoscaling or fixed replicas when min equals max). "
+    "Omit to let the backend decide (vLLM deployments default to Standard, others to Knative mode). "
+    "On an update, omitting it keeps the deployment's current mode.",
+)
 @click.option("--description", default="", help="Deployment description.")
 @click.option(
     "--passed-feature",
@@ -298,6 +306,7 @@ def deployment_create(
     script_file: str | None,
     environment: str | None,
     serving_tool: str | None,
+    knative_mode: bool | None,
     description: str,
     passed_features: tuple[str, ...],
     no_default_predictor: bool,
@@ -317,6 +326,7 @@ def deployment_create(
         script_file: Predictor script, local or HopsFS.
         environment: Inference environment name.
         serving_tool: ``KSERVE`` or ``DEFAULT``.
+        knative_mode: KServe Knative (True) vs Standard (False) mode; None lets the backend decide.
         description: Deployment description.
         passed_features: Features clients send with each request.
         no_default_predictor: Disable the default predictor.
@@ -364,6 +374,7 @@ def deployment_create(
             serving_tool=(serving_tool or "").upper() or None,
             passed_features=list(passed_features) or None,
             default_predictor=False if no_default_predictor else None,
+            knative_mode=knative_mode,
         )
     except Exception as exc:  # noqa: BLE001
         raise click.ClickException(f"Deployment creation failed: {exc}") from exc

--- a/python/hsml/deployment.py
+++ b/python/hsml/deployment.py
@@ -1176,6 +1176,23 @@ class Deployment:
 
     @public
     @property
+    def knative_mode(self):
+        """Whether the deployment runs in KServe Knative mode.
+
+        `True` selects Knative mode, `False` selects Standard mode and `None` lets the backend decide on creation or keeps the stored mode on an update.
+        See [`Predictor.knative_mode`][hsml.predictor.Predictor.knative_mode] for the full mode semantics.
+
+        Info: Adds Knative mode selection, ~=5.1.0
+            Deployments can now select between KServe Knative and Standard mode.
+        """
+        return self._predictor.knative_mode
+
+    @knative_mode.setter
+    def knative_mode(self, knative_mode: bool | None):
+        self._predictor.knative_mode = knative_mode
+
+    @public
+    @property
     def environment(self):
         """Name of inference environment."""
         return self._predictor.environment

--- a/python/hsml/model.py
+++ b/python/hsml/model.py
@@ -387,6 +387,7 @@ class Model:
         schema: DeploymentSchema | dict | None = None,
         passed_features: list[str] | None = None,
         default_predictor: bool | None = None,
+        knative_mode: bool | None = None,
     ) -> deployment.Deployment:
         """Deploy the model.
 
@@ -452,6 +453,9 @@ class Model:
                 Only with the default predictor.
             default_predictor: `None` selects the default predictor automatically for Python models with a feature view and no script,
                 `True` requires it (also for sklearn models, and together with a `script_file` that subclasses it), `False` never uses it.
+            knative_mode: Whether to deploy in KServe Knative mode.
+                `None` (default) lets the backend decide: LLM (vLLM) deployments default to Standard, every other deployment defaults to Knative mode; on an update, `None` keeps the deployment's current mode.
+                Standard mode does not scale to zero (minimum one instance). It autoscales on a CPU or memory metric between `min_instances` and `max_instances` (default: CPU at 80% up to the cluster maximum), and runs a fixed replica count without autoscaler when `min_instances == max_instances` (the default for LLM deployments).
 
         Returns:
             The deployment metadata object of a new or existing deployment.
@@ -483,6 +487,7 @@ class Model:
             schema=schema,
             passed_features=passed_features,
             default_predictor=default_predictor,
+            knative_mode=knative_mode,
         )
 
         return predictor.deploy()

--- a/python/hsml/model_serving.py
+++ b/python/hsml/model_serving.py
@@ -225,6 +225,7 @@ class ModelServing:
         schema: DeploymentSchema | dict | None = None,
         passed_features: list[str] | None = None,
         default_predictor: bool | None = None,
+        knative_mode: bool | None = None,
     ) -> Predictor:
         """Create a Predictor metadata object.
 
@@ -276,6 +277,9 @@ class ModelServing:
             schema: Deployment schema describing the prediction requests; see [`Model.deploy`][hsml.model.Model.deploy].
             passed_features: Feature view features whose values clients send with each request; see [`Model.deploy`][hsml.model.Model.deploy].
             default_predictor: Whether the library's default predictor serves the model; see [`Model.deploy`][hsml.model.Model.deploy].
+            knative_mode: Whether to deploy in KServe Knative mode.
+                `None` (default) lets the backend decide: LLM (vLLM) deployments default to Standard, every other deployment defaults to Knative mode; on an update, `None` keeps the deployment's current mode.
+                Standard mode does not scale to zero (minimum one instance). It autoscales on a CPU or memory metric between `min_instances` and `max_instances` (default: CPU at 80% up to the cluster maximum), and runs a fixed replica count without autoscaler when `min_instances == max_instances` (the default for LLM deployments).
 
         Returns:
             The predictor metadata object.
@@ -304,6 +308,7 @@ class ModelServing:
             schema=schema,
             passed_features=passed_features,
             default_predictor=default_predictor,
+            knative_mode=knative_mode,
         )
 
     @public
@@ -322,6 +327,7 @@ class ModelServing:
         environment: str | None = None,
         env_vars: dict | None = None,
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
+        knative_mode: bool | None = None,
     ) -> Predictor:
         """Create the predictor of a feature view deployment, which serves transformed feature vectors without a model.
 
@@ -346,6 +352,7 @@ class ModelServing:
             environment: The inference environment to use.
             env_vars: Environment variables to set on the predictor.
             tags: Tags to attach to the deployment when it is created.
+            knative_mode: Whether to deploy in KServe Knative mode; see [`ModelServing.create_predictor`][hsml.model_serving.ModelServing.create_predictor].
 
         Example:
             ```python
@@ -371,6 +378,7 @@ class ModelServing:
             environment=environment,
             env_vars=env_vars,
             tags=tags,
+            knative_mode=knative_mode,
         )
 
     @public
@@ -467,6 +475,7 @@ class ModelServing:
         git_provider: str | None = None,
         git_branch: str | None = None,
         git_auto_redeploy: bool = False,
+        knative_mode: bool | None = None,
     ) -> Predictor:
         """Create an Entrypoint metadata object.
 
@@ -503,6 +512,9 @@ class ModelServing:
             git_branch: Optional branch to clone for git-backed endpoints.
             git_auto_redeploy: Roll the endpoint to the branch HEAD whenever a new commit is pushed.
                 Only valid together with `git_url`.
+            knative_mode: Whether to deploy in KServe Knative mode.
+                `None` (default) lets the backend decide: every deployment defaults to Knative mode unless it is a vLLM deployment; on an update, `None` keeps the deployment's current mode.
+                Standard mode does not scale to zero (minimum one instance). It autoscales on a CPU or memory metric between `min_instances` and `max_instances` (default: CPU at 80% up to the cluster maximum), and runs a fixed replica count without autoscaler when `min_instances == max_instances` (the default for LLM deployments).
 
         Returns:
             The predictor metadata object.
@@ -533,6 +545,7 @@ class ModelServing:
             git_provider=git_provider,
             git_branch=git_branch,
             git_auto_redeploy=git_auto_redeploy,
+            knative_mode=knative_mode,
         )
 
     @public
@@ -555,6 +568,7 @@ class ModelServing:
         git_provider: str | None = None,
         git_branch: str | None = None,
         git_auto_redeploy: bool = False,
+        knative_mode: bool | None = None,
     ) -> Deployment:
         """Deploy a Python script or package as an agent.
 
@@ -605,6 +619,9 @@ class ModelServing:
             git_auto_redeploy: Roll the agent to the branch HEAD whenever a new commit is pushed.
                 Only valid together with `git_url`.
                 The running agent keeps serving until the new version is ready.
+            knative_mode: Whether to deploy in KServe Knative mode.
+                `None` (default) lets the backend decide: every deployment defaults to Knative mode unless it is a vLLM deployment; on an update, `None` keeps the deployment's current mode.
+                Standard mode does not scale to zero (minimum one instance). It autoscales on a CPU or memory metric between `min_instances` and `max_instances` (default: CPU at 80% up to the cluster maximum), and runs a fixed replica count without autoscaler when `min_instances == max_instances` (the default for LLM deployments).
 
         Returns:
             The deployment metadata object.
@@ -708,6 +725,7 @@ class ModelServing:
             git_provider=git_provider if git_backed else None,
             git_branch=git_branch if git_backed else None,
             git_auto_redeploy=git_auto_redeploy if git_backed else False,
+            knative_mode=knative_mode,
         )
 
         existing = self.get_deployment(name)

--- a/python/hsml/predictor.py
+++ b/python/hsml/predictor.py
@@ -104,6 +104,7 @@ class Predictor(DeployableComponent):
         tags: tag.Tag | dict[str, Any] | list[tag.Tag | dict[str, Any]] | None = None,
         schema: DeploymentSchema | dict | None = None,
         default_predictor: bool | None = None,
+        knative_mode: bool | None = None,
         **kwargs,
     ):
         self._missing_mandatory_tags = missing_mandatory_tags or []
@@ -115,15 +116,24 @@ class Predictor(DeployableComponent):
             self._validate_serving_tool(serving_tool)
             or self._get_default_serving_tool()
         )
+        effective_knative_mode = self._get_effective_knative_mode(
+            knative_mode, model_server
+        )
         resources = self._validate_resources(
-            util._get_obj_from_json(resources, PredictorResources), serving_tool
-        ) or self._get_default_resources(serving_tool)
+            util._get_obj_from_json(resources, PredictorResources),
+            serving_tool,
+            effective_knative_mode,
+        ) or self._get_default_resources(serving_tool, effective_knative_mode)
 
+        # Default means "not provided": PredictorScalingConfig cannot be built without min_instances.
+        if isinstance(scaling_configuration, Default):
+            scaling_configuration = None
         self._scaling_configuration = util._get_obj_from_json(
             scaling_configuration, PredictorScalingConfig
         ) or PredictorScalingConfig.get_default_scaling_configuration(
             serving_tool=serving_tool,
             min_instances=self._get_raw_num_instances(resources),
+            effective_knative_mode=effective_knative_mode,
         )
 
         super().__init__(
@@ -168,6 +178,7 @@ class Predictor(DeployableComponent):
         self._git_resolved_branch = git_resolved_branch
         self._vllm_variant = vllm_variant
         self._vllm_image_tag = vllm_image_tag
+        self._knative_mode = knative_mode
 
     @public
     def deploy(self) -> deployment.Deployment:
@@ -265,10 +276,22 @@ class Predictor(DeployableComponent):
         )
 
     @classmethod
-    def _validate_resources(cls, resources, serving_tool):
+    def _get_effective_knative_mode(cls, knative_mode, model_server):
+        """Resolve the effective Knative mode used for client-side scaling defaults.
+
+        An explicit `knative_mode` value always wins.
+        Otherwise, every model server defaults to Knative mode except vLLM, which defaults to Standard.
+        """
+        if knative_mode is not None:
+            return knative_mode
+        return model_server != PREDICTOR.MODEL_SERVER_VLLM
+
+    @classmethod
+    def _validate_resources(cls, resources, serving_tool, effective_knative_mode=True):
         if (
             resources is not None
             and serving_tool == PREDICTOR.SERVING_TOOL_KSERVE
+            and effective_knative_mode
             and cls._get_raw_num_instances(resources) != 0
             and client._is_scale_to_zero_required()
         ):
@@ -279,10 +302,11 @@ class Predictor(DeployableComponent):
         return resources
 
     @classmethod
-    def _get_default_resources(cls, serving_tool):
+    def _get_default_resources(cls, serving_tool, effective_knative_mode=True):
         num_instances = (
             0  # enable scale-to-zero by default if required
             if serving_tool == PREDICTOR.SERVING_TOOL_KSERVE
+            and effective_knative_mode
             and client._is_scale_to_zero_required()
             else SCALING_CONFIG.MIN_NUM_INSTANCES
         )
@@ -519,6 +543,9 @@ class Predictor(DeployableComponent):
         kwargs["missing_mandatory_tags"] = util._extract_field_from_json(
             json_decamelized, "missing_mandatory_tags"
         )
+        kwargs["knative_mode"] = util._extract_field_from_json(
+            json_decamelized, "knative_mode"
+        )
         return kwargs
 
     def update_from_response_json(self, json_dict):
@@ -576,6 +603,10 @@ class Predictor(DeployableComponent):
         if self._inference_batcher is not None:
             predictor_dict = {**predictor_dict, **self._inference_batcher.to_dict()}
         if self._transformer is not None:
+            # A transformer built standalone assumed Knative mode for its defaulted instance count; re-resolve it now that the deployment mode is known (Standard mode needs at least one instance).
+            self._transformer._resolve_default_num_instances(
+                self._get_effective_knative_mode(self._knative_mode, self._model_server)
+            )
             predictor_dict = {**predictor_dict, **self._transformer.to_dict()}
         if self._tracing is not None:
             predictor_dict = {**predictor_dict, "tracing": self._tracing.to_dict()}
@@ -594,6 +625,8 @@ class Predictor(DeployableComponent):
             }
         if self._scaling_configuration is not None:
             predictor_dict = {**predictor_dict, **self._scaling_configuration.to_dict()}
+        if self._knative_mode is not None:
+            predictor_dict = {**predictor_dict, "knativeMode": self._knative_mode}
         tags_dict = tag.Tag._tags_to_dict(self._tags)
         if tags_dict:
             predictor_dict = {**predictor_dict, "tags": tags_dict}
@@ -985,6 +1018,26 @@ class Predictor(DeployableComponent):
     @vllm_image_tag.setter
     def vllm_image_tag(self, vllm_image_tag: str):
         self._vllm_image_tag = vllm_image_tag
+
+    @public
+    @property
+    def knative_mode(self):
+        """Whether this deployment runs in KServe Knative mode.
+
+        `True` selects Knative mode, which supports scale-to-zero and Knative-only autoscaling.
+        `False` selects Standard mode, which requires at least one instance and autoscales on a CPU/memory metric between the minimum and maximum instances, or runs a fixed replica count when they are equal.
+        `None` leaves the mode for the backend to decide: LLM (vLLM) deployments default to Standard, every other deployment defaults to Knative mode.
+        Read the current mode from a saved deployment via this property.
+        Setting it to `None` before a save call keeps the stored mode unchanged.
+
+        Info: Adds Knative mode selection, ~=5.1.0
+            Deployments can now select between KServe Knative and Standard mode.
+        """
+        return self._knative_mode
+
+    @knative_mode.setter
+    def knative_mode(self, knative_mode: bool | None):
+        self._knative_mode = knative_mode
 
     @public
     def get_endpoint_url(self) -> str | None:

--- a/python/hsml/scaling_config.py
+++ b/python/hsml/scaling_config.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -32,10 +33,17 @@ if TYPE_CHECKING:
 
 @public
 class ScaleMetric(Enum):
-    """Scaling metric for a predictor or transformer. Can be either 'CONCURRENCY' or 'RPS'."""
+    """Scaling metric for a predictor or transformer.
+
+    `CONCURRENCY` and `RPS` are Knative-only metrics, valid for KServe Knative deployments.
+    `CPU` and `MEMORY` drive CPU/memory-based autoscaling, valid for KServe Standard and non-KServe deployments.
+    In KServe Standard mode a deployment with `min_instances == max_instances` runs a fixed replica count and ignores the metric.
+    """
 
     CONCURRENCY = "CONCURRENCY"
     RPS = "RPS"
+    CPU = "CPU"
+    MEMORY = "MEMORY"
 
     @classmethod
     def _has_value(cls, value):
@@ -111,7 +119,11 @@ class ComponentScalingConfig(ABC):
     @public
     @staticmethod
     def get_default_scaling_configuration(
-        serving_tool: str, min_instances: int | None, component_type: str = "predictor"
+        serving_tool: str,
+        min_instances: int | None,
+        component_type: str = "predictor",
+        effective_knative_mode: bool = True,
+        enforce_scale_to_zero: bool = True,
     ) -> ComponentScalingConfig:
         """Get the default scaling configuration based on the serving tool and number of instances.
 
@@ -119,19 +131,28 @@ class ComponentScalingConfig(ABC):
             serving_tool: the serving tool to use (e.g. kserve)
             min_instances: minimum number of instances, or None to use the default
             component_type: the component type (predictor or transformer)
+            effective_knative_mode: whether the deployment runs in KServe Knative mode.
+                Only meaningful when `serving_tool` is kserve.
+                Standard mode does not scale to zero and does not default to Knative-only autoscaling metrics.
+            enforce_scale_to_zero: whether to reject a non-zero minimum when the cluster requires scale-to-zero for Knative deployments.
+                Transformers are built before the deployment mode is known and skip this check.
+                The backend validates the assembled deployment mode-aware.
 
         Returns:
             The default scaling configuration for the given serving tool.
         """
+        kserve_knative = (
+            serving_tool == PREDICTOR.SERVING_TOOL_KSERVE and effective_knative_mode
+        )
         if min_instances is None:
             min_instances = (
                 0  # enable scale-to-zero by default if required
-                if serving_tool == PREDICTOR.SERVING_TOOL_KSERVE
-                and client._is_scale_to_zero_required()
+                if kserve_knative and client._is_scale_to_zero_required()
                 else SCALING_CONFIG.MIN_NUM_INSTANCES
             )
         if (
-            serving_tool == PREDICTOR.SERVING_TOOL_KSERVE
+            kserve_knative
+            and enforce_scale_to_zero
             and min_instances != 0
             and client._is_scale_to_zero_required()
         ):
@@ -144,7 +165,7 @@ class ComponentScalingConfig(ABC):
                 "Minimum number of instances cannot be 0 for deployments not using KServe. Please, set the minimum number of instances to at least 1."
             )
         kwargs = {"min_instances": min_instances}
-        if serving_tool == PREDICTOR.SERVING_TOOL_KSERVE:
+        if kserve_knative:
             kwargs["scale_metric"] = SCALING_CONFIG.SCALE_METRIC_CONCURRENCY
             kwargs["target"] = SCALING_CONFIG.DEFAULT_CONCURRENCY_TARGET
             kwargs["panic_threshold_percentage"] = (
@@ -181,7 +202,15 @@ class ComponentScalingConfig(ABC):
         )
         scale_metric = util._extract_field_from_json(json_decamelized, "scale_metric")
         if scale_metric:
-            kwargs["scale_metric"] = ScaleMetric(scale_metric)
+            # A newer backend may store metrics this client does not know yet (e.g. CPU/MEMORY on an older client).
+            # Runtime containers parse the deployment JSON with the client bundled in their image, so an unknown metric must not crash them.
+            if ScaleMetric._has_value(scale_metric):
+                kwargs["scale_metric"] = ScaleMetric(scale_metric)
+            else:
+                warnings.warn(
+                    f"Ignoring unknown scale metric '{scale_metric}' returned by the backend; upgrade the hopsworks client to manage it.",
+                    stacklevel=2,
+                )
         kwargs["target"] = util._extract_field_from_json(json_decamelized, "target")
         kwargs["panic_window_percentage"] = util._extract_field_from_json(
             json_decamelized, "panic_window_percentage"
@@ -246,7 +275,12 @@ class ComponentScalingConfig(ABC):
     @public
     @property
     def scale_metric(self):
-        """The metric to use for scaling. Can be either 'CONCURRENCY' or 'RPS'."""
+        """The metric to use for scaling.
+
+        `CONCURRENCY` and `RPS` are Knative-only metrics for KServe Knative deployments.
+        `CPU` and `MEMORY` drive CPU/memory-based autoscaling in KServe Standard mode.
+        Standard deployments default to `CPU` when `min_instances < max_instances`; with `min_instances == max_instances` no autoscaler is configured and the metric is cleared.
+        """
         return self._scale_metric
 
     @scale_metric.setter
@@ -267,7 +301,12 @@ class ComponentScalingConfig(ABC):
     @public
     @property
     def target(self):
-        """Target value for the selected scaling metric that the autoscaler should try to maintain during the stable window. For RPS, this is requests per second. For CONCURRENCY, this is concurrent number of requests."""
+        """Target value for the selected scaling metric that the autoscaler should try to maintain.
+
+        For `RPS`, this is requests per second.
+        For `CONCURRENCY`, this is the number of concurrent requests.
+        For `CPU` and `MEMORY`, this is the utilization percentage.
+        """
         return self._target
 
     @target.setter
@@ -277,7 +316,12 @@ class ComponentScalingConfig(ABC):
     @public
     @property
     def min_instances(self) -> int:
-        """Minimum number of instances to scale to. For deployments using kserve, this must be set to 0 to enable scaling to zero. Default is 0 for deployments using kserve and 1 for deployments not using kserve."""
+        """Minimum number of instances to scale to.
+
+        KServe Knative deployments scale to zero when this is 0, and the cluster may require it.
+        KServe Standard deployments do not scale to zero and need at least 1.
+        Defaults to 0 for KServe Knative deployments when the cluster requires scale-to-zero, otherwise to 1.
+        """
         return self._min_instances
 
     @min_instances.setter
@@ -287,7 +331,11 @@ class ComponentScalingConfig(ABC):
     @public
     @property
     def max_instances(self):
-        """Maximum number of instances to scale to. Maximum allowed is configured in the cluster settings by the cluster administrator. Must be at least 1 and greater than or equal to min_instances."""
+        """Maximum number of instances to scale to.
+
+        Maximum allowed is configured in the cluster settings by the cluster administrator. Must be at least 1 and greater than or equal to min_instances.
+        Defaults to the cluster maximum, except for LLM deployments in KServe Standard mode, which default to `min_instances` (fixed replica count).
+        """
         return self._max_instances
 
     @max_instances.setter

--- a/python/hsml/transformer.py
+++ b/python/hsml/transformer.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import humps
 from hopsworks_apigen import public
 from hopsworks_common import client, util
-from hopsworks_common.constants import PREDICTOR, SCALING_CONFIG, Default
+from hopsworks_common.constants import SCALING_CONFIG, Default
 from hsml.deployable_component import DeployableComponent
 from hsml.resources import TransformerResources
 from hsml.scaling_config import TransformerScalingConfig
@@ -45,21 +45,24 @@ class Transformer(DeployableComponent):
         env_vars: dict[str, str] | None = None,
         **kwargs,
     ):
-        resources = (
-            self._validate_resources(
-                util._get_obj_from_json(resources, TransformerResources)
-            )
-            or self._get_default_resources()
+        resources = self._validate_resources(
+            util._get_obj_from_json(resources, TransformerResources)
         )
+        # A transformer is built standalone, before it is attached to a predictor, so its Knative/Standard mode is not known here.
+        # The provisional default assumes Knative mode (scale-to-zero when the cluster requires it) and is re-resolved mode-aware at serialization time, once the owning predictor is known (see _resolve_default_num_instances).
+        self._num_instances_defaulted = (
+            resources is None or self._get_raw_num_instances(resources) is None
+        )
+        resources = resources or self._get_default_resources()
         if self._get_raw_num_instances(resources) is None:
             resources._num_instances = self._get_default_num_instances()
 
-        self._scaling_configuration: TransformerScalingConfig = util._get_obj_from_json(
-            scaling_configuration, TransformerScalingConfig
-        ) or TransformerScalingConfig.get_default_scaling_configuration(
-            serving_tool=PREDICTOR.SERVING_TOOL_KSERVE,
-            min_instances=self._get_raw_num_instances(resources),
-            component_type="transformer",
+        # Only an explicitly provided (or backend-hydrated) scaling config is stored and serialized: the backend synthesizes a mode-appropriate default when the key is absent, and a local default object would invite in-place edits that are silently never sent.
+        # Default means "not provided": TransformerScalingConfig cannot be built without min_instances.
+        if isinstance(scaling_configuration, Default):
+            scaling_configuration = None
+        self._scaling_configuration: TransformerScalingConfig | None = (
+            util._get_obj_from_json(scaling_configuration, TransformerScalingConfig)
         )
 
         super().__init__(
@@ -75,15 +78,8 @@ class Transformer(DeployableComponent):
 
     @classmethod
     def _validate_resources(cls, resources):
-        if (
-            resources is not None
-            and cls._get_raw_num_instances(resources) != 0
-            and client._is_scale_to_zero_required()
-        ):
-            # ensure scale-to-zero for kserve deployments when required
-            raise ValueError(
-                "Scale-to-zero is required for KServe deployments in this cluster. Please, set the number of transformer instances to 0."
-            )
+        # The cluster's scale-to-zero requirement only applies to Knative deployments, and a transformer is built before the deployment mode is known.
+        # A standard-mode deployment legitimately needs at least one instance, so enforcement is left to the backend, which validates the assembled deployment mode-aware.
         return resources
 
     @classmethod
@@ -91,6 +87,18 @@ class Transformer(DeployableComponent):
         return (
             0  # enable scale-to-zero by default if required
             if client._is_scale_to_zero_required()
+            else SCALING_CONFIG.MIN_NUM_INSTANCES
+        )
+
+    def _resolve_default_num_instances(self, effective_knative_mode: bool):
+        # Re-resolve a defaulted instance count once the deployment mode is known.
+        # The scale-to-zero default only applies to Knative mode; a Standard deployment needs at least one instance, and the backend cannot fix it up because the deprecated instances field always arrives with a value.
+        # Explicitly provided values are never touched.
+        if not self._num_instances_defaulted:
+            return
+        self._resources._num_instances = (
+            self._get_default_num_instances()
+            if effective_knative_mode
             else SCALING_CONFIG.MIN_NUM_INSTANCES
         )
 
@@ -128,6 +136,8 @@ class Transformer(DeployableComponent):
 
     def to_dict(self):
         d = {"transformer": self._script_file, **self._resources.to_dict()}
+        if self._scaling_configuration is not None:
+            d = {**d, **self._scaling_configuration.to_dict()}
         if self._env_vars:
             d["transformerEnvVars"] = [f"{k}={v}" for k, v in self._env_vars.items()]
         return d
@@ -141,6 +151,17 @@ class Transformer(DeployableComponent):
     @env_vars.setter
     def env_vars(self, env_vars: dict[str, str] | None):
         self._env_vars = env_vars
+
+    @DeployableComponent.scaling_configuration.setter
+    def scaling_configuration(
+        self, scaling_configuration: TransformerScalingConfig | dict | Default | None
+    ) -> None:
+        # Mirror the constructor: accept a TransformerScalingConfig or a dict, and treat Default as not provided.
+        if isinstance(scaling_configuration, Default):
+            scaling_configuration = None
+        self._scaling_configuration = util._get_obj_from_json(
+            scaling_configuration, TransformerScalingConfig
+        )
 
     def __repr__(self):
         return f"Transformer({self._script_file!r})"

--- a/python/tests/fixtures/predictor_fixtures.json
+++ b/python/tests/fixtures/predictor_fixtures.json
@@ -560,6 +560,7 @@
       "config_file": "config.yaml",
       "vllmVariant": "VLLM",
       "vllmImageTag": null,
+      "knativeMode": false,
       "requested_instances": 0,
       "predictor_resources": {
         "requested_instances": 0,

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -275,6 +275,7 @@ class TestModel:
             schema=None,
             passed_features=None,
             default_predictor=None,
+            knative_mode=None,
         )
         mock_predictor.deploy.assert_called_once()
 
@@ -310,6 +311,22 @@ class TestModel:
 
         # Assert
         assert mock_predictor_for_model.call_args.kwargs["tags"] == tags
+        mock_predictor.deploy.assert_called_once()
+
+    def test_deploy_forwards_knative_mode(self, mocker, backend_fixtures):
+        # Arrange
+        m_json = backend_fixtures["model"]["get_python"]["response"]["items"][0]
+        mock_predictor = mocker.Mock()
+        mock_predictor_for_model = mocker.patch(
+            "hsml.predictor.Predictor.for_model", return_value=mock_predictor
+        )
+
+        # Act
+        m = model.Model.from_response_json(m_json)
+        m.deploy(name="test", knative_mode=False)
+
+        # Assert
+        assert mock_predictor_for_model.call_args.kwargs["knative_mode"] is False
         mock_predictor.deploy.assert_called_once()
 
     # get-time missing mandatory tag warning

--- a/python/tests/test_model_serving.py
+++ b/python/tests/test_model_serving.py
@@ -99,6 +99,45 @@ class TestTracingForwarding:
         # Assert
         assert mock_for_model.call_args.kwargs["tags"] == tags
 
+    def test_create_predictor_forwards_knative_mode(self, ms, mocker):
+        # Arrange
+        model = mocker.Mock()
+        model._get_default_serving_name.return_value = "my_model"
+        mock_for_model = mocker.patch("hsml.model_serving.Predictor.for_model")
+
+        # Act
+        ms.create_predictor(model, knative_mode=False)
+
+        # Assert
+        assert mock_for_model.call_args.kwargs["knative_mode"] is False
+
+    def test_create_endpoint_forwards_knative_mode(self, ms, mocker):
+        # Arrange
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.create_endpoint(
+            name="endpoint",
+            script_file="script.py",
+            knative_mode=True,
+        )
+
+        # Assert
+        assert mock_for_server.call_args.kwargs["knative_mode"] is True
+
+    def test_deploy_agent_forwards_knative_mode(self, ms, mocker, stub_apis, tmp_path):
+        # Arrange
+        script = tmp_path / "agent.py"
+        script.write_text("print('hi')")
+        mocker.patch.object(ms, "get_deployment", return_value=None)
+        mock_for_server = mocker.patch("hsml.model_serving.Predictor.for_server")
+
+        # Act
+        ms.deploy_agent(entry=str(script), name="my_agent", knative_mode=False)
+
+        # Assert
+        assert mock_for_server.call_args.kwargs["knative_mode"] is False
+
     def test_create_deployment_sets_tags_on_predictor(self, ms, mocker):
         # create_deployment normalizes the tags through the shared Tag helper and
         # stashes the resulting list[Tag] on the predictor so Predictor.to_dict

--- a/python/tests/test_predictor.py
+++ b/python/tests/test_predictor.py
@@ -1535,6 +1535,219 @@ class TestPredictor:
         assert p.vllm_variant == "VLLM_OMNI"
         assert p.vllm_image_tag == "v0.14.0"
 
+    # Knative mode
+
+    def test_knative_mode_none_omitted_from_to_dict(self, mocker):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+
+        # Act
+        p = predictor.Predictor(
+            name="my_model",
+            model_server=PREDICTOR.MODEL_SERVER_PYTHON,
+            model_name="my_model",
+            model_version=1,
+            model_framework=MODEL.FRAMEWORK_SKLEARN,
+        )
+
+        # Assert
+        assert p.knative_mode is None
+        assert "knativeMode" not in p.to_dict()
+
+    def test_knative_mode_true_round_trip(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        p_json = backend_fixtures["predictor"]["get_deployments_singleton"]["response"][
+            "items"
+        ][0]
+
+        # Act
+        p = predictor.Predictor.from_response_json(p_json)
+        p.knative_mode = True
+        serialized = p.to_dict()
+        p2 = predictor.Predictor.from_response_json(serialized)
+
+        # Assert
+        assert serialized["knativeMode"] is True
+        assert p2.knative_mode is True
+
+    def test_knative_mode_false_round_trip(self, mocker, backend_fixtures):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        p_json = backend_fixtures["predictor"][
+            "get_deployment_vllm_kserve_vllm_variant"
+        ]["response"]
+
+        # Act
+        p = predictor.Predictor.from_response_json(p_json)
+        serialized = p.to_dict()
+        p2 = predictor.Predictor.from_response_json(serialized)
+
+        # Assert
+        assert p.knative_mode is False
+        assert serialized["knativeMode"] is False
+        assert p2.knative_mode is False
+
+    def test_extract_fields_from_json_reads_knative_mode(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        p_json = backend_fixtures["predictor"][
+            "get_deployment_vllm_kserve_vllm_variant"
+        ]["response"]
+
+        # Act
+        # extract_fields_from_json expects decamelized input, as on the real
+        # from_response_json path (the backend sends camelCase knativeMode).
+        import humps
+
+        kwargs = predictor.Predictor.extract_fields_from_json(humps.decamelize(p_json))
+
+        # Assert
+        assert kwargs["knative_mode"] is False
+
+    def test_effective_knative_mode_defaults_standard_for_vllm(self, mocker):
+        # Arrange: vLLM predictors default to Standard mode, so client-side scale-to-zero and KPA-only defaults must not kick in even though the cluster forces scale-to-zero.
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        p = predictor.Predictor(
+            name="my_llm",
+            model_server=PREDICTOR.MODEL_SERVER_VLLM,
+            model_framework=MODEL.FRAMEWORK_LLM,
+            serving_tool=PREDICTOR.SERVING_TOOL_KSERVE,
+        )
+
+        # Assert
+        assert p.knative_mode is None
+        assert p.resources.num_instances == SCALING_CONFIG.MIN_NUM_INSTANCES
+        assert p.scaling_configuration.min_instances == SCALING_CONFIG.MIN_NUM_INSTANCES
+        assert p.scaling_configuration.scale_metric is None
+
+    def test_effective_knative_mode_explicit_true_forces_scale_to_zero_for_vllm(
+        self, mocker
+    ):
+        # Arrange: an explicit knative_mode=True overrides the vLLM standard default.
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        p = predictor.Predictor(
+            name="my_llm",
+            model_server=PREDICTOR.MODEL_SERVER_VLLM,
+            model_framework=MODEL.FRAMEWORK_LLM,
+            serving_tool=PREDICTOR.SERVING_TOOL_KSERVE,
+            knative_mode=True,
+        )
+
+        # Assert
+        assert p.resources.num_instances == 0
+        assert p.scaling_configuration.min_instances == 0
+        assert p.scaling_configuration.scale_metric.name == "CONCURRENCY"
+
+    def test_effective_knative_mode_false_skips_kpa_defaults_for_non_vllm(self, mocker):
+        # Arrange: an explicit knative_mode=False (Standard mode) must not force
+        # scale-to-zero nor fill the Knative-only scaling defaults.
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        p = predictor.Predictor(
+            name="my_model",
+            model_server=PREDICTOR.MODEL_SERVER_PYTHON,
+            model_name="my_model",
+            model_version=1,
+            model_framework=MODEL.FRAMEWORK_SKLEARN,
+            serving_tool=PREDICTOR.SERVING_TOOL_KSERVE,
+            knative_mode=False,
+        )
+
+        # Assert
+        assert p.resources.num_instances == SCALING_CONFIG.MIN_NUM_INSTANCES
+        assert p.scaling_configuration.min_instances == SCALING_CONFIG.MIN_NUM_INSTANCES
+        assert p.scaling_configuration.scale_metric is None
+
+    def test_to_dict_resolves_default_transformer_instances_mode_aware(self, mocker):
+        # Arrange: a default-built transformer assumes Knative mode (scale-to-zero) at
+        # construction; serializing under a Standard-mode predictor must lift it to one
+        # instance or the backend rejects the deployment on scale-to-zero clusters.
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+        p = predictor.Predictor(
+            name="my_model",
+            model_server=PREDICTOR.MODEL_SERVER_PYTHON,
+            model_name="my_model",
+            model_version=1,
+            model_framework=MODEL.FRAMEWORK_SKLEARN,
+            serving_tool=PREDICTOR.SERVING_TOOL_KSERVE,
+            knative_mode=False,
+            transformer=transformer.Transformer(script_file="t.py"),
+        )
+
+        # Act
+        serialized = p.to_dict()
+
+        # Assert
+        assert serialized["requestedTransformerInstances"] == 1
+
+        # Act: the same transformer under Knative mode keeps the scale-to-zero default
+        p.knative_mode = True
+        serialized = p.to_dict()
+
+        # Assert
+        assert serialized["requestedTransformerInstances"] == 0
+
+    def test_effective_knative_mode_default_true_for_non_vllm(self, mocker):
+        # Arrange: the pre-existing behavior (knative_mode=None, non-vLLM) is preserved.
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        p = predictor.Predictor(
+            name="my_model",
+            model_server=PREDICTOR.MODEL_SERVER_PYTHON,
+            model_name="my_model",
+            model_version=1,
+            model_framework=MODEL.FRAMEWORK_SKLEARN,
+            serving_tool=PREDICTOR.SERVING_TOOL_KSERVE,
+        )
+
+        # Assert
+        assert p.knative_mode is None
+        assert p.resources.num_instances == 0
+        assert p.scaling_configuration.min_instances == 0
+        assert p.scaling_configuration.scale_metric.name == "CONCURRENCY"
+
+    def test_llm_predictor_does_not_hardcode_knative_mode(self, mocker):
+        # Arrange: the LLM predictor subclass must not force a client-side
+        # default; None flows through untouched so the backend decides.
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        from hsml.llm.predictor import Predictor as LLMPredictor
+
+        # Act
+        p = LLMPredictor(name="my_llm")
+
+        # Assert
+        assert p.knative_mode is None
+
+    def test_llm_predictor_propagates_explicit_knative_mode(self, mocker):
+        # Arrange
+        self._mock_serving_variables(mocker, SERVING_NUM_INSTANCES_NO_LIMIT)
+        from hsml.llm.predictor import Predictor as LLMPredictor
+
+        # Act
+        p = LLMPredictor(name="my_llm", knative_mode=True)
+
+        # Assert
+        assert p.knative_mode is True
+
     # auxiliary methods
 
     def _mock_serving_variables(

--- a/python/tests/test_scaling_config.py
+++ b/python/tests/test_scaling_config.py
@@ -27,7 +27,20 @@ class TestScalingConfig:
     def test_scale_metric_has_value(self):
         assert ScaleMetric._has_value("CONCURRENCY")
         assert ScaleMetric._has_value("RPS")
+        assert ScaleMetric._has_value("CPU")
+        assert ScaleMetric._has_value("MEMORY")
         assert not ScaleMetric._has_value("BOGUS")
+
+    def test_predictor_scaling_config_accepts_cpu_and_memory_metrics(self):
+        cpu = PredictorScalingConfig(min_instances=1, scale_metric="cpu", target=80)
+        memory = PredictorScalingConfig(
+            min_instances=1, scale_metric="memory", target=80
+        )
+
+        assert cpu.scale_metric == ScaleMetric.CPU
+        assert memory.scale_metric == ScaleMetric.MEMORY
+        assert cpu.to_json()["scale_metric"] == "CPU"
+        assert memory.to_json()["scale_metric"] == "MEMORY"
 
     def test_predictor_scaling_config_accepts_scale_metric_string(self):
         sc = PredictorScalingConfig(min_instances=1, scale_metric="rps")
@@ -107,6 +120,71 @@ class TestScalingConfig:
             )
 
         assert "Scale-to-zero is required" in str(exc_info.value)
+
+    def test_get_default_scaling_configuration_standard_mode_no_scale_to_zero_default(
+        self, mocker
+    ):
+        # Standard mode on KServe: no scale-to-zero and no Knative-only KPA defaults, even when the cluster forces scale-to-zero.
+        mocker.patch(
+            "hopsworks_common.client._is_scale_to_zero_required", return_value=True
+        )
+
+        sc = PredictorScalingConfig.get_default_scaling_configuration(
+            PREDICTOR.SERVING_TOOL_KSERVE, None, effective_knative_mode=False
+        )
+
+        assert sc.min_instances == SCALING_CONFIG.MIN_NUM_INSTANCES
+        assert sc.scale_metric is None
+        assert sc.target is None
+        assert sc.panic_window_percentage is None
+        assert sc.panic_threshold_percentage is None
+        assert sc.stable_window_seconds is None
+        assert sc.scale_to_zero_retention_seconds is None
+
+    def test_get_default_scaling_configuration_standard_mode_does_not_raise_on_scale_to_zero(
+        self, mocker
+    ):
+        # A caller-supplied min_instances=0 in standard mode is left to the
+        # backend to validate; the client no longer raises on it.
+        mocker.patch(
+            "hopsworks_common.client._is_scale_to_zero_required", return_value=True
+        )
+
+        sc = PredictorScalingConfig.get_default_scaling_configuration(
+            PREDICTOR.SERVING_TOOL_KSERVE, 0, effective_knative_mode=False
+        )
+
+        assert sc.min_instances == 0
+
+    def test_get_default_scaling_configuration_knative_mode_unaffected(self, mocker):
+        # effective_knative_mode=True (the default) preserves the pre-existing
+        # KServe Knative behavior.
+        mocker.patch(
+            "hopsworks_common.client._is_scale_to_zero_required", return_value=True
+        )
+
+        sc = PredictorScalingConfig.get_default_scaling_configuration(
+            PREDICTOR.SERVING_TOOL_KSERVE, None
+        )
+
+        assert sc.min_instances == 0
+        assert sc.scale_metric.value == SCALING_CONFIG.SCALE_METRIC_CONCURRENCY
+
+    def test_from_json_ignores_unknown_scale_metric(self):
+        # An older client parsing a newer backend's config must not crash (runtime images bundle the client).
+        with pytest.warns(UserWarning, match="unknown scale metric"):
+            sc = PredictorScalingConfig.from_json(
+                {
+                    "predictor_scaling_config": {
+                        "min_instances": 1,
+                        "max_instances": 3,
+                        "scale_metric": "GPU_UTIL",
+                        "target": 80,
+                    }
+                }
+            )
+        assert sc.scale_metric is None
+        assert sc.target == 80
 
     def test_from_json_to_json_roundtrip(self):
         json_payload = {

--- a/python/tests/test_transformer.py
+++ b/python/tests/test_transformer.py
@@ -16,8 +16,7 @@
 
 import copy
 
-import pytest
-from hopsworks_common.constants import SCALING_CONFIG
+from hopsworks_common.constants import SCALING_CONFIG, Default
 from hsml import resources, transformer
 from hsml.constants import RESOURCES
 
@@ -195,6 +194,62 @@ class TestTransformer:
         assert t.resources.limits.memory == RESOURCES.MAX_MEMORY
         assert t.resources.limits.gpus == RESOURCES.GPUS
 
+    def test_constructor_default_scaling_configuration_marker(
+        self, mocker, backend_fixtures
+    ):
+        # A non-provided scaling configuration stays None so an in-place edit cannot be silently dropped; the backend synthesizes the mode-appropriate default.
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        json = backend_fixtures["transformer"]["get_transformer_without_resources"][
+            "response"
+        ]
+
+        # Act
+        t = transformer.Transformer(
+            json["script_file"], resources=None, scaling_configuration=Default()
+        )
+
+        # Assert
+        assert t.scaling_configuration is None
+        assert "scaleMetric" not in t.to_dict()
+        assert "minInstances" not in t.to_dict()
+
+    def test_resolve_default_num_instances_standard_mode_needs_one(self, mocker):
+        # A defaulted instance count assumes Knative mode (scale-to-zero) until the owning predictor resolves the mode; Standard mode lifts it to one instance.
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+        t = transformer.Transformer(script_file="t.py")
+        assert t.resources.num_instances == 0
+
+        # Act
+        t._resolve_default_num_instances(effective_knative_mode=False)
+
+        # Assert
+        assert t.resources.num_instances == 1
+
+        # Act: resolving back to Knative mode restores the scale-to-zero default
+        t._resolve_default_num_instances(effective_knative_mode=True)
+
+        # Assert
+        assert t.resources.num_instances == 0
+
+    def test_resolve_default_num_instances_keeps_explicit_value(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+        t = transformer.Transformer(script_file="t.py", resources={"num_instances": 0})
+
+        # Act
+        t._resolve_default_num_instances(effective_knative_mode=False)
+
+        # Assert: an explicit zero is left for the backend to reject loudly
+        assert t.resources.num_instances == 0
+
     # validate resources
 
     def test_validate_resources_none(self):
@@ -231,6 +286,8 @@ class TestTransformer:
         assert res == tr
 
     def test_validate_resources_num_instances_one_with_scale_to_zero(self, mocker):
+        # The cluster's scale-to-zero requirement only applies to Knative mode deployments and the transformer cannot know the mode at construction.
+        # One instance must be accepted client-side (standard mode requires it) and the backend validates mode-aware.
         # Arrange
         self._mock_serving_variables(
             mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
@@ -238,11 +295,22 @@ class TestTransformer:
         tr = resources.TransformerResources(num_instances=1)
 
         # Act
-        with pytest.raises(ValueError) as e_info:
-            _ = transformer.Transformer._validate_resources(tr)
+        res = transformer.Transformer._validate_resources(tr)
 
         # Assert
-        assert "Scale-to-zero is required" in str(e_info.value)
+        assert res == tr
+
+    def test_init_num_instances_one_with_scale_to_zero_constructs(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=True
+        )
+
+        # Act
+        t = transformer.Transformer(script_file="t.py", resources={"num_instances": 1})
+
+        # Assert
+        assert t.resources.num_instances == 1
 
     # default num instances
 
@@ -351,13 +419,8 @@ class TestTransformer:
         # Assert
         assert t.script_file == script_file
 
-        assert t.scaling_configuration is not None
-        assert isinstance(t.scaling_configuration, transformer.TransformerScalingConfig)
-        assert t.scaling_configuration.min_instances == 0
-        assert (
-            t.scaling_configuration.scale_metric.value
-            == SCALING_CONFIG.SCALE_METRIC_CONCURRENCY
-        )
+        # A non-provided scaling config stays None: a local default object would invite in-place edits that are silently never serialized, and the backend synthesizes the mode-appropriate default.
+        assert t.scaling_configuration is None
 
     # env vars
 
@@ -419,6 +482,69 @@ class TestTransformer:
 
         # Assert
         assert "transformerEnvVars" not in d
+
+    def test_to_dict_defaulted_scaling_config_omitted(self, mocker):
+        # Only explicitly provided configs are stored and serialized; the backend synthesizes the mode-appropriate default when the key is absent.
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        t = transformer.Transformer(script_file="t.py", resources=None)
+
+        # Act
+        d = t.to_dict()
+
+        # Assert
+        assert t.scaling_configuration is None
+        assert "transformerScalingConfig" not in d
+
+    def test_to_dict_provided_scaling_config_serialized(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        t = transformer.Transformer(
+            script_file="t.py",
+            resources=None,
+            scaling_configuration={"min_instances": 2},
+        )
+
+        # Act
+        d = t.to_dict()
+
+        # Assert
+        assert "transformerScalingConfig" in d
+        assert d["transformerScalingConfig"]["minInstances"] == 2
+
+    def test_scaling_config_setter_accepts_dict(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        t = transformer.Transformer(script_file="t.py", resources=None)
+        t.scaling_configuration = {"min_instances": 4}
+
+        # Act
+        d = t.to_dict()
+
+        # Assert
+        assert isinstance(t.scaling_configuration, transformer.TransformerScalingConfig)
+        assert d["transformerScalingConfig"]["minInstances"] == 4
+
+    def test_to_dict_scaling_config_set_after_construction_serialized(self, mocker):
+        # Arrange
+        self._mock_serving_variables(
+            mocker, SERVING_NUM_INSTANCES_NO_LIMIT, force_scale_to_zero=False
+        )
+        t = transformer.Transformer(script_file="t.py", resources=None)
+        t.scaling_configuration = transformer.TransformerScalingConfig(min_instances=3)
+
+        # Act
+        d = t.to_dict()
+
+        # Assert
+        assert "transformerScalingConfig" in d
+        assert d["transformerScalingConfig"]["minInstances"] == 3
 
     def test_extract_fields_from_json_env_vars(self, mocker, backend_fixtures):
         # Arrange

--- a/skills/ml/hops-online-inference/SKILL.md
+++ b/skills/ml/hops-online-inference/SKILL.md
@@ -37,7 +37,7 @@ deployment name via `--name`; recreate over a stale deployment with
 
 - **Resources:** CPU cores, memory, GPUs for the predictor (requests vs limits).
 - **Environment:** which Python environment the predictor runs in.
-- **Scaling:** min/max instances, scale-to-zero, and target concurrency (`ScaleMetric.CONCURRENCY`).
+- **Scaling:** KServe mode (`knative_mode`), min/max instances, and the scale metric and its target.
 - **Before deleting** — `deployment.delete()` / `hops deployment delete --yes` tears down the running endpoint irreversibly; confirm the exact name with the user, and never tear down a deployment you created as a side effect (temp or test ones included) unless they asked.
 
 ## Model Deployment Overview
@@ -124,7 +124,7 @@ deployment = model.deploy(
     scaling_configuration=PredictorScalingConfig(
         min_instances=1,
         max_instances=3,
-        scale_metric=ScaleMetric.CONCURRENCY,   # required — omitting it fails with HTTP 422
+        scale_metric=ScaleMetric.CONCURRENCY,   # Knative-only metric; only valid for KServe Knative deployments
         target=70,                              # target concurrent requests per pod
     ),
     environment="pandas-inference-pipeline",  # Python environment name
@@ -225,16 +225,33 @@ predictor_resources = PredictorResources(
 
 ### Scaling
 
+`model.deploy(knative_mode=...)` picks the KServe mode: `True` for Knative (supports scale-to-zero and `CONCURRENCY`/`RPS` metrics), `False` for Standard (minimum one instance, autoscales on `CPU`/`MEMORY` between min and max instances; equal min and max run a fixed replica count with no autoscaler, the default for LLM deployments).
+Leave it `None` (default) to let the backend decide: vLLM deployments default to Standard, everything else to Knative.
+On an update, `None` keeps the deployment's current mode.
+
+Knative mode (`CONCURRENCY`/`RPS` metrics; the Knative-only window/panic/retention parameters are rejected in Standard mode):
+
 ```python
 from hsml.scaling_config import PredictorScalingConfig, ScaleMetric
 
 scaling = PredictorScalingConfig(
-    min_instances=1,              # minimum pods (0 for scale-to-zero)
+    min_instances=0,              # 0 enables scale-to-zero (required on scale-to-zero clusters)
     max_instances=5,              # maximum pods
     scale_metric=ScaleMetric.CONCURRENCY,  # or ScaleMetric.RPS
     target=70,                    # target concurrent requests per pod
     stable_window_seconds=60,     # averaging interval
     scale_to_zero_retention_seconds=300,  # keep last pod for 5 min
+)
+```
+
+Standard mode (`CPU`/`MEMORY` metrics; minimum one instance, no scale-to-zero):
+
+```python
+scaling = PredictorScalingConfig(
+    min_instances=1,              # at least 1 in Standard mode
+    max_instances=5,              # equal to min_instances runs a fixed replica count
+    scale_metric=ScaleMetric.CPU,  # or ScaleMetric.MEMORY
+    target=80,                    # target utilization percentage
 )
 ```
 


### PR DESCRIPTION
## Summary
- Expose `knative_mode` on `Predictor`/`Deployment`/`Model.deploy`/`create_predictor`/`create_endpoint`/`deploy_agent` and the CLI (`--knative/--standard`). Default is `None` so the backend decides (vLLM/LLM implies Standard mode); the field round-trips through full-body PUTs so stored modes are never silently reset. Serialized as `knativeMode`.
- Client-side scaling defaults become mode-aware via an effective mode (explicit value, else vLLM implies Standard): Standard-mode predictors skip scale-to-zero minimums and Knative-only autoscaling knobs; `ScaleMetric` gains `CPU` and `MEMORY`; unknown scale metrics from a newer backend are ignored with a warning (forward compatibility for runtime images).
- Transformers are built before the mode is known: their scaling config is serialized only when explicitly provided and stays `None` otherwise (a local default object invited in-place edits that were silently never sent), a defaulted instance count is re-resolved against the effective mode at serialization time (Standard lifts it to one instance even on scale-to-zero clusters; explicit values are untouched), and the scale-to-zero check is no longer enforced transformer-side. Also fixes a pre-existing bug where `Transformer.to_dict` dropped an explicitly set scaling configuration.
- Terminology follows KServe's rename of Serverless to Knative and RawDeployment to Standard.

Sibling PRs: hopsworks-ee, hopsworks-front, hopsworks-helm, loadtest (same ticket).

## Rollout ordering
This PR (and runtime images rebuilt from it: storage initializer, inference pipeline) must roll out before the hopsworks-ee PR. The backend defaults Standard mode to the CPU scale metric, and an older bundled client crashes the storage initializer with `ValueError: 'CPU' is not a valid ScaleMetric`.

Release note: SDKs from before this PR cannot manage Standard-mode deployments on scale-to-zero clusters (`kube_serving_min_num_instances = 0`) — they enforce scale-to-zero client-side regardless of mode and their `ScaleMetric` parsing breaks on `CPU`/`MEMORY`. See the hopsworks-ee PR for details.

## Test plan
- Unit: pytest green (serving suites cover round-trip, None-omitted, effective-mode gating, unknown-metric tolerance, the transformer serialization matrix incl. mode-aware defaulted instance resolution, and the `Deployment.knative_mode` proxy); full suite 3992 passed; ruff clean.
- Cluster (verified on a live K8s cluster via SDK driver + loadtest job): standard-mode create/predict, stopped-only mode toggle with backend reconciliation, old-client PUT keeps the stored mode, vLLM default asserted Standard.
