### PR TITLE
[HWORKS-2879][APPEND] Build the java SDK on JDK 17 in a container

### DIFF
--- a/.github/java.Jenkinsfile
+++ b/.github/java.Jenkinsfile
@@ -8,6 +8,10 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '10'))
+        // The freestyle job this replaces had concurrentBuild=false. Two runs in parallel
+        // would install the same GAV into the shared ~/.m2 and write the same
+        // /opt/repository/master/hsfs/$POM_VERSION directory.
+        disableConcurrentBuilds()
     }
 
     triggers {
@@ -37,15 +41,19 @@ pipeline {
                 }
                 sh 'mvn -f java/pom.xml clean deploy generate-sources javadoc:javadoc -Pwith-hops-ee'
                 sh 'mvn -f utils/java/pom.xml clean package'
-                stash name: 'artifacts', includes: '''java/spark/target/*-jar-with-dependencies.jar,\
-utils/java/target/*-jar-with-dependencies.jar,\
-utils/python/hsfs_utils.py'''
+                stash name: 'artifacts', includes: [
+                    'java/spark/target/*-jar-with-dependencies.jar',
+                    'utils/java/target/*-jar-with-dependencies.jar',
+                    'utils/python/hsfs_utils.py',
+                ].join(',')
             }
         }
 
         stage('publish') {
             agent { label 'local' }
+            options { skipDefaultCheckout() }
             steps {
+                deleteDir()
                 unstash 'artifacts'
                 sh '''
                     set -eu

--- a/.github/java.Jenkinsfile
+++ b/.github/java.Jenkinsfile
@@ -1,0 +1,77 @@
+// Java/Scala build for the hsfs SDK jars. Split out of the `hopsworks` freestyle job because
+// main and branch-5.1 need JDK 17 (Spark 4.1, avro 1.12.x) while branch-4.* and branch-5.0
+// stay on the controller's Java 8. The controller has no JDK 17 installation, so the build
+// runs in a container the way clusterj-onlinefs and hopsworks-ee already do; the publish step
+// has to run back on `local`, because /opt/repository is the controller's filesystem.
+pipeline {
+    agent none
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+    }
+
+    triggers {
+        githubPush()
+    }
+
+    stages {
+        stage('build') {
+            agent {
+                docker {
+                    image 'maven:3.8.5-openjdk-17'
+                    label 'local'
+                    // Carries the controller's settings.xml into the container, which is what
+                    // supplies the nexus mirror and the archiva deploy credentials.
+                    args '-v $HOME/.m2:/root/.m2'
+                }
+            }
+            steps {
+                script {
+                    env.POM_VERSION = sh(returnStdout: true, script:
+                        "mvn -f java/pom.xml -q -Dexec.executable=echo -Dexec.args='\${project.version}' --non-recursive exec:exec").trim()
+                    // Derived, never hardcoded: this is the string that was pinned to spark3.5
+                    // in the old job, which is why no spark4.1 jar was ever published.
+                    env.SPARK_FLAVOUR = sh(returnStdout: true, script:
+                        "mvn -f java/pom.xml -q -Dexec.executable=echo -Dexec.args='\${artifact.spark.version}' --non-recursive exec:exec").trim()
+                    echo "POM_VERSION=${env.POM_VERSION}  SPARK_FLAVOUR=${env.SPARK_FLAVOUR}"
+                }
+                sh 'mvn -f java/pom.xml clean deploy generate-sources javadoc:javadoc -Pwith-hops-ee'
+                sh 'mvn -f utils/java/pom.xml clean package'
+                stash name: 'artifacts', includes: '''java/spark/target/*-jar-with-dependencies.jar,\
+utils/java/target/*-jar-with-dependencies.jar,\
+utils/python/hsfs_utils.py'''
+            }
+        }
+
+        stage('publish') {
+            agent { label 'local' }
+            steps {
+                unstash 'artifacts'
+                sh '''
+                    set -eu
+                    DEST=/opt/repository/master
+                    mkdir -p "$DEST/hsfs/$POM_VERSION" "$DEST/hsfs_utils"
+
+                    JAR="java/spark/target/hsfs-spark-$SPARK_FLAVOUR-$POM_VERSION-jar-with-dependencies.jar"
+                    # Fatal, not a soft `if`. The old job skipped silently when the name did not
+                    # match, which is how main went green while publishing nothing.
+                    test -f "$JAR"
+                    cp "$JAR" "$DEST/hsfs/$POM_VERSION/hsfs-spark-$SPARK_FLAVOUR-$POM_VERSION.jar"
+
+                    cp "utils/java/target/hsfs-utils-$POM_VERSION-jar-with-dependencies.jar" \
+                       "$DEST/hsfs_utils/hsfs-utils-$POM_VERSION.jar"
+                    cp utils/python/hsfs_utils.py "$DEST/hsfs_utils/hsfs_utils-$POM_VERSION.py"
+                '''
+            }
+        }
+    }
+
+    post {
+        success {
+            build job: 'k8s-base-images', wait: false
+        }
+        unstable  { slackSend color: 'warning', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable: ${env.BUILD_URL}" }
+        failure   { slackSend color: 'danger',  message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed: ${env.BUILD_URL}" }
+        fixed     { slackSend color: 'good',    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal: ${env.BUILD_URL}" }
+    }
+}


### PR DESCRIPTION
The Spark 4.1 upgrade took `java/pom.xml` to `maven.compiler.source 17` and avro 1.12.1, and the [`hopsworks`](https://jenkins.hops.works/job/hopsworks/) job builds on the controller's Java 8. [Build #1003](https://jenkins.hops.works/job/hopsworks/1003/) failed on the first thing to touch avro:

```
bad class file: .../avro-1.12.1.jar(org/apache/avro/Schema.class)
  class file has wrong version 55.0, should be 52.0
Unable to delombok: InvocationTargetException: Abort
```

Avro dropped Java 8 in 1.12.0, so its class files are Java 11 (55.0) and a JDK 8 javac tops out at 52.0. Reproduced in isolation — same plugin, same avro, one `@Getter` field: JDK 17 succeeds, JDK 8 gives that message verbatim. Pinning avro back only moves the failure one phase later, to `invalid target release: 17`.

The controller has one JDK installation, `default` → `/usr/lib/jvm/java-8-openjdk-amd64`, so there is nothing for a job to point at. This builds in `maven:3.8.5-openjdk-17` instead, the way `clusterj-onlinefs` and `hopsworks-ee` already do. Publishing hops back to `local` because `/opt/repository` is the controller's filesystem and invisible from the container.

### Why a second job

Only `main` and `branch-5.1` need JDK 17. `branch-4.*` and `branch-5.0` are still `source 1.8` / avro 1.11.4 and stay on `hopsworks` unchanged. A freestyle job has a single JDK setting, so the two cannot share one.

Already created on Jenkins, pointing at this file: **[hopsworks-spark-4.1](https://jenkins.hops.works/job/hopsworks-spark-4.1/)** (`origin/main`, `origin/branch-5.1`). `k8s-loadtest` and `k8s-locust-benchmark` now list both jobs as upstream. **It has nothing to run until this merges.**

### The 404

The old job hardcoded the spark flavour to a list ending at `spark3.5`, which is why `repo.hops.works` serves the 3.5 jar but 404s the 4.1 one:

```
hsfs/5.1.0-SNAPSHOT/hsfs-spark-spark3.5-5.1.0-SNAPSHOT.jar   200
hsfs/5.1.0-SNAPSHOT/hsfs-spark-spark4.1-5.1.0-SNAPSHOT.jar   404
```

Both `POM_VERSION` and the flavour are now read from the pom, so `main` publishes `spark4.1` and `branch-5.1` keeps publishing `spark3.5` until the upgrade is backported there. The jar check is also fatal where the old job used a soft `if` — that skip is how a missing artifact left the build green while publishing nothing.

### To flag

`branch-5.1` stops producing the `spark3.3` artifact; the old job ran an extra `-Pspark-3.3` pass. Say the word and I will add the second pass back.

Still to do after merge: narrow the `hopsworks` job's SCM to `origin/branch-4.*` + `origin/branch-5.0`, otherwise both jobs claim `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)