### PR TITLE
[HWORKS-2879][APPEND] Delete Hudi records with the native delete operation

### DIFF
--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/HudiOperationType.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/HudiOperationType.java
@@ -20,7 +20,8 @@ package com.logicalclocks.hsfs;
 public enum HudiOperationType {
   BULK_INSERT,
   INSERT,
-  UPSERT;
+  UPSERT,
+  DELETE;
 
   public String getValue() {
     return name().toLowerCase();

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/HudiEngine.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/HudiEngine.java
@@ -137,8 +137,6 @@ public class HudiEngine {
 
   protected static final String HUDI_WRITE_INSERT_DROP_DUPLICATES = "hoodie.datasource.write.insert.drop.duplicates";
 
-  protected static final String PAYLOAD_CLASS_OPT_KEY = "hoodie.datasource.write.payload.class";
-  protected static final String PAYLOAD_CLASS_OPT_VAL = "org.apache.hudi.common.model.EmptyHoodieRecordPayload";
 
   protected static final String HUDI_KAFKA_TOPIC = "hoodie.streamer.source.kafka.topic";
   protected static final String COMMIT_METADATA_KEYPREFIX_OPT_KEY = "hoodie.datasource.write.commitmeta.key.prefix";
@@ -220,8 +218,11 @@ public class HudiEngine {
       throws IOException, FeatureStoreException,
       ParseException {
 
-    Map<String, String> hudiArgs = setupHudiWriteOpts(featureGroup, HudiOperationType.UPSERT, writeOptions);
-    hudiArgs.put(PAYLOAD_CLASS_OPT_KEY, PAYLOAD_CLASS_OPT_VAL);
+    // Hudi's native delete operation. Overriding the payload class with
+    // EmptyHoodieRecordPayload on an upsert is the pre-1.x idiom; since Hudi 1.1 the
+    // payload is validated against the table's hoodie.record.merge.mode and that
+    // pairing is rejected on tables created at table version 9.
+    Map<String, String> hudiArgs = setupHudiWriteOpts(featureGroup, HudiOperationType.DELETE, writeOptions);
 
     deleteDF.write().format(HUDI_SPARK_FORMAT)
         .options(hudiArgs)

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/HudiEngine.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/HudiEngine.java
@@ -224,6 +224,24 @@ public class HudiEngine {
     // pairing is rejected on tables created at table version 9.
     Map<String, String> hudiArgs = setupHudiWriteOpts(featureGroup, HudiOperationType.DELETE, writeOptions);
 
+    // Hudi's delete resolves each record's partition path from the frame it is given. A
+    // delete frame that omits the partition columns matches nothing, and Hudi still writes
+    // a commit -- a silent no-op. Fail loudly.
+    List<String> frameColumns = Arrays.asList(deleteDF.columns());
+    List<String> missingPartitionColumns =
+        Arrays.stream(hudiArgs.getOrDefault(HUDI_PARTITION_FIELD, "").split(","))
+            .filter(field -> !field.isEmpty())
+            .map(field -> field.split(":")[0])
+            .filter(column -> !frameColumns.contains(column))
+            .collect(Collectors.toList());
+    if (!missingPartitionColumns.isEmpty()) {
+      throw new FeatureStoreException(
+          "Cannot delete records from partitioned feature group `" + featureGroup.getName()
+              + "`: the delete frame is missing the partition column(s) " + missingPartitionColumns
+              + ". Hudi resolves the partition path from the frame, so a delete without them would "
+              + "silently match no records. Include the partition columns in the delete frame.");
+    }
+
     deleteDF.write().format(HUDI_SPARK_FORMAT)
         .options(hudiArgs)
         .mode(SaveMode.Append)

--- a/python/hsfs/core/hudi_engine.py
+++ b/python/hsfs/core/hudi_engine.py
@@ -19,6 +19,7 @@ import copy
 import os
 from urllib.parse import unquote, urlsplit
 
+from hopsworks_common.client.exceptions import FeatureStoreException
 from hsfs import feature_group_commit, util
 from hsfs.core import (
     dataset_api,
@@ -163,6 +164,25 @@ class HudiEngine:
             self._feature_group, dataset
         )
         hudi_options = self._setup_hudi_write_opts(operation, write_options)
+
+        if operation == self.HUDI_DELETE:
+            # Hudi's delete resolves each record's partition path from the frame it
+            # is given. A delete frame that omits the partition columns matches
+            # nothing, and Hudi still writes a commit -- a silent no-op. Fail loudly.
+            partition_path = hudi_options.get(self.HUDI_PARTITION_FIELD) or ""
+            partition_cols = [
+                field.split(":")[0] for field in partition_path.split(",") if field
+            ]
+            missing = [c for c in partition_cols if c not in dataset.columns]
+            if missing:
+                raise FeatureStoreException(
+                    "Cannot delete records from partitioned feature group "
+                    f"`{self._feature_group.name}`: the delete frame is missing the "
+                    f"partition column(s) {missing}. Hudi resolves the partition path "
+                    "from the frame, so a delete without them would silently match no "
+                    "records. Include the partition columns in the delete frame."
+                )
+
         self._migrate_table(self._spark_context, hudi_options, location)
         dataset.write.format(HudiEngine.HUDI_SPARK_FORMAT).options(**hudi_options).mode(
             save_mode

--- a/python/hsfs/core/hudi_engine.py
+++ b/python/hsfs/core/hudi_engine.py
@@ -74,14 +74,13 @@ class HudiEngine:
     HUDI_BULK_INSERT = "bulk_insert"
     HUDI_INSERT = "insert"
     HUDI_UPSERT = "upsert"
+    HUDI_DELETE = "delete"
     HUDI_QUERY_TYPE_OPT_KEY = "hoodie.datasource.query.type"
     HUDI_QUERY_TYPE_SNAPSHOT_OPT_VAL = "snapshot"
     HUDI_QUERY_TYPE_INCREMENTAL_OPT_VAL = "incremental"
     HUDI_QUERY_TIME_TRAVEL_AS_OF_INSTANT = "as.of.instant"
     HUDI_BEGIN_INSTANTTIME_OPT_KEY = "hoodie.datasource.read.begin.instanttime"
     HUDI_END_INSTANTTIME_OPT_KEY = "hoodie.datasource.read.end.instanttime"
-    PAYLOAD_CLASS_OPT_KEY = "hoodie.datasource.write.payload.class"
-    PAYLOAD_CLASS_OPT_VAL = "org.apache.hudi.common.model.EmptyHoodieRecordPayload"
     HUDI_DEFAULT_PARALLELISM = {
         "hoodie.bulkinsert.shuffle.parallelism": "5",
         "hoodie.insert.shuffle.parallelism": "5",
@@ -135,10 +134,12 @@ class HudiEngine:
         return self._feature_group_api._commit(self._feature_group, fg_commit)
 
     def _delete_record(self, delete_df, write_options):
-        write_options[self.PAYLOAD_CLASS_OPT_KEY] = self.PAYLOAD_CLASS_OPT_VAL
-
+        # Hudi's native delete operation. Overriding the payload class with
+        # EmptyHoodieRecordPayload on an upsert is the pre-1.x idiom; since Hudi
+        # 1.1 the payload is validated against the table's hoodie.record.merge.mode
+        # and that pairing is rejected on tables created at table version 9.
         fg_commit = self._write_hudi_dataset(
-            delete_df, "append", self.HUDI_UPSERT, write_options
+            delete_df, "append", self.HUDI_DELETE, write_options
         )
         return self._feature_group_api._commit(self._feature_group, fg_commit)
 

--- a/python/tests/core/test_hudi_engine.py
+++ b/python/tests/core/test_hudi_engine.py
@@ -73,8 +73,9 @@ class TestHudiEngine:
         assert mock_fg_api.return_value._commit.call_count == 1
         assert (
             "hoodie.datasource.write.payload.class"
-            in mock_hudi_engine_write_hudi_dataset.call_args[0][3]
+            not in mock_hudi_engine_write_hudi_dataset.call_args[0][3]
         )
+        assert mock_hudi_engine_write_hudi_dataset.call_args[0][2] == "delete"
         assert mock_hudi_engine_write_hudi_dataset.call_args[0][1] == "append"
 
     def test_register_temporary_table(self, mocker, backend_fixtures):


### PR DESCRIPTION
Follow-up to the Spark 4.1 upgrade, which bumped Hudi `1.0.2.2` → `1.2.0` (`docker-images` `spark_install.sh`).

## Problem

`_delete_record` deletes by running an **upsert with the payload class overridden** to `EmptyHoodieRecordPayload` — the pre-1.x Hudi soft-delete idiom. There is no `delete` operation constant at all.

Since Hudi 1.1 the write payload is validated against the table's `hoodie.record.merge.mode`. `HoodieTableConfig$PayloadGroupings.EVENT_TIME_ORDERING_PAYLOADS` admits only `DefaultHoodieRecordPayload`, `EventTimeAvroPayload`, `AWSDmsAvroPayload` and `MySqlDebeziumAvroPayload`. `EmptyHoodieRecordPayload` is not among them, so on Hudi 1.2.0 every delete against a table created at table version 9 fails:

```
IllegalArgumentException: Configured record merge mode (EVENT_TIME_ORDERING) is inconsistent
with payload class (org.apache.hudi.common.model.EmptyHoodieRecordPayload) or record merge
strategy ID () configured. Please revisit the configs.
```

hsfs sets a precombine field on **every** write, which is what makes Hudi stamp `EVENT_TIME_ORDERING` onto the table at creation, and it never records a table payload class — so a v9 table has nothing to satisfy the check.

Reproduced on a live cluster: `test_pyspark_travel_time[HUDI]` and `test_pyspark_remove_rows_stream[HUDI]` both fail with this, while `test_remove_rows_stream[DELTA]` — same test body, different format — passes. Both reach the same line, from the two public entry points `fg.remove_rows()` (`feature_group.py:5025`) and `fg.commit_delete_record()` (`:5044`), via `_commit_delete` (`feature_group_engine.py:436`).

## Change

1. Use Hudi's **native delete operation** instead of overriding the payload class, so the write honours the table's merge mode rather than contradicting it. `operation` is passed straight to `hoodie.datasource.write.operation` and is not branched on anywhere else, so it is a drop-in substitution.
2. **Guard against a silent no-op** (both SDKs): Hudi's delete resolves each record's partition path from the frame it is given, so a frame omitting the partition columns matches nothing *and still writes a commit*. The frame is now validated against the partition columns the write options were built from, raising `FeatureStoreException` naming what is missing.
3. Same change in the Java SDK (`HudiEngine.deleteRecord`, `HudiOperationType.DELETE`) — otherwise Java/Flink/Beam clients stay broken. The now-unused `PAYLOAD_CLASS_OPT_KEY/VAL` constants are removed in both.

## Verification

All run with Hudi 1.2.0 on the `spark-feature-pipeline` image.

**No config can rescue the old path** — merge mode is a *table* property, so a write cannot override it:

```
OLD baseline (upsert + EmptyPayload)                 -> FAIL
OLD + record.merge.mode=COMMIT_TIME_ORDERING         -> FAIL  HoodieException: Config conflict
OLD + write.record.merge.mode=COMMIT_TIME_ORDERING   -> FAIL  HoodieException: Config conflict
OLD + record.merge.mode=CUSTOM                       -> FAIL  HoodieException: Config conflict
OLD + no precombine field                            -> FAIL  HoodieException: Config conflict
NEW operation=delete                                 -> OK    remaining=[2, 3]
```

**Matrix across table layout and delete-frame shape**, which is what surfaced the silent no-op:

```
=== FRESH v9 (NEW code) ===
  v9 flat        / full-row  -> OK  remaining=[2, 3]
  v9 flat        / pk-only   -> OK  remaining=[2, 3]
  v9 partitioned / full-row  -> OK  remaining=[2, 3]
  v9 partitioned / pk-only   -> deleted NOTHING (now blocked by the guard)
=== LEGACY v8->v9: OLD vs NEW ===
  v8 flat        / full-row  OLD -> OK    NEW -> OK  remaining=[2, 3]
  v8 flat        / pk-only   OLD -> FAIL  NEW -> OK  remaining=[2, 3]
  v8 partitioned / full-row  OLD -> OK    NEW -> OK  remaining=[2, 3]
  v8 partitioned / pk-only   OLD -> FAIL  NEW -> deleted NOTHING (now blocked by the guard)
```

Net effect per case — **no case regresses**:

| case | before | after |
|---|---|---|
| v9, full-row (the reported bug) | hard failure | **fixed** |
| v9/v8, flat, pk-only | loud failure | now works |
| v9/v8, partitioned, pk-only | loud failure | loud failure, clearer message |
| v8 (Hudi 1.0 tables), full-row | worked | still works |

Java modules `hsfs` and `spark` compile.

## Existing (Hudi 1.0) feature groups are not affected

Checked against the **real 1.0.2.2 jar**, not only the simulation:

- `HoodieTableConfig.DEFAULT_PAYLOAD_CLASS_NAME` = `DefaultHoodieRecordPayload` — **on the 1.2 allow-list**.
- 1.0.2.2's max table version is `EIGHT`, so real 1.0 tables are v8, and the v8→v9 auto-upgrade preserves the recorded payload class.
- **1.0.2.2 contains no `PayloadGroupings` class** — the validation did not exist, confirming the regression arrived with the version bump rather than being latent.

So only feature groups created on Hudi ≥ 1.1 are affected, and their deletes are broken permanently (merge mode is fixed at table creation). No migration or backfill is needed.

Consistent with upstream: Hudi 1.1 deprecated payload classes "in favor of merge modes and the merger API", with automatic migration for *known* payloads — `EmptyHoodieRecordPayload` is not one of them, which is why this usage falls through. Hudi 1.2 keeps table version 9 unchanged from 1.1.1.

## Not verified

- **`python/tests/core/test_hudi_engine.py` has not been run** — the suite fails to import on `hsml.decorators`, generated by `hopsworks-apigen`, independently of this change. I updated the one assertion that encoded the old behaviour; CI is the first thing to execute it.
- **No end-to-end loadtest against a patched SDK.** The delete runs inside the Spark job using the SDK baked into the `spark-feature-pipeline` image, so that needs an image rebuild. The evidence above exercises the same Hudi code path directly.
- **Time-travel / incremental read semantics** after a native delete versus an empty-payload upsert are not compared. `test_travel_time` exercises time travel, so worth a reviewer's eye.
- **One residual on the 1.0 claim:** I confirmed the *table-level* default payload is `DefaultHoodieRecordPayload`, but could not execute the Scala `DataSourceWriteOptions` default without a scala-2.12 runtime. If a real 1.0-created feature group recorded `OverwriteWithLatestAvroPayload` instead, that is **not** on the allow-list. One command on any pre-upgrade table settles it: `hdfs dfs -cat …/.hoodie/hoodie.properties | grep -i payload`.