### PR TITLE
[HWORKS-2879][APPEND] Give the containerized java SDK build its maven settings

### DIFF
--- a/.github/java.Jenkinsfile
+++ b/.github/java.Jenkinsfile
@@ -24,10 +24,20 @@ pipeline {
                 docker {
                     image 'maven:3.8.5-openjdk-17'
                     label 'local'
-                    // Carries the controller's settings.xml into the container, which is what
-                    // supplies the nexus mirror and the archiva deploy credentials.
-                    args '-v $HOME/.m2:/root/.m2'
+                    // Carries the controller's settings.xml and its warm local repository
+                    // into the container, which is what supplies the mirror and the archiva
+                    // deploy credentials. /root/.m2 cannot deliver either: the plugin runs the
+                    // container as the agent's uid, which has no /etc/passwd entry, so the JVM
+                    // reports user.home=? and Maven reads no settings at all, and /root is 0700
+                    // to a non-root container. Mount somewhere traversable and move user.home
+                    // with it, the way the maven image documents for -u.
+                    args '-v $HOME/.m2:/var/maven/.m2 -e HOME=/var/maven -e MAVEN_CONFIG=/var/maven/.m2'
                 }
+            }
+            environment {
+                // The JVM takes user.home from getpwuid(), never from $HOME, so -D is the only
+                // thing that moves it. MAVEN_OPTS covers every mvn call in the stage.
+                MAVEN_OPTS = '-Duser.home=/var/maven'
             }
             steps {
                 script {


### PR DESCRIPTION
`hopsworks-spark-4.1` #2 failed on the first module it tried to deploy:

```
Failed to execute goal ...maven-deploy-plugin:2.7:deploy on project hsfs-parent:
authentication failed for https://archiva.hops.works/.../hsfs-parent-...pom,
status: 401 Unauthorized
```

The 401 is a symptom. The install line above it landed in

```
.../workspace/hopsworks-spark-4.1/?/.m2/repository/...
```

and that `?` is `user.home`. The docker-workflow plugin starts the container as `-u 1004:1004`, uid 1004 has no `/etc/passwd` entry in `maven:3.8.5-openjdk-17`, and the JVM answers `user.home=?` rather than falling back to `$HOME`. Maven then looks for `?/.m2/settings.xml` relative to the workspace, finds nothing, and runs with no settings at all — no `<server id="Hops">`, so the deploy went out unauthenticated. `-v $HOME/.m2:/root/.m2` could not have helped even with a resolvable uid, because `/root` is 0700 and the container is not root. The same mount is decorative in `clusterj-onlinefs`, `hopsworks-ee` and `vector-db`; those work because they pass `-s $MAVEN_SETTINGS` or need no credentials.

The same log shows the other half of the loss: 482 artifacts fetched straight from `repo.maven.apache.org` and nothing from the mirror, where the last green freestyle run (`hopsworks` #1002) made 306 archiva requests and 87 `Uploaded to Hops`.

Mounting at `/var/maven/.m2` and moving `user.home` there with `-D` is what the maven image documents for running as `-u`, and it restores both halves of what the freestyle job had: the controller's `settings.xml` and its warm local repository, instead of a full Central re-download every build.

## Not in this PR

Job configuration rather than a file in the repo, so it needs a separate touch:

- The job's branch spec lists `origin/branch-5.1`, which has no `.github/java.Jenkinsfile` yet — that is what #1 failed on. Either backport the file or trim the spec to `origin/main`.
- `disableConcurrentBuilds()` only serialises this job, and `hopsworks` (branch-4.\*/branch-5.0) now writes the same `/home/jenkinsmaster/.m2/repository` in parallel. Tolerable in practice; `-Dmaven.repo.local=/var/maven/.m2/repository-jdk17` would separate them at the cost of one cold build.

## Testing

Not run — it needs a `hopsworks-spark-4.1` build. If #3 still 401s, the archiva credentials are in `mavenEE/conf/settings.xml` rather than the controller's `~/.m2/settings.xml`, and the fallback is the `c-hudi` pattern: write a settings.xml under `withCredentials` and pass `-s`, with `<server id="Hops">` from `jenkins_archiva` and `<server id="HopsEE">` from `a0770738` (nexus jenkins). Both are needed once the deploy is unblocked: `-Pwith-hops-ee` pulls `io.hops:hadoop-client:3.4.3.1-EE-RC4`, which is 404 on archiva and 401 anonymously on nexus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)