### PR TITLE
[HWORKS-3217] Drop a trailing space from a skill description

### DIFF
--- a/skills/platform/hops-collaboration/SKILL.md
+++ b/skills/platform/hops-collaboration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hops-collaboration
-description: Use when managing project membership and when sharing in Hopsworks. Share feature store / feature group / dataset data across projects. 
+description: Use when managing project membership and when sharing in Hopsworks. Share feature store / feature group / dataset data across projects.
 ---
 
 # Project Members, Platform Users, and Sharing


### PR DESCRIPTION
Follow-up to the change that just merged on this branch. Its review on the 5.0 backport found these, after the merge, so they need their own pull request.

## What it fixes

A trailing space on the `description` in the collaboration skill's frontmatter.

The reviewer also asked for the description to become one sentence. It is the author's own wording and reads fine as a single-line scalar, so only the whitespace is gone.

## Testing

Whitespace only; the frontmatter still parses, which the shipped-skill test covers for every skill in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
