### PR TITLE
[HWORKS-3210] hops setup: use the Python engine, print one line, and re-run cleanly

### DIFF
--- a/python/hopsworks/cli/auth.py
+++ b/python/hopsworks/cli/auth.py
@@ -9,6 +9,8 @@ commands and ``hops login``.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import logging
 import urllib.parse
 from typing import TYPE_CHECKING, Any
@@ -81,7 +83,9 @@ def login(
             ``http://``.
         api_key_value: API key; omit to let the SDK pick up its own env/cache.
         project: Default project to attach to.
-        engine: Optional SDK engine override (``python``, ``spark``, …).
+        engine: SDK engine; defaults to ``python``. Left unset, the SDK picks
+            ``spark`` whenever pyspark is importable and then needs a Spark
+            session configured for Hopsworks, which a laptop never has.
         internal: When True, call ``hopsworks.login()`` with no args so the
             SDK reads its in-pod credentials from environment variables.
         hostname_verification: Whether to verify Hopsworks' TLS certificate;
@@ -93,6 +97,7 @@ def login(
     """
     import hopsworks  # noqa: PLC0415 - intentionally lazy
 
+    engine = engine or "python"
     if internal:
         # Let the SDK do its own ``REST_ENDPOINT`` + ``$SECRETS_DIR/token.jwt``
         # discovery. ``project``/``engine`` still apply at the SDK layer.
@@ -101,7 +106,7 @@ def login(
             kwargs["project"] = project
         if engine:
             kwargs["engine"] = engine
-        return hopsworks.login(**kwargs)
+        return _quiet_login(hopsworks, kwargs)
 
     parsed = urllib.parse.urlparse(host if "://" in host else "https://" + host)
     scheme = (parsed.scheme or "https").lower()
@@ -121,7 +126,18 @@ def login(
         kwargs["project"] = project
     if engine:
         kwargs["engine"] = engine
-    return hopsworks.login(**kwargs)
+    return _quiet_login(hopsworks, kwargs)
+
+
+def _quiet_login(hopsworks: Any, kwargs: dict[str, Any]) -> Project:
+    """``hopsworks.login`` without its ``print`` banner.
+
+    The SDK prints "Logged in to project, explore it here <url>" to stdout on
+    every login. A CLI reports through ``output.*`` and its stdout carries the
+    command payload (``--json``, pipelines), so the banner is discarded.
+    """
+    with contextlib.redirect_stdout(io.StringIO()):
+        return hopsworks.login(**kwargs)
 
 
 def verify(

--- a/python/hopsworks/cli/commands/setup.py
+++ b/python/hopsworks/cli/commands/setup.py
@@ -14,6 +14,7 @@ import platform
 import re
 import secrets
 import socket
+import ssl
 import time
 import urllib.parse
 import webbrowser
@@ -300,8 +301,7 @@ def setup_cmd(
         _handle_internal(cfg)
         return None
 
-    if not force and cfg.is_authenticated():
-        _verify_and_report(cfg)
+    if not force and cfg.is_authenticated() and _cached_key_works(cfg):
         return None
 
     host = cfg.host or click.prompt("Hopsworks host", default=config.DEFAULT_HOST)
@@ -339,25 +339,22 @@ def setup_cmd(
         # Skip the browser-flow block below by jumping to the verify+save tail.
         return _finalize_setup(host, api_key, project, server_key_name, cfg)
     except requests.RequestException as exc:
-        raise click.ClickException(f"Could not start token flow: {exc}") from exc
+        raise _failed(host, exc) from exc
 
     flow_id = created["flowId"]
     wait_secret = created["waitSecret"]
     web_url = _prefer_host_scheme(created["webUrl"], host)
 
     opened = _open_browser(web_url, headless=no_browser)
-    output.info("")
-    output.info("The hops CLI needs to authenticate with Hopsworks.")
     if opened:
         output.info("Opening your browser: %s", web_url)
     else:
-        output.info("Visit this URL in a browser to continue:")
-        output.info("  %s", web_url)
+        output.info("Visit this URL in a browser to continue: %s", web_url)
 
     try:
         completed = _wait_for_key(api_base, flow_id, wait_secret, timeout, verify)
     except requests.RequestException as exc:
-        raise click.ClickException(f"Token flow failed: {exc}") from exc
+        raise _failed(host, exc) from exc
 
     api_key = completed.get("apiKey")
     project = completed.get("workspaceUsername")
@@ -370,7 +367,7 @@ def setup_cmd(
     server_key_name = completed.get("apiKeyName")
 
     if not api_key:
-        raise click.ClickException("Server did not return an API key.")
+        raise _failed(host, "the server did not return an API key")
 
     _finalize_setup(host, api_key, project, server_key_name, cfg)
     return None
@@ -393,10 +390,9 @@ def _finalize_setup(
     try:
         auth.verify(host=host, api_key_value=api_key, project=project)
     except Exception as exc:  # noqa: BLE001 - SDK raises a bag of types
-        raise click.ClickException(
-            f"Server returned an API key but verification failed: {exc}. "
-            "No changes written to ~/.hops.toml. Re-run `hops setup`."
-        ) from exc
+        # Nothing is written until the key verifies, so a failure here leaves the
+        # previous configuration intact and `hops setup` can simply be run again.
+        raise _failed(host, exc) from exc
 
     cfg.host = host
     cfg.api_key = api_key
@@ -404,16 +400,7 @@ def _finalize_setup(
     cfg.project = project
     config.save(cfg)
 
-    output.success(
-        "✓ Connected to %s as %s",
-        host.replace("https://", "").replace("http://", ""),
-        project or "(no project)",
-    )
-    output.info(
-        "Token written to %s with api-key name %s",
-        config.CONFIG_PATH,
-        server_key_name or "(server-assigned)",
-    )
+    output.success("✓ Connected to %s as %s", host, project or "(no project)")
 
 
 def _handle_internal(cfg: config.HopsConfig) -> None:
@@ -435,24 +422,65 @@ def _handle_internal(cfg: config.HopsConfig) -> None:
     )
 
 
-def _verify_and_report(cfg: config.HopsConfig) -> None:
-    """Already-configured short-circuit: verify the cached key, print status, exit 0."""
+def _reason(exc: object) -> str:
+    """The first line of ``exc``, clipped, so one failure prints as one line.
+
+    SDK errors run to several lines and embed the whole response body; the rest
+    is recoverable from the logs when someone needs it.
+    """
+    first = str(exc).strip().splitlines()
+    text = first[0] if first else exc.__class__.__name__
+    return text if len(text) <= 160 else text[:157] + "..."
+
+
+def _failed(host: str, exc: object) -> click.ClickException:
+    """The one line every failing path of this command prints.
+
+    A TLS failure names its remedy, since the flags that fix it are on this very
+    command and the raw urllib3 message never mentions them.
+    """
+    hint = ""
+    if isinstance(exc, BaseException) and _is_ssl_error(exc):
+        hint = (
+            " (self-signed certificate? re-run with --insecure, or --ca-bundle <path>)"
+        )
+    return click.ClickException(f"Failed to connect to {host}: {_reason(exc)}{hint}")
+
+
+def _is_ssl_error(exc: BaseException) -> bool:
+    """Whether ``exc`` or anything it wraps is a TLS verification failure."""
+    seen = set()
+    while exc is not None and id(exc) not in seen:
+        if isinstance(exc, (requests.exceptions.SSLError, ssl.SSLError)):
+            return True
+        seen.add(id(exc))
+        exc = exc.__cause__ or exc.__context__
+    return False
+
+
+def _cached_key_works(cfg: config.HopsConfig) -> bool:
+    """Report whether the cached key still authenticates, and say so in one line.
+
+    A key that no longer works is not a failure of this command: the caller falls
+    through to the browser flow, so `hops setup` ends connected whether it was run
+    once or ten times, and `--force` is for replacing a key that still works.
+    """
     try:
         project = auth.verify(
             host=cfg.host or "",
             api_key_value=cfg.api_key or "",
             project=cfg.project,
         )
-    except Exception as exc:  # noqa: BLE001
-        output.warn(
-            "Cached key in %s no longer works: %s. Re-run with --force to refresh.",
-            config.CONFIG_PATH,
-            exc,
+    except Exception as exc:  # noqa: BLE001 - SDK raises a bag of types
+        output.info(
+            "Cached key for %s no longer works (%s); signing in again.",
+            cfg.host or "?",
+            _reason(exc),
         )
-        raise click.ClickException("Authentication failed.") from exc
+        return False
     output.success(
-        "✓ Connected to %s as %s (key: %s)",
-        (cfg.host or "").replace("https://", "").replace("http://", ""),
+        "✓ Connected to %s as %s",
+        cfg.host or "?",
         getattr(project, "name", cfg.project or "?"),
-        cfg.api_key_name or "unnamed",
     )
+    return True

--- a/python/hopsworks/cli/commands/setup.py
+++ b/python/hopsworks/cli/commands/setup.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import os
 import platform
 import re
+import secrets
 import socket
 import time
+import urllib.parse
 import webbrowser
 from typing import Any
 
@@ -30,17 +32,36 @@ KEY_NAME_REGEX = re.compile(r"^[a-zA-Z0-9_-]{1,45}$")
 
 
 def _suggest_key_name() -> str:
-    """Produce a default API key name like ``jim-laptop`` or ``jdowling-dev``.
+    """Produce a default API key name like ``jim-laptop-k3x9``.
 
     Uses ``$USER`` and the short hostname; any character outside ``[a-z0-9_-]``
     is stripped so the result satisfies the backend's validation regex on the
-    first try. Length is clipped to 45.
+    first try. The suffix makes every run's suggestion unique: a setup whose
+    key was minted but whose verification failed leaves that key on the
+    server, and a retry suggesting the same name is refused as a duplicate.
+    Length is clipped to 45.
     """
     user = os.environ.get("USER") or os.environ.get("USERNAME") or "hops"
     host = socket.gethostname().split(".", 1)[0] or platform.node().split(".", 1)[0]
     raw = f"{user}-{host}".lower()
     sanitized = re.sub(r"[^a-z0-9_-]+", "-", raw).strip("-") or "hops-cli"
-    return sanitized[:45]
+    suffix = secrets.token_hex(2)
+    return f"{sanitized[:40]}-{suffix}"
+
+
+def _prefer_host_scheme(web_url: str, host: str) -> str:
+    """Give ``web_url`` the scheme of ``host`` when both name the same server.
+
+    Behind the ingress the backend sees plain http and builds the flow URL
+    from that, so the CLI would print an http link to a cluster the user
+    reached over https (the browser then redirects, and the page's service
+    worker fails on the mixed origin).
+    """
+    web = urllib.parse.urlsplit(web_url)
+    wanted = urllib.parse.urlsplit(host)
+    if web.netloc != wanted.netloc or web.scheme == wanted.scheme:
+        return web_url
+    return urllib.parse.urlunsplit((wanted.scheme,) + web[1:])
 
 
 def _open_browser(url: str, headless: bool) -> bool:
@@ -322,7 +343,7 @@ def setup_cmd(
 
     flow_id = created["flowId"]
     wait_secret = created["waitSecret"]
-    web_url = created["webUrl"]
+    web_url = _prefer_host_scheme(created["webUrl"], host)
 
     opened = _open_browser(web_url, headless=no_browser)
     output.info("")

--- a/python/hopsworks/cli/commands/setup.py
+++ b/python/hopsworks/cli/commands/setup.py
@@ -296,6 +296,8 @@ def setup_cmd(
         insecure: When True, skip TLS verification entirely (with warning).
     """
     cfg = config.load(flag_host=host_flag)
+    if host_flag and not cfg.internal:
+        _forget_other_cluster(cfg, host_flag)
 
     if cfg.internal:
         _handle_internal(cfg)
@@ -371,6 +373,31 @@ def setup_cmd(
 
     _finalize_setup(host, api_key, project, server_key_name, cfg)
     return None
+
+
+def _forget_other_cluster(cfg: config.HopsConfig, host_flag: str) -> None:
+    """Drop the cached key and project when ``--host`` names another cluster.
+
+    ``config.load`` layers the flag host over the cached profile, so the cached
+    key kept ``is_authenticated()`` true and the short-circuit verified the old
+    project against the new host ("project X not found") instead of setting the
+    new cluster up. The project is chosen again in the token flow.
+    """
+    cached_host = config.load().host
+    if not cached_host:
+        return
+    if auth.normalize_host(cached_host) == auth.normalize_host(host_flag):
+        return
+    output.info(
+        "Host %s differs from the cached %s; setting up the new cluster from scratch.",
+        auth.normalize_host(host_flag),
+        cached_host,
+    )
+    cfg.api_key = None
+    cfg.api_key_name = None
+    cfg.project = None
+    cfg.project_id = None
+    cfg.feature_store_id = None
 
 
 def _finalize_setup(

--- a/python/hopsworks/cli/commands/setup.py
+++ b/python/hopsworks/cli/commands/setup.py
@@ -332,8 +332,6 @@ def setup_cmd(
     else:
         output.info("Visit this URL in a browser to continue:")
         output.info("  %s", web_url)
-    output.info("")
-    output.info("Waiting for authentication...")
 
     try:
         completed = _wait_for_key(api_base, flow_id, wait_secret, timeout, verify)

--- a/python/hopsworks/cli/main.py
+++ b/python/hopsworks/cli/main.py
@@ -11,6 +11,7 @@ like ``--help`` measurably slow (~2 s+); deferring keeps them snappy.
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 from typing import TYPE_CHECKING
 
@@ -237,6 +238,10 @@ def cli(
         verify_flag: True for ``--verify``, False for ``--no-verify``, None if neither was passed.
         json_flag: When True, every output helper switches to JSON mode.
     """
+    # The SDK's package import already ran logging.basicConfig(level=INFO), so
+    # its client/engine chatter ("Initializing external client", "Connection
+    # closed") would print on every command; a CLI reports through output.*.
+    logging.getLogger().setLevel(logging.WARNING)
     output.set_json_mode(json_flag)
     if api_key_stdin:
         if api_key_flag:

--- a/python/hopsworks/cli/session.py
+++ b/python/hopsworks/cli/session.py
@@ -8,8 +8,6 @@ invocation, caches the result on ``ctx.obj``, and surfaces a clean
 
 from __future__ import annotations
 
-import contextlib
-import sys
 from typing import TYPE_CHECKING, Any
 
 import click
@@ -74,19 +72,13 @@ def get_project(ctx: click.Context) -> Project:
     try:
         # In internal mode pass ``internal=True`` so the SDK takes its own
         # ``REST_ENDPOINT`` + JWT path. Otherwise pass the user's API key.
-        #
-        # ``hopsworks.login()`` prints a "Logged in to project ..." banner to
-        # stdout. That belongs to interactive notebook use, not the CLI, where
-        # it corrupts ``--json`` output and piped data. Send it to stderr so
-        # stdout carries only the command payload.
-        with contextlib.redirect_stdout(sys.stderr):
-            project = auth.login(
-                host=cfg.host or "",
-                api_key_value=cfg.api_key,
-                project=cfg.project,
-                internal=cfg.internal,
-                hostname_verification=cfg.hostname_verification,
-            )
+        project = auth.login(
+            host=cfg.host or "",
+            api_key_value=cfg.api_key,
+            project=cfg.project,
+            internal=cfg.internal,
+            hostname_verification=cfg.hostname_verification,
+        )
     except Exception as exc:  # noqa: BLE001 - SDK raises a mix of types
         raise click.ClickException(f"Login failed: {exc}") from exc
     obj["project"] = project

--- a/python/tests/cli/test_auth.py
+++ b/python/tests/cli/test_auth.py
@@ -1,0 +1,35 @@
+"""Tests for the CLI's ``hopsworks.login`` wrapper and its logging posture."""
+
+from __future__ import annotations
+
+import logging
+
+import hopsworks
+from click.testing import CliRunner
+from hopsworks.cli import auth
+from hopsworks.cli.main import cli
+
+
+def test_login_defaults_to_python_engine(monkeypatch):
+    """Pyspark on the laptop must not flip the CLI onto the Spark engine."""
+    seen = {}
+    monkeypatch.setattr(hopsworks, "login", lambda **kw: seen.update(kw) or "proj")
+    assert auth.login(host="https://h.example", api_key_value="k") == "proj"
+    assert seen["engine"] == "python"
+    assert (seen["host"], seen["port"]) == ("h.example", 443)
+
+    seen.clear()
+    auth.login(host="http://h.example:8080", engine="spark", internal=False)
+    assert (seen["engine"], seen["port"]) == ("spark", 8080)
+
+    seen.clear()
+    auth.login(host="", internal=True)
+    assert seen == {"hostname_verification": False, "engine": "python"}
+
+
+def test_cli_quiets_sdk_info_logging(monkeypatch, tmp_path):
+    """Every command runs with the root logger at WARNING, hiding SDK chatter."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    logging.getLogger().setLevel(logging.INFO)
+    CliRunner().invoke(cli, ["project", "list"])
+    assert logging.getLogger().level == logging.WARNING

--- a/python/tests/cli/test_auth.py
+++ b/python/tests/cli/test_auth.py
@@ -27,9 +27,13 @@ def test_login_defaults_to_python_engine(monkeypatch):
     assert seen == {"hostname_verification": False, "engine": "python"}
 
 
-def test_cli_quiets_sdk_info_logging(monkeypatch, tmp_path):
-    """Every command runs with the root logger at WARNING, hiding SDK chatter."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+def test_cli_quiets_sdk_info_logging(tmp_home):
+    """Every command runs with the root logger at WARNING, hiding SDK chatter.
+
+    Uses ``tmp_home`` rather than only setting ``$HOME``: ``config.CONFIG_PATH`` is
+    resolved at import time, so overriding the variable alone left this reading the
+    developer's own config and calling their cluster.
+    """
     logging.getLogger().setLevel(logging.INFO)
     CliRunner().invoke(cli, ["project", "list"])
     assert logging.getLogger().level == logging.WARNING

--- a/python/tests/cli/test_reads.py
+++ b/python/tests/cli/test_reads.py
@@ -532,8 +532,9 @@ def test_trino_sql_alias_registered():
 
 def test_login_banner_does_not_pollute_stdout(authed_config, capsys):
     # hopsworks.login() prints a "Logged in to project ..." banner; the CLI
-    # must keep it off stdout so --json output and pipes stay parseable (#6).
+    # swallows it so --json output and pipes stay parseable (#6).
     import click
+    import hopsworks
     from hopsworks.cli import session
 
     def fake_login(**kwargs):
@@ -541,9 +542,9 @@ def test_login_banner_does_not_pollute_stdout(authed_config, capsys):
         return mock.MagicMock(name="Project")
 
     ctx = click.Context(click.Command("x"))
-    with mock.patch.object(session.auth, "login", side_effect=fake_login):
+    with mock.patch.object(hopsworks, "login", side_effect=fake_login):
         session.get_project(ctx)
 
     captured = capsys.readouterr()
     assert "Logged in to project" not in captured.out
-    assert "Logged in to project" in captured.err
+    assert "Logged in to project" not in captured.err

--- a/python/tests/cli/test_setup.py
+++ b/python/tests/cli/test_setup.py
@@ -6,6 +6,7 @@ so the test can exercise branching without pulling in ``hopsworks``.
 
 from __future__ import annotations
 
+import re
 from unittest import mock
 
 import pytest
@@ -37,7 +38,18 @@ def test_suggest_key_name_sanitizes(monkeypatch):
     monkeypatch.setenv("USER", "Jim.Dowling")
     monkeypatch.setattr(setup_mod.socket, "gethostname", lambda: "dev16.hops.works")
     name = setup_mod._suggest_key_name()
-    assert name == "jim-dowling-dev16"
+    assert re.fullmatch(r"jim-dowling-dev16-[0-9a-f]{4}", name), name
+    assert name != setup_mod._suggest_key_name()  # unique per run
+
+
+def test_prefer_host_scheme():
+    f = setup_mod._prefer_host_scheme
+    assert (
+        f("http://c.example/token-flow/tf-1", "https://c.example")
+        == "https://c.example/token-flow/tf-1"
+    )
+    assert f("http://other/x", "https://c.example") == "http://other/x"
+    assert f("https://c.example/x", "https://c.example") == "https://c.example/x"
 
 
 def test_setup_short_circuits_when_cached_key_works(tmp_home, monkeypatch):

--- a/python/tests/cli/test_setup.py
+++ b/python/tests/cli/test_setup.py
@@ -145,6 +145,109 @@ def test_setup_runs_token_flow_when_forced(tmp_home):
     assert saved.project == "demo"
 
 
+def _flow_post(create=None, wait=None):
+    """A ``requests.post`` stand-in routing /create and /wait to canned payloads."""
+    created = mock.Mock()
+    created.json.return_value = create or {
+        "flowId": "tf-abc",
+        "waitSecret": "sekret",
+        "webUrl": "https://c.app.hopsworks.ai/token-flow/tf-abc",
+    }
+    created.raise_for_status = mock.Mock()
+    waited = mock.Mock()
+    waited.json.return_value = wait or {
+        "apiKey": "NEW.KEY",
+        "workspaceUsername": "demo",
+        "apiKeyName": "jim-laptop",
+        "timeout": False,
+    }
+    waited.raise_for_status = mock.Mock()
+
+    def _post(url, *args, **kwargs):
+        return waited if "/wait/" in url else created
+
+    return _post
+
+
+def _run_token_flow(argv, wait=None):
+    """Invoke `hops setup` with the token flow mocked out, and return the post mock."""
+    with (
+        mock.patch.object(
+            setup_mod.requests, "post", side_effect=_flow_post(wait=wait)
+        ) as post,
+        mock.patch.object(setup_mod, "_open_browser", return_value=True),
+        mock.patch.object(setup_mod.auth, "verify") as verify,
+    ):
+        verify.return_value = mock.Mock()
+        verify.return_value.name = "demo"
+        result = CliRunner().invoke(cli, argv)
+    assert result.exit_code == 0, result.output
+    return post
+
+
+def test_setup_new_host_drops_cached_project(tmp_home):
+    """--host for another cluster must not verify the cached project there."""
+    config.save(
+        config.HopsConfig(
+            host="https://old.example",
+            api_key="OLD.KEY",
+            api_key_name="jim-laptop",
+            project="blah",
+            project_id=7,
+        )
+    )
+    create_mock = mock.Mock()
+    create_mock.json.return_value = {
+        "flowId": "tf-new",
+        "waitSecret": "s",
+        "webUrl": "https://new.example/token-flow/tf-new",
+    }
+    wait_mock = mock.Mock()
+    wait_mock.json.return_value = {
+        "apiKey": "NEW.KEY",
+        "workspaceUsername": "fresh",
+        "apiKeyName": "jim-laptop",
+        "timeout": False,
+    }
+
+    def _post(url, *args, **kwargs):
+        return wait_mock if "/wait/" in url else create_mock
+
+    with (
+        mock.patch.object(setup_mod.requests, "post", side_effect=_post),
+        mock.patch.object(setup_mod, "_open_browser", return_value=True),
+        mock.patch.object(setup_mod.auth, "verify") as verify,
+    ):
+        verify.return_value = mock.Mock()
+        verify.return_value.name = "fresh"
+        result = CliRunner().invoke(
+            cli, ["setup", "--host", "https://new.example", "--key-name", "jim-laptop"]
+        )
+
+    assert result.exit_code == 0, result.output
+    verify.assert_called_once()
+    assert verify.call_args.kwargs["project"] == "fresh"
+    assert verify.call_args.kwargs["host"] == "https://new.example"
+    saved = config.load()
+    assert (saved.host, saved.api_key, saved.project) == (
+        "https://new.example",
+        "NEW.KEY",
+        "fresh",
+    )
+    assert saved.project_id is None
+    assert "differs from the cached" in result.output
+
+
+def test_setup_token_flow_verifies_tls_by_default(tmp_home):
+    # Without an explicit opt-out the flow stays strict: the /wait response
+    # carries a fresh API key, so the conservative default matters.
+    post = _run_token_flow(
+        ["setup", "--host", "https://c.app.hopsworks.ai", "--key-name", "k", "--force"],
+    )
+    for call in post.call_args_list:
+        assert call.kwargs["verify"] is True
+
+
 def test_setup_rejects_bad_key_name(tmp_home):
     result = CliRunner().invoke(
         cli,
@@ -178,30 +281,6 @@ def test_setup_internal_mode_does_not_write_config(tmp_home, monkeypatch):
     assert not (tmp_home / ".hops.toml").exists()
 
 
-def _flow_post(create=None, wait=None):
-    """A ``requests.post`` stand-in routing /create and /wait to canned payloads."""
-    created = mock.Mock()
-    created.json.return_value = create or {
-        "flowId": "tf-abc",
-        "waitSecret": "sekret",
-        "webUrl": "https://c.app.hopsworks.ai/token-flow/tf-abc",
-    }
-    created.raise_for_status = mock.Mock()
-    waited = mock.Mock()
-    waited.json.return_value = wait or {
-        "apiKey": "FRESH.KEY",
-        "workspaceUsername": "demo",
-        "apiKeyName": "jim-laptop",
-        "timeout": False,
-    }
-    waited.raise_for_status = mock.Mock()
-
-    def _post(url, *args, **kwargs):
-        return waited if "/wait/" in url else created
-
-    return _post
-
-
 def test_setup_signs_in_again_when_the_cached_key_is_dead(tmp_home):
     """A stale key must not end the command: re-running `hops setup` reconnects."""
     config.save(
@@ -229,7 +308,7 @@ def test_setup_signs_in_again_when_the_cached_key_is_dead(tmp_home):
     assert result.exit_code == 0, result.output
     assert verify.call_count == 2  # the dead cached key, then the fresh one
     assert "signing in again" in result.output
-    assert config.load().api_key == "FRESH.KEY"
+    assert config.load().api_key == "NEW.KEY"
 
 
 def test_setup_success_prints_a_single_line(tmp_home):

--- a/python/tests/cli/test_setup.py
+++ b/python/tests/cli/test_setup.py
@@ -176,3 +176,140 @@ def test_setup_internal_mode_does_not_write_config(tmp_home, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert not (tmp_home / ".hops.toml").exists()
+
+
+def _flow_post(create=None, wait=None):
+    """A ``requests.post`` stand-in routing /create and /wait to canned payloads."""
+    created = mock.Mock()
+    created.json.return_value = create or {
+        "flowId": "tf-abc",
+        "waitSecret": "sekret",
+        "webUrl": "https://c.app.hopsworks.ai/token-flow/tf-abc",
+    }
+    created.raise_for_status = mock.Mock()
+    waited = mock.Mock()
+    waited.json.return_value = wait or {
+        "apiKey": "FRESH.KEY",
+        "workspaceUsername": "demo",
+        "apiKeyName": "jim-laptop",
+        "timeout": False,
+    }
+    waited.raise_for_status = mock.Mock()
+
+    def _post(url, *args, **kwargs):
+        return waited if "/wait/" in url else created
+
+    return _post
+
+
+def test_setup_signs_in_again_when_the_cached_key_is_dead(tmp_home):
+    """A stale key must not end the command: re-running `hops setup` reconnects."""
+    config.save(
+        config.HopsConfig(
+            host="https://c.app.hopsworks.ai",
+            api_key="STALE.KEY",
+            api_key_name="old-key",
+            project="demo",
+        )
+    )
+    verified = mock.Mock()
+    verified.name = "demo"
+
+    with (
+        mock.patch.object(setup_mod.requests, "post", side_effect=_flow_post()),
+        mock.patch.object(setup_mod, "_open_browser", return_value=True),
+        mock.patch.object(
+            setup_mod.auth,
+            "verify",
+            side_effect=[RuntimeError("key revoked"), verified],
+        ) as verify,
+    ):
+        result = CliRunner().invoke(cli, ["setup"])
+
+    assert result.exit_code == 0, result.output
+    assert verify.call_count == 2  # the dead cached key, then the fresh one
+    assert "signing in again" in result.output
+    assert config.load().api_key == "FRESH.KEY"
+
+
+def test_setup_success_prints_a_single_line(tmp_home):
+    config.save(
+        config.HopsConfig(
+            host="https://c.app.hopsworks.ai",
+            api_key="CACHED.KEY",
+            api_key_name="jim-laptop",
+            project="demo",
+        )
+    )
+    verified = mock.Mock()
+    verified.name = "demo"
+
+    with mock.patch.object(setup_mod.auth, "verify", return_value=verified):
+        result = CliRunner().invoke(cli, ["setup"])
+
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert lines == ["✓ Connected to https://c.app.hopsworks.ai as demo"], result.output
+
+
+def test_setup_failure_prints_one_line_naming_the_host(tmp_home):
+    with (
+        mock.patch.object(
+            setup_mod.requests,
+            "post",
+            side_effect=setup_mod.requests.RequestException("connection refused"),
+        ),
+        mock.patch.object(setup_mod.auth, "verify"),
+    ):
+        result = CliRunner().invoke(
+            cli, ["setup", "--host", "https://c.app.hopsworks.ai", "--force"]
+        )
+
+    assert result.exit_code != 0
+    assert (
+        "Failed to connect to https://c.app.hopsworks.ai: connection refused"
+        in result.output
+    )
+
+
+def test_reason_keeps_one_clipped_line():
+    long_error = "first line of the failure\nurl: https://c.example\nbody: " + "x" * 500
+
+    assert setup_mod._reason(long_error) == "first line of the failure"
+    assert len(setup_mod._reason("y" * 400)) == 160
+
+
+def test_setup_failure_names_the_tls_remedy(tmp_home):
+    """A self-signed cluster is the common case; the flags that fix it live here."""
+    with (
+        mock.patch.object(
+            setup_mod.requests,
+            "post",
+            side_effect=setup_mod.requests.exceptions.SSLError(
+                "certificate verify failed"
+            ),
+        ),
+        mock.patch.object(setup_mod.auth, "verify"),
+    ):
+        result = CliRunner().invoke(
+            cli, ["setup", "--host", "https://self-signed.example", "--force"]
+        )
+
+    assert result.exit_code != 0
+    assert "certificate verify failed" in result.output
+    assert "--insecure" in result.output and "--ca-bundle" in result.output
+
+
+def test_setup_failure_without_tls_trouble_has_no_hint(tmp_home):
+    with (
+        mock.patch.object(
+            setup_mod.requests,
+            "post",
+            side_effect=setup_mod.requests.RequestException("connection refused"),
+        ),
+        mock.patch.object(setup_mod.auth, "verify"),
+    ):
+        result = CliRunner().invoke(
+            cli, ["setup", "--host", "https://c.app.hopsworks.ai", "--force"]
+        )
+
+    assert "--insecure" not in result.output


### PR DESCRIPTION
`hops setup` installed from `main` is unusable on a laptop that has pyspark installed, and noisy everywhere. On a machine with pyspark it prints Spark start-up and SDK INFO lines and then fails for a reason that has nothing to do with the key:

```
2026-09-05 06:02:09,372 INFO: Initializing external client
WARNING: Using incubator modules: jdk.incubator.vector
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
26/09/05 06:02:10 WARN Utils: Your hostname, jim-travel, resolves to a loopback address: 127.0.1.1 ...
26/09/05 06:02:10 WARN NativeCodeLoader: Unable to load native-hadoop library ...
Cached key in /home/jdowling/.hops.toml no longer works: Spark is misconfigured for communication with
Hopsworks, missing or invalid property: spark.hadoop.hops.ssl.trustore.name. Re-run with --force to refresh.
Error: Authentication failed.
```

Three fixes.

- **Python engine and quiet output** (`ee0d5a5c3`). With pyspark on the path the SDK selected the Spark engine, which cannot work from a laptop, so verification failed on a misleading error; `auth.login` now passes `engine="python"`. The root logger is set to WARNING and the SDK's "Logged in to project" print is swallowed, so the CLI reports through its own output helpers. This commit and the next one already existed on the teleport CLI branch (#1125) but were stranded there, so anyone installing from `main` hit this; they are moved here and removed from that PR.
- **Unique suggested key name, flow URL keeps the host scheme** (`bae486000`). A setup whose key was minted but whose verification failed left the key on the server, and the retry suggested the same name and was refused as a duplicate. Behind an ingress the backend builds the flow URL from the plain-http request it sees, so the CLI printed an http link for a cluster reached over https.
- **A different `--host` starts a fresh setup** (`a2c86bf46`). `config.load` layers the flag host over the cached profile, so a cached key kept `is_authenticated()` true and setup verified the old project against the new host ("project X not found") instead of setting the new cluster up. Also moved here from #1125.
- **Idempotent re-run and one line per outcome** (`9e28f6e92`). A cached key that no longer verifies ended the command with `Error: Authentication failed.` and told the user to re-run with `--force` — the command doing everything except the thing it exists for. It now reports the dead key and continues into the browser flow, so running `hops setup` twice ends connected either way and `--force` is left for replacing a key that still works. Success prints only `Connected to <host> as <project>`; every failing path prints `Failed to connect to <host>: <reason>` through one helper, with the reason clipped to its first line because SDK errors carry the whole response body. A TLS failure names the flags that fix it, since `--insecure` and `--ca-bundle` are on this command and urllib3's message never mentions them.

Also makes `test_cli_quiets_sdk_info_logging` hermetic: it set `$HOME`, but `config.CONFIG_PATH` resolves at import, so it read the developer's own config and called their cluster during a unit-test run.

## Verification

Live on jim-teleport, from this branch:

```
$ hops setup                       # cached key still good
✓ Connected to https://10.112.231.130 as teleport2
```

No Spark start-up, no SDK INFO lines, one line of output. End to end from a **dead** cached key, with the browser step completed server-side so the run is scriptable:

```
$ hops setup --insecure --no-browser
Cached key for https://10.112.231.130 no longer works (Could not find project teleport2); signing in again.
TLS verification disabled (--insecure). The /wait response carries your API key — only use this on a trusted network.
Visit this URL in a browser to continue: https://10.112.231.130/token-flow/tf-01huWqNon2WEBnKwJboSgbSJoei8HKDZ
✓ Connected to https://10.112.231.130 as teleport2
```

Exit 0, `~/.hops.toml` written with the minted key; before this change that same starting state exited 1 without attempting a sign-in. The key minted by the check was deleted afterwards. Where the previous behaviour left a bare urllib3 error, a self-signed cluster now reads `Failed to connect to <host>: ... (self-signed certificate? re-run with --insecure, or --ca-bundle <path>)`.

Tests: 239 in `tests/cli`, 6 new (dead key signs in again, single-line success, single-line failure naming the host, the TLS hint present and absent, reason clipping). Merges cleanly with #1142.

## Loadtests

No loadtest exercises the `hops` CLI or the token flow; the suite drives the SDK and REST directly. Verified live instead, above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
