### PR TITLE
[FSTORE-2105] Don't emit KLL for a column with no finite values, and bin over the finite ones

### DIFF
--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -392,10 +392,15 @@ public class ColumnProfiler {
 
     if (kll && nonNullVal > 0) {
       byte[] kllBytes = computeKll(df, nn);
-      builder.kllBytes(kllBytes);
       KllDoublesSketch sketch = KllAggregator.heapify(kllBytes);
-      double[] percentiles = sketch.getQuantiles(PERCENTILE_FRACTIONS);
-      builder.approxPercentiles(percentiles);
+      // Spark counts NaN as non-null but the sketch skips it, so an all-NaN column
+      // yields an empty sketch. getQuantiles here and getCDF in the serializer both
+      // throw on one, so emit no KLL for it.
+      if (!sketch.isEmpty()) {
+        builder.kllBytes(kllBytes);
+        double[] percentiles = sketch.getQuantiles(PERCENTILE_FRACTIONS);
+        builder.approxPercentiles(percentiles);
+      }
     } else if (!kll && nonNullVal > 0) {
       double[] percentiles = computeApproxPercentiles(df, nn);
       builder.approxPercentiles(percentiles);

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -213,19 +214,27 @@ public class ColumnProfiler {
         // sample stddev. Use stddev_pop to match the Deequ baseline byte-for-byte.
         exprs.add(functions.stddev_pop(cn).alias(nn + "__stddev"));
         exprs.add(functions.sum(cn).alias(nn + "__sum"));
-        // NaN-free copies for the histogram. Spark ranks NaN above every other double, so
-        // one NaN makes __max NaN and every range derived from it NaN too. The emitted
-        // minimum/maximum keep Spark's values for Deequ parity; only the binning uses
-        // these. Same pass, no extra Spark job.
-        Column finite = functions.when(functions.not(functions.isnan(cn)), cn);
+        // Finite-only copies for the binning: one NaN makes __max NaN and one infinity
+        // makes it infinite, and neither works as a bin edge. The emitted minimum/maximum
+        // keep Spark's values for Deequ parity. Same pass, no extra Spark job.
+        Column finite = functions.when(isFinite(cn), cn);
         exprs.add(functions.min(finite).alias(nn + "__min_finite"));
         exprs.add(functions.max(finite).alias(nn + "__max_finite"));
-        exprs.add(functions.count(finite).alias(nn + "__nonnan"));
+        exprs.add(functions.count(finite).alias(nn + "__nfinite"));
       }
     }
     Column first = exprs.get(0);
     Column[] rest = exprs.subList(1, exprs.size()).toArray(new Column[0]);
     return df.agg(first, rest).first();
+  }
+
+  /**
+   * Spark predicate selecting the finite values of a double column. Spark orders NaN above
+   * +Infinity, so one comparison excludes NaN and both infinities. Matches what
+   * {@link KllAggregator} feeds its sketch, so the histogram and the buckets bin the same rows.
+   */
+  static Column isFinite(Column doubleCol) {
+    return functions.abs(doubleCol).lt(functions.lit(Double.POSITIVE_INFINITY));
   }
 
   // ---------------------------------------------------------------------------
@@ -392,30 +401,39 @@ public class ColumnProfiler {
       builder.correlations(correlationMap.get(nn));
     }
 
-    // Bin over the finite values: minVal/maxVal are NaN as soon as the column holds one
-    // NaN, which would label every bin "NaN to NaN", and nonNullVal counts NaN rows that
-    // do not belong in any bin. Both are null when nothing finite exists, and the
-    // histogram is then omitted rather than emitted as garbage.
+    // Bin over the finite values: minVal/maxVal go non-finite as soon as the column holds
+    // one NaN or infinity. From the same agg() pass; min/max are null exactly when the
+    // column has nothing finite.
     Double minFinite = aggRow.getAs(nn + "__min_finite");
     Double maxFinite = aggRow.getAs(nn + "__max_finite");
-    long nonNanVal = ((Number) aggRow.getAs(nn + "__nonnan")).longValue();
+    long finiteVal = ((Number) aggRow.getAs(nn + "__nfinite")).longValue();
+    // A bin grid needs a finite width. Finite bounds are not enough: a span wider than
+    // Double.MAX_VALUE overflows the subtraction to infinity, which collapses every split
+    // point and makes getCDF throw just as an infinite bound would.
+    boolean binnable = minFinite != null && maxFinite != null
+        && Double.isFinite(maxFinite - minFinite);
 
-    if (histogram && minFinite != null && maxFinite != null) {
-      List<Map<String, Object>> hist = histogramBuilder.buildNumeric(
-          df, nn, minFinite, maxFinite, histogramBins, nonNanVal);
+    if (histogram) {
+      // An empty list says "binned, nothing to bin"; omitting the key makes the SDK's
+      // FeatureGroup._are_statistics_missing read the registered statistics as incomplete
+      // and relaunch the statistics job on every compute_statistics() call.
+      List<Map<String, Object>> hist = Collections.emptyList();
+      if (binnable) {
+        hist = histogramBuilder.buildNumeric(
+            df, nn, minFinite, maxFinite, histogramBins, finiteVal);
+      }
       builder.histogram(hist);
     }
 
-    if (kll && nonNullVal > 0) {
+    if (kll && finiteVal > 0) {
       byte[] kllBytes = computeKll(df, nn);
       KllDoublesSketch sketch = KllAggregator.heapify(kllBytes);
-      // Spark counts NaN as non-null but the sketch skips it, so an all-NaN column
-      // yields an empty sketch. getQuantiles here and getCDF in the serializer both
-      // throw on one, so emit no KLL for it.
       if (!sketch.isEmpty()) {
-        builder.kllBytes(kllBytes);
-        double[] percentiles = sketch.getQuantiles(PERCENTILE_FRACTIONS);
-        builder.approxPercentiles(percentiles);
+        builder.approxPercentiles(sketch.getQuantiles(PERCENTILE_FRACTIONS));
+        // The buckets, unlike the percentiles, need a finite grid over the sketch's range.
+        if (Double.isFinite(sketch.getMaxItem() - sketch.getMinItem())) {
+          builder.kllBytes(kllBytes);
+        }
       }
     } else if (!kll && nonNullVal > 0) {
       double[] percentiles = computeApproxPercentiles(df, nn);

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -200,7 +200,9 @@ public class ColumnProfiler {
       String nn = col.name;
 
       exprs.add(functions.count(cc).alias(nn + "__nonnull"));
-      exprs.add(functions.sum(functions.when(cc.isNull(), 1).otherwise(0)).alias(nn + "__nullcount"));
+      // count(when(isNull)) rather than sum(when(isNull, 1).otherwise(0)): sum returns NULL
+      // over zero rows, and the read side unboxes this into a long.
+      exprs.add(functions.count(functions.when(cc.isNull(), 1)).alias(nn + "__nullcount"));
       exprs.add(functions.approx_count_distinct(cc).alias(nn + "__approx_distinct"));
       if (exactUniqueness) {
         exprs.add(functions.countDistinct(cc).alias(nn + "__exact_distinct"));
@@ -333,10 +335,9 @@ public class ColumnProfiler {
       boolean histogram, int histogramBins, boolean kll, boolean exactUniqueness) {
     String nn = col.name;
 
-    // count(col) returns Long; sum(when(...).otherwise(0)) returns Long when the sum
-    // fits, but Spark can pass it back as Integer internally — cast via Number for safety.
+    // Both are count()s, so an empty dataframe yields 0 rather than a NULL to unbox.
     long nonNull = aggRow.getAs(nn + "__nonnull");
-    long nullCount = ((Number) aggRow.getAs(nn + "__nullcount")).longValue();
+    long nullCount = aggRow.getAs(nn + "__nullcount");
     long total = nonNull + nullCount;
     long approxDistinct = aggRow.getAs(nn + "__approx_distinct");
     // exactNumDistinctValues + derived stats (distinctness/uniqueness/entropy) are only

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -213,6 +213,14 @@ public class ColumnProfiler {
         // sample stddev. Use stddev_pop to match the Deequ baseline byte-for-byte.
         exprs.add(functions.stddev_pop(cn).alias(nn + "__stddev"));
         exprs.add(functions.sum(cn).alias(nn + "__sum"));
+        // NaN-free copies for the histogram. Spark ranks NaN above every other double, so
+        // one NaN makes __max NaN and every range derived from it NaN too. The emitted
+        // minimum/maximum keep Spark's values for Deequ parity; only the binning uses
+        // these. Same pass, no extra Spark job.
+        Column finite = functions.when(functions.not(functions.isnan(cn)), cn);
+        exprs.add(functions.min(finite).alias(nn + "__min_finite"));
+        exprs.add(functions.max(finite).alias(nn + "__max_finite"));
+        exprs.add(functions.count(finite).alias(nn + "__nonnan"));
       }
     }
     Column first = exprs.get(0);
@@ -384,9 +392,17 @@ public class ColumnProfiler {
       builder.correlations(correlationMap.get(nn));
     }
 
-    if (histogram && minVal != null && maxVal != null) {
+    // Bin over the finite values: minVal/maxVal are NaN as soon as the column holds one
+    // NaN, which would label every bin "NaN to NaN", and nonNullVal counts NaN rows that
+    // do not belong in any bin. Both are null when nothing finite exists, and the
+    // histogram is then omitted rather than emitted as garbage.
+    Double minFinite = aggRow.getAs(nn + "__min_finite");
+    Double maxFinite = aggRow.getAs(nn + "__max_finite");
+    long nonNanVal = ((Number) aggRow.getAs(nn + "__nonnan")).longValue();
+
+    if (histogram && minFinite != null && maxFinite != null) {
       List<Map<String, Object>> hist = histogramBuilder.buildNumeric(
-          df, nn, minVal, maxVal, histogramBins, nonNullVal);
+          df, nn, minFinite, maxFinite, histogramBins, nonNanVal);
       builder.histogram(hist);
     }
 

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -265,9 +265,13 @@ public class ColumnProfiler {
 
   private ValueFrequencyStats computeColumnValueFrequencyStats(Dataset<Row> df,
       String columnName) {
-    Column cc = functions.col(columnName);
-    List<Row> rows = df.filter(cc.isNotNull())
-        .groupBy(cc)
+    // Project to a fixed name before grouping. A feature may legitimately be called
+    // "count" (the name passes the feature-name rules), and grouping on it directly
+    // leaves two "count" columns in the result, so the select below cannot resolve.
+    Column cc = functions.col(columnName).alias("_v");
+    List<Row> rows = df.select(cc)
+        .filter(functions.col("_v").isNotNull())
+        .groupBy(functions.col("_v"))
         .count()
         .select(functions.col("count"))
         .collectAsList();

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -231,14 +231,14 @@ public class ColumnProfiler {
   }
 
   /**
-   * True when an equi-width grid of {@code bins} over {@code [min, max]} has strictly
-   * increasing edges, which is what {@code getCDF} demands of its split points and what
-   * keeps a bin label from being derived from a bound it does not describe.
+   * True when the equi-width grid of {@code bins} over {@code [min, max]} has strictly
+   * increasing edges - what {@code getCDF} demands of its split points, and what a bin label
+   * needs in order to describe the bound it names.
    *
-   * <p>Finite bounds are not sufficient in either direction. A span wider than
-   * Double.MAX_VALUE overflows the subtraction to infinity and collapses every split point;
-   * a span below {@code bins * Double.MIN_VALUE} underflows the division to zero, so every
-   * split point lands on {@code min} instead. A zero span is fine: the histogram emits a
+   * <p>Checked literally, edge by edge, because every shortcut has a hole: a finite range
+   * can overflow to infinity, a finite width can underflow to zero, and a width that is
+   * finite and positive can still be smaller than the spacing of doubles at {@code min}, so
+   * that later edges round onto earlier ones. A zero range is fine: the histogram emits a
    * single bin for it and the bucket grid falls back to a width of 1.
    */
   static boolean hasUsableBinGrid(double min, double max, int bins) {
@@ -250,7 +250,16 @@ public class ColumnProfiler {
       return true;
     }
     double width = range / bins;
-    return width > 0 && min + width > min;
+    double previous = min;
+    for (int i = 1; i < bins; i++) {
+      // The same formula HistogramBuilder and ProfileJsonSerializer use for their edges.
+      double edge = min + i * width;
+      if (!(edge > previous)) {
+        return false;
+      }
+      previous = edge;
+    }
+    return true;
   }
 
   /**
@@ -430,11 +439,11 @@ public class ColumnProfiler {
     }
 
     // Bin over the finite values: minVal/maxVal go non-finite as soon as the column holds
-    // one NaN or infinity. From the same agg() pass; min/max are null exactly when the
-    // column has nothing finite.
+    // one NaN or infinity. All three come from the same agg() pass, and min/max are null
+    // exactly when the column has nothing finite.
     Double minFinite = aggRow.getAs(nn + "__min_finite");
     Double maxFinite = aggRow.getAs(nn + "__max_finite");
-    long finiteVal = ((Number) aggRow.getAs(nn + "__nfinite")).longValue();
+    long finiteVal = aggRow.getAs(nn + "__nfinite");
     boolean binnable = minFinite != null && maxFinite != null
         && hasUsableBinGrid(minFinite, maxFinite, histogramBins);
 
@@ -453,6 +462,8 @@ public class ColumnProfiler {
     if (kll && finiteVal > 0) {
       byte[] kllBytes = computeKll(df, nn);
       KllDoublesSketch sketch = KllAggregator.heapify(kllBytes);
+      // finiteVal > 0 already implies a non-empty sketch; kept because buildKllBuckets
+      // depends on it directly, not on how the caller happened to gate the call.
       if (!sketch.isEmpty()) {
         builder.approxPercentiles(sketch.getQuantiles(PERCENTILE_FRACTIONS));
         // The buckets, unlike the percentiles, need a usable grid over the sketch's range.

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -231,6 +231,29 @@ public class ColumnProfiler {
   }
 
   /**
+   * True when an equi-width grid of {@code bins} over {@code [min, max]} has strictly
+   * increasing edges, which is what {@code getCDF} demands of its split points and what
+   * keeps a bin label from being derived from a bound it does not describe.
+   *
+   * <p>Finite bounds are not sufficient in either direction. A span wider than
+   * Double.MAX_VALUE overflows the subtraction to infinity and collapses every split point;
+   * a span below {@code bins * Double.MIN_VALUE} underflows the division to zero, so every
+   * split point lands on {@code min} instead. A zero span is fine: the histogram emits a
+   * single bin for it and the bucket grid falls back to a width of 1.
+   */
+  static boolean hasUsableBinGrid(double min, double max, int bins) {
+    double range = max - min;
+    if (!Double.isFinite(range)) {
+      return false;
+    }
+    if (range == 0.0) {
+      return true;
+    }
+    double width = range / bins;
+    return width > 0 && min + width > min;
+  }
+
+  /**
    * Spark predicate selecting the finite values of a double column. Spark orders NaN above
    * +Infinity, so one comparison excludes NaN and both infinities. Matches what
    * {@link KllAggregator} feeds its sketch, so the histogram and the buckets bin the same rows.
@@ -412,11 +435,8 @@ public class ColumnProfiler {
     Double minFinite = aggRow.getAs(nn + "__min_finite");
     Double maxFinite = aggRow.getAs(nn + "__max_finite");
     long finiteVal = ((Number) aggRow.getAs(nn + "__nfinite")).longValue();
-    // A bin grid needs a finite width. Finite bounds are not enough: a span wider than
-    // Double.MAX_VALUE overflows the subtraction to infinity, which collapses every split
-    // point and makes getCDF throw just as an infinite bound would.
     boolean binnable = minFinite != null && maxFinite != null
-        && Double.isFinite(maxFinite - minFinite);
+        && hasUsableBinGrid(minFinite, maxFinite, histogramBins);
 
     if (histogram) {
       // An empty list says "binned, nothing to bin"; omitting the key makes the SDK's
@@ -435,8 +455,9 @@ public class ColumnProfiler {
       KllDoublesSketch sketch = KllAggregator.heapify(kllBytes);
       if (!sketch.isEmpty()) {
         builder.approxPercentiles(sketch.getQuantiles(PERCENTILE_FRACTIONS));
-        // The buckets, unlike the percentiles, need a finite grid over the sketch's range.
-        if (Double.isFinite(sketch.getMaxItem() - sketch.getMinItem())) {
+        // The buckets, unlike the percentiles, need a usable grid over the sketch's range.
+        if (hasUsableBinGrid(sketch.getMinItem(), sketch.getMaxItem(),
+            ProfileJsonSerializer.KLL_BUCKETS)) {
           builder.kllBytes(kllBytes);
         }
       }

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/HistogramBuilder.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/HistogramBuilder.java
@@ -74,8 +74,9 @@ class HistogramBuilder {
     }
 
     // Non-finite values belong to no bin and must not reach binExpr: NaN floors to bin 0,
-    // and floor(Infinity) is Long.MAX_VALUE, whose cast to int throws CAST_OVERFLOW under
-    // Spark 4's ANSI mode and fails the job before least() can clamp it.
+    // and floor(Infinity) is Long.MAX_VALUE, which least() clamps into the last bin - or,
+    // where ANSI mode is on, fails the job outright on the cast to int. Hopsworks pins
+    // spark.sql.ansi.enabled=false, so the default is the silent miscount, not the error.
     Dataset<Row> binned = df.filter(col.isNotNull().and(ColumnProfiler.isFinite(col)))
         .withColumn("_bin", binExpr)
         .groupBy("_bin")

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/HistogramBuilder.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/HistogramBuilder.java
@@ -50,7 +50,7 @@ class HistogramBuilder {
    * @param minValue pre-computed minimum over the finite values (non-null, from agg row)
    * @param maxValue pre-computed maximum over the finite values (non-null, from agg row)
    * @param histogramBins number of bins
-   * @param totalRows total non-null, non-NaN rows (denominator for ratio)
+   * @param totalRows total finite rows (denominator for ratio)
    * @return list of histogram entry maps with keys: value, count, ratio
    */
   List<Map<String, Object>> buildNumeric(Dataset<Row> df,
@@ -73,9 +73,10 @@ class HistogramBuilder {
       );
     }
 
-    // NaN belongs to no bin: it is outside [minValue, maxValue] by construction, and
-    // floor((NaN - min) / width) casts to 0, which would pile every NaN row into bin 0.
-    Dataset<Row> binned = df.filter(col.isNotNull().and(functions.not(functions.isnan(col))))
+    // Non-finite values belong to no bin and must not reach binExpr: NaN floors to bin 0,
+    // and floor(Infinity) is Long.MAX_VALUE, whose cast to int throws CAST_OVERFLOW under
+    // Spark 4's ANSI mode and fails the job before least() can clamp it.
+    Dataset<Row> binned = df.filter(col.isNotNull().and(ColumnProfiler.isFinite(col)))
         .withColumn("_bin", binExpr)
         .groupBy("_bin")
         .count();

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/HistogramBuilder.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/HistogramBuilder.java
@@ -47,10 +47,10 @@ class HistogramBuilder {
    *
    * @param df source dataframe
    * @param columnName column to histogram
-   * @param minValue pre-computed column minimum (non-null, from agg row)
-   * @param maxValue pre-computed column maximum (non-null, from agg row)
+   * @param minValue pre-computed minimum over the finite values (non-null, from agg row)
+   * @param maxValue pre-computed maximum over the finite values (non-null, from agg row)
    * @param histogramBins number of bins
-   * @param totalRows total non-null rows (denominator for ratio)
+   * @param totalRows total non-null, non-NaN rows (denominator for ratio)
    * @return list of histogram entry maps with keys: value, count, ratio
    */
   List<Map<String, Object>> buildNumeric(Dataset<Row> df,
@@ -73,7 +73,9 @@ class HistogramBuilder {
       );
     }
 
-    Dataset<Row> binned = df.filter(col.isNotNull())
+    // NaN belongs to no bin: it is outside [minValue, maxValue] by construction, and
+    // floor((NaN - min) / width) casts to 0, which would pile every NaN row into bin 0.
+    Dataset<Row> binned = df.filter(col.isNotNull().and(functions.not(functions.isnan(col))))
         .withColumn("_bin", binExpr)
         .groupBy("_bin")
         .count();

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/HistogramBuilder.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/HistogramBuilder.java
@@ -119,9 +119,15 @@ class HistogramBuilder {
       String columnName,
       int histogramBins,
       long totalRows) {
+    // Project to a fixed name before grouping, as ColumnProfiler's uniqueness pass does. For
+    // a feature named "count", grouping on the column itself leaves two "count" columns, and
+    // Spark resolves the orderBy against the grouping one rather than failing: the bins come
+    // out ordered by value, and the top-N cut keeps the wrong values.
+    Column value = functions.col(columnName).alias("_v");
     Dataset<Row> grouped = df
-        .filter(functions.col(columnName).isNotNull())
-        .groupBy(functions.col(columnName))
+        .select(value)
+        .filter(functions.col("_v").isNotNull())
+        .groupBy(functions.col("_v"))
         .count()
         .orderBy(functions.desc("count"))
         .limit(histogramBins);

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/KllAggregator.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/KllAggregator.java
@@ -35,6 +35,9 @@ import java.util.Iterator;
  * it to the driver, where sketches are merged. This is the recommended pattern for
  * pure-Java aggregators that cannot implement {@code java.io.Serializable}.
  *
+ * <p>Only finite values are fed to the sketch: callers derive bin edges from its min/max, and
+ * a column with nothing finite yields an <em>empty</em> sketch, which most operations reject.
+ *
  * <p>K=2048 matches the Deequ baseline's effective sketch resolution (Deequ also used K=2048).
  * Normalised rank error is ~0.13%, tight enough for extreme-quantile monitoring on wide-range
  * integer columns where K=200 showed ≥3% tail error. Larger K = more memory per sketch;
@@ -100,7 +103,7 @@ public class KllAggregator {
         Row row = rows.next();
         if (!row.isNullAt(0)) {
           double value = ((Number) row.get(0)).doubleValue();
-          if (!Double.isNaN(value)) {
+          if (Double.isFinite(value)) {
             sketch.update(value);
           }
         }

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -110,8 +110,7 @@ class ProfileJsonSerializer {
       map.put("histogram", profile.getHistogram());
     }
     if (profile.getKllBytes() != null) {
-      map.put("kll", buildKllMap(profile.getKllBytes(), profile.getMinimum(),
-          profile.getMaximum(), profile.getNumRecordsNonNull()));
+      map.put("kll", buildKllMap(profile.getKllBytes()));
     }
     if (profile.getApproxPercentiles() != null) {
       map.put("approxPercentiles", toDoubleList(profile.getApproxPercentiles()));
@@ -180,18 +179,32 @@ class ProfileJsonSerializer {
    * matching the numeric histogram, so read-time consumers have a histogram-from-sketch shape
    * without re-merging.
    */
-  private Map<String, Object> buildKllMap(byte[] kllBytes, double minValue, double maxValue,
-      long totalRows) {
+  private Map<String, Object> buildKllMap(byte[] kllBytes) {
     KllDoublesSketch sketch = KllAggregator.heapify(kllBytes);
     Map<String, Object> kll = new LinkedHashMap<String, Object>();
     kll.put("kllFormat", "datasketches-native-v1");
     kll.put("bytes", Base64.getEncoder().encodeToString(kllBytes));
-    kll.put("buckets", buildKllBuckets(sketch, minValue, maxValue, totalRows));
+    kll.put("buckets", buildKllBuckets(sketch));
     return kll;
   }
 
-  private List<Map<String, Object>> buildKllBuckets(KllDoublesSketch sketch,
-      double minValue, double maxValue, long totalRows) {
+  /**
+   * Bins the sketch over its own range and weight rather than the column's.
+   *
+   * <p>KllAggregator never feeds NaN to the sketch, while Spark ranks NaN above every other
+   * double and counts it as non-null: the column maximum is NaN as soon as one NaN is
+   * present, and numRecordsNonNull counts rows the sketch never saw. Reading either from the
+   * profile would put every bin edge in the wrong place and scale every count by the NaN
+   * fraction. The sketch's own min/max/N are always finite and always describe exactly the
+   * values it holds.
+   *
+   * <p>getMinItem/getMaxItem throw on an empty sketch; ColumnProfiler only sets kllBytes
+   * for a non-empty one, so this is unreachable with an empty sketch.
+   */
+  private List<Map<String, Object>> buildKllBuckets(KllDoublesSketch sketch) {
+    double minValue = sketch.getMinItem();
+    double maxValue = sketch.getMaxItem();
+    long totalRows = sketch.getN();
     int numBuckets = 20;
     double range = maxValue - minValue;
     double binWidth = range > 0 ? range / numBuckets : 1.0;

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -191,12 +191,12 @@ class ProfileJsonSerializer {
   /**
    * Bins the sketch over its own range and weight rather than the column's.
    *
-   * <p>KllAggregator never feeds NaN to the sketch, while Spark ranks NaN above every other
-   * double and counts it as non-null: the column maximum is NaN as soon as one NaN is
-   * present, and numRecordsNonNull counts rows the sketch never saw. Reading either from the
-   * profile would put every bin edge in the wrong place and scale every count by the NaN
-   * fraction. The sketch's own min/max/N are always finite and always describe exactly the
-   * values it holds.
+   * <p>KllAggregator feeds the sketch finite values only, while the profile's maximum goes
+   * non-finite as soon as the column holds one NaN or infinity and numRecordsNonNull counts
+   * rows the sketch never saw. Reading either from the profile misplaces every bin edge and
+   * scales every count by the non-finite fraction; a non-finite bound also collapses the
+   * split points, which {@code getCDF} rejects. The sketch's own min/max/N are finite by
+   * construction and describe exactly the values it holds.
    *
    * <p>getMinItem/getMaxItem throw on an empty sketch; ColumnProfiler only sets kllBytes
    * for a non-empty one, so this is unreachable with an empty sketch.

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -202,7 +202,10 @@ class ProfileJsonSerializer {
    * construction and describe exactly the values it holds.
    *
    * <p>getMinItem/getMaxItem throw on an empty sketch; ColumnProfiler only sets kllBytes
-   * for a non-empty one, so this is unreachable with an empty sketch.
+   * for a non-empty one, so this is unreachable with an empty sketch. Likewise, getCDF
+   * rejects split points that do not strictly increase; ColumnProfiler.hasUsableBinGrid
+   * checks that with the same {@code min + i * binWidth} formula used below, so the two
+   * must change together.
    */
   private List<Map<String, Object>> buildKllBuckets(KllDoublesSketch sketch) {
     double minValue = sketch.getMinItem();

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ProfileJsonSerializer.java
@@ -59,6 +59,9 @@ class ProfileJsonSerializer {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  /** Buckets in the KLL-derived histogram. ColumnProfiler needs it to check the grid. */
+  static final int KLL_BUCKETS = 20;
+
   /**
    * Serialises a list of column profiles to the Deequ-compatible JSON envelope.
    *
@@ -205,7 +208,7 @@ class ProfileJsonSerializer {
     double minValue = sketch.getMinItem();
     double maxValue = sketch.getMaxItem();
     long totalRows = sketch.getN();
-    int numBuckets = 20;
+    int numBuckets = KLL_BUCKETS;
     double range = maxValue - minValue;
     double binWidth = range > 0 ? range / numBuckets : 1.0;
 

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -228,6 +228,30 @@ public class ColumnProfilerSmokeTest {
     Assertions.assertEquals(9, col.get("exactNumDistinctValues").asLong());
   }
 
+  @Test
+  void profilesAllNaNColumnWithoutThrowing() throws Exception {
+    // Spark counts NaN as non-null, but KllAggregator skips NaN when building the
+    // sketch, so an all-NaN column used to reach getQuantiles with an empty sketch
+    // and fail the whole job with SketchesArgumentException.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("all_nan", DataTypes.DoubleType, true),
+    });
+    List<Row> rows = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      rows.add(RowFactory.create(Double.NaN));
+    }
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, false, 20, false, true);
+
+    JsonNode col = findColumn(new ObjectMapper().readTree(json).get("columns"), "all_nan");
+    Assertions.assertNotNull(col, "all_nan column profile must be present");
+    Assertions.assertFalse(col.has("approxPercentiles"),
+        "an empty sketch must not yield approxPercentiles");
+    Assertions.assertFalse(col.has("kll"),
+        "an empty sketch must not be emitted as kll (the serializer calls getCDF on it)");
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -232,24 +232,37 @@ public class ColumnProfilerSmokeTest {
   void profilesAllNaNColumnWithoutThrowing() throws Exception {
     // Spark counts NaN as non-null, but KllAggregator skips NaN when building the
     // sketch, so an all-NaN column used to reach getQuantiles with an empty sketch
-    // and fail the whole job with SketchesArgumentException.
+    // and fail the whole job with SketchesArgumentException. some_nan is the
+    // counterpart the emptiness check must not swallow: NaN is present but not
+    // exclusive, so the sketch holds the finite values and KLL is still emitted.
     StructType schema = new StructType(new StructField[]{
       DataTypes.createStructField("all_nan", DataTypes.DoubleType, true),
+      DataTypes.createStructField("some_nan", DataTypes.DoubleType, true),
     });
     List<Row> rows = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
-      rows.add(RowFactory.create(Double.NaN));
+      rows.add(RowFactory.create(Double.NaN, i % 2 == 0 ? Double.NaN : (double) i));
     }
     Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
 
     String json = new ColumnProfiler().profile(df, null, false, false, 20, false, true);
+    JsonNode columns = new ObjectMapper().readTree(json).get("columns");
 
-    JsonNode col = findColumn(new ObjectMapper().readTree(json).get("columns"), "all_nan");
-    Assertions.assertNotNull(col, "all_nan column profile must be present");
-    Assertions.assertFalse(col.has("approxPercentiles"),
+    JsonNode allNan = findColumn(columns, "all_nan");
+    Assertions.assertNotNull(allNan, "all_nan column profile must be present");
+    Assertions.assertFalse(allNan.has("approxPercentiles"),
         "an empty sketch must not yield approxPercentiles");
-    Assertions.assertFalse(col.has("kll"),
+    Assertions.assertFalse(allNan.has("kll"),
         "an empty sketch must not be emitted as kll (the serializer calls getCDF on it)");
+
+    JsonNode someNan = findColumn(columns, "some_nan");
+    Assertions.assertNotNull(someNan, "some_nan column profile must be present");
+    Assertions.assertTrue(someNan.has("kll"),
+        "a sketch holding the finite values must still be emitted as kll");
+    Assertions.assertEquals(99, someNan.get("approxPercentiles").size(),
+        "a non-empty sketch must still yield the full percentile vector");
+    Assertions.assertEquals(1.0, someNan.get("approxPercentiles").get(0).asDouble(), 1e-9,
+        "percentiles must be estimated from the finite values only");
   }
 
   // ---------------------------------------------------------------------------

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -379,7 +379,7 @@ public class ColumnProfilerSmokeTest {
     }
     Assertions.assertEquals(8, histTotal,
         "histogram must count the eight finite values only; a non-finite value reaching "
-            + "binExpr throws CAST_OVERFLOW under ANSI mode");
+            + "binExpr is clamped into a real bin, or throws where ANSI mode is on");
     Assertions.assertTrue(histogram.get(0).get("value").asText().startsWith("1.00 to"),
         "first bin must start at the finite minimum: " + histogram.get(0).get("value").asText());
 
@@ -415,6 +415,31 @@ public class ColumnProfilerSmokeTest {
         "a span that overflows to infinity must not be emitted as kll (getCDF rejects it)");
     Assertions.assertEquals(99, huge.get("approxPercentiles").size(),
         "the percentiles do not need a bin grid and must survive");
+  }
+
+  @Test
+  void profilesAnEmptyDataframeWithoutThrowing() throws Exception {
+    // A training-dataset split can come out empty, and compute_and_save_split_statistics
+    // profiles each split without an emptiness check. sum() returns NULL over zero rows,
+    // so unboxing the null count failed the statistics job before any column was profiled.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("num", DataTypes.DoubleType, true),
+      DataTypes.createStructField("txt", DataTypes.StringType, true),
+    });
+    Dataset<Row> empty = SparkEngine.getInstance().getSparkSession()
+        .createDataFrame(new ArrayList<Row>(), schema);
+
+    // Every statistics flag on, then every flag off: the null count is read either way.
+    for (boolean on : new boolean[]{true, false}) {
+      String json = new ColumnProfiler().profile(empty, null, on, on, 20, on, on);
+      JsonNode num = findColumn(new ObjectMapper().readTree(json).get("columns"), "num");
+      Assertions.assertNotNull(num, "num column profile must be present with flags=" + on);
+      Assertions.assertEquals(0, num.get("numRecordsNull").asLong(),
+          "an empty dataframe has no null records");
+      Assertions.assertEquals(0, num.get("numRecordsNonNull").asLong(),
+          "an empty dataframe has no non-null records");
+      Assertions.assertFalse(num.has("kll"), "an empty dataframe must not be emitted as kll");
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -320,11 +320,101 @@ public class ColumnProfilerSmokeTest {
     Assertions.assertEquals(5, bucketTotal,
         "bucket counts must be scaled by the sketch weight, not numRecordsNonNull");
 
-    // Nothing finite to bin: the histogram is omitted rather than emitted as NaN bins.
+    // Nothing finite to bin: an empty histogram rather than NaN-labelled bins, and the key
+    // stays present so the SDK does not read the registered statistics as incomplete and
+    // relaunch the statistics job on every compute_statistics().
     JsonNode allNan = findColumn(columns, "all_nan");
     Assertions.assertNotNull(allNan, "all_nan column profile must be present");
-    Assertions.assertFalse(allNan.has("histogram"),
-        "a column with no finite values must not emit a histogram");
+    Assertions.assertTrue(allNan.has("histogram"),
+        "the histogram key must stay present for a column with nothing to bin");
+    Assertions.assertEquals(0, allNan.get("histogram").size(),
+        "a column with no finite values must emit no bins");
+  }
+
+  @Test
+  void binsInfiniteValuesOverTheFiniteRange() throws Exception {
+    // An infinity is as unusable as a NaN in a bin grid, and worse in the KLL path: it
+    // used to enter the sketch, so getMaxItem() returned Infinity, every split point
+    // collapsed to Infinity or NaN and getCDF failed the whole statistics job with
+    // "Values must be unique, monotonically increasing and not NaN".
+    // huge_range holds only finite values, but its span overflows a double subtraction to
+    // infinity, so a finiteness check per value is not enough to make a bin grid safe.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("mixed", DataTypes.DoubleType, true),
+      DataTypes.createStructField("all_inf", DataTypes.DoubleType, true),
+      DataTypes.createStructField("huge_range", DataTypes.DoubleType, true),
+    });
+    List<Row> rows = new ArrayList<>();
+    for (int i = 1; i <= 8; i++) {
+      rows.add(RowFactory.create((double) i, Double.POSITIVE_INFINITY, 0.0));
+    }
+    rows.add(RowFactory.create(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+        -Double.MAX_VALUE));
+    rows.add(RowFactory.create(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY,
+        Double.MAX_VALUE));
+    rows.add(RowFactory.create(Double.NaN, Double.POSITIVE_INFINITY, 0.0));
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, false, true);
+    JsonNode columns = new ObjectMapper().readTree(json).get("columns");
+
+    // mixed holds 1..8 plus +Inf, -Inf and NaN: bins span [1, 8] and hold eight rows.
+    JsonNode mixed = findColumn(columns, "mixed");
+    Assertions.assertNotNull(mixed, "mixed column profile must be present");
+    // minimum/maximum stay as Spark computes them, for Deequ parity: -Infinity is the
+    // smallest double, and NaN outranks even +Infinity.
+    Assertions.assertEquals("-Infinity", mixed.get("minimum").asText(),
+        "minimum must still report the infinity Spark sees");
+    Assertions.assertEquals("NaN", mixed.get("maximum").asText(),
+        "maximum must still report what Spark sees, which NaN dominates");
+
+    JsonNode histogram = mixed.get("histogram");
+    Assertions.assertEquals(20, histogram.size(), "histogram must have 20 bins");
+    long histTotal = 0;
+    for (JsonNode bin : histogram) {
+      String label = bin.get("value").asText();
+      Assertions.assertFalse(label.contains("NaN") || label.contains("Infinity"),
+          "no bin label may be derived from a non-finite range: " + label);
+      histTotal += bin.get("count").asLong();
+    }
+    Assertions.assertEquals(8, histTotal,
+        "histogram must count the eight finite values only; a non-finite value reaching "
+            + "binExpr throws CAST_OVERFLOW under ANSI mode");
+    Assertions.assertTrue(histogram.get(0).get("value").asText().startsWith("1.00 to"),
+        "first bin must start at the finite minimum: " + histogram.get(0).get("value").asText());
+
+    JsonNode buckets = mixed.get("kll").get("buckets");
+    Assertions.assertEquals(1.0, buckets.get(0).get("low_value").asDouble(), 1e-9,
+        "first bucket must start at the finite minimum");
+    Assertions.assertEquals(8.0, buckets.get(19).get("high_value").asDouble(), 1e-9,
+        "last bucket must end at the finite maximum, not at Infinity");
+    long bucketTotal = 0;
+    for (JsonNode bucket : buckets) {
+      bucketTotal += bucket.get("count").asLong();
+    }
+    Assertions.assertEquals(8, bucketTotal, "bucket counts must match the sketch weight");
+    Assertions.assertEquals(1.0, mixed.get("approxPercentiles").get(0).asDouble(), 1e-9,
+        "percentiles must be estimated from the finite values only");
+
+    // Nothing finite at all: same contract as an all-NaN column.
+    JsonNode allInf = findColumn(columns, "all_inf");
+    Assertions.assertNotNull(allInf, "all_inf column profile must be present");
+    Assertions.assertFalse(allInf.has("kll"),
+        "a column with no finite values must not be emitted as kll");
+    Assertions.assertFalse(allInf.has("approxPercentiles"),
+        "a column with no finite values must not yield approxPercentiles");
+    Assertions.assertEquals(0, allInf.get("histogram").size(),
+        "a column with no finite values must emit no bins");
+
+    // Finite bounds, infinite span: the grid is still unbuildable, so treat it the same way.
+    JsonNode huge = findColumn(columns, "huge_range");
+    Assertions.assertNotNull(huge, "huge_range column profile must be present");
+    Assertions.assertEquals(0, huge.get("histogram").size(),
+        "a span that overflows to infinity must emit no bins");
+    Assertions.assertFalse(huge.has("kll"),
+        "a span that overflows to infinity must not be emitted as kll (getCDF rejects it)");
+    Assertions.assertEquals(99, huge.get("approxPercentiles").size(),
+        "the percentiles do not need a bin grid and must survive");
   }
 
   // ---------------------------------------------------------------------------

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -265,6 +265,68 @@ public class ColumnProfilerSmokeTest {
         "percentiles must be estimated from the finite values only");
   }
 
+  @Test
+  void binsPartlyNaNColumnOverItsFiniteRange() throws Exception {
+    // Spark ranks NaN above every other double and counts it as non-null, so a column
+    // holding one NaN reported maximum=NaN. Both bin grids were derived from that: the
+    // histogram labelled all 20 bins "NaN to NaN", and the KLL buckets fell back to a
+    // width-1.0 grid and scaled their counts by numRecordsNonNull, which counts the NaN
+    // rows the sketch never saw.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("all_nan", DataTypes.DoubleType, true),
+      DataTypes.createStructField("some_nan", DataTypes.DoubleType, true),
+    });
+    List<Row> rows = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      rows.add(RowFactory.create(Double.NaN, i % 2 == 0 ? Double.NaN : (double) i));
+    }
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, false, true);
+    JsonNode columns = new ObjectMapper().readTree(json).get("columns");
+
+    // some_nan holds 1, 3, 5, 7, 9 plus five NaN: bins span [1, 9] and hold five rows.
+    JsonNode someNan = findColumn(columns, "some_nan");
+    Assertions.assertNotNull(someNan, "some_nan column profile must be present");
+    JsonNode histogram = someNan.get("histogram");
+    Assertions.assertNotNull(histogram, "some_nan must have a histogram");
+    Assertions.assertEquals(20, histogram.size(), "histogram must have 20 bins");
+
+    long histTotal = 0;
+    double ratioTotal = 0.0;
+    for (JsonNode bin : histogram) {
+      Assertions.assertFalse(bin.get("value").asText().contains("NaN"),
+          "no bin label may be derived from a NaN range: " + bin.get("value").asText());
+      histTotal += bin.get("count").asLong();
+      ratioTotal += bin.get("ratio").asDouble();
+    }
+    Assertions.assertEquals(5, histTotal, "histogram must count the five finite values only");
+    Assertions.assertEquals(1.0, ratioTotal, 1e-9, "bin ratios must sum to 1 over non-NaN rows");
+    Assertions.assertTrue(histogram.get(0).get("value").asText().startsWith("1.00 to"),
+        "first bin must start at the finite minimum, not NaN: "
+            + histogram.get(0).get("value").asText());
+
+    // The KLL buckets bin the sketch over its own range and weight.
+    JsonNode buckets = someNan.get("kll").get("buckets");
+    Assertions.assertEquals(20, buckets.size(), "kll must have 20 buckets");
+    Assertions.assertEquals(1.0, buckets.get(0).get("low_value").asDouble(), 1e-9,
+        "first bucket must start at the sketch minimum");
+    Assertions.assertEquals(9.0, buckets.get(19).get("high_value").asDouble(), 1e-9,
+        "last bucket must end at the sketch maximum, not a width-1.0 fallback grid");
+    long bucketTotal = 0;
+    for (JsonNode bucket : buckets) {
+      bucketTotal += bucket.get("count").asLong();
+    }
+    Assertions.assertEquals(5, bucketTotal,
+        "bucket counts must be scaled by the sketch weight, not numRecordsNonNull");
+
+    // Nothing finite to bin: the histogram is omitted rather than emitted as NaN bins.
+    JsonNode allNan = findColumn(columns, "all_nan");
+    Assertions.assertNotNull(allNan, "all_nan column profile must be present");
+    Assertions.assertFalse(allNan.has("histogram"),
+        "a column with no finite values must not emit a histogram");
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -442,6 +442,31 @@ public class ColumnProfilerSmokeTest {
     }
   }
 
+  @Test
+  void profilesAColumnNamedCount() throws Exception {
+    // "count" passes the feature-name rules and is an ordinary thing to call a feature.
+    // The uniqueness pass grouped on the column itself, so the count() output collided
+    // with it and the select failed with AMBIGUOUS_REFERENCE, taking the whole job down.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("count", DataTypes.DoubleType, true),
+      DataTypes.createStructField("label", DataTypes.StringType, true),
+    });
+    List<Row> rows = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      rows.add(RowFactory.create((double) (i % 5), "v" + (i % 5)));
+    }
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    // exactUniqueness on: this is the pass that groups per column.
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, true, true);
+    JsonNode col = findColumn(new ObjectMapper().readTree(json).get("columns"), "count");
+    Assertions.assertNotNull(col, "the column named 'count' must be profiled");
+    Assertions.assertEquals(5, col.get("exactNumDistinctValues").asLong(),
+        "each of the five values appears twice");
+    Assertions.assertEquals(0.0, col.get("uniqueness").asDouble(), 1e-9,
+        "no value is a singleton, so uniqueness is 0");
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -491,6 +491,40 @@ public class ColumnProfilerSmokeTest {
         "no value is a singleton, so uniqueness is 0");
   }
 
+  @Test
+  void profilesAStringColumnNamedCount() throws Exception {
+    // The numeric path above groups on a synthetic "_bin"; the categorical histogram grouped
+    // on the column itself. For a String or Boolean feature named "count" that does not throw
+    // the way the uniqueness pass did: Spark resolves orderBy(desc("count")) against the
+    // grouping column, so the bins came out ordered by value and the top-N cut kept the
+    // lexically largest values instead of the most frequent ones.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("count", DataTypes.StringType, true),
+    });
+    // Frequency order is the reverse of lexical order, and there are more distinct values
+    // than bins, so binding "count" to the wrong column changes both the order and the
+    // survivors of the top-N cut: v00 appears 25 times, v01 24 times, ... v24 once.
+    List<Row> rows = new ArrayList<>();
+    for (int v = 0; v < 25; v++) {
+      for (int n = 0; n < 25 - v; n++) {
+        rows.add(RowFactory.create(String.format("v%02d", v)));
+      }
+    }
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
+
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, true, false);
+    JsonNode col = findColumn(new ObjectMapper().readTree(json).get("columns"), "count");
+    Assertions.assertNotNull(col, "the column named 'count' must be profiled");
+    Assertions.assertEquals(25, col.get("exactNumDistinctValues").asLong());
+    JsonNode hist = col.get("histogram");
+    Assertions.assertEquals(20, hist.size(), "top-20 of 25 distinct values");
+    for (int i = 0; i < 20; i++) {
+      Assertions.assertEquals(String.format("v%02d", i), hist.get(i).get("value").asText(),
+          "bins are ordered by frequency, most frequent first: " + hist);
+      Assertions.assertEquals(25 - i, hist.get(i).get("count").asLong());
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -343,16 +343,17 @@ public class ColumnProfilerSmokeTest {
       DataTypes.createStructField("mixed", DataTypes.DoubleType, true),
       DataTypes.createStructField("all_inf", DataTypes.DoubleType, true),
       DataTypes.createStructField("huge_range", DataTypes.DoubleType, true),
+      DataTypes.createStructField("subnormal_range", DataTypes.DoubleType, true),
     });
     List<Row> rows = new ArrayList<>();
     for (int i = 1; i <= 8; i++) {
-      rows.add(RowFactory.create((double) i, Double.POSITIVE_INFINITY, 0.0));
+      rows.add(RowFactory.create((double) i, Double.POSITIVE_INFINITY, 0.0, 0.0));
     }
     rows.add(RowFactory.create(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
-        -Double.MAX_VALUE));
+        -Double.MAX_VALUE, 0.0));
     rows.add(RowFactory.create(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY,
-        Double.MAX_VALUE));
-    rows.add(RowFactory.create(Double.NaN, Double.POSITIVE_INFINITY, 0.0));
+        Double.MAX_VALUE, Double.MIN_VALUE));
+    rows.add(RowFactory.create(Double.NaN, Double.POSITIVE_INFINITY, 0.0, 0.0));
     Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
 
     String json = new ColumnProfiler().profile(df, null, false, true, 20, false, true);
@@ -406,7 +407,18 @@ public class ColumnProfilerSmokeTest {
     Assertions.assertEquals(0, allInf.get("histogram").size(),
         "a column with no finite values must emit no bins");
 
-    // Finite bounds, infinite span: the grid is still unbuildable, so treat it the same way.
+    // Finite bounds, unusable span: same treatment. huge_range overflows the subtraction
+    // to infinity; subnormal_range underflows the division, so every split point would
+    // land on the minimum. Neither can produce a strictly increasing grid.
+    JsonNode subnormal = findColumn(columns, "subnormal_range");
+    Assertions.assertNotNull(subnormal, "subnormal_range column profile must be present");
+    Assertions.assertEquals(0, subnormal.get("histogram").size(),
+        "a span whose width underflows to zero must emit no bins, not 20 identical ones");
+    Assertions.assertFalse(subnormal.has("kll"),
+        "a span whose width underflows to zero must not be emitted as kll");
+    Assertions.assertEquals(99, subnormal.get("approxPercentiles").size(),
+        "the percentiles do not need a bin grid and must survive");
+
     JsonNode huge = findColumn(columns, "huge_range");
     Assertions.assertNotNull(huge, "huge_range column profile must be present");
     Assertions.assertEquals(0, huge.get("histogram").size(),

--- a/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
+++ b/java/spark/src/test/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfilerSmokeTest.java
@@ -337,23 +337,17 @@ public class ColumnProfilerSmokeTest {
     // used to enter the sketch, so getMaxItem() returned Infinity, every split point
     // collapsed to Infinity or NaN and getCDF failed the whole statistics job with
     // "Values must be unique, monotonically increasing and not NaN".
-    // huge_range holds only finite values, but its span overflows a double subtraction to
-    // infinity, so a finiteness check per value is not enough to make a bin grid safe.
     StructType schema = new StructType(new StructField[]{
       DataTypes.createStructField("mixed", DataTypes.DoubleType, true),
       DataTypes.createStructField("all_inf", DataTypes.DoubleType, true),
-      DataTypes.createStructField("huge_range", DataTypes.DoubleType, true),
-      DataTypes.createStructField("subnormal_range", DataTypes.DoubleType, true),
     });
     List<Row> rows = new ArrayList<>();
     for (int i = 1; i <= 8; i++) {
-      rows.add(RowFactory.create((double) i, Double.POSITIVE_INFINITY, 0.0, 0.0));
+      rows.add(RowFactory.create((double) i, Double.POSITIVE_INFINITY));
     }
-    rows.add(RowFactory.create(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
-        -Double.MAX_VALUE, 0.0));
-    rows.add(RowFactory.create(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY,
-        Double.MAX_VALUE, Double.MIN_VALUE));
-    rows.add(RowFactory.create(Double.NaN, Double.POSITIVE_INFINITY, 0.0, 0.0));
+    rows.add(RowFactory.create(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY));
+    rows.add(RowFactory.create(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY));
+    rows.add(RowFactory.create(Double.NaN, Double.POSITIVE_INFINITY));
     Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
 
     String json = new ColumnProfiler().profile(df, null, false, true, 20, false, true);
@@ -406,27 +400,45 @@ public class ColumnProfilerSmokeTest {
         "a column with no finite values must not yield approxPercentiles");
     Assertions.assertEquals(0, allInf.get("histogram").size(),
         "a column with no finite values must emit no bins");
+  }
 
-    // Finite bounds, unusable span: same treatment. huge_range overflows the subtraction
-    // to infinity; subnormal_range underflows the division, so every split point would
-    // land on the minimum. Neither can produce a strictly increasing grid.
-    JsonNode subnormal = findColumn(columns, "subnormal_range");
-    Assertions.assertNotNull(subnormal, "subnormal_range column profile must be present");
-    Assertions.assertEquals(0, subnormal.get("histogram").size(),
-        "a span whose width underflows to zero must emit no bins, not 20 identical ones");
-    Assertions.assertFalse(subnormal.has("kll"),
-        "a span whose width underflows to zero must not be emitted as kll");
-    Assertions.assertEquals(99, subnormal.get("approxPercentiles").size(),
-        "the percentiles do not need a bin grid and must survive");
+  @Test
+  void emitsNoBinsWhenTheGridCannotIncrease() throws Exception {
+    // Three columns made of nothing but finite values, each of which defeats a weaker
+    // guard than "the edges strictly increase":
+    //   huge_range      the range overflows a double subtraction to infinity
+    //   subnormal_range the width, range / 20, underflows to zero
+    //   snowflake_ids   LongType ids at ~1e18 minted within one millisecond: the width is
+    //                   finite and positive but smaller than the spacing of doubles there,
+    //                   so later edges round onto earlier ones
+    // Each used to reach getCDF with duplicate split points and fail the whole job.
+    StructType schema = new StructType(new StructField[]{
+      DataTypes.createStructField("huge_range", DataTypes.DoubleType, true),
+      DataTypes.createStructField("subnormal_range", DataTypes.DoubleType, true),
+      DataTypes.createStructField("snowflake_ids", DataTypes.LongType, true),
+    });
+    List<Row> rows = new ArrayList<>();
+    long firstId = 1_700_000_000_000_000_000L;
+    for (int i = 0; i <= 20; i++) {
+      rows.add(RowFactory.create(0.0, 0.0, firstId + i * 200L));
+    }
+    rows.add(RowFactory.create(-Double.MAX_VALUE, Double.MIN_VALUE, firstId));
+    rows.add(RowFactory.create(Double.MAX_VALUE, 0.0, firstId));
+    Dataset<Row> df = SparkEngine.getInstance().getSparkSession().createDataFrame(rows, schema);
 
-    JsonNode huge = findColumn(columns, "huge_range");
-    Assertions.assertNotNull(huge, "huge_range column profile must be present");
-    Assertions.assertEquals(0, huge.get("histogram").size(),
-        "a span that overflows to infinity must emit no bins");
-    Assertions.assertFalse(huge.has("kll"),
-        "a span that overflows to infinity must not be emitted as kll (getCDF rejects it)");
-    Assertions.assertEquals(99, huge.get("approxPercentiles").size(),
-        "the percentiles do not need a bin grid and must survive");
+    String json = new ColumnProfiler().profile(df, null, false, true, 20, false, true);
+    JsonNode columns = new ObjectMapper().readTree(json).get("columns");
+
+    for (String name : new String[]{"huge_range", "subnormal_range", "snowflake_ids"}) {
+      JsonNode col = findColumn(columns, name);
+      Assertions.assertNotNull(col, name + " column profile must be present");
+      Assertions.assertEquals(0, col.get("histogram").size(),
+          name + ": an unusable grid must emit no bins, not 20 identical ones");
+      Assertions.assertFalse(col.has("kll"),
+          name + ": an unusable grid must not be emitted as kll (getCDF rejects it)");
+      Assertions.assertEquals(99, col.get("approxPercentiles").size(),
+          name + ": the percentiles do not need a bin grid and must survive");
+    }
   }
 
   @Test


### PR DESCRIPTION
## Problem

Profiling a numeric column whose non-null values are all `NaN` fails the whole statistics Spark job:

```
org.apache.datasketches.common.SketchesArgumentException: The sketch must not be empty for this operation.
  at org.apache.datasketches.kll.KllDoublesSketch.getQuantiles(KllDoublesSketch.java:194)
  at com.logicalclocks.hsfs.spark.engine.profile.ColumnProfiler.buildNumericFields(ColumnProfiler.java:397)
  at com.logicalclocks.hsfs.spark.engine.profile.ColumnProfiler.profile(ColumnProfiler.java:140)
  at com.logicalclocks.hsfs.spark.engine.SparkEngine.profile(SparkEngine.java:785)
```

Two files disagree about NaN:

- `KllAggregator` builds the sketch from `.filter(col("_v").isNotNull())` and then `if (!Double.isNaN(value)) sketch.update(value)`, so NaN contributes nothing and an all-NaN column yields an **empty** sketch.
- `ColumnProfiler` gated the call on `kll && nonNullVal > 0`, and **in Spark NaN is non-null**, so the guard passed and `getQuantiles` was called on the empty sketch.

Both halves were introduced together in `dcc96b21a` ([FSTORE-1412] #980), so this is an original oversight rather than a regression. It is distinct from the NaN issue fixed under FSTORE-2066, which was NaN in the computed statistic *values* breaking the `feature_descriptive_statistics` insert — that happens after profiling, this crashes during it.

### Why only the training-dataset path saw it

The feature-group `compute_stats` job does not use the KLL path (0 `KllAggregator` references in its logs); `create_fv_td` does (hundreds) and dies. The symptom reaching the user is therefore a bare `JobExecutionException: The Hopsworks Job failed` out of `create_train_validation_test_split` / `create_training_data`, with the real exception only in the Spark job's logs.

Originally found on a 5-node dev cluster (5.1.0-SNAPSHOT), reproduced 3/3 by `test_fs_statistics_wide_tables.py::test_workflow[HUDI]`, each run dying after exactly 800 `KllAggregator` references — i.e. at the same column every time, with no timing component.

## The rule this PR settles on

One sentence, applied at every site: **a value that is not finite is not a value, and a bin grid that is not finite is not a grid.** Anything unbinnable emits no bins rather than garbage or an exception.

## Fix 1 — don't emit KLL for a column with no finite values

`ColumnProfiler.buildNumericFields`: require `!sketch.isEmpty()`, with `builder.kllBytes(...)` moved inside the check.

**The check has to cover `kllBytes`, not just `getQuantiles`.** `ProfileJsonSerializer` builds its KLL map whenever `getKllBytes() != null`, heapifies those bytes and calls `getCDF`, which throws on an empty sketch as well. Verified against datasketches-java 6.2.0: an empty `KllDoublesSketch(2048)` serialises to 8 bytes, `heapify` accepts it, `isEmpty()` is `true`, and **both** `getQuantiles` and `getCDF` throw.

The branch is now gated on the finite count rather than the non-null count, so a column with nothing finite skips the `computeKll` `mapPartitions`+`collect` entirely; `!sketch.isEmpty()` remains as the invariant `buildKllBuckets` relies on.

## Fix 2 — bin the histogram and KLL buckets over the finite values

Spark ranks NaN above every other double, so a numeric column holding a **single** NaN reports `maximum = NaN`, and both bin grids were derived from it:

- `HistogramBuilder` got `range = NaN`, so `range == 0.0` was false, `binWidth` was NaN and all 20 bins were labelled `"NaN to NaN"`. `floor((NaN - min) / NaN)` casts to `0`, so every NaN row was also counted into bin 0.
- `ProfileJsonSerializer`'s KLL buckets fell back to `binWidth = 1.0`, spanning `min..min+20` instead of the real range, and scaled bucket counts by `numRecordsNonNull` — which counts the NaN rows `KllAggregator` never fed to the sketch.

So **any** numeric column with even one NaN silently got a wrong histogram and wrong KLL buckets. Measured on a half-NaN column holding 1, 3, 5, 7, 9: 20 bins all labelled `"NaN to NaN"`, and KLL buckets on a 1..21 grid with every count doubled. This affects the feature-group `compute_stats` path too, not just `create_fv_td`.

- **Histogram**: range and denominator come from finite-only copies of min/max/count, added to the *existing* single `agg()` pass so there is no extra Spark job.
- **KLL buckets**: range and weight come from the sketch itself (`getMinItem`/`getMaxItem`/`getN`), which by construction holds nothing non-finite and knows its own N. This also removes a latent unboxing NPE on the `Double` min/max parameters.

## Fix 3 — the infinities, and grids that overflow

Excluding NaN alone leaves the same crash reachable, so the exclusion is now `Double.isFinite` everywhere: in `KllAggregator.PartitionSketchBuilder`, in the new `__min_finite`/`__max_finite`/`__nfinite` agg columns, and in the `HistogramBuilder` filter (one `ColumnProfiler.isFinite(Column)` helper, since Spark orders NaN above `+Infinity` and a single `abs(c) < Infinity` comparison excludes all three).

**What was already broken and what this PR would have added.** Measured against the real `getCDF` arithmetic:

| column | pre-PR bounds (profile min/max) | post-PR bounds (sketch min/max) |
|---|---|---|
| `{1, 2, +Inf}` | `binWidth=Infinity` → **throws** | `binWidth=Infinity` → **throws** |
| `{1, 2, NaN, +Inf}` | `max=NaN` → `binWidth=1.0` → OK | `binWidth=Infinity` → **throws** |

An infinity-bearing column already failed the job before this PR, so that half is pre-existing rather than a regression. The second row is the part fix 2 would have introduced on its own: a NaN maximum used to *mask* the infinity by making `range` NaN, which sent `binWidth` down the `1.0` fallback. Fix 3 closes both.

**A finite bound is not enough, a finite width is not enough, and a positive width is not enough — every edge has to increase.** Three inputs made of nothing but finite values each defeat a weaker guard, and each was reproduced end to end through `ColumnProfiler`:

| column | what breaks |
|---|---|
| `{-Double.MAX_VALUE, 0.0, Double.MAX_VALUE}` | range overflows to `+Infinity`; every split point collapses |
| `{0.0, Double.MIN_VALUE}` | range `4.9e-324` is finite, but `range / 20` **underflows to 0**; every split point lands on `min` |
| `LongType` ids at `1.7e18` spanning 4000 | width `204.8` is finite and positive but smaller than the spacing of doubles at `min` (`ulp = 256`); **later edges round onto earlier ones** |

All three end in the same `getCDF` rejection, and the second also made the histogram emit twenty identical `"0.00 to 0.00"` bins rather than throwing. The third is the realistic one — an Integral id column at snowflake scale, minted within one millisecond, in a small feature group; ids are always profiled as numeric.

What `getCDF` demands of its split points, and what a bin label needs in order to describe the bound it names, is that the edges *strictly increase*. `ColumnProfiler.hasUsableBinGrid` checks exactly that, edge by edge, using the same `min + i * width` formula `HistogramBuilder` and `buildKllBuckets` use — the invariant stated literally rather than approximated, so overflow, underflow and precision loss fall out of one loop. A zero range still passes (single bin for the histogram, width-1.0 fallback for the buckets). Both call sites use it, the bucket count is a shared `ProfileJsonSerializer.KLL_BUCKETS`, and `buildKllBuckets`' javadoc names the coupling so the formula cannot change in one place only. Verified against `getCDF` on nine cases including constant and negative ranges. `approxPercentiles` needs no grid and is emitted regardless.

**The `HistogramBuilder` filter is load-bearing, in two different ways.** `floor(Infinity)` is `Long.MAX_VALUE`; its `cast("int")` throws `[CAST_OVERFLOW]` where ANSI mode is on, and where it is off — the Hopsworks default — `least()` clamps the row into the last bin instead, a silent miscount. Reverting only that filter fails the new test either way.

## Fix 4 — an empty dataframe

Found by sweeping the profiler for other bad-data crashes rather than reported. The null count was aggregated with `sum(when(isNull, 1).otherwise(0))`, which returns **NULL over zero rows**, and `buildProfile` unboxes it into a `long` — so a dataframe with no rows died with a `NullPointerException` before any column was profiled, with every statistics flag on or off alike.

**This is latent robustness, not a live bug — I could not reach it through the product.** `_compute_and_save_split_statistics` (`statistics_engine.py:293`) does profile each training-dataset split with no emptiness check, unlike the monitoring path which guards with `_is_dataframe_empty`, so the gap is real in the source. But three attempts on a dev cluster, each run with and without this fix and compared, produced identical output both ways:

| vector | result, identical patched and unpatched |
|---|---|
| training dataset with an empty time-range split | no `split_statistics` at all — the profiler is never invoked |
| feature group whose only insert is empty | `_is_dataframe_empty` catches it and registers `count=0` placeholders |
| empty second commit on a populated feature group | no statistics job is scheduled at all |

So no ordinary feature-group or training-dataset flow puts a zero-row dataframe in front of `ColumnProfiler` today. The NPE is real in the code and the unit test reproduces it exactly on revert; keeping the fix costs two lines and removes a trap for whatever calls the profiler next. It is **not** evidence of a user-visible failure, and there is deliberately no loadtest coverage for it — a test on any of the three vectors above would pass with or without the fix.

Counting instead of summing makes the aggregate total by construction, so the read side cannot unbox a null. Identical value for a non-empty column, and `ColumnProfilerParityTest` still matches the Deequ baseline's `numRecordsNull`.

## Fix 5 — a feature named `count`

Also found by sweeping rather than reported, and unlike fix 4 this one is **reachable in ordinary use**. The uniqueness pass grouped on the source column itself:

```java
df.filter(cc.isNotNull()).groupBy(cc).count().select(col("count"))
```

`groupBy(x).count()` returns the grouping column plus one named `count`, so a feature that is itself called `count` leaves two of them and the select resolves neither:

```
AnalysisException: [AMBIGUOUS_REFERENCE] Reference `count` is ambiguous, could be: [`count`, `count`]
```

`count` satisfies the feature-name rules and is an obvious name for an event or click counter; it needs only `exact_uniqueness=true`, which the narrow schema in logicalclocks/loadtest#1011 already sets; and it hits numeric and string columns alike. The whole statistics job dies — the same user-visible shape as the NaN crash.

Projecting to a fixed name before grouping removes the collision for every feature name rather than just this one, and matches `KllAggregator`, which already selects into `_v`. Aliasing the aggregate instead would only move the collision onto the new alias, itself a legal feature name.

**The categorical histogram has the same shape and a worse symptom** (review follow-up). `HistogramBuilder.buildCategorical` did `groupBy(col(name)).count().orderBy(desc("count"))`, so a String or Boolean feature named `count` leaves two `count` columns there too. It does not throw: Spark resolves the sort against the *grouping* column,

```
Sort [count#0 DESC NULLS LAST]
+- Aggregate [count#0], [count#0, count(1) AS count#1L]
```

while `select`/`filter` on the same frame raise `AMBIGUOUS_REFERENCE`. The bins came out ordered by value descending and `limit(histogramBins)` kept the lexically largest values rather than the most frequent ones — a wrong histogram registered without any error. Same fix, same `_v` alias. The earlier sweep note below claimed this path held; it only checked for a throw.

**Purely internal.** `_v` never leaves the method, which returns entropy and a singleton count. An alias changes no values, so the frequency distribution and both derived statistics are unchanged: `ColumnProfilerParityTest` still matches the Deequ baseline on `uniqueness`, `distinctness` and `entropy` at `1e-6`, and `smokeTestUniqueness` still asserts the same exact figures. Same request and response on the wire.

## What else was swept, and found clean

Everything below profiles without throwing, under **both** ANSI settings: all-null numeric and string columns, single-row and constant columns, a `Double.MIN_VALUE`..`Double.MAX_VALUE` span, decimal/timestamp/boolean columns, exact-uniqueness over an all-null column, and column names containing spaces, dashes, `*`, leading digits, or colliding with the profiler's own `__nonnull` / `_bin` aliases.

A third pass tried specifically to defeat the fixes above, and everything except the underflowing span held: `range = 1e-320` (whose width stays a valid denormal), `range = Double.MAX_VALUE`, columns named `_v`, `_bin`, `count` and `nonnull` with every flag on, a frame with no profilable columns at all, and a single finite value among NaNs. That pass also ran a **string** column named `count` through the categorical histogram path and recorded it as clean, which was wrong: it did not throw, but it ordered the bins by value (see fix 5). Checking only for exceptions was the gap.

A second sweep with realistic feature-store shapes, every statistics flag on: 20k distinct UUIDs, 200 x 4KB JSON blobs as categorical labels, strings carrying quotes, backslashes, newlines, tabs, emoji, CJK and the empty string, `Long.MIN_VALUE`..`Long.MAX_VALUE` (whose sum overflows a double), `decimal(38,18)` at full precision, a 99.9%-null column beside a 99%-zero-skewed one and a nullable boolean, array/map/binary columns alongside scalars (correctly skipped), a 40-column all-constant correlation matrix, and the column names `value`, `sum`, `min`, `max`, `avg`, `key` and `_bin`. All clean; only `count` broke, which is fix 5.

Two non-issues worth recording so they are not re-investigated:

- **A column name containing a dot** throws `UNRESOLVED_COLUMN`, because `functions.col("a.b")` parses as nested field access. Unreachable: feature names are validated against `^[a-z][a-z0-9_]*$` (`FeaturestoreConstants.FEATURESTORE_REGEX`). Two names differing only in case are ambiguous for the same reason, and unreachable for the same reason.
- **The uniqueness pass collects one row per distinct value to the driver** (`collectAsList` on the per-value frequency table). 20k distinct UUIDs collected 20k rows; an entity-id column with millions of distinct values would collect millions. Independent of naming and not addressed here — the three numbers it needs could be aggregated in Spark instead.
- **`df.stat().corr()` on a constant or all-null column** throws `SparkArithmeticException: DIVIDE_BY_ZERO` — but only with ANSI mode on. Hopsworks pins `spark.sql.ansi.enabled=false` (helm `charts/spark/values.yaml`), where `corr` simply returns NaN. Latent for any cluster that opts into ANSI; not fixed here.

## Unbinnable columns emit `histogram: []`, not a missing key

Omitting the key has a consumer side effect: `FeatureGroup._are_statistics_missing` (`python/hsfs/feature_group.py:3231-3238`) returns True whenever `histograms=True` and a numeric column has no `histogram` key, so `compute_statistics()` (`feature_group.py:5514`) discards the registered statistics and launches a new Spark statistics job on every call. That already happened for all-null numeric columns; emitting `[]` fixes those too, and matches what the categorical branch has always done (`buildCategorical` returns `[]` for an all-null column).

`[]` was checked against every consumer: `_parse_numeric_histogram_edges([])` returns `None` at its own `if not histogram` guard, so `distribution_engine.py:332`'s `if histogram is not None` is entered and abandoned at `:335`, falling through to the same `np.linspace` path a missing key took; `_align_numeric_histogram` already declares `list[dict] | None`; `_build_categorical_distribution` and `impute_mode_category` guard on falsiness. The one behaviour change is `top_k_categorical_binner` (`builtin_transformations.py:536`), which tests `histogram is not None and isinstance(histogram, list)` and so now takes the histogram branch with an empty category list instead of falling back to `unique_values`. Reachable only for a categorical binner applied to a numeric feature that is entirely non-finite in the training split, where the `unique_values` fallback is empty as well.

The correlations half of `_are_statistics_missing` needs nothing: `computeCorrelations` does `correlationMap.put(colA, corrForA)` unconditionally for every numeric column (`ColumnProfiler.java:323`), so the key is always present.

## Why it is safe

- **No wire-format change for a column with only finite values.** The sketch's min/max/N equal the column's, so the emitted buckets are byte-identical. `ColumnProfilerParityTest` confirms this against the captured Deequ 2.0.7-spark-3.5 baseline — histogram counts, ratios and bin labels — and still passes. Neither baseline contains an all-null or non-finite column, so the `[]` change does not touch it.
- **`minimum`/`maximum` are left as Spark computes them**, non-finite values included, since they are Deequ-parity fields. Measured on a cluster: a half-NaN column registers with `min=1.0` and `max=None`, i.e. the backend's `sanitize()` nulls the non-finite value and registration succeeds.
- **`getMinItem`/`getMaxItem` throw on an empty sketch**, so the bucket code depends on fix 1 for that never to happen; stated in the javadoc at the call site.
- **`KllMerger` needs no change** — it already guards at `KllMerger:112` (`merged == null || merged.isEmpty()`) and returns early before `getQuantiles`/`getMinItem`.

## Testing

Full reactor `mvn clean test -pl hsfs,spark -Pspark-4.1 -Dspark.version=4.1.3` on JDK 17: **33 + 90 tests, 0 failures**, including `ColumnProfilerParityTest`. `mvn checkstyle:check` clean.

`ColumnProfilerSmokeTest` gains seven tests:

- `profilesAllNaNColumnWithoutThrowing` — an all-NaN column emits neither `kll` nor `approxPercentiles`; a half-NaN column profiled in the same run still emits both, with the full 99-element percentile vector starting at the finite minimum. The guard is pinned in both directions, so it cannot pass by dropping KLL everywhere.
- `binsPartlyNaNColumnOverItsFiniteRange` — a half-NaN column's histogram carries no NaN labels, counts only the finite rows and has ratios summing to 1; its KLL buckets span exactly the sketch's range with counts summing to the sketch weight; a column with nothing finite emits `histogram: []`.
- `binsInfiniteValuesOverTheFiniteRange` — a column holding `±Infinity` and `NaN` alongside 1..8 bins over `[1, 8]`, counts only the eight finite rows, and carries no `Infinity` or `NaN` bin label, while `minimum`/`maximum` still report `-Infinity`/`NaN`; an all-infinity column emits no `kll` and no bins.
- `emitsNoBinsWhenTheGridCannotIncrease` — the three unusable-grid columns above (overflowing range, underflowing width, snowflake-scale ids) each emit no bins and no `kll` but keep their 99 percentiles.
- `profilesAColumnNamedCount` — a feature named `count` is profiled with `exact_uniqueness` on, reporting the right distinct count and uniqueness.
- `profilesAStringColumnNamedCount` — a String feature named `count` with `histograms` on: 25 distinct values whose frequency order is the reverse of their lexical order, 20 bins, asserting both the order and which values survive the top-N cut.

Every production change was revert-checked individually, and each fails in a distinguishable way:

| reverted | failure |
|---|---|
| fix 1 | `KllDoublesSketch.getQuantiles`, the same frame as the cluster failure |
| fix 2 (agg `isFinite`) | `no bin label may be derived from a NaN range: NaN to NaN` |
| fix 3 (`KllAggregator`) | `SketchesArgumentException: Values must be unique, monotonically increasing and not NaN` |
| fix 3 (histogram filter) | `SparkArithmeticException: [CAST_OVERFLOW]` |
| fix 3 (finite-width guard) | `SketchesArgumentException: Values must be unique, monotonically increasing and not NaN` |
| `histogram: []` | NPE on the absent key |
| fix 4 (empty dataframe) | `NullPointerException` unboxing the null count |
| fix 5 (feature named `count`) | `AnalysisException: [AMBIGUOUS_REFERENCE]` |
| fix 5 (categorical histogram `_v` alias) | `expected: <v00> but was: <v24>` — bins ordered by value, not frequency |
| the grid predicate (back to a finite-range check) | `SketchesArgumentException` on the underflowing span |
| the grid predicate (back to a first-edge check) | `SketchesArgumentException` on the snowflake-scale ids |

### Cluster verification

**Full statistics suite at the PR head (`09daa8c9e`): 12 / 12 passed.** The seven profiler classes from this exact commit were patched into the feature-pipeline image (`replaced 7 of 7 expected`, published as `sha256:be72232f…`), the live tag was pointed at it, and every Spark driver in the run was confirmed to have resolved that digest. The loadtest side ran logicalclocks/loadtest#1011's `test_code` (overlay verified present in every pod). Both drivers, both time-travel formats:

| test | DELTA | HUDI |
|---|---|---|
| `python_driver/test_fs_statistics_wide_tables.py::test_workflow` | passed | passed |
| `pyspark_driver/test_fs_statistics_wide_tables.py::test_pyspark_batch` | passed | passed |
| `python_driver/test_statistics.py::test_workflow` | passed | passed |
| `pyspark_driver/test_statistics.py::test_pyspark_statistics` | passed | passed |
| `python_driver/test_feature_monitoring.py::test_feature_monitoring` | passed | passed |
| `pyspark_driver/test_feature_monitoring.py::test_pyspark_feature_monitoring` | passed | passed |

The shared tag was restored afterwards. The earlier, narrower runs below established the failing direction for each fix; this run establishes that nothing in the statistics surface regressed with all of them together.

Run on a 5-node dev cluster (5.1.0-SNAPSHOT, Spark 4.1.3.0) via `test_fs_statistics_wide_tables.py::test_workflow[HUDI]` plus the extended coverage in logicalclocks/loadtest#1011, **both without and with this branch's jar** in the feature-pipeline image:

- **Without the infinity fix** (image carrying fixes 1 and 2 only): the previously fatal all-NaN column profiles and its histogram is clean, but an infinity-bearing column produces 20 of 20 bins labelled `"NaN to NaN"` — `-Infinity + 0 * Infinity` is NaN, so the grid degenerates exactly as a NaN maximum made it.
- **With this branch's jar**: the same test passes (`1 passed`, exit 0). The patched classes were verified into the real jar (`replaced 7 of 7 expected`, asserted, so a wrong jar could not ship half-patched) and published with `crane append`; the driver and both executors resolved `imageID sha256:ef92c08f…`, confirming they ran the patched code rather than a cached layer. The shared tag was restored afterwards.
- **Non-finite values do reach the profiler on HUDI.** Both a half-NaN and a half-infinity column arrived with `num_null=0` over 200 rows, so this is not a case the write path quietly sanitises away.
- One nuance: the ingestion statistics job did **not** compute a sketch for those columns even with `kll=1` persisted, so on that path the infinity defect surfaces as a wrong histogram rather than as the crash. The crash path is the training-dataset one in the ticket. The overflow case remains unit-level only.

## Adjacent findings, not fixed here

Each is pre-existing and outside this fix; noting them rather than widening the PR.

- **The JVM emits `"NaN"`/`"Infinity"` as JSON *strings***, because Jackson's `QUOTE_NON_NUMERIC_NUMBERS` is on by default. The SDK's `_finite_or_none` (`feature_descriptive_statistics.py:38`) tests `isinstance(value, numbers.Real)` and so passes the string through unscrubbed; only the pandas path, which produces real floats, is covered by its test. Registration still succeeded on the cluster because the backend's `sanitize()` nulls them, but the SDK-side scrubber does not do what its docstring claims for this producer.
- **`kll=false` still profiles a non-finite column into non-finite percentiles.** `buildNumericFields`'s `else if (!kll && nonNullVal > 0)` runs Spark's `percentile_approx` on the raw column, so an all-NaN column yields `approxPercentiles: ["NaN" × 99]`. The fix above is therefore flag-dependent.
- **An empty dataframe NPEs before any of this code runs**, at `ColumnProfiler.java:340`: `sum(when(isNull,1).otherwise(0))` returns NULL over zero rows and is unboxed. Identical with `kll` on or off.
- **`KllMerger` can still emit infinities for sketches persisted by an older build.** `getQuantiles`/`getMinItem` do not throw on them, so `min`, `max` and `percentiles` carry `Infinity` into `distribution_engine`, where `np.linspace` on those bounds raises `DTypePromotionError` or yields NaN edges. New sketches cannot contain them after fix 3, so this only affects data already written.
- **The ingestion statistics read path never surfaces `kll`.** Measured: a feature group with `kll=1` persisted in `statistics_config` and exactly one `feature_group_statistics` row returned `extendedStatistics` keys `['correlations', 'histogram']`. This is why logicalclocks/loadtest#1011 asserts only on the histogram.

## Not covered

- **Backport.** The buggy code is on `main`, `branch-5.1` and `branch-5.0`; this PR targets `main` only, and it was found on 5.1.0-SNAPSHOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiqiySqGSDvscmLV6yiPB8

[FSTORE-1412]: https://hopsworks.atlassian.net/browse/FSTORE-1412

