### PR TITLE
[FSTORE-2109] Stop training dataset writes from pinning a HybridRowQueue per shuffle partition

### DIFF
--- a/python/hsfs/core/transformation_function_engine.py
+++ b/python/hsfs/core/transformation_function_engine.py
@@ -1248,6 +1248,7 @@ class TransformationFunctionEngine:
         transformation_context: dict[str, Any] | None = None,
         n_processes: int | None = None,
         training_dataset_version: int | None = None,
+        pre_transform: Callable[[Any], Any] | None = None,
     ) -> (
         dict[str, pd.DataFrame | pl.DataFrame | TypeVar("pyspark.sql.DataFrame")]
         | pd.DataFrame
@@ -1268,10 +1269,19 @@ class TransformationFunctionEngine:
             transformation_context: Context variables passed to the transformation functions.
             n_processes: Number of worker processes for applying the transformations.
             training_dataset_version: When given, statistics are retrieved from the backend for this version instead of being fit.
+            pre_transform: Applied to a single frame after the statistics are fit and before the transformations run, so a `coalesce(1)` neither changes the profiled statistics nor evaluates the transformations once per parent partition (FSTORE-2109). Not supported for split dictionaries.
 
         Returns:
             The transformed dataset, in the same shape as `dataset`.
         """
+        # no caller passes the hook for splits; without this it would be
+        # silently dropped
+        if pre_transform is not None and isinstance(dataset, dict):
+            raise ValueError(
+                "pre_transform is only supported when `dataset` is a single "
+                "dataframe, not a dictionary of splits."
+            )
+
         if training_dataset_version is not None:
             # The statistics of an existing training dataset version already
             # exist in the backend: bind them, then every frame (train
@@ -1280,6 +1290,8 @@ class TransformationFunctionEngine:
                 training_dataset, feature_view_obj, training_dataset_version
             )
             if not isinstance(dataset, dict):
+                if pre_transform is not None:
+                    dataset = pre_transform(dataset)
                 return TransformationFunctionEngine._transform(
                     feature_view_obj, dataset, transformation_context, n_processes
                 )
@@ -1297,6 +1309,7 @@ class TransformationFunctionEngine:
                 dataset,
                 transformation_context=transformation_context,
                 n_processes=n_processes,
+                pre_transform=pre_transform,
             )
 
         # The train split is fit on and transformed first: fitting binds the
@@ -1361,6 +1374,7 @@ class TransformationFunctionEngine:
         | TypeVar("pyspark.sql.DataFrame"),
         transformation_context: dict[str, Any] | None = None,
         n_processes: int | None = None,
+        pre_transform: Callable[[Any], Any] | None = None,
     ) -> pd.DataFrame | pl.DataFrame | TypeVar("pyspark.sql.DataFrame"):
         """Fit the required statistics on the train data and return it transformed.
 
@@ -1385,6 +1399,7 @@ class TransformationFunctionEngine:
             feature_dataframe: The train data.
             transformation_context: Context variables passed to the transformation functions.
             n_processes: Number of worker processes for applying the transformations.
+            pre_transform: Applied to the train data once the statistics are fit and before the transformations run.
 
         Returns:
             The transformed train data.
@@ -1424,6 +1439,7 @@ class TransformationFunctionEngine:
                 label_encoder_features,
                 transformation_context,
                 n_processes,
+                pre_transform=pre_transform,
             )
 
         if statistics_features:
@@ -1439,6 +1455,10 @@ class TransformationFunctionEngine:
             for tf in feature_view_obj.transformation_functions:
                 tf.transformation_statistics = stats.feature_descriptive_statistics
 
+        # statistics are fit on the frame as read; reshape only now
+        if pre_transform is not None:
+            feature_dataframe = pre_transform(feature_dataframe)
+
         return TransformationFunctionEngine._transform(
             feature_view_obj, feature_dataframe, transformation_context, n_processes
         )
@@ -1453,6 +1473,7 @@ class TransformationFunctionEngine:
         label_encoder_features: set[str],
         transformation_context: dict[str, Any] | None,
         n_processes: int | None,
+        pre_transform: Callable[[Any], Any] | None = None,
     ) -> pd.DataFrame | pl.DataFrame | TypeVar("pyspark.sql.DataFrame"):
         """Fit statistics over a chained DAG and return the transformed data.
 
@@ -1471,6 +1492,7 @@ class TransformationFunctionEngine:
             label_encoder_features: The statistics features consumed by encoders.
             transformation_context: Context variables passed to the transformation functions.
             n_processes: Number of worker processes for applying each stage.
+            pre_transform: Applied once the last stage that fits statistics has been profiled and before its transformations run.
 
         Returns:
             The fully transformed train data.
@@ -1485,20 +1507,20 @@ class TransformationFunctionEngine:
         )
 
         provisional_statistics: list = []
-        provisioned_features: set[str] = set()
         working_dataframe = feature_dataframe
         original_columns = list(feature_dataframe.columns)
         statistics_engine = training_dataset._statistics_engine
         previous_barrier = None
 
-        remaining = list(graph.nodes)  # topological order
-        while remaining:
-            stage, remaining = TransformationFunctionEngine._next_statistics_stage(
-                remaining, provisioned_features
-            )
-            features_to_fit = {
-                f for tf in stage for f in tf.hopsworks_udf.statistics_features
-            } - provisioned_features
+        stages = TransformationFunctionEngine._plan_statistics_stages(
+            list(graph.nodes)  # topological order
+        )
+        # pre_transform goes after the last stage that fits anything
+        pre_transform_stage = max(
+            (i for i, (_, features_to_fit) in enumerate(stages) if features_to_fit),
+            default=0,
+        )
+        for stage_index, (stage, features_to_fit) in enumerate(stages):
             if features_to_fit:
                 # Present in working_dataframe: raw features from the start,
                 # intermediate features materialized by earlier stages. Profiled
@@ -1522,9 +1544,10 @@ class TransformationFunctionEngine:
                 provisional_statistics.extend(
                     provisional.feature_descriptive_statistics
                 )
-                provisioned_features |= features_to_fit
             for tf in stage:
                 tf.transformation_statistics = provisional_statistics
+            if pre_transform is not None and stage_index == pre_transform_stage:
+                working_dataframe = pre_transform(working_dataframe)
             # expected_features keeps the already-present columns so a dropping
             # transformation does not remove inputs later stages still need;
             # drops are applied once in the final projection below.
@@ -1564,6 +1587,34 @@ class TransformationFunctionEngine:
         if is_spark_dataframe:
             return working_dataframe.select(*final_columns)
         return working_dataframe[final_columns]
+
+    @staticmethod
+    def _plan_statistics_stages(
+        transformation_functions: list[transformation_function.TransformationFunction],
+    ) -> list[tuple[list[transformation_function.TransformationFunction], set[str]]]:
+        """Split a topologically ordered list into its statistics stages.
+
+        Parameters:
+            transformation_functions: All transformation functions, in topological order.
+
+        Returns:
+            One `(stage, features_to_fit)` pair per stage, in execution order,
+            where `features_to_fit` are the features whose statistics must be
+            profiled before that stage runs.
+        """
+        stages = []
+        remaining = list(transformation_functions)
+        provisioned_features: set[str] = set()
+        while remaining:
+            stage, remaining = TransformationFunctionEngine._next_statistics_stage(
+                remaining, provisioned_features
+            )
+            features_to_fit = {
+                f for tf in stage for f in tf.hopsworks_udf.statistics_features
+            } - provisioned_features
+            provisioned_features |= features_to_fit
+            stages.append((stage, features_to_fit))
+        return stages
 
     @staticmethod
     def _next_statistics_stage(

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -57,13 +57,18 @@ try:
         col,
         concat,
         current_timestamp,
+        datediff,
+        expr,
         from_json,
+        length,
         lit,
         monotonically_increasing_id,
         regexp_replace,
         row_number,
         struct,
         udf,
+        unix_millis,
+        when,
     )
     from pyspark.sql.types import (
         ArrayType,
@@ -80,6 +85,7 @@ try:
         StringType,
         StructField,
         StructType,
+        TimestampNTZType,
         TimestampType,
     )
 
@@ -1165,15 +1171,20 @@ class Engine:
             # Statistics are always refit (training_dataset_version not
             # passed): an unsplit in-memory training dataset retrieved by
             # version is not consistent.
+            # coalesce(1) must land between the fit and the transformations
+            # (FSTORE-2109), so the engine applies it.
             dataset = transformation_function_engine.TransformationFunctionEngine._fit_and_transform(
                 training_dataset,
                 feature_view_obj,
                 dataset,
                 transformation_context=transformation_context,
+                pre_transform=(
+                    (lambda frame: frame.coalesce(1))
+                    if training_dataset.coalesce
+                    else None
+                ),
             )
 
-            if training_dataset.coalesce:
-                dataset = dataset.coalesce(1)
             path = training_dataset.location + "/" + training_dataset.name
             return self._write_training_dataset_single(
                 dataset,
@@ -1353,13 +1364,14 @@ class Engine:
                 "Given event time should be in `datetime`, `date`, `str` or `int` type"
             )
 
-        # registering the UDF
-        _convert_event_time_to_timestamp = udf(
-            convert_event_time_to_timestamp, LongType()
-        )
+        # A Python UDF below the coalesced write pins a 64 MB HybridRowQueue
+        # per shuffle partition (FSTORE-2109); use a native expression when
+        # the column type allows one.
+        ts_col = self._event_time_epoch_millis(dataset, event_time)
+        if ts_col is None:
+            ts_col = udf(convert_event_time_to_timestamp, LongType())(col(event_time))
 
         result_dfs = {}
-        ts_col = _convert_event_time_to_timestamp(col(event_time))
         for split in training_dataset.splits:
             result_df = dataset.filter(ts_col >= split.start_time).filter(
                 ts_col < split.end_time
@@ -1368,6 +1380,40 @@ class Engine:
                 result_df = result_df.drop(event_time)
             result_dfs[split.name] = result_df
         return result_dfs
+
+    @staticmethod
+    def _event_time_epoch_millis(dataset, event_time):
+        """Epoch milliseconds of the event time column as a native expression.
+
+        Returns None when the column type has no native form.
+        """
+        # not schema[event_time]: that subscript is case sensitive, col() is not
+        event_time_type = next(
+            (f.dataType for f in dataset.schema.fields if f.name == event_time), None
+        )
+        if isinstance(event_time_type, TimestampNTZType):
+            # unix_millis rejects timestamp_ntz; with both operands NTZ the
+            # result does not depend on spark.sql.session.timeZone.
+            quoted = event_time.replace("`", "``")
+            return expr(
+                "timestampdiff(MILLISECOND, TIMESTAMP_NTZ '1970-01-01 00:00:00', "
+                f"`{quoted}`)"
+            )
+        if isinstance(event_time_type, TimestampType):
+            return unix_millis(col(event_time))
+        if isinstance(event_time_type, DateType):
+            # midnight UTC of that day, independent of the session zone
+            days = datediff(col(event_time), lit("1970-01-01")).cast(LongType())
+            return days * lit(86_400_000)
+        if isinstance(event_time_type, (IntegerType, LongType)):
+            # up to ten digits is seconds
+            value = col(event_time).cast(LongType())
+            return (
+                when(value == 0, lit(None).cast(LongType()))
+                .when(length(value.cast("string")) <= 10, value * lit(1000))
+                .otherwise(value)
+            )
+        return None
 
     def _write_training_dataset_splits(
         self,

--- a/python/tests/core/test_transformation_function_engine.py
+++ b/python/tests/core/test_transformation_function_engine.py
@@ -436,6 +436,187 @@ class TestTransformationFunctionEngine:
         # fitted ones.
         assert persisted["imputed_feature_1"].mean == 3.0
 
+    def _pre_transform_call_order(self, mocker, transformations, dataset):
+        # fit / pre / apply calls in the order one _fit_and_transform makes them
+        feature_store_id = 99
+        mocker.patch("hopsworks_common.client._get_instance")
+        engine._set_instance(engine=python.Engine(), engine_type="python")
+        self._fake_persisting_statistics(mocker)
+
+        order = []
+        real_compute = transformation_function_engine.TransformationFunctionEngine._compute_transformation_fn_statistics
+        real_no_save = statistics_engine.StatisticsEngine._compute_transformation_fn_statistics_no_save
+        real_apply = transformation_function_engine.TransformationFunctionEngine._apply_transformation_functions
+
+        def record_compute(*args, **kwargs):
+            order.append("fit")
+            return real_compute(*args, **kwargs)
+
+        def record_no_save(stats_engine, *args, **kwargs):
+            order.append("fit")
+            return real_no_save(stats_engine, *args, **kwargs)
+
+        def record_apply(*args, **kwargs):
+            order.append("apply")
+            return real_apply(*args, **kwargs)
+
+        mocker.patch.object(
+            transformation_function_engine.TransformationFunctionEngine,
+            "_compute_transformation_fn_statistics",
+            side_effect=record_compute,
+        )
+        mocker.patch.object(
+            statistics_engine.StatisticsEngine,
+            "_compute_transformation_fn_statistics_no_save",
+            autospec=True,
+            side_effect=record_no_save,
+        )
+        mocker.patch.object(
+            transformation_function_engine.TransformationFunctionEngine,
+            "_apply_transformation_functions",
+            side_effect=record_apply,
+        )
+
+        fg = feature_group.FeatureGroup(
+            name="t",
+            version=1,
+            featurestore_id=feature_store_id,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature(c) for c in dataset.columns],
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="t",
+            featurestore_id=feature_store_id,
+            query=fg.select_all(),
+            transformation_functions=transformations,
+        )
+        td = training_dataset.TrainingDataset(
+            name="t",
+            version=1,
+            data_format="CSV",
+            featurestore_id=feature_store_id,
+            splits={},
+            id=10,
+        )
+
+        def pre_transform(frame):
+            order.append("pre")
+            return frame
+
+        result = transformation_function_engine.TransformationFunctionEngine._fit_and_transform(
+            training_dataset=td,
+            feature_view_obj=fv,
+            dataset=dataset,
+            pre_transform=pre_transform,
+        )
+        return order, result
+
+    def test_fit_and_transform_pre_transform_runs_after_the_fit(self, mocker):
+        feature_store_id = 99
+        mocker.patch("hopsworks_common.client._get_instance")
+        tf_scale = transformation_function.TransformationFunction(
+            feature_store_id,
+            hopsworks_udf=min_max_scaler("feature_1"),
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+        order, _ = self._pre_transform_call_order(
+            mocker,
+            [tf_scale],
+            pd.DataFrame({"feature_1": [1.0, 2.0, 3.0], "other": [10, 20, 30]}),
+        )
+
+        assert order == ["fit", "pre", "apply"]
+
+    def test_fit_and_transform_pre_transform_runs_without_statistics(self, mocker):
+        # nothing to fit, but coalesce=True still has to reach the write
+        feature_store_id = 99
+        mocker.patch("hopsworks_common.client._get_instance")
+
+        @udf(int)
+        def plus_one(feature_1):
+            return feature_1 + 1
+
+        tf_plus = transformation_function.TransformationFunction(
+            feature_store_id,
+            hopsworks_udf=plus_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+        order, _ = self._pre_transform_call_order(
+            mocker,
+            [tf_plus],
+            pd.DataFrame({"feature_1": [1, 2, 3], "other": [10, 20, 30]}),
+        )
+
+        assert order == ["pre", "apply"]
+
+    def test_fit_and_transform_pre_transform_chained_runs_after_last_barrier(
+        self, mocker
+    ):
+        feature_store_id = 99
+        mocker.patch("hopsworks_common.client._get_instance")
+        tf_impute = transformation_function.TransformationFunction(
+            feature_store_id,
+            hopsworks_udf=impute_mean("feature_1").alias("imputed_feature_1"),
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+        tf_scale = transformation_function.TransformationFunction(
+            feature_store_id,
+            hopsworks_udf=min_max_scaler("imputed_feature_1").alias("scaled_feature_1"),
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+        order, _ = self._pre_transform_call_order(
+            mocker,
+            [tf_impute, tf_scale],
+            pd.DataFrame(
+                {"feature_1": [1.0, None, 3.0, 5.0], "other": [10, 20, 30, 40]}
+            ),
+        )
+
+        assert order == ["fit", "apply", "fit", "pre", "apply"]
+        assert order.count("pre") == 1
+        # one application per stage: nothing executes twice
+        assert order.count("apply") == 2
+
+    def test_fit_and_transform_pre_transform_rejected_for_splits(self, mocker):
+        feature_store_id = 99
+        mocker.patch("hopsworks_common.client._get_instance")
+        engine._set_instance(engine=python.Engine(), engine_type="python")
+        fg = feature_group.FeatureGroup(
+            name="t",
+            version=1,
+            featurestore_id=feature_store_id,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature("feature_1")],
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="t",
+            featurestore_id=feature_store_id,
+            query=fg.select_all(),
+            transformation_functions=[],
+        )
+        td = training_dataset.TrainingDataset(
+            name="t",
+            version=1,
+            data_format="CSV",
+            featurestore_id=feature_store_id,
+            splits={},
+            id=10,
+        )
+
+        with pytest.raises(ValueError, match="single dataframe"):
+            transformation_function_engine.TransformationFunctionEngine._fit_and_transform(
+                training_dataset=td,
+                feature_view_obj=fv,
+                dataset={"train": pd.DataFrame({"feature_1": [1.0]})},
+                pre_transform=lambda frame: frame,
+            )
+
     @staticmethod
     def _fake_persisting_statistics(mocker):
         # Skip the backend save in both persisting paths. The raw-feature fit

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -37,11 +37,16 @@ from hsfs import (
     transformation_function,
     util,
 )
+from hsfs.builtin_transformations import min_max_scaler
 from hsfs.client import exceptions
 from hsfs.constructor import fs_query as fs_query_mod
 from hsfs.constructor import hudi_feature_group_alias, query
 from hsfs.core import data_source as ds
-from hsfs.core import online_ingestion, training_dataset_engine
+from hsfs.core import (
+    online_ingestion,
+    training_dataset_engine,
+    transformation_function_engine,
+)
 from hsfs.core.constants import GE_MAJOR, HAS_GREAT_EXPECTATIONS
 from hsfs.core.feature_descriptive_statistics import FeatureDescriptiveStatistics
 from hsfs.core.transformation_execution_dag import TransformationExecutionDAG
@@ -76,6 +81,7 @@ from pyspark.sql.types import (
     StringType,
     StructField,
     StructType,
+    TimestampNTZType,
     TimestampType,
 )
 
@@ -3794,6 +3800,91 @@ class TestSpark:
             assert result[column].schema == expected[column].schema
             assert result[column].collect() == expected[column].collect()
 
+    def test_time_series_split_timestamp_ntz(self, mocker):
+        # TimestampNTZType is not a TimestampType; only the plan shows a
+        # fall-through to the UDF, the rows come out right either way.
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+
+        spark_engine = spark.Engine()
+
+        td = training_dataset.TrainingDataset(
+            name="test",
+            version=1,
+            data_format="CSV",
+            featurestore_id=99,
+            splits={"col1": None, "col2": None},
+            id=10,
+            train_start=1000000000,
+            train_end=1488600000,
+            test_end=1488718800,
+        )
+
+        d = {
+            "col_0": [1, 2],
+            "col_1": ["test_1", "test_2"],
+            "event_time": ["2017-03-04", "2017-03-05"],
+        }
+        df = pd.DataFrame(data=d)
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+        spark_df = spark_df.withColumn(
+            "event_time", spark_df["event_time"].cast(TimestampNTZType())
+        )
+        assert isinstance(spark_df.schema["event_time"].dataType, TimestampNTZType)
+
+        # Act
+        result = spark_engine._time_series_split(
+            training_dataset=td,
+            dataset=spark_df,
+            event_time="event_time",
+            drop_event_time=False,
+        )
+
+        # Assert
+        for split in result:
+            plan = result[split]._jdf.queryExecution().executedPlan().toString()
+            assert "BatchEvalPython" not in plan, plan
+            assert "ArrowEvalPython" not in plan, plan
+        assert [r["col_0"] for r in result["train"].collect()] == [1]
+        assert [r["col_0"] for r in result["test"].collect()] == [2]
+
+    def test_time_series_split_event_time_case_mismatch(self, mocker):
+        # must reach the UDF fallback, not raise KEY_NOT_EXISTS
+        # Arrange
+        mocker.patch("hopsworks_common.client._get_instance")
+
+        spark_engine = spark.Engine()
+
+        td = training_dataset.TrainingDataset(
+            name="test",
+            version=1,
+            data_format="CSV",
+            featurestore_id=99,
+            splits={"col1": None, "col2": None},
+            id=10,
+            train_start=1000000000,
+            train_end=1488600000,
+            test_end=1488718800,
+        )
+
+        df = pd.DataFrame({"col_0": [1, 2], "event_time": ["2017-03-04", "2017-03-05"]})
+        spark_df = spark_engine._spark_session.createDataFrame(df)
+        spark_df = spark_df.withColumn(
+            "event_time", spark_df["event_time"].cast(TimestampType())
+        )
+
+        # Act
+        result = spark_engine._time_series_split(
+            training_dataset=td,
+            dataset=spark_df,
+            event_time="EVENT_TIME",
+            drop_event_time=False,
+        )
+
+        # Assert
+        assert [r["col_0"] for r in result["train"].collect()] == [1]
+        assert [r["col_0"] for r in result["test"].collect()] == [2]
+
     def test_time_series_split_epoch_sec(self, mocker):
         # Arrange
         mocker.patch("hopsworks_common.client._get_instance")
@@ -5933,6 +6024,160 @@ class TestSpark:
         # Assert
         assert result.schema == expected_spark_df.schema
         assert result.collect() == expected_spark_df.collect()
+
+    def test_fit_and_transform_coalesce_keeps_udf_above_the_merge(self, mocker):
+        # a UDF below the Coalesce runs once per parent partition (FSTORE-2109)
+        mocker.patch("hopsworks_common.client._get_instance")
+        hopsworks_common.connection._hsfs_engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        @udf(int, drop=["col_0"])
+        def plus_one(col_0):
+            return col_0 + 1
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=plus_one,
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature(name="col_0", type=IntegerType(), index=0)],
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("col_0")],
+        )
+        td = training_dataset.TrainingDataset(
+            name="test",
+            version=1,
+            data_format="PARQUET",
+            featurestore_id=99,
+            splits={},
+            id=10,
+            coalesce=True,
+        )
+        spark_df = spark_engine._spark_session.createDataFrame(
+            pd.DataFrame({"col_0": list(range(20))})
+        ).repartition(4)
+
+        # Act
+        merged_first = transformation_function_engine.TransformationFunctionEngine._fit_and_transform(
+            training_dataset=td,
+            feature_view_obj=fv,
+            dataset=spark_df,
+            pre_transform=lambda frame: frame.coalesce(1),
+        )
+        # the pre-change shape: transform first, merge afterwards
+        merged_last = transformation_function_engine.TransformationFunctionEngine._fit_and_transform(
+            training_dataset=td, feature_view_obj=fv, dataset=spark_df
+        ).coalesce(1)
+
+        # Assert
+        def node_order(df):
+            plan = df._jdf.queryExecution().executedPlan().toString()
+            evals = [
+                plan.index(name)
+                for name in ("BatchEvalPython", "ArrowEvalPython")
+                if name in plan
+            ]
+            assert evals, plan
+            return min(evals), plan.index("Coalesce")
+
+        # a parent prints above its children
+        udf_pos, coalesce_pos = node_order(merged_first)
+        assert udf_pos < coalesce_pos
+        udf_pos_last, coalesce_pos_last = node_order(merged_last)
+        assert coalesce_pos_last < udf_pos_last
+        assert merged_first.rdd.getNumPartitions() == 1
+        assert merged_first.collect() == merged_last.collect()
+
+    def test_fit_and_transform_coalesce_fits_statistics_before_the_merge(self, mocker):
+        # Merging before the fit would also cure the OOM, but on different
+        # statistics.
+        mocker.patch("hopsworks_common.client._get_instance")
+        hopsworks_common.connection._hsfs_engine_type = "spark"
+        spark_engine = spark.Engine()
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            hopsworks_udf=min_max_scaler("f1"),
+            transformation_type=TransformationType.MODEL_DEPENDENT,
+        )
+        fg1 = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            features=[feature.Feature(name="f1", type=IntegerType(), index=0)],
+            id=11,
+            stream=False,
+        )
+        fv = feature_view.FeatureView(
+            name="test",
+            featurestore_id=99,
+            query=fg1.select_all(),
+            transformation_functions=[tf("f1")],
+        )
+        td = training_dataset.TrainingDataset(
+            name="test",
+            version=1,
+            data_format="PARQUET",
+            featurestore_id=99,
+            splits={},
+            id=10,
+            coalesce=True,
+        )
+        spark_df = spark_engine._spark_session.createDataFrame(
+            pd.DataFrame({"f1": [float(i) for i in range(20)]})
+        ).repartition(4)
+
+        profiled_partitions = []
+
+        def fake_compute(
+            training_dataset_obj,
+            columns,
+            label_encoder_features,
+            feature_dataframe,
+            feature_view_obj,
+        ):
+            profiled_partitions.append(feature_dataframe.rdd.getNumPartitions())
+            return mocker.Mock(
+                feature_descriptive_statistics=[
+                    FeatureDescriptiveStatistics(
+                        feature_name=c, min=0.0, max=19.0, mean=9.5
+                    )
+                    for c in columns
+                ]
+            )
+
+        mocker.patch.object(
+            transformation_function_engine.TransformationFunctionEngine,
+            "_compute_transformation_fn_statistics",
+            side_effect=fake_compute,
+        )
+
+        # Act
+        result = transformation_function_engine.TransformationFunctionEngine._fit_and_transform(
+            training_dataset=td,
+            feature_view_obj=fv,
+            dataset=spark_df,
+            pre_transform=lambda frame: frame.coalesce(1),
+        )
+
+        # Assert
+        # profiled on all four partitions, merged only for the transform
+        assert profiled_partitions == [4]
+        assert result.rdd.getNumPartitions() == 1
 
     def test_apply_transformation_function_overwrite_feature(self, mocker):
         # An unaliased single-output UDF named after its input feature


### PR DESCRIPTION
[FSTORE-2109](https://hopsworks.atlassian.net/browse/FSTORE-2109)

## Problem

A `fv_*_create_fv_td_*` job fails on a **60-row** dataset:

```
org.apache.spark.memory.SparkOutOfMemoryError: [UNABLE_TO_ACQUIRE_MEMORY] Unable to acquire 65536 bytes of memory, got 0
  at org.apache.spark.util.collection.unsafe.sort.UnsafeInMemorySorter.<init>
  at org.apache.spark.sql.execution.SortExec.createSorter
```

With `coalesce=True` the training dataset is written by a single task. Any Python UDF sitting **below** the `Coalesce` is then evaluated once per upstream shuffle partition, and each evaluation creates a `HybridRowQueue` that pins a 64 MB page until the task ends. `HybridRowQueue` is a Scala `case class` whose fields are identical for every queue in a task, so `TaskMemoryManager.consumers` (a `HashSet`) registers only the first — the rest are neither attributed nor spillable. ~30 non-empty partitions exhaust a 4 GB executor.

Memory sizing is not a fix: a training dataset with all 200 partitions non-empty would need ~23 GB of executor memory. This is behind the 8 failing `python_driver/test_fully_qualified_names.py` tests and `python_driver/test_snowflake_schema::test_workflow` in the helm nightly.

Two sites reach it, and both are fixed here.

## 1. The time-series split filter

`_time_series_split` filtered every split through the `convert_event_time_to_timestamp` Python UDF. The epoch-millisecond column is now built with native expressions, dispatched on the column type:

| type | UDF today | native |
| --- | --- | --- |
| timestamp | `int(dt.timestamp() * 1000)` | `unix_millis(col)` |
| **timestamp_ntz** (what Spark 4 actually yields) | same | `timestampdiff(MILLISECOND, TIMESTAMP_NTZ '1970-01-01 00:00:00', col)` |
| date | UTC midnight in ms | `datediff(col, '1970-01-01') * 86400000` |
| int / bigint | `0 → null`, ≤10 digits → `× 1000`, else as-is | `when`/`length` equivalent |

Any other type keeps the UDF, and so does an event time whose case does not match the column: the type is resolved by scanning the schema, since `StructType.__getitem__` is case-sensitive where `col()` follows `spark.sql.caseSensitive`.

**timestamp_ntz is the case that matters.** Spark 4 reads a feature group's event time as `timestamp_ntz`; `TimestampNTZType` is not a subclass of `TimestampType` and `unix_millis` rejects it outright, so a timestamp/date/bigint dispatch silently falls back to the UDF and nothing changes — verified on the cluster, where the first revision of this branch still OOMed with `BatchEvalPython` in the plan. `FeaturestoreConstants.EVENT_TIME_FEATURE_TYPES` describes the *feature* type, not the Spark type the query read yields. `test_time_series_split_timestamp_ntz` pins this: it asserts the executed plan has no `BatchEvalPython` node, and fails if the branch is removed.

Both operands of the `timestampdiff` are NTZ, so the result is zone-free by construction and independent of `spark.sql.session.timeZone`. The alternatives either depend on the session zone or work by accident:

| form | session tz UTC | session tz America/New_York |
| --- | --- | --- |
| `unix_millis(col)` | AnalysisException | AnalysisException |
| `unix_millis(col.cast("timestamp"))` | match | off by the zone offset |
| `unix_millis(to_utc_timestamp(col, "UTC"))` | match | off by the zone offset |
| `unix_millis(to_timestamp_ltz(col, "UTC"))` | match | match, but the `"UTC"` is a *format pattern* that Spark ignores for non-string input; it relies on `ToTimestamp` passing NTZ micros through on a compatibility path |
| `timestampdiff(MILLISECOND, TIMESTAMP_NTZ '1970-01-01', col)` | match | match |

(`F.timestamp_diff` exists only on pyspark >= 4, so the expression goes through `F.expr`, which also works on 3.5.)

## 2. The unsplit path

An unsplit training dataset ran `_fit_and_transform` first and `coalesce(1)` afterwards, so a **transformation function's** UDF sat below the merge — python and pandas mode alike, since `ArrowEvalPython` shares the evaluator factory.

The merge cannot simply move ahead of the fit: approximate statistics depend on the partitioning they are computed over. On 1M rows, profiling the same data over 200 partitions versus one gives percentiles 249/499/749 vs 250/500/750 and `std_dev` differing in its last bits, so fitting on a coalesced frame would refit every transformation on different statistics *and* change the persisted training-dataset statistics. `repartition(1)` is not order-preserving, and materializing the transformed frame does not scale.

So the engine takes the reshaping as `pre_transform` and applies it once the statistics are fitted and before the transformations run. For a chained fit the statistics stages are planned up front (`_plan_statistics_stages`), so the hook lands after the last stage that profiles anything: no profiling pass moves and every transformation still executes exactly once. Earlier stages sit behind their statistics barrier, which is already persisted, so the write task reads them from cache instead of re-evaluating their UDFs. **No `cache`, `persist` or `checkpoint` is added.**

## Verification

**On the cluster** (hopsworks 5.1.0-SNAPSHOT, Spark 4.1.3.0), re-running the exact `create_fv_td` job that fails in the nightly with the SDK swapped in the driver, same config and sizing (driver 2048m / executor 4096m):

| run | plan | outcome |
| --- | --- | --- |
| unmodified SDK | `BatchEvalPython [convert_event_time_to_timestamp]` | `UNABLE_TO_ACQUIRE_MEMORY` |
| control (wrapper, patch skipped) | same | `UNABLE_TO_ACQUIRE_MEMORY` |
| timestamp/date/bigint only | still `BatchEvalPython`, no `unix_millis` | `UNABLE_TO_ACQUIRE_MEMORY` |
| **with timestamp_ntz** | `unix_millis` ×7, **0** `BatchEvalPython` | **SUCCEEDED**, 167 s |

On the successful run the executors show zero `HybridRowQueue` acquisitions and zero `PythonUDFWithNamedArgumentsRunner` invocations, against 64 MB queues and ~2.16 GB of untracked memory on every failing run.

**Output equality.** Row-for-row identical for timestamp_ntz, date from 1970 on, bigint, int-seconds, `0`/NULL and negative epochs, on pyspark 3.5.5 **and** 4.1.1, under session zones UTC **and** America/New_York. `0` was already treated as missing rather than an error, because the UDF's `if not event_time: return None` shadowed its own `ValueError`. Two deliberate differences, both places where the UDF was wrong: for `timestamp` the UDF's value followed the Python **worker's OS zone** (`TimestampType.fromInternal` is `datetime.fromtimestamp`), not the session zone, so it was off by the zone offset on a non-UTC worker; and dates before 1970 came out 1 ms late (`date.timetuple()[:7]` hands `tm_wday` to `datetime()` as microseconds, so `date(1969, 12, 31)` gave -86399999 instead of -86400000). The native form is UTC in both cases, which is what the cluster's executors run anyway. The unsplit change reproduces the pre-change row-and-value hash (`751561226b8ec847`) on 1M rows with the same fitted statistics.

**Performance**, local A/B on the same data (the fix also removes the UDF's per-row cost):

| rows | split filter, parallel write | split filter, `coalesce(1)` |
| --- | --- | --- |
| 100k | 4.1 s → 2.7 s | 5.4 s → 3.1 s |
| 1M | 7.2 s → 3.1 s | 12.0 s → 4.2 s |
| 10M | 37.6 s → 5.0 s (**7.5×**) | 82.8 s → 13.9 s (**6.0×**) |

Unsplit transform path, 1M rows: 20.1 s → 6.9 s at default pages, and `UNABLE_TO_ACQUIRE_MEMORY` → writes all 1M rows on a 3 GB pool with 64 MB pages.

It does **not** buy predicate pushdown — measured `PushedFilters: []` for both the UDF and the native form at every size, since the comparison is on a function of the column.

**Tests.** Eight new: an NTZ event time produces a plan without `BatchEvalPython`; an event-time name whose case differs from the column still reaches the UDF fallback instead of raising `KEY_NOT_EXISTS`; statistics are profiled on all four partitions while only the transformed frame is merged; the plan keeps the Python UDF above the `Coalesce` (and below it without the hook, with identical rows); call order is `["fit", "pre", "apply"]`, `["pre", "apply"]` with no statistics, and `["fit", "apply", "fit", "pre", "apply"]` chained with exactly one application per stage; and a split dict is rejected rather than silently mis-shaped. The four pre-existing `coalesce.call_count` tests pass unmodified. Suites: `test_spark.py` 266 passed (only the 5 pre-existing avro/kafka failures), transformation engine 153 passed, python engine 234 passed.

## Not covered here

The split path fits its statistics on a coalesced frame (it merges before `_fit_and_transform`) while the unsplit path fits on the full partitioning, so the same data through the two paths yields different approximate percentiles. Pre-existing, and changing it would change existing split-TD outputs — worth its own ticket.

No upstream JIRA covers the `HybridRowQueue` case-class/HashSet de-duplication; the Spark-side fix is identity equality for the queue, which would fix every path including user code, and should be reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FSTORE-2109]: https://hopsworks.atlassian.net/browse/FSTORE-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

