### PR TITLE
[HWORKS-3191] hops CLI: reduce startup and login latency

### DIFF
--- a/python/hopsworks/__init__.py
+++ b/python/hopsworks/__init__.py
@@ -662,7 +662,9 @@ def get_env_vars_api() -> env_var_api.EnvVarsApi:
 def _set_active_project(project):
     _client = client._get_instance()
     if _client._is_external():
-        _client._provide_project(project.name)
+        # login already fetched this project; hand the id over instead of
+        # letting the client look it up a second time.
+        _client._provide_project(project.name, project_id=project.id)
 
 
 @public

--- a/python/hopsworks_common/client/__init__.py
+++ b/python/hopsworks_common/client/__init__.py
@@ -16,10 +16,12 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 from typing import Literal
 
 from hopsworks_apigen import also_available_as
-from hopsworks_common.client import external, hopsworks, istio
+from hopsworks_common.client import external, hopsworks
 from hopsworks_common.constants import HOSTS
 
 
@@ -73,9 +75,19 @@ def _stop() -> None:
     if _client:
         _client._close()
     _client = None
-    if istio._client:
+    # Only touch the istio client if that subpackage was ever imported; importing
+    # it here just to close nothing would pull in grpc and pandas.
+    istio = sys.modules.get("hopsworks_common.client.istio")
+    if istio is not None and istio._client:
         istio._client._close()
-    istio._client = None
+    if istio is not None:
+        istio._client = None
+    # The serving defaults belong to the connection that loaded them; the next
+    # connection reloads them on first use instead of reading the old cluster's.
+    global _kserve_installed, _serving_num_instances_limits, _knative_domain
+    _kserve_installed = None
+    _serving_num_instances_limits = None
+    _knative_domain = None
 
 
 @also_available_as("hopsworks.client._is_saas_connection")
@@ -95,6 +107,8 @@ def _set_kserve_installed(kserve_installed):
 @also_available_as("hopsworks.client._is_kserve_installed")
 def _is_kserve_installed() -> bool:
     global _kserve_installed
+    if _kserve_installed is None:
+        _load_serving_defaults()
     return _kserve_installed
 
 
@@ -110,6 +124,8 @@ def _set_serving_num_instances_limits(num_instances_range):
 @also_available_as("hopsworks.client._get_serving_num_instances_limits")
 def _get_serving_num_instances_limits():
     global _serving_num_instances_limits
+    if _serving_num_instances_limits is None:
+        _load_serving_defaults()
     return _serving_num_instances_limits
 
 
@@ -126,7 +142,28 @@ _knative_domain = None
 @also_available_as("hopsworks.client._get_knative_domain")
 def _get_knative_domain():
     global _knative_domain
+    if _knative_domain is None:
+        _load_serving_defaults()
     return _knative_domain
+
+
+def _load_serving_defaults() -> None:
+    """Fetch the serving defaults from the connected cluster, once, on first use.
+
+    The defaults are the KServe flag, the instance limits, the Knative domain and the istio client.
+    They used to be loaded during login.
+    That cost six requests and the istio import for every caller, including ones that never touch model serving.
+    """
+    if _connection is not None:
+        _connection._load_serving_defaults()
+
+
+def __getattr__(name: str):
+    # ``client.istio`` stays reachable as before, but the subpackage (grpc,
+    # pandas, numpy: ~0.4 s) is imported the first time it is actually used.
+    if name == "istio":
+        return importlib.import_module("hopsworks_common.client.istio")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @also_available_as("hopsworks.client._set_knative_domain")

--- a/python/hopsworks_common/client/external.py
+++ b/python/hopsworks_common/client/external.py
@@ -105,12 +105,13 @@ class Client(base.Client):
 
         self._provide_project(project)
 
-    def _provide_project(self, project):
+    def _provide_project(self, project, project_id=None):
         self._project_name = project
         _logger.debug("Project name: %s", self._project_name)
 
-        project_info = self._get_project_info(project)
-        self._project_id = str(project_info["projectId"])
+        if project_id is None:
+            project_id = self._get_project_info(project)["projectId"]
+        self._project_id = str(project_id)
         _logger.debug("Setting Project ID: %s", self._project_id)
 
         self._username = self._get_username()

--- a/python/hopsworks_common/client/istio/__init__.py
+++ b/python/hopsworks_common/client/istio/__init__.py
@@ -36,4 +36,7 @@ def init(host, port, project=None, api_key_value=None, scheme="http"):
 
 def _get_instance() -> hopsworks.Client | external.Client | None:
     global _client
+    if _client is None:
+        # The serving defaults (which set this client up) load on first use.
+        _main._load_serving_defaults()
     return _client

--- a/python/hopsworks_common/connection.py
+++ b/python/hopsworks_common/connection.py
@@ -35,7 +35,6 @@ from hopsworks_common.core import (
     services_api,
     variable_api,
 )
-from hopsworks_common.core.opensearch import OpenSearchClientSingleton
 from hopsworks_common.decorators import _connected, _not_connected
 from requests.exceptions import ConnectionError
 from typing_extensions import Self
@@ -155,8 +154,52 @@ class Connection:
         self._api_key_value = api_key_value
         self._connected = False
         self._backend_version = None
+        self._feature_store_api_cache = None
+        self._model_registry_api_cache = None
+        self._model_serving_api_cache = None
+        self._serving_defaults_loaded = False
+        self._serving_defaults_loading = False
 
         self._connect()
+
+    # The hsfs/hsml API objects are built on first use. Constructing them imports
+    # hsfs and hsml (pandas, pyarrow, sqlalchemy, boto: ~0.7 s), which a caller
+    # that only needs the REST client, such as the hops CLI, never pays for.
+    @property
+    def _feature_store_api(self):
+        if self._feature_store_api_cache is None:
+            from hsfs.core import feature_store_api
+
+            self._feature_store_api_cache = feature_store_api.FeatureStoreApi()
+        return self._feature_store_api_cache
+
+    @_feature_store_api.setter
+    def _feature_store_api(self, value) -> None:
+        self._feature_store_api_cache = value
+
+    @property
+    def _model_registry_api(self):
+        if self._model_registry_api_cache is None:
+            from hsml.core import model_registry_api
+
+            self._model_registry_api_cache = model_registry_api.ModelRegistryApi()
+        return self._model_registry_api_cache
+
+    @_model_registry_api.setter
+    def _model_registry_api(self, value) -> None:
+        self._model_registry_api_cache = value
+
+    @property
+    def _model_serving_api(self):
+        if self._model_serving_api_cache is None:
+            from hsml.core import model_serving_api
+
+            self._model_serving_api_cache = model_serving_api.ModelServingApi()
+        return self._model_serving_api_cache
+
+    @_model_serving_api.setter
+    def _model_serving_api(self, value) -> None:
+        self._model_serving_api_cache = value
 
     @usage._method_logger
     @_connected
@@ -211,6 +254,7 @@ class Connection:
         Returns:
             A model serving handle object to perform operations on.
         """
+        self._load_serving_defaults()
         return self._model_serving_api._get()
 
     @usage._method_logger
@@ -315,7 +359,8 @@ class Connection:
         regexMatcher = re.compile(versionPattern)
 
         client_version = version.__version__
-        self.backend_version = self._variable_api._get_version("hopsworks")
+        if self._backend_version is None:
+            self.backend_version = self._variable_api._get_version("hopsworks")
 
         major_minor_client = regexMatcher.search(client_version).group(0)
         major_minor_backend = regexMatcher.search(self._backend_version).group(0)
@@ -397,20 +442,15 @@ class Connection:
                 )
 
             client._set_connection(self)
-            from hsfs.core import feature_store_api
-            from hsml.core import model_registry_api, model_serving_api
-
             global _hsfs_engine_type
             _hsfs_engine_type = self._engine
-            self._feature_store_api = feature_store_api.FeatureStoreApi()
-            self._model_registry_api = model_registry_api.ModelRegistryApi()
-            self._model_serving_api = model_serving_api.ModelServingApi()
             self._project_api = project_api.ProjectApi()
             self._hosts_api = hosts_api.HostsApi()
             self._services_api = services_api.ServicesApi()
             self._secret_api = secret_api.SecretsApi()
             self._variable_api = variable_api.VariableApi()
-            usage._init_usage(self._host, self._variable_api._get_version("hopsworks"))
+            self.backend_version = self._variable_api._get_version("hopsworks")
+            usage._init_usage(self._host, self._backend_version)
 
             self._provide_project()
         except (TypeError, ConnectionError):
@@ -435,23 +475,59 @@ class Connection:
         if not self._project:
             return
 
-        from hsfs import engine
+        if self._engine not in ("python", "training"):
+            # Spark engines must come up while the project is being set (the
+            # session needs the certificates before user code runs); the Python
+            # engine initialises itself on first use instead of importing hsfs
+            # here.
+            from hsfs import engine
 
-        engine._get_instance()
-        if self._variable_api._get_data_science_profile_enabled():
-            # load_default_configuration has to be called before using hsml
-            # but after a project is provided to client
-            try:
-                # istio client, default resources,...
-                self._model_serving_api._load_default_configuration()
-            except RestAPIError as e:
-                if e.response.error_code == 403 and e.error_code == 320004:
-                    print(
-                        'The used API key does not include "SERVING" scope, the related functionality will be disabled.'
-                    )
-                    _logger.debug(f"The ignored exception: {e}")
-                else:
-                    raise e
+            engine._get_instance()
+
+    def _load_serving_defaults(self) -> None:
+        """Load the model-serving defaults and the istio client, once.
+
+        Called on first use of anything serving-related (see
+        ``client._load_serving_defaults``) rather than during login, so a caller
+        that never deploys a model pays neither the requests nor the import.
+        """
+        if (
+            self._serving_defaults_loaded
+            or self._serving_defaults_loading
+            or not self._connected
+            or not self._project
+        ):
+            return
+        # Loading reads the serving settings itself (via the client getters), so
+        # the in-progress flag stops that recursion; ``loaded`` is only set once
+        # the load succeeded, or was deliberately skipped, so a transient error
+        # leaves the next call free to retry.
+        self._serving_defaults_loading = True
+        try:
+            serving_available = self._variable_api._get_data_science_profile_enabled()
+            if serving_available:
+                try:
+                    # istio client, default resources,...
+                    self._model_serving_api._load_default_configuration()
+                except RestAPIError as e:
+                    if e.response.error_code == 403 and e.error_code == 320004:
+                        print(
+                            'The used API key does not include "SERVING" scope, the related functionality will be disabled.'
+                        )
+                        _logger.debug(f"The ignored exception: {e}")
+                        serving_available = False
+                    else:
+                        raise e
+            if not serving_available:
+                # Serving is off for this session: give the getters definite
+                # values (no KServe, no instance limits, no Knative domain)
+                # instead of None.
+                client._set_kserve_installed(False)
+                client._set_serving_num_instances_limits([-1, -1])
+                client._set_knative_domain("")
+            self._serving_defaults_loaded = True
+        finally:
+            self._serving_defaults_loading = False
 
     def _close(self) -> None:
         """Close a connection gracefully.
@@ -470,13 +546,24 @@ class Connection:
         if not self._connected:
             return  # the connection is already closed
 
-        from hsfs import engine
-
-        if OpenSearchClientSingleton._instance:
-            OpenSearchClientSingleton._close_all()
+        opensearch = sys.modules.get("hopsworks_common.core.opensearch")
+        if opensearch is not None and opensearch.OpenSearchClientSingleton._instance:
+            opensearch.OpenSearchClientSingleton._close_all()
         client._stop()
-        engine._stop()
+        # Nothing to stop unless hsfs was actually used on this connection.
+        if "hsfs.engine" in sys.modules:
+            from hsfs import engine
+
+            engine._stop()
+        # hsfs.engine._get_type() answers from this; after close it must fail
+        # again rather than report the closed connection's engine.
+        global _hsfs_engine_type
+        _hsfs_engine_type = None
         self._feature_store_api = None
+        self._model_registry_api = None
+        self._model_serving_api = None
+        self._serving_defaults_loaded = False
+        self._serving_defaults_loading = False
         self._connected = False
         _logger.info("Connection closed.")
 

--- a/python/hopsworks_common/util.py
+++ b/python/hopsworks_common/util.py
@@ -46,8 +46,14 @@ from hopsworks_common.git_file_status import GitFileStatus
 from six import string_types
 
 
-if HAS_PANDAS:
-    import pandas as pd
+def _pandas():
+    """pandas, if something has imported it; else None.
+
+    A pandas object can only exist once pandas is imported, so the isinstance
+    checks below need nothing more, and ``import hopsworks`` no longer pays the
+    ~0.4 s pandas import for callers that never use a DataFrame.
+    """
+    return sys.modules.get("pandas") if HAS_PANDAS else None
 
 
 FEATURE_STORE_NAME_SUFFIX = "_featurestore"
@@ -56,6 +62,7 @@ FEATURE_STORE_NAME_SUFFIX = "_featurestore"
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import pandas as pd
     from hsfs import feature_group
 
 
@@ -91,7 +98,10 @@ class NumpyEncoder(json.JSONEncoder):
                 return np.vectorize(encode_binary)(obj), True
             return obj.tolist(), True
 
-        if isinstance(obj, datetime) or (HAS_PANDAS and isinstance(obj, pd.Timestamp)):
+        pd = _pandas()
+        if isinstance(obj, datetime) or (
+            pd is not None and isinstance(obj, pd.Timestamp)
+        ):
             return obj.isoformat(), True
         if isinstance(obj, (bytes, bytearray)):
             return encode_binary(obj), True
@@ -663,11 +673,12 @@ def _handle_tensor_input(input_tensor):
 
 @also_available_as("hsml.util._handle_dataframe_input")
 def _handle_dataframe_input(input_ex):
-    if HAS_PANDAS and isinstance(input_ex, pd.DataFrame):
+    pd = _pandas()
+    if pd is not None and isinstance(input_ex, pd.DataFrame):
         if not input_ex.empty:
             return input_ex.iloc[0].tolist()
         raise ValueError(f"input_example of type {type(input_ex)} can not be empty")
-    if HAS_PANDAS and isinstance(input_ex, pd.Series):
+    if pd is not None and isinstance(input_ex, pd.Series):
         if not input_ex.empty:
             return input_ex.tolist()
         raise ValueError(f"input_example of type {type(input_ex)} can not be empty")

--- a/python/hsfs/engine/__init__.py
+++ b/python/hsfs/engine/__init__.py
@@ -75,8 +75,14 @@ def _set_instance(
 
 
 def _get_type() -> str:
-    if _engine:
-        return hopsworks_common.connection._hsfs_engine_type
+    # The connection knows the engine type before the engine object exists (the
+    # Python engine is built on first use), so callers that only branch on the
+    # type must not force that construction.
+    engine_type = hopsworks_common.connection._hsfs_engine_type
+    if not engine_type and _engine:
+        engine_type = _engine_type
+    if engine_type:
+        return engine_type
     raise Exception("Couldn't find execution engine. Try reconnecting to Hopsworks.")
 
 

--- a/python/tests/client/test_lazy_client.py
+++ b/python/tests/client/test_lazy_client.py
@@ -1,0 +1,147 @@
+"""The client package stays light until serving is used.
+
+Lazy istio import, serving defaults on first read, single project and version
+lookups.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest import mock
+
+import hopsworks_common.client as client
+import pytest
+from hopsworks_common import connection as connection_mod
+from hopsworks_common.client import external
+from hopsworks_common.connection import Connection
+
+
+def test_importing_hopsworks_does_not_import_istio_or_hsfs():
+    code = (
+        "import sys, hopsworks; "
+        "print('hopsworks_common.client.istio' in sys.modules, 'hsfs' in sys.modules)"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    ).stdout
+    assert out.split() == ["False", "False"]
+
+
+def test_istio_attribute_resolves_lazily():
+    assert client.istio.__name__ == "hopsworks_common.client.istio"
+
+
+def test_stop_without_istio_loaded(monkeypatch):
+    monkeypatch.setattr(client, "_client", mock.MagicMock())
+    monkeypatch.setitem(sys.modules, "hopsworks_common.client.istio", None)
+    client._stop()  # must not import or touch istio
+    assert client._client is None
+
+
+def test_stop_forgets_serving_defaults(monkeypatch):
+    monkeypatch.setattr(client, "_client", mock.MagicMock())
+    monkeypatch.setattr(client, "_kserve_installed", True)
+    monkeypatch.setattr(client, "_serving_num_instances_limits", [0, 4])
+    monkeypatch.setattr(client, "_knative_domain", "old.example")
+    client._stop()
+    assert (
+        client._kserve_installed,
+        client._serving_num_instances_limits,
+        client._knative_domain,
+    ) == (None, None, None)
+
+
+def test_serving_getters_load_defaults_on_first_read(monkeypatch):
+    conn = mock.MagicMock()
+    monkeypatch.setattr(client, "_connection", conn)
+    monkeypatch.setattr(client, "_kserve_installed", None)
+    monkeypatch.setattr(client, "_serving_num_instances_limits", None)
+    monkeypatch.setattr(client, "_knative_domain", None)
+
+    def load():
+        client._set_kserve_installed(True)
+        client._set_serving_num_instances_limits([1, 2])
+        client._set_knative_domain("example.com")
+
+    conn._load_serving_defaults.side_effect = load
+    assert client._is_kserve_installed() is True
+    assert client._get_serving_num_instances_limits() == [1, 2]
+    assert client._get_knative_domain() == "example.com"
+    conn._load_serving_defaults.assert_called_once()
+
+
+def test_istio_instance_triggers_defaults(monkeypatch):
+    conn = mock.MagicMock()
+    monkeypatch.setattr(client, "_connection", conn)
+    monkeypatch.setattr(client.istio, "_client", None)
+    assert client.istio._get_instance() is None
+    conn._load_serving_defaults.assert_called_once()
+
+
+def test_external_provide_project_reuses_known_id(monkeypatch):
+    # _provide_project ends by handing over to the connection; stub that hop.
+    monkeypatch.setattr(client, "_get_connection", lambda: mock.MagicMock())
+    c = external.Client.__new__(external.Client)
+    c._engine = "none"
+    c._get_project_info = mock.MagicMock()
+    c._get_username = mock.MagicMock(return_value="meb")
+    c._provide_project("proj", project_id=119)
+    assert (c._project_name, c._project_id, c._username) == ("proj", "119", "meb")
+    c._get_project_info.assert_not_called()
+    c._provide_project("proj")
+    c._get_project_info.assert_called_once_with("proj")
+
+
+def test_check_compatibility_uses_cached_version():
+    conn = Connection.__new__(Connection)
+    conn._connected = True
+    conn._backend_version = connection_mod.version.__version__
+    conn._variable_api = mock.MagicMock()
+    conn._check_compatibility()
+    conn._variable_api._get_version.assert_not_called()
+
+
+def test_engine_type_known_before_engine_is_built(monkeypatch):
+    import hopsworks_common.connection as connection
+    from hsfs import engine
+
+    monkeypatch.setattr(engine, "_engine", None)
+    monkeypatch.setattr(connection, "_hsfs_engine_type", "python")
+    assert engine._get_type() == "python"
+    monkeypatch.setattr(connection, "_hsfs_engine_type", None)
+    with pytest.raises(Exception, match="Couldn't find execution engine"):
+        engine._get_type()
+    # An engine object built by hsfs.engine._init also fixes the type.
+    monkeypatch.setattr(engine, "_engine", mock.MagicMock())
+    monkeypatch.setattr(engine, "_engine_type", "spark")
+    assert engine._get_type() == "spark"
+
+
+def test_close_forgets_engine_type(monkeypatch):
+    import hopsworks_common.connection as connection
+
+    conn = Connection.__new__(Connection)
+    conn._connected = True
+    conn._feature_store_api_cache = None
+    conn._model_registry_api_cache = None
+    conn._model_serving_api_cache = None
+    monkeypatch.setattr(connection, "_hsfs_engine_type", "python")
+    monkeypatch.setattr(connection.client, "_stop", lambda: None)
+    monkeypatch.delitem(sys.modules, "hsfs.engine", raising=False)
+    conn._close()
+    assert connection._hsfs_engine_type is None
+    assert conn._connected is False
+
+
+def test_set_active_project_passes_id(monkeypatch):
+    import hopsworks
+
+    hw_client = mock.MagicMock()
+    hw_client._is_external.return_value = True
+    monkeypatch.setattr(hopsworks.client, "_get_instance", lambda: hw_client)
+    project = mock.MagicMock()
+    project.name = "proj"
+    project.id = 119
+    hopsworks._set_active_project(project)
+    hw_client._provide_project.assert_called_once_with("proj", project_id=119)

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -145,19 +145,25 @@ class TestConnection:
 
 
 class TestProvideProject:
-    # Tests for hopsworks_common.connection.Connection._provide_project, which runs
-    # during hopsworks.login() after the client is initialized and is responsible for
-    # loading the default model serving configuration.
+    # Tests for Connection._provide_project (runs during hopsworks.login() after the
+    # client is initialized) and Connection._load_serving_defaults (runs on first use
+    # of anything model-serving related).
 
     @pytest.fixture
     def conn(self):
         conn = MagicMock(spec=Connection)
         conn._connected = True
         conn._project = None
+        conn._engine = "python"
+        conn._serving_defaults_loaded = False
+        conn._serving_defaults_loading = False
         conn._variable_api = MagicMock()
         conn._model_serving_api = MagicMock()
-        # Bind the real method so the decorator can read _connected from our mock.
+        # Bind the real methods so the decorator can read _connected from our mock.
         conn._provide_project = Connection._provide_project.__get__(conn, Connection)
+        conn._load_serving_defaults = Connection._load_serving_defaults.__get__(
+            conn, Connection
+        )
         return conn
 
     @pytest.fixture
@@ -173,7 +179,7 @@ class TestProvideProject:
 
     @pytest.fixture(autouse=True)
     def _stub_hsfs_engine(self, mocker):
-        mocker.patch("hsfs.engine._get_instance")
+        self.engine_get = mocker.patch("hsfs.engine._get_instance")
 
     def _make_rest_error(self, status_error_code, error_code):
         err = RestAPIError.__new__(RestAPIError)
@@ -183,67 +189,85 @@ class TestProvideProject:
         return err
 
     def test_name_delegates_to_external_client(self, conn, client_instance):
-        conn._variable_api._get_data_science_profile_enabled.return_value = False
-
         conn._provide_project(name="proj")
-
         assert conn._project == "proj"
         client_instance._provide_project.assert_called_once_with("proj")
 
     def test_name_is_not_forwarded_when_internal(self, conn, client_instance):
         client_instance._is_external.return_value = False
-        conn._variable_api._get_data_science_profile_enabled.return_value = False
-
         conn._provide_project(name="proj")
-
         assert conn._project == "proj"
         client_instance._provide_project.assert_not_called()
 
     def test_uses_client_project_name_when_already_set(self, conn, client_instance):
         client_instance._project_name = "already-set"
-        conn._variable_api._get_data_science_profile_enabled.return_value = False
-
         conn._provide_project()
-
         assert conn._project == "already-set"
 
     def test_short_circuits_when_no_project(self, conn, client_instance):
         conn._provide_project()
-
+        conn._load_serving_defaults()
         conn._variable_api._get_data_science_profile_enabled.assert_not_called()
         conn._model_serving_api._load_default_configuration.assert_not_called()
+
+    def test_provide_project_defers_serving_defaults(self, conn, client_instance):
+        # Login no longer pays for the serving lookups; they run on first use.
+        client_instance._project_name = "proj"
+        conn._variable_api._get_data_science_profile_enabled.return_value = True
+        conn._provide_project()
+        conn._model_serving_api._load_default_configuration.assert_not_called()
+        conn._variable_api._get_data_science_profile_enabled.assert_not_called()
+
+    def test_python_engine_does_not_warm_up_hsfs(self, conn, client_instance):
+        client_instance._project_name = "proj"
+        conn._provide_project()
+        self.engine_get.assert_not_called()
+        conn._engine = "spark"
+        conn._provide_project()
+        self.engine_get.assert_called_once()
 
     def test_loads_default_configuration_when_profile_enabled(
         self, conn, client_instance
     ):
         client_instance._project_name = "proj"
         conn._variable_api._get_data_science_profile_enabled.return_value = True
-
         conn._provide_project()
-
+        conn._load_serving_defaults()
+        conn._load_serving_defaults()  # idempotent
         conn._model_serving_api._load_default_configuration.assert_called_once()
 
     def test_skips_default_configuration_when_profile_disabled(
-        self, conn, client_instance
+        self, conn, client_instance, mocker
     ):
+        set_kserve = mocker.patch(
+            "hopsworks_common.connection.client._set_kserve_installed"
+        )
+        set_limits = mocker.patch(
+            "hopsworks_common.connection.client._set_serving_num_instances_limits"
+        )
+        set_knative = mocker.patch(
+            "hopsworks_common.connection.client._set_knative_domain"
+        )
         client_instance._project_name = "proj"
         conn._variable_api._get_data_science_profile_enabled.return_value = False
-
         conn._provide_project()
-
+        conn._load_serving_defaults()
         conn._model_serving_api._load_default_configuration.assert_not_called()
+        # Serving off: the getters get definite values rather than None.
+        set_kserve.assert_called_once_with(False)
+        set_limits.assert_called_once_with([-1, -1])
+        set_knative.assert_called_once_with("")
 
     def test_missing_serving_scope_is_swallowed(self, conn, client_instance, capsys):
         # 403 + 320004 means the API key lacks the SERVING scope; model serving is disabled
-        # but login must still succeed.
+        # but the caller must still succeed.
         client_instance._project_name = "proj"
         conn._variable_api._get_data_science_profile_enabled.return_value = True
         conn._model_serving_api._load_default_configuration.side_effect = (
             self._make_rest_error(status_error_code=403, error_code=320004)
         )
-
         conn._provide_project()
-
+        conn._load_serving_defaults()
         assert "SERVING" in capsys.readouterr().out
 
     def test_other_rest_api_errors_are_reraised(self, conn, client_instance):
@@ -252,6 +276,42 @@ class TestProvideProject:
         conn._model_serving_api._load_default_configuration.side_effect = (
             self._make_rest_error(status_error_code=500, error_code=999999)
         )
-
+        conn._provide_project()
         with pytest.raises(RestAPIError):
-            conn._provide_project()
+            conn._load_serving_defaults()
+        # A failed load must not be remembered as done: the next call retries.
+        assert conn._serving_defaults_loaded is False
+        conn._model_serving_api._load_default_configuration.side_effect = None
+        conn._load_serving_defaults()
+        assert conn._serving_defaults_loaded is True
+        assert conn._model_serving_api._load_default_configuration.call_count == 2
+
+    def test_load_is_not_reentrant(self, conn, client_instance):
+        # Loading reads the serving settings itself; a nested call must no-op
+        # instead of recursing, and the load still counts as done afterwards.
+        client_instance._project_name = "proj"
+        conn._variable_api._get_data_science_profile_enabled.return_value = True
+        conn._model_serving_api._load_default_configuration.side_effect = lambda: (
+            conn._load_serving_defaults()
+        )
+        conn._provide_project()
+        conn._load_serving_defaults()
+        conn._model_serving_api._load_default_configuration.assert_called_once()
+        assert conn._serving_defaults_loaded is True
+
+    def test_missing_scope_counts_as_loaded(
+        self, conn, client_instance, capsys, mocker
+    ):
+        set_kserve = mocker.patch(
+            "hopsworks_common.connection.client._set_kserve_installed"
+        )
+        client_instance._project_name = "proj"
+        conn._variable_api._get_data_science_profile_enabled.return_value = True
+        conn._model_serving_api._load_default_configuration.side_effect = (
+            self._make_rest_error(status_error_code=403, error_code=320004)
+        )
+        conn._provide_project()
+        conn._load_serving_defaults()
+        conn._load_serving_defaults()
+        assert capsys.readouterr().out.count("SERVING") == 1
+        set_kserve.assert_called_once_with(False)


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-3191

## Why

Every `hops` command paid about 1.0 s of Python imports and 1.1 s of `hopsworks.login()` before doing anything. Measured against a dev cluster (jim-teleport, 2026-09-02):

| | before | after |
| --- | --- | --- |
| `import hopsworks` | 0.73 s | 0.19 s |
| `hopsworks.login()` (Python engine, API key) | 1.09 s, 12 requests | 0.28 s, 4 requests |
| `hops --help` | 1.0 s | 0.35 s |
| `hops project info` | 2.2 s | 0.63 s |
| `hops job list` | | 0.68 s |
| `hops fg list` (imports hsfs on demand) | | 1.9 s |

Where the time went: `hopsworks_common.client` imported the istio gRPC client at module load (pandas, numpy: 0.43 s); `hopsworks_common.util` imported pandas for two `isinstance` checks; `connect()` imported `hsfs` and `hsml` to build API objects nobody had asked for (pandas, pyarrow, sqlalchemy, boto); the login fetched `/variables/versions` twice (compatibility check and usage logging) and `getProjectInfo` twice (login, then the external client); and `_provide_project` ran the six KServe/serving lookups plus istio client setup for every caller.

## Measurements (jim-teleport, 2026-09-02, laptop over WireGuard)

Import self-time of a full CLI login before the change, by top-level package (ms): pandas 208, sqlalchemy 204, hsfs 101, pyarrow 100, numpy 91, hopsworks_common 69, botocore 61, opensearchpy 29, grpc 19, cryptography 15, google 14, fastavro 12; total 1255 ms of imports for one command.

Requests made by `hopsworks.login()` before: `/variables/versions` x2, `/project/getProjectInfo/<name>` x2, `/project`, `/project/<id>/credentials`, then `/variables/enable_data_science_profile`, `/variables/kube_kserve_installed`, `/project/<id>/inference/endpoints`, `/variables/kube_serving_min_num_instances`, `/variables/kube_serving_max_num_instances`, `/variables/kube_knative_domain_name` (12, sequential, 20 to 110 ms each). After: `/variables/versions`, `/project/getProjectInfo/<name>`, `/project`, `/project/<id>/credentials` (4). The six serving requests now run on the first read of a serving setting or of the istio client, as measured live.

After the change, `import hopsworks` loads neither pandas, numpy, hsfs nor hsml; `hops project info` and `hops job list` finish without importing hsfs at all, and `hops fg list` imports it on demand (that import is what remains of its 1.9 s).

No JWT is involved on a laptop: the API key goes on every request, so there was nothing to cache on the auth side.

## What

- `hopsworks_common.client`: `istio` is imported on first attribute access (PEP 562 `__getattr__`); `_stop()` closes it only if it was loaded. The serving getters (`_is_kserve_installed`, `_get_serving_num_instances_limits`, `_get_knative_domain`) and `istio._get_instance()` trigger `Connection._load_serving_defaults()` on first read.
- `Connection`: feature-store, model-registry and model-serving API objects are properties built on first use; the backend version is fetched once; the Python engine is no longer warmed up at login (it initialises itself on first use, Spark engines keep the eager path); `_load_serving_defaults()` is idempotent and keeps the SERVING-scope 403 handling; `_get_model_serving()` loads the defaults up front so a missing scope is still reported there; `close()` only stops the hsfs engine and OpenSearch client if they were used.
- `hopsworks.login`: hands the project id it already fetched to the external client instead of a second `getProjectInfo`.
- `hopsworks_common.util`: pandas resolved through `sys.modules` for the `isinstance` checks; a pandas object cannot exist before pandas is imported.

## Tests

- New `tests/client/test_lazy_client.py`: importing `hopsworks` loads neither istio nor hsfs (subprocess), lazy `client.istio` attribute, `_stop()` without istio, getters trigger the deferred load once, `istio._get_instance()` triggers it, external `_provide_project` reuses a known id, cached version skips the request, `_set_active_project` passes the id.
- `tests/test_connection.py::TestProvideProject` updated: serving defaults now load in `_load_serving_defaults()` (idempotent, SERVING-scope handling), `_provide_project` no longer loads them, Python engine not warmed up while Spark still is.
- Full `tests/` suite (Python 3.13, pinned pytest, run from the repo root): 4270 passed, 13 skipped; the only failures are the 5 `test_spark` avro tests that need `PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1` locally, unrelated to this change.

Live on jim-teleport: login issues exactly `versions`, `getProjectInfo`, `project`, `credentials`; the first read of the KServe flag issues the six serving requests and builds the istio client; `get_model_serving()`, `get_model_registry()` and `get_feature_store()` work, importing `hsml`/`hsfs` at that point.

## Review rounds

Five Copilot passes, every finding fixed on the branch and folded into the single commit:

1. A failed serving-defaults load was remembered as done. An in-progress flag now stops the recursion through the client getters, and "loaded" is only recorded after success or a deliberate skip, so a raised error leaves the next read free to retry.
2. With serving off (data science profile disabled, or a key without the SERVING scope) the getters returned `None` against their `bool`/list contract. The load records definite defaults for that session: KServe not installed, no instance limits, empty Knative domain (the fifth pass asked for the domain too).
3. The serving values outlived `client._stop()`, so a second `login()` in the same process would have read the previous cluster's values. `_stop()` clears them.
4. After `Connection.close()` the engine type stayed set, so `hsfs.engine._get_type()` kept answering for a closed connection; `close()` resets it. And `_get_type()` falls back to the registry's own type when an engine object exists without a connection type, so it never returns `None`.

Running the loadtests caught a fifth case, not reported by Copilot: `hsfs.engine._get_type()` raised "Couldn't find execution engine" when called before anything had built the engine object, which the login-time warm-up used to guarantee. It now answers from the connection's engine type.

## Loadtests

Run from the laptop with `loadtest/tests/run_against_cluster.sh` against jim-teleport (10.112.231.130, Kafka external bootstrap 10.112.231.128), SDK installed from this branch at 7dd6f2f0d (the later amendments only touch `_stop()`/`close()` bookkeeping and the `_get_type()` fallback, covered by unit tests): **23 passed in 1:23:23**.

- `workflows/proxy/test_terminal_proxy_token.py` (3): CLI-style login and terminal attach token flow.
- `workflows/feature_store/python_driver/test_feature_group_insert.py` (15): `test_feature_groups`, `test_fg_null_complex_type`, `test_multi_part_insert` for DELTA, HUDI and ICEBERG, so the Python engine's lazy initialisation, Kafka inserts and materialization jobs.
- `workflows/feature_store/python_driver/test_feature_group_read.py` (4): training data for the three formats plus Delta read after log retention.
- `workflows/model_serving/python_driver/external/test_deploy_model_and_predict.py::test_deploy_and_predict_sklearn_model_with_kserve` (1): deferred serving defaults and istio client in a real deployment.

Not covered: Spark-engine (pyspark driver) workflows, which keep the eager engine warm-up unchanged; the in-cluster loadtest Job path, whose runner image cannot install the SDK from GitHub on this cluster (a known git/libcurl issue in that image).

## Follow-ups (not in this PR)

- A CLI entry point outside the `hopsworks` package would avoid the remaining 0.19 s package import for `hops --help`.
- `hops fg`/`fv` commands still import `hsfs` (about 1.2 s); that is the feature-store engine's own import cost.


