### PR TITLE
[HWORKS-2879][APPEND] Bump hsfs kafka-clients from 3.4.0 to 3.9.1

### DIFF
--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <javax.version>2.2.11</javax.version>
-    <kafka.version>3.4.0</kafka.version>
+    <kafka.version>3.9.1</kafka.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Follow-up to #1042 ([HWORKS-2879][HWORKS-3145] Spark upgrade to 4.1), which moved the SDK to Spark 4.1 without carrying the Kafka client pin forward.

Companion to logicalclocks/hudi#39, which is the actual outage fix. This one is hygiene.

## What

```diff
 java/hsfs/pom.xml
-    <kafka.version>3.4.0</kafka.version>
+    <kafka.version>3.9.1</kafka.version>
```

## Why

`hsfs` is packaged `jar-with-dependencies`, so its `kafka-clients` is baked into `hsfs-spark-spark4.1` **un-relocated**. On the Spark image that sits on the same classpath as the un-relocated copy inside `hudi-utilities-slim-bundle`, and jobs run with:

```
-cp /srv/hops/spark/jars/*:/srv/hops/spark/hopsworks-jars/*
```

JVM wildcard expansion follows readdir order, so which jar supplies `org.apache.kafka.*` varies per pod. Observed on a live cluster — two pods of the *same* Spark application:

```
exec-1 : SslConfigs <- hsfs-spark-spark4.1-5.1.0-SNAPSHOT.jar     knows PEM (KIP-651): true
driver : SslConfigs <- hudi-utilities-slim-bundle_2.13-1.2.0.jar  knows PEM (KIP-651): false
```

Hudi's copy being 2.6.0 is what breaks Kafka TLS today (hudi#39 raises it to 3.9.1). This PR moves the other copy so that after both land the two are identical and the race stops mattering, rather than merely being survivable.

3.9.1 is the version `apache/spark` `branch-4.1` pins, so it matches `spark-sql-kafka-0-10_2.13-4.1.3.0` — the connector that performs the SDK's Kafka I/O — and it matches the brokers (Strimzi `0.45.1-h5-kafka-3.9.1`).

## Where the property lives

In `java/hsfs/pom.xml`, not a profile in `java/pom.xml`. A module's own property beats one inherited from a parent profile, so the `<kafka.version>3.4.1</kafka.version>` the `spark-3.5` profile carried never reached this module:

```
$ cd java/hsfs && mvn -N help:evaluate -Dexpression=kafka.version -Pspark-3.5
3.4.0
```

The `spark-4.1` profile that replaced it sets no `kafka.version` at all. Adding one there would be dead code.

## Scope

`java/beam` stays on 3.4.0 on purpose — it is not on the Spark classpath, and `beam-sdks-java-io-kafka` is pinned to Beam 2.48.0, so moving it is risk without benefit here.

## Risk

The SDK's Kafka surface is small and unchanged across 3.4 → 3.9: `KafkaProducer`, `ProducerRecord`, `RecordMetadata`, `Callback`, `Serializer`/`Deserializer`, `Headers`, `PartitionInfo`, `SslConfigs`. No removed APIs among them. `java/spark`, `java/beam` and `java/flink` pull `kafka-clients` transitively through `hsfs`, so their builds are the check.

Verified locally: `mvn -N help:evaluate -Dexpression=kafka.version` in `java/hsfs` resolves **3.9.1**; `kafka-clients:3.9.1` resolves on Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QS58weJyATK451SH7xcLvg

[HWORKS-2879]: https://hopsworks.atlassian.net/browse/HWORKS-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ