### PR TITLE
[HWORKS-2879][5.1] Backport the Spark 4.1 upgrade and its appends

### DIFF
--- a/.github/java.Jenkinsfile
+++ b/.github/java.Jenkinsfile
@@ -1,0 +1,85 @@
+// Java/Scala build for the hsfs SDK jars. Split out of the `hopsworks` freestyle job because
+// main and branch-5.1 need JDK 17 (Spark 4.1, avro 1.12.x) while branch-4.* and branch-5.0
+// stay on the controller's Java 8. The controller has no JDK 17 installation, so the build
+// runs in a container the way clusterj-onlinefs and hopsworks-ee already do; the publish step
+// has to run back on `local`, because /opt/repository is the controller's filesystem.
+pipeline {
+    agent none
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+        // The freestyle job this replaces had concurrentBuild=false. Two runs in parallel
+        // would install the same GAV into the shared ~/.m2 and write the same
+        // /opt/repository/master/hsfs/$POM_VERSION directory.
+        disableConcurrentBuilds()
+    }
+
+    triggers {
+        githubPush()
+    }
+
+    stages {
+        stage('build') {
+            agent {
+                docker {
+                    image 'maven:3.8.5-openjdk-17'
+                    label 'local'
+                    // Carries the controller's settings.xml into the container, which is what
+                    // supplies the nexus mirror and the archiva deploy credentials.
+                    args '-v $HOME/.m2:/root/.m2'
+                }
+            }
+            steps {
+                script {
+                    env.POM_VERSION = sh(returnStdout: true, script:
+                        "mvn -f java/pom.xml -q -Dexec.executable=echo -Dexec.args='\${project.version}' --non-recursive exec:exec").trim()
+                    // Derived, never hardcoded: this is the string that was pinned to spark3.5
+                    // in the old job, which is why no spark4.1 jar was ever published.
+                    env.SPARK_FLAVOUR = sh(returnStdout: true, script:
+                        "mvn -f java/pom.xml -q -Dexec.executable=echo -Dexec.args='\${artifact.spark.version}' --non-recursive exec:exec").trim()
+                    echo "POM_VERSION=${env.POM_VERSION}  SPARK_FLAVOUR=${env.SPARK_FLAVOUR}"
+                }
+                sh 'mvn -f java/pom.xml clean deploy generate-sources javadoc:javadoc -Pwith-hops-ee'
+                sh 'mvn -f utils/java/pom.xml clean package'
+                stash name: 'artifacts', includes: [
+                    'java/spark/target/*-jar-with-dependencies.jar',
+                    'utils/java/target/*-jar-with-dependencies.jar',
+                    'utils/python/hsfs_utils.py',
+                ].join(',')
+            }
+        }
+
+        stage('publish') {
+            agent { label 'local' }
+            options { skipDefaultCheckout() }
+            steps {
+                deleteDir()
+                unstash 'artifacts'
+                sh '''
+                    set -eu
+                    DEST=/opt/repository/master
+                    mkdir -p "$DEST/hsfs/$POM_VERSION" "$DEST/hsfs_utils"
+
+                    JAR="java/spark/target/hsfs-spark-$SPARK_FLAVOUR-$POM_VERSION-jar-with-dependencies.jar"
+                    # Fatal, not a soft `if`. The old job skipped silently when the name did not
+                    # match, which is how main went green while publishing nothing.
+                    test -f "$JAR"
+                    cp "$JAR" "$DEST/hsfs/$POM_VERSION/hsfs-spark-$SPARK_FLAVOUR-$POM_VERSION.jar"
+
+                    cp "utils/java/target/hsfs-utils-$POM_VERSION-jar-with-dependencies.jar" \
+                       "$DEST/hsfs_utils/hsfs-utils-$POM_VERSION.jar"
+                    cp utils/python/hsfs_utils.py "$DEST/hsfs_utils/hsfs_utils-$POM_VERSION.py"
+                '''
+            }
+        }
+    }
+
+    post {
+        success {
+            build job: 'k8s-base-images', wait: false
+        }
+        unstable  { slackSend color: 'warning', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable: ${env.BUILD_URL}" }
+        failure   { slackSend color: 'danger',  message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed: ${env.BUILD_URL}" }
+        fixed     { slackSend color: 'good',    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal: ${env.BUILD_URL}" }
+    }
+}

--- a/.github/java.Jenkinsfile
+++ b/.github/java.Jenkinsfile
@@ -24,19 +24,24 @@ pipeline {
                 docker {
                     image 'maven:3.8.5-openjdk-17'
                     label 'local'
-                    // Carries the controller's settings.xml and its warm local repository
-                    // into the container, which is what supplies the mirror and the archiva
-                    // deploy credentials. /root/.m2 cannot deliver either: the plugin runs the
-                    // container as the agent's uid, which has no /etc/passwd entry, so the JVM
-                    // reports user.home=? and Maven reads no settings at all, and /root is 0700
-                    // to a non-root container. Mount somewhere traversable and move user.home
+                    // The .m2 mount carries the controller's settings.xml and its warm local
+                    // repository into the container, which is what supplies the mirror and the
+                    // archiva deploy credentials. /root/.m2 cannot deliver either, being 0700 to
+                    // a non-root container, so mount somewhere traversable and move user.home
                     // with it, the way the maven image documents for -u.
-                    args '-v $HOME/.m2:/var/maven/.m2 -e HOME=/var/maven -e MAVEN_CONFIG=/var/maven/.m2'
+                    // The passwd/group mounts are what make that uid resolvable at all. The
+                    // plugin runs the container as the agent's uid, which the image has no entry
+                    // for, and everything downstream of getpwuid() fails: Maven read no settings
+                    // (user.home=?), and Hadoop's UserGroupInformation login died on
+                    // `new UnixPrincipal(null)`, failing every test that builds a SparkSession
+                    // with "Invalid UID, could not determine effective user".
+                    args '-v $HOME/.m2:/var/maven/.m2 -e HOME=/var/maven -e MAVEN_CONFIG=/var/maven/.m2 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro'
                 }
             }
             environment {
-                // The JVM takes user.home from getpwuid(), never from $HOME, so -D is the only
-                // thing that moves it. MAVEN_OPTS covers every mvn call in the stage.
+                // getpwuid() resolves now, so the JVM takes user.home from the controller's
+                // passwd entry, a /home path that is not mounted in. $HOME is still ignored, so
+                // -D remains the only thing that moves it, for every mvn call in the stage.
                 MAVEN_OPTS = '-Duser.home=/var/maven'
             }
             steps {

--- a/.github/java.Jenkinsfile
+++ b/.github/java.Jenkinsfile
@@ -24,10 +24,20 @@ pipeline {
                 docker {
                     image 'maven:3.8.5-openjdk-17'
                     label 'local'
-                    // Carries the controller's settings.xml into the container, which is what
-                    // supplies the nexus mirror and the archiva deploy credentials.
-                    args '-v $HOME/.m2:/root/.m2'
+                    // Carries the controller's settings.xml and its warm local repository
+                    // into the container, which is what supplies the mirror and the archiva
+                    // deploy credentials. /root/.m2 cannot deliver either: the plugin runs the
+                    // container as the agent's uid, which has no /etc/passwd entry, so the JVM
+                    // reports user.home=? and Maven reads no settings at all, and /root is 0700
+                    // to a non-root container. Mount somewhere traversable and move user.home
+                    // with it, the way the maven image documents for -u.
+                    args '-v $HOME/.m2:/var/maven/.m2 -e HOME=/var/maven -e MAVEN_CONFIG=/var/maven/.m2'
                 }
+            }
+            environment {
+                // The JVM takes user.home from getpwuid(), never from $HOME, so -D is the only
+                // thing that moves it. MAVEN_OPTS covers every mvn call in the stage.
+                MAVEN_OPTS = '-Duser.home=/var/maven'
             }
             steps {
                 script {

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone UTC && echo UTC | sudo tee /etc/timezone
@@ -52,10 +52,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
-        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
+        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell" >> $GITHUB_ENV
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Cache local Maven repository
         uses: actions/cache@v4
@@ -29,7 +29,15 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Test
         working-directory: ./java
-        run: mvn clean test -Pspark-3.5 -Dspark.version=3.5.5 -Dhudi.version=1.0.2
+        # The spark-4.1 profile pins the Hops Spark fork (4.1.3.0). Its
+        # artifacts are public (nexus.hops.works/repository/spark), but their
+        # poms depend on io.hops:hadoop-client-* and io.hops.hive:* hosted in
+        # the authenticated hops-artifacts repository, which CI (and fork PRs
+        # in particular) cannot access, so CI overrides spark.version to build
+        # against upstream Apache Spark instead. The Hops Hudi fork bundles
+        # resolve anonymously from the open nexus.hops.works/repository/hudi,
+        # so no hudi override is needed.
+        run: mvn clean test -Pspark-4.1 -Dspark.version=4.1.3
 
   unit_tests_local_tz:
     name: Unit Tests (Local TZ)
@@ -42,11 +50,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Cache local Maven repository
         uses: actions/cache@v4
@@ -58,9 +66,17 @@ jobs:
 
       - name: Test
         working-directory: ./java
-        run: mvn clean test -Pspark-3.5 -Dspark.version=3.5.5 -Dhudi.version=1.0.2
+        # The spark-4.1 profile pins the Hops Spark fork (4.1.3.0). Its
+        # artifacts are public (nexus.hops.works/repository/spark), but their
+        # poms depend on io.hops:hadoop-client-* and io.hops.hive:* hosted in
+        # the authenticated hops-artifacts repository, which CI (and fork PRs
+        # in particular) cannot access, so CI overrides spark.version to build
+        # against upstream Apache Spark instead. The Hops Hudi fork bundles
+        # resolve anonymously from the open nexus.hops.works/repository/hudi,
+        # so no hudi override is needed.
+        run: mvn clean test -Pspark-4.1 -Dspark.version=4.1.3
 
-  unit_tests_spark35:
+  unit_tests_spark41:
     name: Unit Tests
     runs-on: ubuntu-latest
 
@@ -71,11 +87,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Cache local Maven repository
         uses: actions/cache@v4
@@ -88,4 +104,12 @@ jobs:
 
       - name: Test
         working-directory: ./java
-        run: mvn clean test -Pspark-3.5 -Dspark.version=3.5.5 -Dhudi.version=1.0.2
+        # The spark-4.1 profile pins the Hops Spark fork (4.1.3.0). Its
+        # artifacts are public (nexus.hops.works/repository/spark), but their
+        # poms depend on io.hops:hadoop-client-* and io.hops.hive:* hosted in
+        # the authenticated hops-artifacts repository, which CI (and fork PRs
+        # in particular) cannot access, so CI overrides spark.version to build
+        # against upstream Apache Spark instead. The Hops Hudi fork bundles
+        # resolve anonymously from the open nexus.hops.works/repository/hudi,
+        # so no hudi override is needed.
+        run: mvn clean test -Pspark-4.1 -Dspark.version=4.1.3

--- a/.github/workflows/mkdocs-test.yml
+++ b/.github/workflows/mkdocs-test.yml
@@ -52,15 +52,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Build javadoc documentation
         working-directory: java
-        run: mvn clean install javadoc:javadoc javadoc:aggregate -DskipTests -Dspark.version=3.5.5 -Dhudi.version=1.0.2 && cp -r target/site/apidocs ../logicalclocks.github.io/docs/javadoc
+        # The spark-4.1 profile pins the Hops Spark fork (4.1.3.0). Its
+        # artifacts are public (nexus.hops.works/repository/spark), but their
+        # poms depend on io.hops:hadoop-client-* and io.hops.hive:* hosted in
+        # the authenticated hops-artifacts repository, which CI (and fork PRs
+        # in particular) cannot access, so CI overrides spark.version to build
+        # against upstream Apache Spark instead. The Hops Hudi fork bundles
+        # resolve anonymously from the open nexus.hops.works/repository/hudi,
+        # so no hudi override is needed.
+        run: mvn clean install javadoc:javadoc javadoc:aggregate -Pspark-4.1 -DskipTests -Dspark.version=4.1.3 && cp -r target/site/apidocs ../logicalclocks.github.io/docs/javadoc
 
       - name: Check for broken links
         working-directory: logicalclocks.github.io

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -132,11 +132,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone UTC && echo UTC | sudo tee /etc/timezone
@@ -171,10 +171,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
-        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
+        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell" >> $GITHUB_ENV
 
       - name: Run Pytest suite
         run: pytest python/tests
@@ -185,11 +185,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone UTC && echo UTC | sudo tee /etc/timezone
@@ -221,10 +221,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
-        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
+        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell" >> $GITHUB_ENV
 
       - name: Run Pytest suite
         run: pytest python/tests
@@ -235,11 +235,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone UTC && echo UTC | sudo tee /etc/timezone
@@ -274,10 +274,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
-        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
+        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell" >> $GITHUB_ENV
 
       - name: Run Pytest suite
         run: pytest python/tests
@@ -288,11 +288,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone UTC && echo UTC | sudo tee /etc/timezone
@@ -327,10 +327,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
-        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
+        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell" >> $GITHUB_ENV
 
       - name: Run Pytest suite
         run: pytest python/tests
@@ -341,11 +341,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Set Timezone
         run: sudo timedatectl set-timezone Europe/Amsterdam && echo Europe/Amsterdam | sudo tee /etc/timezone
@@ -380,10 +380,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
-        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
+        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell" >> $GITHUB_ENV
 
       - name: Run Pytest suite
         run: pytest python/tests
@@ -421,10 +421,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
-        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell" >> $GITHUB_ENV
+        run: echo "PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell" >> $GITHUB_ENV
 
       - name: Run Pytest suite
         env:
@@ -470,12 +470,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         shell: cmd
         run: |
-          echo PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell >> %GITHUB_ENV%
+          echo PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell >> %GITHUB_ENV%
 
       - name: Run Pytest suite
         run: pytest python/tests
@@ -521,12 +521,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ivy2
-          key: ivy-spark-avro-3.5.5
+          key: ivy-spark-avro-4.1.1
 
       - name: Set PYSPARK_SUBMIT_ARGS for Avro support
         shell: cmd
         run: |
-          echo PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.12:3.5.5 pyspark-shell >> %GITHUB_ENV%
+          echo PYSPARK_SUBMIT_ARGS=--packages org.apache.spark:spark-avro_2.13:4.1.1 pyspark-shell >> %GITHUB_ENV%
 
       - name: Run Pytest suite
         run: pytest python/tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,7 +320,7 @@ You can then build either `hsfs` or `hsfs_utils`:
 
 ```bash
 cd java
-mvn clean package -Pspark-3.5,with-hops-ee
+mvn clean package -Pspark-4.1,with-hops-ee
 # Or
 cd ../utils/python
 mvn clean package

--- a/java/beam/pom.xml
+++ b/java/beam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>5.1.0-RC0</version>
+    <version>5.1.0-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/beam/src/main/java/com/logicalclocks/hsfs/beam/StreamFeatureGroup.java
+++ b/java/beam/src/main/java/com/logicalclocks/hsfs/beam/StreamFeatureGroup.java
@@ -45,6 +45,11 @@ public class StreamFeatureGroup extends FeatureGroupBase<PCollection<Object>> {
 
   protected FeatureGroupEngine featureGroupEngine = new FeatureGroupEngine();
 
+  public static class StreamFeatureGroupBuilder {
+    StreamFeatureGroupBuilder() {
+    }
+  }
+
   @Builder
   public StreamFeatureGroup(FeatureStore featureStore, @NonNull String name, Integer version, String description,
       List<String> primaryKeys, List<String> partitionKeys, String hudiPrecombineKey,

--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>5.1.0-RC0</version>
+    <version>5.1.0-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/flink/src/main/java/com/logicalclocks/hsfs/flink/StreamFeatureGroup.java
+++ b/java/flink/src/main/java/com/logicalclocks/hsfs/flink/StreamFeatureGroup.java
@@ -49,6 +49,11 @@ public class StreamFeatureGroup extends FeatureGroupBase<DataStream<?>> {
 
   protected FeatureGroupEngine featureGroupEngine = new FeatureGroupEngine();
 
+  public static class StreamFeatureGroupBuilder {
+    StreamFeatureGroupBuilder() {
+    }
+  }
+
   @Builder
   public StreamFeatureGroup(FeatureStore featureStore, @NonNull String name, Integer version, String description,
                             List<String> primaryKeys, List<String> partitionKeys, String hudiPrecombineKey,

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -77,13 +77,6 @@
       </exclusions>
     </dependency>
 
-    <dependency>
-      <groupId>com.databricks</groupId>
-      <artifactId>dbutils-api_${scala-short.version}</artifactId>
-      <version>${dbutils.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- https://mvnrepository.com/artifact/org.scala-lang/scala-library -->
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <javax.version>2.2.11</javax.version>
-    <kafka.version>3.4.0</kafka.version>
+    <kafka.version>3.9.1</kafka.version>
   </properties>
 
   <dependencies>

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>5.1.0-RC0</version>
+    <version>5.1.0-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/HudiOperationType.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/HudiOperationType.java
@@ -20,7 +20,8 @@ package com.logicalclocks.hsfs;
 public enum HudiOperationType {
   BULK_INSERT,
   INSERT,
-  UPSERT;
+  UPSERT,
+  DELETE;
 
   public String getValue() {
     return name().toLowerCase();

--- a/java/hsfs/src/main/java/com/logicalclocks/hsfs/StreamFeatureGroup.java
+++ b/java/hsfs/src/main/java/com/logicalclocks/hsfs/StreamFeatureGroup.java
@@ -38,6 +38,11 @@ public class StreamFeatureGroup<T> extends FeatureGroupBase<List<T>> {
 
   protected FeatureGroupEngine featureGroupEngine = new FeatureGroupEngine();
 
+  public static class StreamFeatureGroupBuilder<T> {
+    StreamFeatureGroupBuilder() {
+    }
+  }
+
   @Builder
   public StreamFeatureGroup(FeatureStoreBase featureStore, @NonNull String name, Integer version, String description,
                             TimeTravelFormat timeTravelFormat, List<String> primaryKeys, List<String> partitionKeys,

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
         <spark.version>4.1.3.0</spark.version>
         <hudi.groupId>io.hops.hudi</hudi.groupId>
         <hudi.version>1.2.0</hudi.version>
-        <awssdk.version>2.10.40</awssdk.version>
+        <awssdk.version>2.45.1</awssdk.version>
         <scala.version>2.13.17</scala.version>
         <scala-short.version>2.13</scala-short.version>
         <json.version>20231013</json.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <maven-scala-plugin.version>2.15.2</maven-scala-plugin.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <guava.version>30.1.1-jre</guava.version>
         <httpclient.version>4.5.6</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
@@ -27,27 +27,27 @@
         <handy.version>2.1.8</handy.version>
         <lombok.version>1.18.36</lombok.version>
         <lombok.plugin.version>1.18.20.0</lombok.plugin.version>
-        <fasterxml.jackson.databind.version>2.10.0</fasterxml.jackson.databind.version>
+        <fasterxml.jackson.databind.version>2.21.2</fasterxml.jackson.databind.version>
         <datasketches.version>6.2.0</datasketches.version>
-        <spark.version>3.5.5.2</spark.version>
-        <hudi.version>1.0.2.2</hudi.version>
+        <spark.version>4.1.3.0</spark.version>
+        <hudi.groupId>io.hops.hudi</hudi.groupId>
+        <hudi.version>1.2.0</hudi.version>
         <awssdk.version>2.10.40</awssdk.version>
-        <scala.version>2.12.10</scala.version>
-        <scala-short.version>2.12</scala-short.version>
-        <dbutils.version>0.0.5</dbutils.version>
+        <scala.version>2.13.17</scala.version>
+        <scala-short.version>2.13</scala-short.version>
         <json.version>20231013</json.version>
         <hoverfly.version>0.12.2</hoverfly.version>
         <junit.version>5.9.1</junit.version>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
         <mockito.version>4.3.1</mockito.version>
-        <avro.version>1.11.4</avro.version>
+        <avro.version>1.12.1</avro.version>
         <commons-text.version>1.13.1</commons-text.version>
         <skipHops>true</skipHops>
 
-        <artifact.spark.version>spark3.5</artifact.spark.version>
+        <artifact.spark.version>spark4.1</artifact.spark.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <delombok.output>${project.basedir}/delombok</delombok.output>
+        <delombok.output>${project.build.directory}/generated-sources/delombok</delombok.output>
     </properties>
 
     <dependencies>
@@ -303,19 +303,19 @@
 
     <profiles>
         <profile>
-            <id>spark-3.3</id>
+            <id>spark-4.1</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
-                <artifact.spark.version>spark3.3</artifact.spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-3.5</id>
-            <properties>
-                <spark.version>3.5.5.2</spark.version>
-                <deequ.version>2.0.7-spark-3.5</deequ.version>
-                <artifact.spark.version>spark3.5</artifact.spark.version>
-                <fasterxml.jackson.databind.version>2.15.2</fasterxml.jackson.databind.version>
-                <kafka.version>3.4.1</kafka.version>
+                <spark.version>4.1.3.0</spark.version>
+                <hudi.groupId>io.hops.hudi</hudi.groupId>
+                <hudi.version>1.2.0</hudi.version>
+                <scala.version>2.13.17</scala.version>
+                <scala-short.version>2.13</scala-short.version>
+                <avro.version>1.12.1</avro.version>
+                <fasterxml.jackson.databind.version>2.21.2</fasterxml.jackson.databind.version>
+                <artifact.spark.version>spark4.1</artifact.spark.version>
             </properties>
         </profile>
         <!-- Needs to be included when running mvn deploy or mvn install -->
@@ -352,7 +352,28 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        
+        <repository>
+            <id>spark</id>
+            <name>Hops Spark Repository</name>
+            <url>https://nexus.hops.works/repository/spark/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>hudi</id>
+            <name>Hops Hudi Repository</name>
+            <url>https://nexus.hops.works/repository/hudi/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <distributionManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-parent</artifactId>
     <packaging>pom</packaging>
-    <version>5.1.0-RC0</version>
+    <version>5.1.0-RC1</version>
     <modules>
         <module>hsfs</module>
         <module>spark</module>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>${fasterxml.jackson.databind.version}</version>
         </dependency>
 
         <dependency>
@@ -113,34 +113,30 @@
 
         <!-- https://mvnrepository.com/artifact/org.apache.hudi/hudi-spark-bundle -->
         <dependency>
-            <groupId>io.hops.hudi</groupId>
-            <artifactId>hudi-spark3.5-bundle_${scala-short.version}</artifactId>
+            <groupId>${hudi.groupId}</groupId>
+            <artifactId>hudi-${artifact.spark.version}-bundle_${scala-short.version}</artifactId>
             <version>${hudi.version}</version>
             <scope>provided</scope>
+            <!-- The bundle is a shaded fat jar; its declared transitives (io.hops.hive,
+                 hudi-metaserver-client, ...) live in authenticated repositories and are
+                 not needed to compile or test against the bundle. -->
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
-            <groupId>io.hops.hudi</groupId>
+            <groupId>${hudi.groupId}</groupId>
             <artifactId>hudi-utilities-slim-bundle_${scala-short.version}</artifactId>
             <version>${hudi.version}</version>
             <scope>provided</scope>
+            <!-- Same as the spark bundle above: shaded jar, transitives excluded. -->
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
@@ -161,7 +157,7 @@
                 <dependency>
                     <groupId>io.hops</groupId>
                     <artifactId>hadoop-client</artifactId>
-                    <version>3.4.3.1-EE-RC4</version>
+                    <version>3.4.3.2-EE-RC3</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>hsfs-parent</artifactId>
         <groupId>com.logicalclocks</groupId>
-        <version>5.1.0-RC0</version>
+        <version>5.1.0-RC1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/ExternalFeatureGroup.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/ExternalFeatureGroup.java
@@ -68,6 +68,11 @@ public class ExternalFeatureGroup extends FeatureGroupBase<Dataset<Row>> {
 
   private final StatisticsEngine statisticsEngine = new StatisticsEngine(EntityEndpointType.FEATURE_GROUP);
 
+  public static class ExternalFeatureGroupBuilder {
+    ExternalFeatureGroupBuilder() {
+    }
+  }
+
   @Builder
   public ExternalFeatureGroup(FeatureStore featureStore, @NonNull String name, Integer version, String query,
                               ExternalDataFormat dataFormat, String path, Map<String, String> options,

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/FeatureGroup.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/FeatureGroup.java
@@ -61,6 +61,11 @@ public class FeatureGroup extends FeatureGroupBase<Dataset<Row>> {
   protected FeatureGroupEngine featureGroupEngine = new FeatureGroupEngine();
   protected StatisticsEngine statisticsEngine = new StatisticsEngine(EntityEndpointType.FEATURE_GROUP);
 
+  public static class FeatureGroupBuilder {
+    FeatureGroupBuilder() {
+    }
+  }
+
   @Builder
   public FeatureGroup(FeatureStore featureStore, @NonNull String name, Integer version,
                       String description, List<String> primaryKeys, List<String> partitionKeys,

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/TrainingDataset.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/TrainingDataset.java
@@ -53,6 +53,11 @@ public class TrainingDataset extends TrainingDatasetBase {
   private TrainingDatasetEngine trainingDatasetEngine = new TrainingDatasetEngine();
   private StatisticsEngine statisticsEngine = new StatisticsEngine(EntityEndpointType.TRAINING_DATASET);
 
+  public static class TrainingDatasetBuilder {
+    TrainingDatasetBuilder() {
+    }
+  }
+
   @Builder(builderMethodName = "buildTrainingDataset")
   public TrainingDataset(Integer version, String description, DataFormat dataFormat,
                          Boolean coalesce, StorageConnector storageConnector, String location, List<Split> splits,

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/SparkEngine.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/SparkEngine.java
@@ -768,7 +768,8 @@ public class SparkEngine extends EngineBase {
         .mode(SaveMode.Append)
         // write options cannot be null
         .options(writeOptions == null ? new HashMap<>() : writeOptions)
-        .partitionBy(featureGroupUtils.getPartitionColumns(featureGroup))
+        .partitionBy(JavaConverters.seqAsJavaList(featureGroupUtils.getPartitionColumns(featureGroup))
+            .toArray(new String[0]))
         .saveAsTable(featureGroupUtils.getTableName(featureGroup));
   }
 

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/DeltaStreamerConfig.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/DeltaStreamerConfig.java
@@ -90,7 +90,7 @@ public class DeltaStreamerConfig implements Serializable {
     cfg.retryOnSourceFailures = true;
 
     // Field within source record to decide how to break ties between records with same key in input data.
-    cfg.sourceOrderingField =  writeOptions.get(HudiEngine.DELTA_SOURCE_ORDERING_FIELD_OPT_KEY);
+    cfg.sourceOrderingFields = writeOptions.get(HudiEngine.DELTA_SOURCE_ORDERING_FIELD_OPT_KEY);
 
     cfg.configs = new ArrayList<String>() {{
         // User provided options

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/DeltaStreamerKafkaSource.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/DeltaStreamerKafkaSource.java
@@ -97,7 +97,7 @@ public class DeltaStreamerKafkaSource extends KafkaSource<JavaRDD<GenericRecord>
   
   protected JavaRDD<GenericRecord> maybeAppendKafkaOffsets(JavaRDD<ConsumerRecord<Object, Object>> kafkaRDd) {
     if (shouldAddOffsets) {
-      AvroConvertor convertor = new AvroConvertor(schemaProvider.getSourceSchema());
+      AvroConvertor convertor = new AvroConvertor(schemaProvider.getSourceSchema().toString());
       return kafkaRDd.map(convertor::withKafkaFieldsAppended);
     } else {
       return kafkaRDd.map(consumerRecord -> (GenericRecord) consumerRecord.value());

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/HudiEngine.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/HudiEngine.java
@@ -49,8 +49,10 @@ import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.metadata.HoodieMetadataWriteUtils;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.NativeTableMetadataFactory;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -458,7 +460,7 @@ public class HudiEngine {
         .build();
     
     HoodieWriteConfig hoodieWriteConfig = HoodieMetadataWriteUtils.createMetadataWriteConfig(hudiWriteConfig,
-        HoodieFailedWritesCleaningPolicy.EAGER);
+        HoodieFailedWritesCleaningPolicy.EAGER, HoodieTableVersion.current());
     
     HoodieTableMetaClient.newTableBuilder()
         .fromProperties(hoodieWriteConfig.getProps())
@@ -585,7 +587,7 @@ public class HudiEngine {
         .build();
     HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
     StorageConfiguration<?> storageConf = HadoopFSUtils.getStorageConfWithCopy(jsc.hadoopConfiguration());
-    HoodieTableMetadata tableMetadata = HoodieTableMetadata.create(
+    HoodieTableMetadata tableMetadata = NativeTableMetadataFactory.getInstance().create(
         engineContext, new HoodieHadoopStorage(basePath, storageConf), metadataConfig, basePath);
     List<String> allPartitions = tableMetadata.getAllPartitionPaths();
     final Histogram tableHistogram = new Histogram(new UniformReservoir(1_000_000));

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/HudiEngine.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/HudiEngine.java
@@ -137,8 +137,6 @@ public class HudiEngine {
 
   protected static final String HUDI_WRITE_INSERT_DROP_DUPLICATES = "hoodie.datasource.write.insert.drop.duplicates";
 
-  protected static final String PAYLOAD_CLASS_OPT_KEY = "hoodie.datasource.write.payload.class";
-  protected static final String PAYLOAD_CLASS_OPT_VAL = "org.apache.hudi.common.model.EmptyHoodieRecordPayload";
 
   protected static final String HUDI_KAFKA_TOPIC = "hoodie.streamer.source.kafka.topic";
   protected static final String COMMIT_METADATA_KEYPREFIX_OPT_KEY = "hoodie.datasource.write.commitmeta.key.prefix";
@@ -220,8 +218,29 @@ public class HudiEngine {
       throws IOException, FeatureStoreException,
       ParseException {
 
-    Map<String, String> hudiArgs = setupHudiWriteOpts(featureGroup, HudiOperationType.UPSERT, writeOptions);
-    hudiArgs.put(PAYLOAD_CLASS_OPT_KEY, PAYLOAD_CLASS_OPT_VAL);
+    // Hudi's native delete operation. Overriding the payload class with
+    // EmptyHoodieRecordPayload on an upsert is the pre-1.x idiom; since Hudi 1.1 the
+    // payload is validated against the table's hoodie.record.merge.mode and that
+    // pairing is rejected on tables created at table version 9.
+    Map<String, String> hudiArgs = setupHudiWriteOpts(featureGroup, HudiOperationType.DELETE, writeOptions);
+
+    // Hudi's delete resolves each record's partition path from the frame it is given. A
+    // delete frame that omits the partition columns matches nothing, and Hudi still writes
+    // a commit -- a silent no-op. Fail loudly.
+    List<String> frameColumns = Arrays.asList(deleteDF.columns());
+    List<String> missingPartitionColumns =
+        Arrays.stream(hudiArgs.getOrDefault(HUDI_PARTITION_FIELD, "").split(","))
+            .filter(field -> !field.isEmpty())
+            .map(field -> field.split(":")[0])
+            .filter(column -> !frameColumns.contains(column))
+            .collect(Collectors.toList());
+    if (!missingPartitionColumns.isEmpty()) {
+      throw new FeatureStoreException(
+          "Cannot delete records from partitioned feature group `" + featureGroup.getName()
+              + "`: the delete frame is missing the partition column(s) " + missingPartitionColumns
+              + ". Hudi resolves the partition path from the frame, so a delete without them would "
+              + "silently match no records. Include the partition columns in the delete frame.");
+    }
 
     deleteDF.write().format(HUDI_SPARK_FORMAT)
         .options(hudiArgs)

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/TableMigrateUtils.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/hudi/TableMigrateUtils.java
@@ -57,24 +57,24 @@ public class TableMigrateUtils {
             .setLoadActiveTimelineOnLoad(false)
             .build();
     
-    // During Hudi upgrades we might need to bump this version. This version matches Hudi 1.0.2
+    // During Hudi upgrades we might need to bump this version. This version matches Hudi 1.2.0
     if (metaClient.getTableConfig().contains(HoodieTableConfig.VERSION)
-        && metaClient.getTableConfig().getTableVersion() != HoodieTableVersion.EIGHT) {
+        && metaClient.getTableConfig().getTableVersion() != HoodieTableVersion.NINE) {
       doHiveSync(writeOptions, javaSparkContext, metaClient);
       // Migrate to version 6 first if the table is older than version 6.
-      // If the table is version 6 or 7, it will be migrated to version 8 directly
+      // If the table is version 6, 7 or 8, it will be migrated to version 9 directly.
       if (metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.SIX)) {
         migrateToVersionSix(writeOptions, metaClient, javaSparkContext);
-      } else if (metaClient.getTableConfig().getTableVersion().greaterThan(HoodieTableVersion.EIGHT)) {
+      } else if (metaClient.getTableConfig().getTableVersion().greaterThan(HoodieTableVersion.NINE)) {
         return;
       }
       migratePartitionFields(metaClient);
       metaClient.getTableConfig().setValue(HudiEngine.HUDI_TABLE_VERSION,
-          String.valueOf(HoodieTableVersion.EIGHT.versionCode()));
+          String.valueOf(HoodieTableVersion.NINE.versionCode()));
       new UpgradeDowngrade(metaClient, getUpdatedWriteConfig(writeOptions, metaClient),
           new HoodieSparkEngineContext(javaSparkContext),
-          SparkUpgradeDowngradeHelper.getInstance()).run(HoodieTableVersion.EIGHT, null);
-      LOG.info("Migration to version 8 completed");
+          SparkUpgradeDowngradeHelper.getInstance()).run(HoodieTableVersion.NINE, null);
+      LOG.info("Migration to version 9 completed");
     }
   }
 

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/engine/profile/ColumnProfiler.java
@@ -47,7 +47,7 @@ import java.util.Map;
  * Replacement for Deequ's {@code ColumnProfilerRunner} producing JSON wire-compatible with
  * Deequ 2.0.7-spark-3.5 for all keys except {@code kll}.
  *
- * <h3>KLL gating divergence from Deequ</h3>
+ * <h2>KLL gating divergence from Deequ</h2>
  *
  * <p>Deequ always emits {@code kll} for numeric columns regardless of {@code withKLLProfiling()};
  * the toggle is a no-op in 2.0.7-spark-3.5.
@@ -56,7 +56,7 @@ import java.util.Map;
  * The {@code kll=false} path produces smaller profiles.
  * The golden-parity test (task #6) accounts for this known divergence.
  *
- * <h3>Entropy computation</h3>
+ * <h2>Entropy computation</h2>
  *
  * <p>Shannon entropy is derived from the exact per-value frequency distribution via
  * {@code groupBy(col).count()} per column.
@@ -64,7 +64,7 @@ import java.util.Map;
  * {@code ln(exactNumDistinctValues)}, but the groupBy is required for correctness when
  * duplicates exist.
  *
- * <h3>Uniqueness formula</h3>
+ * <h2>Uniqueness formula</h2>
  *
  * <p>{@code uniqueness = singletons / nonNull}: Deequ's exact definition (fraction of values
  * appearing exactly once).
@@ -73,7 +73,7 @@ import java.util.Map;
  * (An earlier shortcut, {@code (2 * exactDistinct - nonNull) / nonNull}, is only equivalent
  * when no value occurs more than twice and undercounts otherwise.)
  *
- * <h3>stdDev</h3>
+ * <h2>stdDev</h2>
  *
  * <p>Uses Spark's {@code stddev_pop()} (population standard deviation, dividing by n).
  * Deequ's StandardDeviation metric also uses population stddev; verified against the baseline.

--- a/java/spark/src/main/java/com/logicalclocks/hsfs/spark/util/StorageConnectorUtils.java
+++ b/java/spark/src/main/java/com/logicalclocks/hsfs/spark/util/StorageConnectorUtils.java
@@ -26,7 +26,6 @@ import com.logicalclocks.hsfs.util.Constants;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
-import javax.ws.rs.NotSupportedException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -332,7 +331,7 @@ public class StorageConnectorUtils {
     } else if (connector instanceof StorageConnector.GlueConnector) {
       return read((StorageConnector.GlueConnector) connector, dataSource, dataFormat, options);
     } else if (connector instanceof StorageConnector.KafkaConnector) {
-      throw new NotSupportedException("Reading a Kafka Stream into a static Spark Dataframe is not supported.");
+      throw new UnsupportedOperationException("Reading a Kafka Stream into a static Spark DataFrame is not supported.");
     } else {
       throw new FeatureStoreException("Unknown type of StorageConnector.");
     }

--- a/python/hopsworks_common/version.py
+++ b/python/hopsworks_common/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "5.1.0rc0"
+__version__ = "5.1.0rc1"

--- a/python/hsfs/core/hudi_engine.py
+++ b/python/hsfs/core/hudi_engine.py
@@ -19,6 +19,7 @@ import copy
 import os
 from urllib.parse import unquote, urlsplit
 
+from hopsworks_common.client.exceptions import FeatureStoreException
 from hsfs import feature_group_commit, util
 from hsfs.core import (
     dataset_api,
@@ -74,14 +75,13 @@ class HudiEngine:
     HUDI_BULK_INSERT = "bulk_insert"
     HUDI_INSERT = "insert"
     HUDI_UPSERT = "upsert"
+    HUDI_DELETE = "delete"
     HUDI_QUERY_TYPE_OPT_KEY = "hoodie.datasource.query.type"
     HUDI_QUERY_TYPE_SNAPSHOT_OPT_VAL = "snapshot"
     HUDI_QUERY_TYPE_INCREMENTAL_OPT_VAL = "incremental"
     HUDI_QUERY_TIME_TRAVEL_AS_OF_INSTANT = "as.of.instant"
     HUDI_BEGIN_INSTANTTIME_OPT_KEY = "hoodie.datasource.read.begin.instanttime"
     HUDI_END_INSTANTTIME_OPT_KEY = "hoodie.datasource.read.end.instanttime"
-    PAYLOAD_CLASS_OPT_KEY = "hoodie.datasource.write.payload.class"
-    PAYLOAD_CLASS_OPT_VAL = "org.apache.hudi.common.model.EmptyHoodieRecordPayload"
     HUDI_DEFAULT_PARALLELISM = {
         "hoodie.bulkinsert.shuffle.parallelism": "5",
         "hoodie.insert.shuffle.parallelism": "5",
@@ -135,10 +135,12 @@ class HudiEngine:
         return self._feature_group_api._commit(self._feature_group, fg_commit)
 
     def _delete_record(self, delete_df, write_options):
-        write_options[self.PAYLOAD_CLASS_OPT_KEY] = self.PAYLOAD_CLASS_OPT_VAL
-
+        # Hudi's native delete operation. Overriding the payload class with
+        # EmptyHoodieRecordPayload on an upsert is the pre-1.x idiom; since Hudi
+        # 1.1 the payload is validated against the table's hoodie.record.merge.mode
+        # and that pairing is rejected on tables created at table version 9.
         fg_commit = self._write_hudi_dataset(
-            delete_df, "append", self.HUDI_UPSERT, write_options
+            delete_df, "append", self.HUDI_DELETE, write_options
         )
         return self._feature_group_api._commit(self._feature_group, fg_commit)
 
@@ -162,6 +164,25 @@ class HudiEngine:
             self._feature_group, dataset
         )
         hudi_options = self._setup_hudi_write_opts(operation, write_options)
+
+        if operation == self.HUDI_DELETE:
+            # Hudi's delete resolves each record's partition path from the frame it
+            # is given. A delete frame that omits the partition columns matches
+            # nothing, and Hudi still writes a commit -- a silent no-op. Fail loudly.
+            partition_path = hudi_options.get(self.HUDI_PARTITION_FIELD) or ""
+            partition_cols = [
+                field.split(":")[0] for field in partition_path.split(",") if field
+            ]
+            missing = [c for c in partition_cols if c not in dataset.columns]
+            if missing:
+                raise FeatureStoreException(
+                    "Cannot delete records from partitioned feature group "
+                    f"`{self._feature_group.name}`: the delete frame is missing the "
+                    f"partition column(s) {missing}. Hudi resolves the partition path "
+                    "from the frame, so a delete without them would silently match no "
+                    "records. Include the partition columns in the delete frame."
+                )
+
         self._migrate_table(self._spark_context, hudi_options, location)
         dataset.write.format(HudiEngine.HUDI_SPARK_FORMAT).options(**hudi_options).mode(
             save_mode

--- a/python/hsfs/core/iceberg_engine.py
+++ b/python/hsfs/core/iceberg_engine.py
@@ -219,8 +219,8 @@ class IcebergEngine:
 
     ICEBERG_SPARK_FORMAT = "iceberg"
     ICEBERG_SPARK_CATALOG_IMPL = "org.apache.iceberg.spark.SparkCatalog"
-    ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP = "as-of-timestamp"
-    ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID = "snapshot-id"
+    ICEBERG_QUERY_TIME_TRAVEL_AS_OF_INSTANT = "timestampAsOf"
+    ICEBERG_QUERY_TIME_TRAVEL_AS_OF_VERSION = "versionAsOf"
     ICEBERG_START_SNAPSHOT_ID = "start-snapshot-id"
     ICEBERG_END_SNAPSHOT_ID = "end-snapshot-id"
     ICEBERG_DOT_PREFIX = "iceberg."
@@ -1012,7 +1012,7 @@ class IcebergEngine:
         The snapshot is resolved client-side against the snapshots' own
         ``committed_at`` clock, the clock the backend derives the recorded
         commit time from.
-        Passing ``as-of-timestamp`` instead lets Iceberg resolve the bound
+        Passing ``timestampAsOf`` instead lets Iceberg resolve the bound
         server-side against the snapshot-log timestamps, a different clock: a
         recorded commit time landing just below snapshot N's log timestamp
         would then silently read snapshot N-1.
@@ -1030,11 +1030,15 @@ class IcebergEngine:
         """
         snapshots = self._read_snapshots(location)
         if not snapshots:
-            return {self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_TIMESTAMP: str(end_ts)}
+            return {
+                self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_INSTANT: util._get_delta_datestr_from_timestamp(
+                    end_ts
+                )
+            }
         snapshot_id = self._latest_snapshot_id_at(snapshots, end_ts)
         if snapshot_id is None:
             snapshot_id = snapshots[0]["snapshot_id"]
-        return {self.ICEBERG_QUERY_TIME_TRAVEL_SNAPSHOT_ID: str(snapshot_id)}
+        return {self.ICEBERG_QUERY_TIME_TRAVEL_AS_OF_VERSION: str(snapshot_id)}
 
     @staticmethod
     def _is_catalog_identifier(address: str) -> bool:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -74,7 +74,7 @@ python = [
     "fastavro>=1.4.11,<=1.12.0",
     "tqdm",
     "hops-deltalake==1.4.0-post121; sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')",
-    "pyiceberg>=0.9.0,<0.12.0",
+    "pyiceberg>=0.11.0,<0.12.0",
     "httpx<=0.28.1",
 ]
 sqlalchemy-1 = [
@@ -89,11 +89,11 @@ dev-no-opt = [
     "pytest-cov>=4.0",
     "ruff==0.15.6",
     "docsig==0.79.0",
-    "pyspark==3.5.5",
+    "pyspark==4.1.1",
     "moto[s3]==5.0.0",
     "pandas>=2.2.0",
     "typeguard==4.2.1",
-    "delta-spark==3.3.1",
+    "delta-spark==4.3.1",
     "setuptools; python_version >= '3.12'",
 ]
 dev-pandas1 = [
@@ -103,12 +103,12 @@ dev-pandas1 = [
     "pytest-cov>=4.0",
     "ruff==0.15.6",
     "docsig==0.79.0",
-    "pyspark==3.5.5",
+    "pyspark==4.1.1",
     "moto[s3]==5.0.0",
     "pandas<=1.5.3; python_version < '3.12'",
     "numpy<2; python_version < '3.12'",
     "sqlalchemy<=1.4.48",
-    "delta-spark==3.3.1",
+    "delta-spark==4.3.1",
 ]
 dev = ["hopsworks[dev-no-opt,great-expectations,polars,python,mcp,trino]"]
 polars = [

--- a/python/tests/core/test_hudi_engine.py
+++ b/python/tests/core/test_hudi_engine.py
@@ -73,8 +73,9 @@ class TestHudiEngine:
         assert mock_fg_api.return_value._commit.call_count == 1
         assert (
             "hoodie.datasource.write.payload.class"
-            in mock_hudi_engine_write_hudi_dataset.call_args[0][3]
+            not in mock_hudi_engine_write_hudi_dataset.call_args[0][3]
         )
+        assert mock_hudi_engine_write_hudi_dataset.call_args[0][2] == "delete"
         assert mock_hudi_engine_write_hudi_dataset.call_args[0][1] == "append"
 
     def test_register_temporary_table(self, mocker, backend_fixtures):

--- a/python/tests/core/test_iceberg_engine.py
+++ b/python/tests/core/test_iceberg_engine.py
@@ -129,7 +129,7 @@ class TestIcebergEngine:
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
 
         # Assert
-        assert options == {"snapshot-id": "11"}
+        assert options == {"versionAsOf": "11"}
 
     def test_setup_iceberg_read_opts_time_travel_query_before_first_snapshot(
         self, mocker
@@ -151,7 +151,7 @@ class TestIcebergEngine:
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
 
         # Assert
-        assert options == {"snapshot-id": "11"}
+        assert options == {"versionAsOf": "11"}
 
     def test_setup_iceberg_read_opts_time_travel_query_no_snapshots(self, mocker):
         # Arrange: table without snapshots keeps the timestamp bound
@@ -163,7 +163,7 @@ class TestIcebergEngine:
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
 
         # Assert
-        assert options == {"as-of-timestamp": "1234567890000"}
+        assert options == {"timestampAsOf": "2009-02-13 23:31:30.000Z"}
 
     def test_setup_iceberg_read_opts_incremental_query(self, mocker):
         # Arrange
@@ -201,7 +201,7 @@ class TestIcebergEngine:
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
 
         # Assert
-        assert options == {"snapshot-id": "11"}
+        assert options == {"versionAsOf": "11"}
 
     def test_setup_iceberg_read_opts_incremental_query_no_snapshots_at_all(
         self, mocker
@@ -226,7 +226,7 @@ class TestIcebergEngine:
         options = iceberg_engine._setup_iceberg_read_opts(fg_alias, "location")
 
         # Assert
-        assert options == {"snapshot-id": "11"}
+        assert options == {"versionAsOf": "11"}
 
     def test_setup_iceberg_read_opts_incremental_query_no_start_no_end(self, mocker):
         # Unresolvable start without an end bound reads the latest table state.

--- a/python/tests/engine/test_python_spark_convert_dataframe.py
+++ b/python/tests/engine/test_python_spark_convert_dataframe.py
@@ -15,7 +15,15 @@
 #
 from __future__ import annotations
 
+import pandas as pd
+import pytest
 from hsfs.engine import python, spark
+
+
+pytestmark = pytest.mark.skipif(
+    tuple(int(part) for part in pd.__version__.split(".")[:2]) < (2, 2),
+    reason="PySpark 4.1 requires pandas >= 2.2.0.",
+)
 
 
 class TestPythonSparkConvertDataframe:

--- a/python/tests/engine/test_python_spark_transformation_functions.py
+++ b/python/tests/engine/test_python_spark_transformation_functions.py
@@ -50,8 +50,9 @@ from pyspark.sql.types import (
 
 # TODO : Remove skipping UT in windows after Greater expectations has been upgraded to 1.0 or after it has been made optional
 @pytest.mark.skipif(
-    os.name == "nt",
-    reason="Skip tests in windows since it fails due to dependency problem with greater expectations 0.18.2, Fixed on upgrading to 1.0",
+    os.name == "nt"
+    or tuple(int(part) for part in pd.__version__.split(".")[:2]) < (2, 2),
+    reason="Skip on unsupported Spark runtime: Windows, or pandas < 2.2 for PySpark 4.1.",
 )
 class TestPythonSparkTransformationFunctions:
     def _create_training_dataset(self):

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -80,11 +80,18 @@ from pyspark.sql.types import (
 
 
 hopsworks_common.connection._hsfs_engine_type = "spark"
+_PANDAS_UNSUPPORTED_BY_PYSPARK = tuple(
+    int(part) for part in pd.__version__.split(".")[:2]
+) < (2, 2)
 
 
 @pytest.mark.skipif(
     sys.platform.startswith("win"),
     reason="Spark tests transiently fail on Windows.",
+)
+@pytest.mark.skipif(
+    _PANDAS_UNSUPPORTED_BY_PYSPARK,
+    reason="PySpark 4.1 requires pandas >= 2.2.0.",
 )
 class TestSpark:
     # Helper Functions

--- a/python/tests/engine/test_spark_dag_regression.py
+++ b/python/tests/engine/test_spark_dag_regression.py
@@ -36,8 +36,9 @@ from hsfs.transformation_function import TransformationType
 
 
 pytestmark = pytest.mark.skipif(
-    os.name == "nt",
-    reason="Skip on Windows — Spark + Great Expectations dependency conflict",
+    os.name == "nt"
+    or tuple(int(part) for part in pd.__version__.split(".")[:2]) < (2, 2),
+    reason="Skip on unsupported Spark runtime: Windows, or pandas < 2.2 for PySpark 4.1.",
 )
 
 

--- a/python/tests/test_spark_connect_utils.py
+++ b/python/tests/test_spark_connect_utils.py
@@ -108,7 +108,7 @@ class TestIsSparkDataframe:
     def test_classic_dataframe_returns_true(self):
         from pyspark.sql import DataFrame as ClassicDataFrame
 
-        instance = ClassicDataFrame.__new__(ClassicDataFrame)
+        instance = object.__new__(ClassicDataFrame)
         assert _is_spark_dataframe(instance) is True
 
     def test_connect_dataframe_returns_true(self):

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -8,17 +8,17 @@
     <version>5.1.0-RC0</version>
 
     <properties>
-        <hops.version>3.4.3.1-EE-RC4</hops.version>
+        <hops.version>3.4.3.2-EE-RC3</hops.version>
         <hsfs.version>${project.version}</hsfs.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.logicalclocks</groupId>
-            <artifactId>hsfs-spark-spark3.5</artifactId>
+            <artifactId>hsfs-spark-spark4.1</artifactId>
             <version>${hsfs.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -48,9 +48,8 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
+            <version>1.10.0</version>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>5.1.0-RC0</version>
+    <version>5.1.0-RC1</version>
 
     <properties>
         <hops.version>3.4.3.2-EE-RC3</hops.version>


### PR DESCRIPTION
Backports the HWORKS-2879 Spark 4.1 line from `main` to `branch-5.1`, in the order the commits landed on main.

| # | main commit | subject |
|---|---|---|
| 1 | `c541af5fa` | [HWORKS-2879][HWORKS-3145] Spark upgrade to 4.1. Hudi upgrade to 1.2.0, PyIceberg to 0.11.0 (#1042) |
| 2 | `890e5e6ea` | [HWORKS-2879][APPEND] Build the java SDK on JDK 17 in a container (#1126) |
| 3 | `234be289b` | [HWORKS-2879][APPEND] Give the containerized java SDK build its maven settings (#1127) |
| 4 | `65dd521ed` | [HWORKS-2879][APPEND] Give the build container a resolvable uid (#1128) |
| 5 | `364c3accc` | [HWORKS-2879][APPEND] Bump the AWS SDK v2 in hsfs from 2.10.40 to 2.45.1 (#1129) |
| 6 | `bacf6fb02` | [HWORKS-2879][APPEND] Delete Hudi records with the native delete operation (#1130) |
| 7 | `5228fbe28` | [HWORKS-2879][APPEND] Bump hsfs kafka-clients from 3.4.0 to 3.9.1 (#1133) |

All seven cherry-picked with `-x`, no conflicts, commit messages unchanged.

Every file this PR touches was diffed against `origin/main` afterwards. What is
left is branch identity (`5.1.0-RC0` vs `5.1.0-SNAPSHOT` in the four poms) plus
two main-only tickets that are not part of this backport: HWORKS-3185 (the
jackson bump and the netty BOM pin in `java/pom.xml`) and FSTORE-2029 (the
pushdown tests in `python/tests/engine/test_spark.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ey3EZL5iF5d2G94MA5HipZ


[HWORKS-2879]: https://hopsworks.atlassian.net/browse/HWORKS-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-2879]: https://hopsworks.atlassian.net/browse/HWORKS-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-2879]: https://hopsworks.atlassian.net/browse/HWORKS-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-2879]: https://hopsworks.atlassian.net/browse/HWORKS-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-2879]: https://hopsworks.atlassian.net/browse/HWORKS-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-2879]: https://hopsworks.atlassian.net/browse/HWORKS-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-2879]: https://hopsworks.atlassian.net/browse/HWORKS-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ