### PR TITLE
[HWORKS-3074][APPEND] Silence great_expectations' metric-registry INFO chatter

### DIFF
--- a/python/hopsworks_common/core/constants.py
+++ b/python/hopsworks_common/core/constants.py
@@ -44,14 +44,20 @@ HAS_GREAT_EXPECTATIONS: bool = (
 )
 GE_MAJOR: int | None = None
 if HAS_GREAT_EXPECTATIONS:
-    # GE 1.x's _docs_decorators logs an INFO line for every closure it scans
-    # during module init (DataSourceManager._register_* / _bind_asset_factory_*),
-    # producing hundreds of useless lines whenever GE loads. Suppress here so it
-    # is in place before the validation modules import great_expectations.
+    # GE 1.x chatters on INFO while its modules initialise: _docs_decorators logs
+    # a line for every closure it scans (DataSourceManager._register_* /
+    # _bind_asset_factory_*), and registry.register_metric one per metric GE
+    # itself declares twice ("Multiple declarations of metric ..."). Both land in
+    # the user's notebook because `hopsworks` puts the root logger at INFO.
+    # Suppress here so it is in place before the validation modules import
+    # great_expectations.
     import importlib.metadata
     import logging
 
     logging.getLogger("great_expectations._docs_decorators").setLevel(logging.WARNING)
+    logging.getLogger("great_expectations.expectations.registry").setLevel(
+        logging.WARNING
+    )
     # The version comes from package metadata, never from importing the package:
     # this module sits on the SDK's import spine, and executing GE's module init
     # here (it pulls altair, scipy and jsonschema) put ~8 seconds on every

--- a/python/tests/test_import_side_effects.py
+++ b/python/tests/test_import_side_effects.py
@@ -18,6 +18,8 @@ import json
 import subprocess
 import sys
 
+import pytest
+
 
 def test_importing_the_sdk_does_not_execute_great_expectations():
     # constants.py sits on the SDK's import spine; executing great_expectations there put
@@ -38,3 +40,31 @@ def test_importing_the_sdk_does_not_execute_great_expectations():
     assert result["ge_loaded"] is False
     if result["has_ge"]:
         assert isinstance(result["ge_major"], int)
+
+
+def test_loading_a_validation_module_does_not_log_ge_metric_chatter():
+    # GE 1.x registers its core metrics from its own module init and logs "Multiple
+    # declarations of metric ... for engine ..." at INFO for each one it declares twice.
+    # The validation modules import GE long after `hopsworks` has pointed the root logger
+    # at stderr on INFO, so those five lines land in every notebook that calls login().
+    # constants.py pins that logger to WARNING before any GE import can happen; run in a
+    # subprocess because logger levels are process-global state an earlier import decides.
+    code = (
+        "import json, sys\n"
+        "import hopsworks\n"
+        "try:\n"
+        "    import hsfs.expectation_suite\n"
+        "except Exception as e:\n"
+        "    print(json.dumps({'ge_loaded': False, 'error': type(e).__name__}))\n"
+        "else:\n"
+        "    print(json.dumps({'ge_loaded': 'great_expectations' in sys.modules}))\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    result = json.loads(out.stdout.strip().splitlines()[-1])
+    if not result["ge_loaded"]:
+        pytest.skip(
+            f"great_expectations was not loaded: {result.get('error', 'absent')}"
+        )
+    assert "Multiple declarations of metric" not in out.stderr, out.stderr


### PR DESCRIPTION
Follow-up to #1120.

## The noise

`hopsworks.login()` in a notebook prints five lines nobody can act on:

```
2026-08-30 19:52:09,027 INFO: Multiple declarations of metric table.column_types for engine PandasExecutionEngine.
2026-08-30 19:52:09,028 INFO: Multiple declarations of metric table.column_types for engine SparkDFExecutionEngine.
2026-08-30 19:52:09,144 INFO: Multiple declarations of metric column.standard_deviation for engine PandasExecutionEngine.
2026-08-30 19:52:09,145 INFO: Multiple declarations of metric column.standard_deviation.aggregate_fn for engine SparkDFExecutionEngine.
2026-08-30 19:52:09,145 INFO: Multiple declarations of metric column.standard_deviation for engine SparkDFExecutionEngine.
```

`great_expectations` 1.x registers its core metrics from its own module init —
`_register_core_metrics()` runs at the bottom of `great_expectations/__init__.py` — and
`registry.register_metric` logs at INFO for each metric GE itself declares twice. Nothing is
being validated, and `PandasExecutionEngine` / `SparkDFExecutionEngine` are GE's own engine
names, not ours.

## Why now

#1120 took the GE import off the SDK's import spine, so GE now loads when a validation module
imports it — after `hopsworks/__init__.py`'s `basicConfig(level=INFO, stream=stderr)` has given
the root logger a handler. Before, GE loaded from `constants.py` during `import hopsworks`,
ahead of that `basicConfig`, so the records fell through to `logging.lastResort` at WARNING and
were dropped. Measured with GE 1.17.1 in a clean venv: five lines with `d0b0174ea`, zero with
its parent. `branch-5.1` and `branch-5.0` are therefore not affected.

## The change

Pin `great_expectations.expectations.registry` to WARNING next to the `_docs_decorators`
suppression already in `constants.py`, which runs before any validation module can import GE.
WARNING and above still pass, so a genuine registry problem is still reported.

## Verification

Fresh py3.10 venv, `great-expectations==1.17.1`, this branch installed as `5.1.0.dev1`:

| | `Multiple declarations` lines |
|---|---|
| `origin/main` | 5 |
| this branch | 0 |

- Imported all 14 GE-touching entry points (`hopsworks`, `hopsworks_common`, `hsml`, `hsfs`,
  `expectation_suite`, `ge_expectation`, `validation_report`, `ge_validation_result`,
  `feature_group`, `feature_store_activity`, three `core/*_engine` modules, `engine.python`)
  with logging pre-configured at INFO — no leaks from any of them.
- `import hopsworks` alone installs the suppression, so an explicit `import great_expectations`
  in user code is quiet too, and GE still stays out of `sys.modules` (#1120's contract holds).
- `ge.get_context(mode="ephemeral")` does not reset the level.
- A WARNING emitted on that logger is still delivered.
- **GE 0.18.12**, the floor of the `>=0.18.12,<=1.17.1` pin: zero lines before *and* after, so
  this is a no-op there; `GE_MAJOR` still resolves to `0`.
- The new test fails on `origin/main` (five lines in the assertion message), passes here, and
  skips when the optional extras are missing, which is what the `dev-no-opt` job hits.
- `ruff check` / `ruff format --check` clean.

## Known limitations

- The suppression is process-global logger state. A `logging.config.dictConfig` that names the
  `great_expectations` logger resets its children to `NOTSET` and the lines come back — the same
  is already true of the `_docs_decorators` line, and it is arguably what someone asking for GE
  INFO wants.
- A user who deliberately re-declares a metric GE already owns no longer sees the INFO line
  about it. With GE's own metrics tripping the message five times per load, that signal was not
  readable anyway.
- GE still logs two INFO lines of its own from `get_context(mode="ephemeral")`
  (`data_context.types.base`, `datasource.fluent.config`). Quieting those would mean touching the
  parent logger, which this PR deliberately does not do.

Note for the reviewer: the docstring in `python/tests/test_hopsworks_lazy_alias.py` justifies
asserting on stdout alone by saying GE prints this "whenever it loads". That is no longer true on
`main` with GE 1.x; the stdout-only assertion is still the right call, so I left it alone.
