### PR TITLE
[HWORKS-3185] Bump jackson and pin netty in the published hsfs uber jars

### DIFF
--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <flink.version>1.17.1.0</flink.version>
     <fasterxml.version>2.13.4.2</fasterxml.version>
-    <bouncycastle.version>1.79</bouncycastle.version>
+    <bouncycastle.version>1.81.1</bouncycastle.version>
     <guava.version>14.0.1</guava.version>
     <httpclient.version>4.5.6</httpclient.version>
   </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,7 +27,7 @@
         <handy.version>2.1.8</handy.version>
         <lombok.version>1.18.36</lombok.version>
         <lombok.plugin.version>1.18.20.0</lombok.plugin.version>
-        <fasterxml.jackson.databind.version>2.21.2</fasterxml.jackson.databind.version>
+        <fasterxml.jackson.databind.version>2.21.4</fasterxml.jackson.databind.version>
         <datasketches.version>6.2.0</datasketches.version>
         <spark.version>4.1.3.0</spark.version>
         <hudi.groupId>io.hops.hudi</hudi.groupId>
@@ -49,6 +49,41 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <delombok.output>${project.build.directory}/generated-sources/delombok</delombok.output>
     </properties>
+
+    <!-- The published hsfs-spark / hsfs-flink artifacts are `jar-with-dependencies`
+         uber jars (maven-assembly-plugin, below), and spark_install.sh drops them
+         straight into /srv/hops/spark/hopsworks-jars in the
+         hopsworks-base:spark-feature-pipeline image. Every compile- and
+         runtime-scope dependency here is therefore scanned as a shipped library,
+         which is easy to forget when reading these poms as if they only described a
+         thin client SDK.
+
+         netty is not declared anywhere in this project. It arrives at runtime scope
+         underneath software.amazon.awssdk:netty-nio-client, which the ssm / sts /
+         secretsmanager clients pull in as their async HTTP transport, and it landed
+         in the published jar at three versions at once (4.1.119, 4.1.136 and 4.2.7),
+         because nothing reconciled the AWS SDK 4.1 line against the 4.2 line Spark
+         brings in as `provided`.
+
+         Pinned to 4.2.17.Final, matching the Spark fork. A bom import applies to
+         every netty artifact regardless of scope, including the ones Spark provides,
+         so pinning the 4.1 line here would not just constrain the AWS SDK, it would
+         downgrade Spark's netty too. Spark 4.1 needs 4.2 classes
+         (io.netty.channel.kqueue.KQueueIoHandler and the rest of the 4.2 IoHandler
+         API) and TestStorageConnector fails with NoClassDefFoundError on a 4.1 pin.
+         4.2.x is also what the AWS SDK already runs against in production, since
+         these jars load inside a Spark image whose own netty is 4.2. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.17.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -314,7 +349,7 @@
                 <scala.version>2.13.17</scala.version>
                 <scala-short.version>2.13</scala-short.version>
                 <avro.version>1.12.1</avro.version>
-                <fasterxml.jackson.databind.version>2.21.2</fasterxml.jackson.databind.version>
+                <fasterxml.jackson.databind.version>2.21.4</fasterxml.jackson.databind.version>
                 <artifact.spark.version>spark4.1</artifact.spark.version>
             </properties>
         </profile>


### PR DESCRIPTION
The hsfs artifacts are not the thin client SDK these poms read like. Published `hsfs-spark-spark4.1-<v>.jar` is a 51 MB `jar-with-dependencies` uber jar (maven-assembly-plugin in java/pom.xml), and docker-images' base-image/spark-feature-pipeline/spark_install.sh downloads it straight into /srv/hops/spark/hopsworks-jars in hopsworks-base:spark-feature-pipeline. Every compile- and runtime-scope dependency here is therefore scanned as a shipped library.

Checking the published jar rather than a local build matters here: a local `mvn install` leaves a 168 KB thin jar in ~/.m2, so the bundled dependencies are invisible unless you look at what repo.hops.works actually serves.

Two things in it:

  * jackson-databind and jackson-core at 2.21.2, the exact version the Spark fork was bumped off in 4.1_fix_vulnarabilities. Bumped to 2.21.4 in both places the property is set (the default properties and the spark-4.1 profile). jackson-annotations stays at 2.21 because the bom drops the patch segment from 2.20 onward.

  * netty at three versions in a single jar: 4.1.119.Final, 4.1.136.Final and 4.2.7.Final. netty is not declared anywhere in this project -- it arrives at runtime scope under software.amazon.awssdk:netty-nio-client, the async HTTP transport for the ssm / sts / secretsmanager clients, and nothing reconciled that against the 4.2 line Spark contributes as `provided`. Added a dependencyManagement importing netty-bom.

The netty version took two attempts and the tests decided it. 4.1.137.Final looked right on the reasoning that netty-nio-client 2.45.1 is written against the 4.1 line, and the advisories accept either line. But a bom import applies to every netty artifact regardless of scope, so it downgrades Spark's provided netty too, and Spark 4.1 needs 4.2 classes: TestStorageConnector then fails with `NoClassDefFoundError: io/netty/channel/kqueue/KQueueIoHandler` in five tests. 4.2.17.Final is both the fix and the honest choice, since these jars load inside a Spark image whose netty is already 4.2 -- the AWS SDK has been running on netty 4.2 in production regardless of what the jar bundled.

Also bumps bouncycastle 1.79 -> 1.81.1 in the flink module. That one is `bcpkix-jdk18on` at test scope, so it ships nowhere and closes no finding; it is hygiene only.

Verified by building the uber jar and reading what actually landed in it:

    before   jackson 2.21.2   netty 4.1.119 + 4.1.136 + 4.2.7
    after    jackson 2.21.4   netty 4.2.17.Final only

Tests pass across the modules that assemble: hsfs 33, spark 84, flink 33, beam 33, 0 failures 0 errors.

Not changed, deliberately: the hudi fork. Only two hudi jars ship (hudi-spark4.1-bundle and hudi-utilities-slim-bundle) and, checked against the published artifacts, the first bundles only jackson-datatype-jsr310 and jackson-module-afterburner at 2.20.0 while the second bundles none of these at all. Neither artifact has a finding. hudi's zookeeper 3.5.7, thrift 0.13.0 and lz4-java 1.8.0 live in modules whose bundles Hopsworks does not ship -- hudi-hive-sync-bundle is the one carrying thrift and jackson-databind, and it is not in spark_install.sh.


Claude-Session: https://claude.ai/code/session_015B2RucKxNKWyW6z4ScQyA6

This PR adds/fixes/changes...

- please summarize your changes to the code
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM

**Checklist For The Assigned Reviewer:**

```markdown
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
