### PR TITLE
[HWORKS-3217] Capture the logger under test in the deprecation tests

### DIFF
--- a/java/hsfs/src/test/java/com/logicalclocks/hsfs/TestStreamFeatureGroup.java
+++ b/java/hsfs/src/test/java/com/logicalclocks/hsfs/TestStreamFeatureGroup.java
@@ -35,8 +35,12 @@ class TestStreamFeatureGroup {
   @Test
   void testParsingJson() throws JsonProcessingException {
     // Arrange
-    Logger logger = Logger.getRootLogger();
-    logger.removeAllAppenders();
+    // Capture on the logger under test, not the root logger. An appender on root sees every
+    // library's output, so any unrelated line logged while this JSON is parsed - which is what
+    // a fresh JVM does on a CI runner - is counted as a deprecation warning and fails the
+    // assertion. Removing the appender afterwards also leaves the root logger's own
+    // configuration alone, which removeAllAppenders() did not.
+    Logger logger = Logger.getLogger(FeatureGroupBase.class);
     Appender appender = Mockito.mock(Appender.class);
     logger.addAppender(appender);
 
@@ -51,13 +55,13 @@ class TestStreamFeatureGroup {
     // Assert
     Assert.assertEquals(false, fg.getDeprecated());
     Mockito.verify(appender, Mockito.times(0)).doAppend(argument.capture());
+    logger.removeAppender(appender);
   }
 
   @Test
   void testParsingJsonWhenDeprecated() throws JsonProcessingException {
     // Arrange
-    Logger logger = Logger.getRootLogger();
-    logger.removeAllAppenders();
+    Logger logger = Logger.getLogger(FeatureGroupBase.class);
     Appender appender = Mockito.mock(Appender.class);
     logger.addAppender(appender);
 
@@ -75,6 +79,7 @@ class TestStreamFeatureGroup {
     Assert.assertEquals(Level.WARN, argument.getValue().getLevel());
     Assert.assertEquals("Feature Group `test_fg`, version `1` is deprecated", argument.getValue().getMessage());
     Assert.assertEquals("com.logicalclocks.hsfs.FeatureGroupBase", argument.getValue().getLoggerName());
+    logger.removeAppender(appender);
   }
 
   @Test


### PR DESCRIPTION
The two deprecation tests in `TestStreamFeatureGroup` attach a mock appender to the **root** logger and assert the exact number of events it receives while one JSON document is parsed. An appender on root sees every library's output, so any unrelated line logged in that window is counted as a deprecation warning, and the message assertions then read whichever event happened to be captured last.

That is not hypothetical: the java job fails this way on `branch-5.0` today, three events instead of one, on a pull request that changes no Java at all. It reproduces on demand.

They now attach to the logger the assertions already name, `com.logicalclocks.hsfs.FeatureGroupBase`, and remove that appender afterwards instead of calling `removeAllAppenders()` on root, which threw away the root logger's own configuration for whatever ran next in the same JVM.

## Verification

Two unrelated log lines injected into the same window, everything else identical:

```
old test + unrelated noise -> FAILURE  "But was 3 times"   (the error the job reports)
new test + unrelated noise -> SUCCESS
```

The module's full suite passes either way when nothing else logs: 33 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
