### PR TITLE
[HWORKS-2879][APPEND] Give the build container a resolvable uid

### DIFF
--- a/.github/java.Jenkinsfile
+++ b/.github/java.Jenkinsfile
@@ -24,19 +24,24 @@ pipeline {
                 docker {
                     image 'maven:3.8.5-openjdk-17'
                     label 'local'
-                    // Carries the controller's settings.xml and its warm local repository
-                    // into the container, which is what supplies the mirror and the archiva
-                    // deploy credentials. /root/.m2 cannot deliver either: the plugin runs the
-                    // container as the agent's uid, which has no /etc/passwd entry, so the JVM
-                    // reports user.home=? and Maven reads no settings at all, and /root is 0700
-                    // to a non-root container. Mount somewhere traversable and move user.home
+                    // The .m2 mount carries the controller's settings.xml and its warm local
+                    // repository into the container, which is what supplies the mirror and the
+                    // archiva deploy credentials. /root/.m2 cannot deliver either, being 0700 to
+                    // a non-root container, so mount somewhere traversable and move user.home
                     // with it, the way the maven image documents for -u.
-                    args '-v $HOME/.m2:/var/maven/.m2 -e HOME=/var/maven -e MAVEN_CONFIG=/var/maven/.m2'
+                    // The passwd/group mounts are what make that uid resolvable at all. The
+                    // plugin runs the container as the agent's uid, which the image has no entry
+                    // for, and everything downstream of getpwuid() fails: Maven read no settings
+                    // (user.home=?), and Hadoop's UserGroupInformation login died on
+                    // `new UnixPrincipal(null)`, failing every test that builds a SparkSession
+                    // with "Invalid UID, could not determine effective user".
+                    args '-v $HOME/.m2:/var/maven/.m2 -e HOME=/var/maven -e MAVEN_CONFIG=/var/maven/.m2 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro'
                 }
             }
             environment {
-                // The JVM takes user.home from getpwuid(), never from $HOME, so -D is the only
-                // thing that moves it. MAVEN_OPTS covers every mvn call in the stage.
+                // getpwuid() resolves now, so the JVM takes user.home from the controller's
+                // passwd entry, a /home path that is not mounted in. $HOME is still ignored, so
+                // -D remains the only thing that moves it, for every mvn call in the stage.
                 MAVEN_OPTS = '-Duser.home=/var/maven'
             }
             steps {


### PR DESCRIPTION
Follow-up to #1126 and #1127. Fixes the `hopsworks-spark-4.1` job, which has never gone green — [build #3](https://jenkins.hops.works/job/hopsworks-spark-4.1/3/console) failed with 18 errored tests in `hsfs-spark`.

### What happens

The docker agent starts the container as the controller's uid (`docker run -t -d -u 1004:1004 ... maven:3.8.5-openjdk-17`). That image has no `/etc/passwd` entry for 1004, so `getpwuid()` returns NULL and every consumer of it breaks.

#1127 already hit this and patched the Maven half with `-Duser.home=/var/maven`. The other half surfaced on the next run:

```
UnixLoginModule.login → UserGroupInformation.getLoginUser
  → Utils.getCurrentUserName → SparkContext.<init> → SparkEngine.getInstance

java.io.IOException: Invalid UID, could not determine effective user
Caused by: java.lang.NullPointerException: invalid null input: name
	at com.sun.security.auth.UnixPrincipal.<init>(UnixPrincipal.java:67)
```

All 18 errors are "this test builds a SparkSession" — `TestSparkEngine`, `TestStorageConnector`, `ColumnProfilerSmokeTest`, `KllMergeSmokeTest`. None of them changed; `TestSparkEngine` dates from 2024-07.

### Why CI didn't catch it

`.github/workflows/java.yml` runs on `ubuntu-latest` directly as `runner`, uid 1001, which has a real passwd entry — so UGI resolves and the tests pass. It also only triggers `on: pull_request`, so the merge to main never re-ran it. Neither is fixable by adding coverage: the failure only exists inside a container started with an unresolvable uid.

### The fix

Two read-only mounts on the agent's `args`, so the uid resolves:

```
-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro
```

`HADOOP_USER_NAME` is not an alternative — the OS login module is `REQUIRED` in Hadoop's JAAS config and is the module that throws, so the uid has to actually resolve. `-Duser.home=/var/maven` stays, for a new reason: `getpwuid()` now succeeds and hands the JVM `/home/jenkinsmaster`, which isn't mounted into the container. The comments are updated to say so.

### Verification

Ran the build stage locally against the same image, with a uid equally unresolvable inside it, `verify` in place of `deploy`:

| | result |
|---|---|
| as the job runs it today | `hsfs-spark-spark4.1` FAILURE, `Tests run: 84, Errors: 18` |
| with the passwd/group mounts | BUILD SUCCESS, all 5 modules, 0 errors, 1:27 |

Both artifacts the `publish` stage hard-asserts on come out with the expected names: `hsfs-spark-spark4.1-5.1.0-SNAPSHOT-jar-with-dependencies.jar` and `hsfs-utils-5.1.0-SNAPSHOT-jar-with-dependencies.jar`. The edited Jenkinsfile also passes the controller's declarative linter.

### Not in this PR

- The job is configured for `origin/main`, `origin/branch-5.1` and `origin/branch-5.2`. Only `main` carries `.github/java.Jenkinsfile` today, so nothing else is affected yet — but the same two mounts need to travel with the file if it's backported.
- `clusterj-onlinefs` and `hopsworks-ee` still use `-v $HOME/.m2:/root/.m2`, which by #1127's own reasoning delivers no `settings.xml`. They don't start a SparkSession, so they never hit the UGI half.
- `generate-sources javadoc:javadoc` in the build step produces no published artifact — no `-javadoc.jar` or `-sources.jar` is attached, and nothing is stashed from it. Looks vestigial from the freestyle job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
