### PR TITLE
[HWORKS-2879][APPEND] Bump the AWS SDK v2 in hsfs from 2.10.40 to 2.45.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
         <spark.version>4.1.3.0</spark.version>
         <hudi.groupId>io.hops.hudi</hudi.groupId>
         <hudi.version>1.2.0</hudi.version>
-        <awssdk.version>2.10.40</awssdk.version>
+        <awssdk.version>2.45.1</awssdk.version>
         <scala.version>2.13.17</scala.version>
         <scala-short.version>2.13</scala-short.version>
         <json.version>20231013</json.version>


### PR DESCRIPTION
## Why

`hsfs-spark` is built with `maven-assembly-plugin` / `jar-with-dependencies` and there is no `maven-shade-plugin` anywhere in `java/`, so every AWS SDK class it pulls is packed **unshaded** and lands on the Spark classpath alongside the platform's own SDK.

`awssdk.version` has been `2.10.40` since the FSTORE-1439 repo merge (`git log -S"2.10.40"` returns exactly one commit). Meanwhile the Hadoop fork ships:

| hops-hadoop | awssdk v2 |
|---|---|
| 3.4.3.0 | 2.35.4 |
| 3.4.3.1 | 2.45.1 |
| 3.4.3.2 | 2.45.1 |

So twelve modules exist twice on the classpath, 35 minor versions apart — `annotations`, `apache-client`, `auth`, `aws-core`, `aws-query-protocol`, `http-client-spi`, `netty-nio-client`, `profiles`, `protocol-core`, `regions`, `sdk-core`, `utils`. Which copy wins is decided purely by classpath order, and that order differs per image: on `spark-feature-pipeline` `hopsworks-jars/` trails Hadoop's classpath, but `base-image/terminal-spark/Dockerfile:115` copies `hopsworks-jars/` **into** `${SPARK_HOME}/jars/`, which is first.

To be clear about scope: **this drift predates the Spark 4.1 upgrade** — it is not a regression from it. It surfaced while tracing a related SDK mismatch in the Spark distribution (logicalclocks/spark#61).

## Change

One line: `awssdk.version` `2.10.40` → `2.45.1`, matching `hops-enterprise/hadoop-project/pom.xml`'s `aws-java-sdk-v2.version` for the `hadoop-aws` this distribution bundles.

## API surface is unchanged

hsfs uses only `regions.Region`, `utils.CollectionUtils`, and the **sync** `SsmClient`, `StsClient`, `SecretsManagerClient` with their `GetParameter*`, `GetSecretValue*`, `GetCallerIdentity*` models. All stable across the two versions.

## Verification

- `mvn compile` on all four modules (`hsfs`, `spark`, `flink`, `beam`): **BUILD SUCCESS** on Java 17.
- `mvn -pl hsfs test`: **33/33 pass**, including `TestHopsworksExternalClient`, which is the class that exercises SecretsManager/SSM/STS.
- Assembly builds; the resulting `hsfs-spark-spark4.1-5.1.0-SNAPSHOT-jar-with-dependencies.jar` packs 2.45.1 across all 29 SDK modules (`ssm`, `sdk-core`, `auth` all report `version=2.45.1`).

## Nothing else needs bumping

I diffed the resolved dependency tree before and after:

| change | needs action? |
|---|---|
| `netty-*` 4.1.42 → 4.1.133 in the tree | **No.** In the assembled jar Netty is `4.1.119.Final` both before and after — something else in the `spark` module's graph pins it and wins either way. The bump does not move Netty in the shipped artifact. |
| `reactive-streams` 1.0.2 → 1.0.4 | No — transitive, no pin in this repo. |
| `com.typesafe.netty:netty-reactive-streams` 2.0.3 dropped | No — the newer SDK no longer needs it. |
| `jackson-annotations` 2.21 compile → provided | No — same version either way, and Spark 4.1 ships `jackson-annotations/2.21`. |

The rest of this repo's stack is already current and needed no matching bump: Java 17 (`maven.compiler.source/target`), Jackson `2.21.2`, slf4j `2.0.17`.

## Follow-up worth considering, not in this PR

- **Relocate the SDK.** Bumping syncs it today but re-couples hsfs releases to every Hadoop SDK bump. Shading `software.amazon.awssdk` in the assembly would isolate it permanently.
- **Drop `netty-nio-client`.** hsfs uses only sync clients, so the async transport — and the Netty it drags into the uber jar — appears to be dead weight. Spark 4.1 ships Netty **4.2.7**, so a bundled 4.1.x is a standing mismatch regardless of version.

Not verified: I could not exercise the SSM/STS/Secrets Manager paths against a real AWS account, so the evidence is compile + unit tests + packaging.