### PR TITLE
[FSTORE-2111] Model monitoring fan-out includes logging metadata columns and the FM job fails against a training-dataset reference

### DIFF
--- a/python/hsfs/core/feature_monitoring_config.py
+++ b/python/hsfs/core/feature_monitoring_config.py
@@ -164,6 +164,13 @@ class FeatureMonitoringConfig:
         # In-memory only (not serialized): set by FeatureView.create_model_monitoring so
         # with_reference_training_dataset can default to / validate against the model's TD.
         self._associated_model_td_version: int | None = None
+        # In-memory only (not serialized): set by FeatureView.create_model_monitoring
+        # to the feature view's training features.
+        # compare_on*() without a feature_name fans out over these instead of the whole
+        # logging feature group schema, whose serving keys, predicted_* and logging
+        # metadata columns have no counterpart in a training-dataset reference.
+        # Explicitly named features are not restricted.
+        self._fanout_feature_names: set[str] | None = None
         self._job_name = job_name
         self._feature_monitoring_type = (
             feature_monitoring_type
@@ -212,6 +219,21 @@ class FeatureMonitoringConfig:
         else:
             self._valid_features = None
             self._valid_feature_names = valid_feature_names
+
+    def _fanout_valid_features(self) -> dict[str, str] | None:
+        """Return the name -> type map a feature_name-less compare_on*() fans out over.
+
+        Returns `_valid_features` unchanged when no fan-out restriction is set.
+        Returns None when `_valid_features` is None, that is when the config was built
+        without feature type information.
+        """
+        if self._valid_features is None or self._fanout_feature_names is None:
+            return self._valid_features
+        return {
+            name: ftype
+            for name, ftype in self._valid_features.items()
+            if name in self._fanout_feature_names
+        }
 
     def _parse_feature_statistics_configs(
         self,
@@ -530,7 +552,7 @@ class FeatureMonitoringConfig:
             if self._valid_features is not None:
                 feature_names = (
                     self._feature_monitoring_config_engine._resolve_compatible_features(
-                        metric=metric, valid_features=self._valid_features
+                        metric=metric, valid_features=self._fanout_valid_features()
                     )
                 )
             else:
@@ -666,7 +688,8 @@ class FeatureMonitoringConfig:
             if self._valid_features is not None:
                 feature_names = (
                     self._feature_monitoring_config_engine._resolve_compatible_features(
-                        metric=metric_upper, valid_features=self._valid_features
+                        metric=metric_upper,
+                        valid_features=self._fanout_valid_features(),
                     )
                 )
             else:

--- a/python/hsfs/core/feature_monitoring_result_engine.py
+++ b/python/hsfs/core/feature_monitoring_result_engine.py
@@ -15,12 +15,15 @@
 #
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
+from hopsworks_common.client.exceptions import FeatureStoreException
 from hsfs import util
 from hsfs.core import distribution_distance
 from hsfs.core import feature_monitoring_config as fmc
+from hsfs.core import monitoring_window_config as mwc
 from hsfs.core.distribution_engine import (
     _WINDOW_DETECTION,
     _WINDOW_REFERENCE,
@@ -38,6 +41,9 @@ from hsfs.core.statistics_comparison_result import StatisticsComparisonResult
 if TYPE_CHECKING:
     from hsfs.core.feature_statistics_config import FeatureStatisticsConfig
     from hsfs.core.statistics_comparison_config import StatisticsComparisonConfig
+
+
+logger = logging.getLogger(__name__)
 
 
 class FeatureMonitoringResultEngine:
@@ -251,6 +257,14 @@ class FeatureMonitoringResultEngine:
         # FeatureMonitoringResultEngine instance doesn't carry state across runs.
         self._distribution_engine._clear_cache()
 
+        if (
+            reference_statistics is not None
+            and self._compares_model_logs_to_training_dataset(fm_config)
+        ):
+            detection_statistics = self._drop_features_without_reference(
+                detection_statistics, reference_statistics
+            )
+
         # validate fds
         self._validate_detection_and_reference_statistics(
             detection_statistics=detection_statistics,
@@ -328,6 +342,66 @@ class FeatureMonitoringResultEngine:
 
         # save and return
         return self._save(fm_result)
+
+    @staticmethod
+    def _compares_model_logs_to_training_dataset(
+        fm_config: fmc.FeatureMonitoringConfig,
+    ) -> bool:
+        """True for a model monitoring config whose reference is a training dataset.
+
+        That is the one setup where the detection side legitimately carries columns
+        the reference cannot answer for: the logging feature group's serving keys,
+        predicted_* and logging metadata columns against the training features of the
+        training dataset.
+        Every other config keeps the strict detection/reference validation.
+        """
+        reference = fm_config.reference_window_config
+        return (
+            fm_config.model_name is not None
+            and reference is not None
+            and reference.window_config_type == mwc.WindowConfigType.TRAINING_DATASET
+        )
+
+    def _drop_features_without_reference(
+        self,
+        detection_statistics: list[FeatureDescriptiveStatistics],
+        reference_statistics: list[FeatureDescriptiveStatistics],
+    ) -> list[FeatureDescriptiveStatistics]:
+        """Keep the detection features the reference window has statistics for.
+
+        Model monitoring only (see _compares_model_logs_to_training_dataset).
+        A training-dataset reference answers for the training features only, while the
+        detection window of a logging feature group can also cover serving keys,
+        predicted_* and logging metadata columns.
+        Those have nothing to compare against, so they are skipped with a warning
+        instead of failing the whole run.
+
+        Raises:
+            hopsworks.client.exceptions.FeatureStoreException: If no detection feature
+                has reference statistics.
+        """
+        reference_names = {fds.feature_name for fds in reference_statistics}
+        kept = [
+            fds for fds in detection_statistics if fds.feature_name in reference_names
+        ]
+        skipped = sorted(
+            fds.feature_name
+            for fds in detection_statistics
+            if fds.feature_name not in reference_names
+        )
+        if skipped and not kept:
+            raise FeatureStoreException(
+                f"None of the monitored features {skipped} have statistics in the "
+                "reference window, so there is nothing to compare. Check that the "
+                "monitored features exist in the reference training dataset."
+            )
+        if skipped:
+            logger.warning(
+                "Skipping features without reference statistics: %s. Only features "
+                "present in both the detection and the reference window are compared.",
+                skipped,
+            )
+        return kept
 
     def _validate_detection_and_reference_statistics(
         self,

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -4665,6 +4665,16 @@ class FeatureView:
         config._model_name = model_name
         config._model_version = model_version
         config._associated_model_td_version = training_dataset_version
+        # The logging feature group also carries the serving keys, the helper columns,
+        # the predicted_* columns and the logging metadata columns.
+        # None of those exist in the training dataset the reference window reads, so a
+        # fan-out over them leaves the FM job without reference statistics and it fails.
+        # Fan out over the training features of the model's training dataset only, the
+        # same set feature logging resolves; a feature_name given explicitly is not
+        # restricted.
+        config._fanout_feature_names = set(
+            self._get_untransformed_feature_names(training_dataset_version)
+        )
         return config
 
     @public

--- a/python/tests/core/test_feature_monitoring_config.py
+++ b/python/tests/core/test_feature_monitoring_config.py
@@ -850,6 +850,38 @@ class TestFeatureMonitoringConfigDistribution:
         assert "label" not in feature_names_monitored
         assert "active" not in feature_names_monitored
 
+    def test_fan_out_honours_fanout_feature_names(self):
+        # FeatureView.create_model_monitoring narrows the fan-out to the training
+        # features: the logging FG's predicted_*, serving key and metadata columns
+        # have no counterpart in the training-dataset reference.
+        valid_features = {
+            "amount": "double",
+            "predicted_label": "bigint",
+            "log_id": "string",
+            "model_name": "string",
+        }
+        cfg = self._build_config(valid_features=valid_features)
+        cfg._fanout_feature_names = {"amount"}
+        cfg.compare_on_distribution(metric="PSI", threshold=0.2)
+
+        feature_names_monitored = {
+            fs.feature_name for fs in cfg._feature_statistics_configs
+        }
+        assert feature_names_monitored == {"amount"}
+
+    def test_named_feature_not_restricted_by_fanout_feature_names(self):
+        valid_features = {"amount": "double", "predicted_label": "bigint"}
+        cfg = self._build_config(valid_features=valid_features)
+        cfg._fanout_feature_names = {"amount"}
+        cfg.compare_on_distribution(
+            metric="PSI", threshold=0.2, feature_name="predicted_label"
+        )
+
+        feature_names_monitored = {
+            fs.feature_name for fs in cfg._feature_statistics_configs
+        }
+        assert feature_names_monitored == {"predicted_label"}
+
     def test_empty_compatible_set_raises_valueerror(self):
         # All features are complex types → no compatible features
         valid_features = {

--- a/python/tests/core/test_feature_monitoring_logging_fg.py
+++ b/python/tests/core/test_feature_monitoring_logging_fg.py
@@ -158,6 +158,48 @@ class TestIsSubHourCron:
 # ---------------------------------------------------------------------------
 
 
+class TestModelMonitoringFanOutFeatures:
+    def test_create_model_monitoring_fans_out_over_training_features_only(self):
+        """Fan-out covers the training features of the model's training dataset only.
+
+        Labels, serving keys and helper columns are excluded by the same resolver
+        feature logging uses, `_get_untransformed_feature_names`, asked for the
+        training dataset version recorded on the model.
+        """
+        from hsfs.feature_view import FeatureView
+
+        fv = MagicMock(spec=FeatureView)
+        fv.logging_enabled = True
+        fv._get_untransformed_feature_names.return_value = [
+            "sepal_length",
+            "petal_length",
+        ]
+        logging_fg = MagicMock()
+        config = MagicMock()
+        logging_fg.create_feature_monitoring.return_value = config
+        fv.feature_logging.get_feature_group.return_value = logging_fg
+
+        with (
+            patch("hsml.core.model_api.ModelApi._get") as mock_model_get,
+            patch("hsfs.feature_view.client._get_instance") as mock_client,
+        ):
+            mock_client.return_value._project_id = 1
+            mock_model_get.return_value.training_dataset_version = 2
+
+            returned = FeatureView.create_model_monitoring(
+                fv,
+                name="test",
+                model_name="iris",
+                model_version=1,
+                cron_expression="0 0 12 ? * * *",
+            )
+
+        assert returned is config
+        assert config._fanout_feature_names == {"sepal_length", "petal_length"}
+        fv._get_untransformed_feature_names.assert_called_once_with(2)
+        assert config._associated_model_td_version == 2
+
+
 class TestSubHourCronWarningOnModelMonitoring:
     def test_create_model_monitoring_sub_hour_warns(self):
         """create_model_monitoring with a sub-hour cron emits a UserWarning."""

--- a/python/tests/core/test_feature_monitoring_result_engine.py
+++ b/python/tests/core/test_feature_monitoring_result_engine.py
@@ -707,6 +707,145 @@ class TestFeatureMonitoringResultEngine:
         # Should not raise
         result_engine._validate_detection_and_reference_statistics(det, ref)
 
+    def test_drop_features_without_reference_keeps_only_shared_features(self, caplog):
+        # A training-dataset reference has no statistics for the logging FG's
+        # predicted_*, serving key and metadata columns; they are skipped, not fatal.
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        det = [
+            FeatureDescriptiveStatistics(
+                feature_name=name, feature_type="Fractional", count=10
+            )
+            for name in ["sepal_length", "predicted_label", "log_id", "id"]
+        ]
+        ref = [
+            FeatureDescriptiveStatistics(
+                feature_name="sepal_length", feature_type="Fractional", count=10
+            )
+        ]
+
+        with caplog.at_level("WARNING"):
+            kept = result_engine._drop_features_without_reference(det, ref)
+
+        assert [fds.feature_name for fds in kept] == ["sepal_length"]
+        assert "Skipping features without reference statistics" in caplog.text
+        for skipped in ["id", "log_id", "predicted_label"]:
+            assert skipped in caplog.text
+        assert "sepal_length" not in caplog.text
+        # the validator that used to fail on the length mismatch now passes
+        result_engine._validate_detection_and_reference_statistics(kept, ref)
+
+    def test_drop_features_without_reference_raises_when_nothing_is_left(self):
+        from hopsworks_common.client.exceptions import FeatureStoreException
+
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        det = [
+            FeatureDescriptiveStatistics(
+                feature_name="log_id", feature_type="String", count=10
+            )
+        ]
+        ref = [
+            FeatureDescriptiveStatistics(
+                feature_name="sepal_length", feature_type="Fractional", count=10
+            )
+        ]
+
+        with pytest.raises(FeatureStoreException):
+            result_engine._drop_features_without_reference(det, ref)
+
+    @staticmethod
+    def _make_two_feature_config(model_name):
+        """Scalar mean comparison on 'good' and 'missing_ref' against a TD reference."""
+        from hsfs.core import feature_monitoring_config as fmc
+        from hsfs.core import monitoring_window_config as mwc
+        from hsfs.core.feature_statistics_config import FeatureStatisticsConfig
+        from hsfs.core.statistics_comparison_config import StatisticsComparisonConfig
+
+        fs_configs = [
+            FeatureStatisticsConfig(
+                feature_name=name,
+                statistics_comparison_configs=[
+                    StatisticsComparisonConfig(metric="mean", threshold=1.0, id=i)
+                ],
+            )
+            for i, name in enumerate(["good", "missing_ref"], start=301)
+        ]
+        return fmc.FeatureMonitoringConfig(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+            feature_monitoring_type=fmc.FeatureMonitoringType.STATISTICS_COMPARISON,
+            name="two_features",
+            id=DEFAULT_CONFIG_ID,
+            model_name=model_name,
+            model_version=1 if model_name else None,
+            feature_statistics_configs=fs_configs,
+            reference_window_config=mwc.MonitoringWindowConfig(
+                window_config_type=mwc.WindowConfigType.TRAINING_DATASET,
+                training_dataset_version=1,
+            ),
+        )
+
+    @staticmethod
+    def _make_two_feature_stats():
+        det = [
+            FeatureDescriptiveStatistics(
+                feature_name=name, feature_type="Fractional", count=10, mean=1.5
+            )
+            for name in ["good", "missing_ref"]
+        ]
+        ref = [
+            FeatureDescriptiveStatistics(
+                feature_name="good", feature_type="Fractional", count=10, mean=1.0
+            )
+        ]
+        return det, ref
+
+    def test_model_monitoring_td_reference_skips_configured_feature_without_reference(
+        self, mocker
+    ):
+        # Model monitoring against a training dataset: the logging FG carries columns
+        # the TD has no statistics for, so the run compares what it can.
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        mocker.patch.object(result_engine, "_save", side_effect=lambda r: r)
+        det, ref = self._make_two_feature_stats()
+
+        fm_result = result_engine._run_and_save_statistics_comparison(
+            fm_config=self._make_two_feature_config(model_name="iris"),
+            detection_statistics=det,
+            reference_statistics=ref,
+        )
+
+        assert [fsr.feature_name for fsr in fm_result.feature_statistics_results] == [
+            "good"
+        ]
+
+    def test_plain_config_still_fails_when_configured_feature_lacks_reference(
+        self, mocker
+    ):
+        # Outside model monitoring a configured feature with no reference statistics
+        # is a real inconsistency and must keep failing the run.
+        result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        mocker.patch.object(result_engine, "_save", side_effect=lambda r: r)
+        det, ref = self._make_two_feature_stats()
+
+        with pytest.raises(AssertionError):
+            result_engine._run_and_save_statistics_comparison(
+                fm_config=self._make_two_feature_config(model_name=None),
+                detection_statistics=det,
+                reference_statistics=ref,
+            )
+
     def test_validate_raises_when_detection_feature_missing_from_reference(self):
         result_engine = feature_monitoring_result_engine.FeatureMonitoringResultEngine(
             feature_store_id=DEFAULT_FEATURE_STORE_ID,


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2111

## Problem

`fv.create_model_monitoring(...)` builds its config on the logging feature group, so `compare_on_distribution(metric="PSI")` without a `feature_name` fanned out over the whole logging schema: serving keys, helper columns, `predicted_*` columns and the logging metadata columns (`log_id`, `td_version`, `model_name`, `model_version`, `request_id`, `request_parameters`). The training-dataset reference has statistics for the training features only, and the backend returns that subset, so the FM job died in `_validate_detection_and_reference_statistics`:

```
AssertionError: Detection feature statistics must contain a reference feature statistics for the same feature and feature type.
```

Seen nightly as `iris_mm_1_log_1_run_fm_mm_psi_all_features` FAILED while the per-feature PSI jobs on the same logging FG pass.

## Change

- `FeatureMonitoringConfig` gets an in-memory `_fanout_feature_names` set. `create_model_monitoring()` fills it with the training features of the model's training dataset, resolved by `_get_untransformed_feature_names` exactly as feature logging does, so labels, serving keys and helper columns stay out. `compare_on()` and `compare_on_distribution()` fan out over that subset. A `feature_name` given explicitly is still validated against the full logging schema.
- For a model monitoring config whose reference is a training dataset (`_compares_model_logs_to_training_dataset`), `FeatureMonitoringResultEngine._drop_features_without_reference()` runs before the validator: detection features with no reference counterpart are skipped with a warning, and a `FeatureStoreException` names them when nothing is left to compare. Configs saved before this change run instead of failing. Every other config keeps the strict detection/reference validation.

## Testing

- Unit tests added in `test_feature_monitoring_config.py`, `test_feature_monitoring_logging_fg.py` and `test_feature_monitoring_result_engine.py`, including the partial case through `_run_and_save_statistics_comparison` (configured `good` + `missing_ref`, reference `good` only) for both the model monitoring config and a plain config. The four monitoring test modules pass (124 tests), ruff check and format clean.
- Reproduced and verified on a cluster running master (javier-loadtest): with the SDK from this branch the fan-out job monitors `sepal_length, sepal_width, petal_length, petal_width`, finishes, and the loadtest scenario passes (external twin in logicalclocks/loadtest#1029).

🤖 Generated with [Claude Code](https://claude.com/claude-code)