### PR TITLE
[HWORKS-3227] Removing a member from a project leaves their home directory owned by a user with no access

### DIFF
--- a/python/hopsworks_common/core/project_members_api.py
+++ b/python/hopsworks_common/core/project_members_api.py
@@ -204,7 +204,12 @@ class ProjectMembersApi:
         return self._find_member(email)
 
     @public
-    def remove_member(self, email: str, delete_home_dir: bool = False) -> None:
+    def remove_member(
+        self,
+        email: str,
+        delete_home_dir: bool = False,
+        new_file_owner: str | None = None,
+    ) -> None:
         """Remove a member from the project by email.
 
         Danger: Deletes the member's project files when `delete_home_dir=True`
@@ -223,6 +228,9 @@ class ProjectMembersApi:
         Parameters:
             email: Email address of the member to remove.
             delete_home_dir: Whether to also delete the member's home directory in the project.
+            new_file_owner: Email address of the data owner that takes over the removed member's home directory.
+                Defaults to the data owner who has been in the project longest.
+                Ignored when `delete_home_dir` is set, since there is then nothing to take over.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request, for example if a data scientist tries to remove someone other than themselves.
@@ -230,4 +238,6 @@ class ProjectMembersApi:
         _client = client._get_instance()
         path_params = ["project", _client._project_id, "projectMembers", email]
         query_params = {"deleteHomeDir": "true" if delete_home_dir else "false"}
+        if new_file_owner is not None:
+            query_params["newFileOwner"] = new_file_owner
         _client._send_request("DELETE", path_params, query_params=query_params)

--- a/python/hopsworks_common/project.py
+++ b/python/hopsworks_common/project.py
@@ -379,7 +379,12 @@ class Project:
         return self._project_members_api.add_member(email, role)
 
     @public
-    def remove_member(self, email: str, delete_home_dir: bool = False) -> None:
+    def remove_member(
+        self,
+        email: str,
+        delete_home_dir: bool = False,
+        new_file_owner: str | None = None,
+    ) -> None:
         """Remove a user from the project.
 
         Danger: Deletes the member's project files when `delete_home_dir=True`
@@ -398,11 +403,15 @@ class Project:
         Parameters:
             email: Email address of the member to remove.
             delete_home_dir: Whether to also delete the member's home directory in the project.
+            new_file_owner: Email address of the data owner that takes over the removed member's home directory.
+                Defaults to the data owner who has been in the project longest.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request, for example if a data scientist tries to remove someone other than themselves.
         """
-        self._project_members_api.remove_member(email, delete_home_dir=delete_home_dir)
+        self._project_members_api.remove_member(
+            email, delete_home_dir=delete_home_dir, new_file_owner=new_file_owner
+        )
 
     @public
     def get_search_api(self) -> search_api.SearchApi:

--- a/python/hopsworks_common/project_member.py
+++ b/python/hopsworks_common/project_member.py
@@ -129,7 +129,9 @@ class ProjectMember:
         return self
 
     @public
-    def remove(self, delete_home_dir: bool = False) -> None:
+    def remove(
+        self, delete_home_dir: bool = False, new_file_owner: str | None = None
+    ) -> None:
         """Remove this member from the project.
 
         Danger: Deletes the member's project files when `delete_home_dir=True`
@@ -148,12 +150,16 @@ class ProjectMember:
 
         Parameters:
             delete_home_dir: Whether to also delete the member's home directory in the project.
+            new_file_owner: Email address of the data owner that takes over this member's home directory.
+                Defaults to the data owner who has been in the project longest.
 
         Raises:
             hopsworks.client.exceptions.RestAPIError: If the backend encounters an error when handling the request, for example if a data scientist tries to remove someone other than themselves.
         """
         self._project_members_api.remove_member(
-            self.email, delete_home_dir=delete_home_dir
+            self.email,
+            delete_home_dir=delete_home_dir,
+            new_file_owner=new_file_owner,
         )
 
     def json(self) -> str:

--- a/python/tests/core/test_project_members_api.py
+++ b/python/tests/core/test_project_members_api.py
@@ -188,6 +188,33 @@ class TestProjectMembersApi:
         delete_call = client_instance._send_request.call_args_list[0]
         assert delete_call.kwargs["query_params"] == {"deleteHomeDir": "false"}
 
+    def test_remove_member_names_the_data_owner_that_takes_over_the_files(self, mocker):
+        api = ProjectMembersApi()
+        client_instance = _patch_client(mocker, None)
+
+        api.remove_member("bob@example.com", new_file_owner="carol@example.com")
+
+        delete_call = client_instance._send_request.call_args_list[0]
+        assert delete_call.kwargs["query_params"] == {
+            "deleteHomeDir": "false",
+            "newFileOwner": "carol@example.com",
+        }
+
+    def test_remove_member_omits_the_file_owner_when_none_is_chosen(self, mocker):
+        # The backend picks the longest-serving data owner when the parameter is absent, so sending
+        # it empty would be a different request than "no preference".
+        api = ProjectMembersApi()
+        client_instance = _patch_client(mocker, None)
+
+        api.remove_member("bob@example.com")
+
+        assert (
+            "newFileOwner"
+            not in client_instance._send_request.call_args_list[0].kwargs[
+                "query_params"
+            ]
+        )
+
 
 class TestProjectMember:
     def test_update_role_delegates_to_api_and_updates_local_state(self, mocker):
@@ -213,5 +240,19 @@ class TestProjectMember:
         member.remove(delete_home_dir=True)
 
         member._project_members_api.remove_member.assert_called_once_with(
-            "bob@example.com", delete_home_dir=True
+            "bob@example.com", delete_home_dir=True, new_file_owner=None
+        )
+
+    def test_remove_passes_the_chosen_file_owner_through(self, mocker):
+        member = ProjectMember.from_response_json(
+            _member("bob@example.com", "Data owner")
+        )[0]
+        member._project_members_api = MagicMock()
+
+        member.remove(new_file_owner="carol@example.com")
+
+        member._project_members_api.remove_member.assert_called_once_with(
+            "bob@example.com",
+            delete_home_dir=False,
+            new_file_owner="carol@example.com",
         )

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -123,7 +123,19 @@ class TestProject:
         project.remove_member("alice@example.com", delete_home_dir=True)
 
         project._project_members_api.remove_member.assert_called_once_with(
-            "alice@example.com", delete_home_dir=True
+            "alice@example.com", delete_home_dir=True, new_file_owner=None
+        )
+
+    def test_remove_member_passes_the_chosen_file_owner_through(self, mocker):
+        project = Project(project_name="my_project")
+        project._project_members_api = mocker.MagicMock()
+
+        project.remove_member("alice@example.com", new_file_owner="carol@example.com")
+
+        project._project_members_api.remove_member.assert_called_once_with(
+            "alice@example.com",
+            delete_home_dir=False,
+            new_file_owner="carol@example.com",
         )
 
     def test_get_members_api_returns_the_members_api(self, mocker):


### PR DESCRIPTION
Removing a member hands their project home directory, and everything under it, to a data owner rather than leaving it owned by a user the removal deletes (hopsworks-ee#3331). `new_file_owner` names which data owner.

## Change

`new_file_owner`, an email, on the three places that remove a member: `Project.remove_member`, `ProjectMembersApi.remove_member` and `ProjectMember.remove`.

```python
project.remove_member("alice@example.com")                                    # longest-serving data owner
project.remove_member("alice@example.com", new_file_owner="carol@example.com") # this one
project.remove_member("alice@example.com", delete_home_dir=True)              # nothing to hand over
```

Absent, the backend keeps its default: the data owner who has been in the project longest. The parameter is left out of the query string rather than sent empty in that case, since an empty value is a different request than "no preference".

The backend refuses a chosen member who is not a data owner of the project, and refuses a removal that would leave the project with no data owner at all. Both arrive as a `RestAPIError`; neither is pre-validated here, where the client would have to fetch and interpret the project roles to guess at an answer the backend has to check anyway.

## Verification

28 tests across `tests/core/test_project_members_api.py` and `tests/test_project.py`: the parameter reaches the query string, is absent when nobody is chosen, and is passed through by both wrappers. ruff and docsig clean.

No loadtest change here: loadtest#1028 covers the behaviour through the same SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
