### PR TITLE
[FSTORE-2112] Model monitoring detection window reads no rows from the logging feature group and the run is reported as a success

### DIFF
--- a/python/hsfs/core/feature_monitoring_config_engine.py
+++ b/python/hsfs/core/feature_monitoring_config_engine.py
@@ -605,11 +605,14 @@ class FeatureMonitoringConfigEngine:
                 # failing the monitoring job.
                 logger.warning(
                     "No offline commits for logging feature group '%s' (id=%s) backing "
-                    "model-monitoring config '%s'; offline data is not materialized yet. "
+                    "model-monitoring config '%s' (model_name=%s, model_version=%s); "
+                    "offline data is not materialized yet. "
                     "Treating the detection window as empty.",
                     getattr(entity, "name", "<unknown>"),
                     getattr(entity, "id", "<unknown>"),
                     config_name,
+                    model_filter[0],
+                    model_filter[1],
                 )
                 detection_window_unmaterialized = True
             else:
@@ -690,6 +693,26 @@ class FeatureMonitoringConfigEngine:
                     ]
                 else:
                     raise
+
+        if (
+            model_filter is not None
+            and not detection_window_unmaterialized
+            and all(fds.count == 0 for fds in detection_statistics)
+        ):
+            # Empty windows are persisted as regular results, so this is the only
+            # place a model name or version mismatch between the deployment's
+            # inference logs and the config becomes visible.
+            logger.warning(
+                "Model-monitoring config '%s' read no inference rows for model_name=%s, "
+                "model_version=%s from '%s' in the detection window ending at %s. "
+                "Check that the deployment logs its features with this model name and "
+                "version. Treating the detection window as empty.",
+                config_name,
+                model_filter[0],
+                model_filter[1],
+                getattr(entity, "name", "<unknown>"),
+                f"commit {end_commit_time}" if end_commit_time is not None else "now",
+            )
 
         reference_statistics = None
         if config.reference_window_config is not None:

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -2041,27 +2041,30 @@ class FeatureViewEngine:
                 )
                 == training_dataset_version
             )
+        # The logging feature group stores model_version as a string.
+        # A model object takes precedence over an explicit name and version.
         if hsml_model:
             query = query.filter(
                 (
                     fg.get_feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME)
                     == hsml_model.name
                 )
-                and (
+                & (
                     fg.get_feature(constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME)
-                    == hsml_model.version
+                    == str(hsml_model.version)
                 )
             )
-        if model_name:
-            query = query.filter(
-                fg.get_feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME)
-                == model_name
-            )
-        if model_version:
-            query = query.filter(
-                fg.get_feature(constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME)
-                == model_version
-            )
+        else:
+            if model_name:
+                query = query.filter(
+                    fg.get_feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME)
+                    == model_name
+                )
+            if model_version:
+                query = query.filter(
+                    fg.get_feature(constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME)
+                    == str(model_version)
+                )
         if filter:
             query = query.filter(
                 self._convert_to_log_fg_filter(fg, fv, filter, fv_feat_name_map)
@@ -2083,12 +2086,15 @@ class FeatureViewEngine:
             return None
 
         if isinstance(filter, Logic):
+            convert = lambda f: self._convert_to_log_fg_filter(  # noqa: E731
+                fg, fv, f, fv_feat_name_map
+            )
             return Logic(
                 filter.type,
-                left_f=self._convert_to_log_fg_filter(fv, filter.left_f),
-                right_f=self._convert_to_log_fg_filter(fv, filter.right_f),
-                left_l=self._convert_to_log_fg_filter(fv, filter.left_l),
-                right_l=self._convert_to_log_fg_filter(fv, filter.right_l),
+                left_f=convert(filter._left_f),
+                right_f=convert(filter._right_f),
+                left_l=convert(filter._left_l),
+                right_l=convert(filter._right_l),
             )
         if isinstance(filter, Filter):
             fv_feature_name = fv_feat_name_map.get(
@@ -2096,10 +2102,14 @@ class FeatureViewEngine:
             )
             if fv_feature_name is None:
                 raise FeatureStoreException(
-                    "Filter feature {filter.feature.name} does not exist in feature view feature."
+                    f"Filter feature '{filter.feature.name}' is not one of the "
+                    "features of the feature view being logged."
                 )
+            # The logging feature group's columns carry the feature view's
+            # names, which differ from the source feature group's whenever a
+            # join prefix or an explicit rename applies.
             return Filter(
-                fg.get_feature(filter.feature.name),
+                fg.get_feature(fv_feature_name),
                 filter.condition,
                 filter.value,
             )

--- a/python/hsfs/core/monitoring_window_config_engine.py
+++ b/python/hsfs/core/monitoring_window_config_engine.py
@@ -451,6 +451,17 @@ class MonitoringWindowConfigEngine:
             "statistics should contain the feature descriptive statistics"
         )
 
+        # Registering statistics for a window that already has a statistics row
+        # appends to that row and returns all of it, so a second config on the
+        # same entity and window gets back features it did not ask for.
+        # Keep only the requested ones.
+        if feature_names:
+            requested = set(feature_names)
+            return [
+                fds
+                for fds in registered_stats.feature_descriptive_statistics
+                if fds.feature_name in requested
+            ]
         return registered_stats.feature_descriptive_statistics
 
     def _fetch_entity_data_in_monitoring_window(

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -2337,7 +2337,7 @@ class Engine:
             size = 1
             batch = False
 
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         metadata = {
             td_col_name: [
                 training_dataset_version if training_dataset_version else pd.NA

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -2808,7 +2808,7 @@ class Engine:
             constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME,
             lit(model_version).cast(StringType()),
         )
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         logging_df = logging_df.withColumn(
             time_col_name, lit(now).cast(TimestampType())
         )

--- a/python/tests/core/test_feature_monitoring_config_engine.py
+++ b/python/tests/core/test_feature_monitoring_config_engine.py
@@ -14,12 +14,13 @@
 #   limitations under the License.
 #
 
+import logging
 from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
 from hopsworks_common.client.exceptions import RestAPIError
-from hsfs import util
+from hsfs import feature_group, util
 from hsfs.core import feature_monitoring_config as fmc
 from hsfs.core import feature_monitoring_config_engine
 from hsfs.core import monitoring_window_config as mwc
@@ -726,3 +727,94 @@ class TestFeatureMonitoringConfigEngine:
             ValueError, match="specific_value is not allowed for distribution"
         ):
             config_engine._validate_statistics_comparison_config(mock_sc)
+
+    def _build_mock_model_monitoring_config(self, feature_names):
+        """Model-monitoring config mock: model filter set, no reference window."""
+        config = self._build_mock_fm_config(feature_names, with_reference_window=False)
+        config.model_name = "xgboost_mm"
+        config.model_version = 1
+        config.trigger_type = fmc.TriggerType.CRON
+        return config
+
+    def test_run_feature_monitoring_empty_model_window_names_model_filter(
+        self, mocker, caplog
+    ):
+        # Arrange: the filtered read of the logging FG returns no rows
+        feature_names = ["sepal_length"]
+        empty_fds = [FeatureDescriptiveStatistics(feature_name="sepal_length", count=0)]
+
+        config_engine = feature_monitoring_config_engine.FeatureMonitoringConfigEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        mocker.patch.object(
+            config_engine._feature_monitoring_config_api,
+            "_get_by_name",
+            return_value=self._build_mock_model_monitoring_config(feature_names),
+        )
+        mocker.patch.object(
+            config_engine._monitoring_window_config_engine,
+            "_run_single_window_monitoring",
+            return_value=empty_fds,
+        )
+        mocker.patch.object(
+            config_engine._result_engine, "_run_and_save_statistics_comparison"
+        )
+        entity = MagicMock()
+        entity.name = "iris_mm_1_log"
+
+        # Act
+        with caplog.at_level(logging.WARNING):
+            config_engine._run_feature_monitoring(
+                entity=entity, config_name="mm_psi_sepal_length"
+            )
+
+        # Assert
+        assert (
+            "read no inference rows for model_name=xgboost_mm, model_version=1"
+            in caplog.text
+        )
+        # A feature view entity has no commit to anchor on
+        assert "detection window ending at now" in caplog.text
+        assert "iris_mm_1_log" in caplog.text
+
+    def test_run_feature_monitoring_unmaterialized_log_names_model_filter(
+        self, mocker, caplog
+    ):
+        # Arrange: the logging FG has no offline commit yet
+        feature_names = ["sepal_length"]
+
+        config_engine = feature_monitoring_config_engine.FeatureMonitoringConfigEngine(
+            feature_store_id=DEFAULT_FEATURE_STORE_ID,
+            feature_group_id=DEFAULT_FEATURE_GROUP_ID,
+        )
+        mocker.patch.object(
+            config_engine._feature_monitoring_config_api,
+            "_get_by_name",
+            return_value=self._build_mock_model_monitoring_config(feature_names),
+        )
+        mocker.patch.object(
+            config_engine, "_get_latest_fg_commit_time", return_value=None
+        )
+        mock_read = mocker.patch.object(
+            config_engine._monitoring_window_config_engine,
+            "_run_single_window_monitoring",
+        )
+        mock_save = mocker.patch.object(
+            config_engine._result_engine, "_run_and_save_statistics_comparison"
+        )
+        entity = MagicMock(spec=feature_group.FeatureGroup)
+        entity.name = "iris_mm_1_log"
+        entity.id = 7
+
+        # Act
+        with caplog.at_level(logging.WARNING):
+            config_engine._run_feature_monitoring(
+                entity=entity, config_name="mm_psi_sepal_length"
+            )
+
+        # Assert: nothing is read, the empty stats are saved, the warning names the model
+        mock_read.assert_not_called()
+        assert mock_save.call_args.kwargs["detection_statistics"][0].count == 0
+        assert "model_name=xgboost_mm, model_version=1" in caplog.text
+        assert caplog.text.count("Treating the detection window as empty") == 1

--- a/python/tests/core/test_feature_view_engine.py
+++ b/python/tests/core/test_feature_view_engine.py
@@ -4871,3 +4871,116 @@ class TestFeatureLoggingWithoutEventTime:
         assert event_time[0] == expected_data
         assert event_time[1] == expected_names
         assert event_time[2] == constants.FEATURE_LOGGING.EVENT_TIME
+
+    def test_read_feature_logs_model_filter(self, mocker):
+        # Arrange
+        fake_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=fake_engine)
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+
+        logging_fg = mocker.Mock()
+        logging_fg.get_feature.side_effect = lambda name: feature.Feature(
+            name, type="string"
+        )
+        query = mocker.Mock()
+        query.filter.return_value = query
+        logging_fg.select_all.return_value = query
+        mocker.patch.object(fv_engine, "_get_logging_fg", return_value=logging_fg)
+        mocker.patch.object(fv_engine, "_get_fv_feature_name_map", return_value={})
+
+        hsml_model = mocker.Mock()
+        hsml_model.name = "xgboost_mm"
+        hsml_model.version = 1
+
+        # Act: the model object wins over an explicit version
+        fv_engine._read_feature_logs(
+            fv=mocker.Mock(), hsml_model=hsml_model, model_version=2
+        )
+
+        # Assert: both model filters apply as one conjunction, the version is
+        # compared as the string the logging feature group stores, and the
+        # explicit model_version is ignored
+        (model_logic,) = [c.args[0] for c in query.filter.call_args_list]
+        assert model_logic._type == model_logic.AND
+        assert model_logic._left_f._feature.name == "model_name"
+        assert model_logic._left_f._value == "xgboost_mm"
+        assert model_logic._right_f._feature.name == "model_version"
+        assert model_logic._right_f._value == "1"
+        fake_engine._read_feature_log.assert_called_once_with(
+            query, constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME
+        )
+
+        # Act: explicit name and version without a model object
+        query.filter.reset_mock()
+        fv_engine._read_feature_logs(
+            fv=mocker.Mock(), model_name="xgboost_mm", model_version=2
+        )
+
+        # Assert
+        name_filter, version_filter = [c.args[0] for c in query.filter.call_args_list]
+        assert name_filter._feature.name == "model_name"
+        assert name_filter._value == "xgboost_mm"
+        assert version_filter._feature.name == "model_version"
+        assert version_filter._value == "2"
+
+    def test_read_feature_logs_logic_filter(self, mocker):
+        # Arrange
+        fake_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=fake_engine)
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+
+        logging_fg = mocker.Mock()
+        logging_fg.get_feature.side_effect = lambda name: feature.Feature(
+            name, type="double", feature_group_id=20
+        )
+        query = mocker.Mock()
+        query.filter.return_value = query
+        logging_fg.select_all.return_value = query
+        mocker.patch.object(fv_engine, "_get_logging_fg", return_value=logging_fg)
+        # The feature view renames the second feature, so its logging column is
+        # named after the feature view, not the source feature group.
+        mocker.patch.object(
+            fv_engine,
+            "_get_fv_feature_name_map",
+            return_value={
+                "5_sepal_length": "sepal_length",
+                "5_sepal_width": "iris_sepal_width",
+            },
+        )
+        user_filter = (
+            feature.Feature("sepal_length", type="double", feature_group_id=5) > 1.0
+        ) & (feature.Feature("sepal_width", type="double", feature_group_id=5) < 4.0)
+
+        # Act
+        fv_engine._read_feature_logs(fv=mocker.Mock(), filter=user_filter)
+
+        # Assert: the logic is rebuilt on the logging feature group, using the
+        # feature view's names
+        (logic,) = [c.args[0] for c in query.filter.call_args_list]
+        assert logic._type == logic.AND
+        assert logic._left_f._feature.feature_group_id == 20
+        assert logic._left_f._feature.name == "sepal_length"
+        assert logic._left_f._value == 1.0
+        assert logic._right_f._feature.feature_group_id == 20
+        assert logic._right_f._feature.name == "iris_sepal_width"
+        assert logic._right_f._value == 4.0
+
+    def test_read_feature_logs_filter_feature_not_in_feature_view(self, mocker):
+        # Arrange
+        fake_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=fake_engine)
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+
+        logging_fg = mocker.Mock()
+        query = mocker.Mock()
+        query.filter.return_value = query
+        logging_fg.select_all.return_value = query
+        mocker.patch.object(fv_engine, "_get_logging_fg", return_value=logging_fg)
+        mocker.patch.object(fv_engine, "_get_fv_feature_name_map", return_value={})
+
+        # Act / Assert
+        with pytest.raises(FeatureStoreException, match="is not one of the features"):
+            fv_engine._read_feature_logs(
+                fv=mocker.Mock(),
+                filter=feature.Feature("nope", type="double", feature_group_id=5) > 1.0,
+            )

--- a/python/tests/core/test_monitoring_window_config_engine.py
+++ b/python/tests/core/test_monitoring_window_config_engine.py
@@ -591,6 +591,55 @@ class TestGetWindowStartEndTimesAnchor:
             anchor_end_ms=anchor_ms,
         )
 
+    def test_run_single_window_monitoring_returns_only_requested_features(self, mocker):
+        """Only the requested features come back from a merged statistics row.
+
+        Statistics registered on a window that already has a row come back merged
+        with the features other configs registered there.
+        """
+        engine = mwce.MonitoringWindowConfigEngine()
+        config = mwc.MonitoringWindowConfig(
+            window_config_type=mwc.WindowConfigType.ROLLING_TIME,
+            time_offset="1d",
+            row_percentage=1.0,
+        )
+        fg = MagicMock(spec=feature_group.FeatureGroup)
+        fg._feature_store_id = 1
+        fg.ENTITY_TYPE = "featuregroups"
+        fg.time_travel_format = "DELTA"
+
+        mocker.patch.object(engine, "_init_statistics_engine")
+        stats_engine_mock = MagicMock()
+        engine._statistics_engine = stats_engine_mock
+        merged_stats = MagicMock()
+        merged_stats.feature_descriptive_statistics = [
+            FeatureDescriptiveStatistics(
+                feature_name="sepal_length", feature_type="Fractional", count=4
+            ),
+            FeatureDescriptiveStatistics(
+                feature_name="sepal_width", feature_type="Fractional", count=4
+            ),
+        ]
+        stats_engine_mock._compute_and_save_monitoring_statistics.return_value = (
+            merged_stats
+        )
+        mocker.patch.object(
+            engine,
+            "_fetch_entity_data_in_monitoring_window",
+            return_value=MagicMock(),
+        )
+
+        result = engine._run_single_window_monitoring(
+            entity=fg,
+            monitoring_window_config=config,
+            feature_names=["sepal_width"],
+            end_commit_time_override=1788969469391,
+            model_filter=("xgboost_mm", 1),
+        )
+
+        assert [fds.feature_name for fds in result] == ["sepal_width"]
+        stats_engine_mock._get_by_time_window.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # KLL-merge dispatch tests

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -10208,3 +10208,29 @@ class TestPython:
                 self._get_val_multi(result, {"user_id": 1, "item_id": 10}, "val")
                 == "new"
             )
+
+    def test_get_logging_metadata_log_time_is_utc(self):
+        # Act
+        batch = python.Engine._get_logging_metadata(
+            size=2,
+            td_col_name="td_version",
+            time_col_name=constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME,
+            model_col_name=constants.FEATURE_LOGGING.MODEL_COLUMN_NAME,
+            training_dataset_version=1,
+            model_name="test_model",
+            model_version=1,
+        )
+        single = python.Engine._get_logging_metadata(
+            td_col_name="td_version",
+            time_col_name=constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME,
+            model_col_name=constants.FEATURE_LOGGING.MODEL_COLUMN_NAME,
+            model_name="test_model",
+            model_version=1,
+        )
+
+        # Assert: the log time is timezone-aware UTC whatever the process timezone is
+        log_time_col = constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME
+        assert str(batch[log_time_col].dt.tz) == "UTC"
+        assert single[log_time_col].tzinfo == timezone.utc
+        assert batch[constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME] == ["1", "1"]
+        assert single[constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME] == "1"

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -7468,6 +7468,39 @@ class TestSpark:
             .collect()
         )
 
+    def test_get_feature_logging_df_log_time_is_utc(
+        self, mocker, logging_features, logging_test_dataframe, spark_engine
+    ):
+        # Prepare
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="spark")
+
+        logging_features, meta_data_logging_columns, column_names = logging_features
+        args = TestSpark.get_logging_arguments(
+            logging_data=logging_test_dataframe,
+            logging_feature_group_features=meta_data_logging_columns + logging_features,
+            column_names=column_names,
+        )
+        before = datetime.datetime.now(datetime.timezone.utc).timestamp()
+
+        # Act
+        logging_dataframe, _, _ = spark_engine._get_feature_logging_df(**args)
+        # Compare the stored instant rather than a collected datetime: the epoch
+        # of a TimestampType column is independent of the session and driver
+        # timezones, so the assertion holds wherever the suite runs.
+        log_epochs = [
+            row[0]
+            for row in logging_dataframe.selectExpr(
+                f"unix_timestamp({constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME})"
+            ).collect()
+        ]
+
+        # Assert
+        after = datetime.datetime.now(datetime.timezone.utc).timestamp()
+        assert len(log_epochs) == 3
+        for log_epoch in log_epochs:
+            assert before - 5 <= log_epoch <= after + 5
+
     def test_get_feature_logging_df_logging_data_no_missing_no_additional_list(
         self, mocker, logging_features, logging_test_dataframe, spark_engine
     ):


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2112

## Summary
The loadtest model monitoring scenario passed while every monitoring job profiled an empty detection window: the predictor logged inference rows under a stand-in model name, so the filter on the deployed model matched no partition (fixed in the companion loadtest PR). This PR carries the SDK-side fixes found while ruling out the ticket's hypotheses and running the scenario with real rows.

- Model monitoring windows keep only the features the config asked for from the registered statistics. The backend appends statistics registered for a feature group window that already has a row to that row and returns the whole row, so a second config on the same logging FG commit got the first config's feature too and failed the detection/reference validation.
- Inference `log_time` is stamped with `datetime.now(timezone.utc)` in both engines. The Kafka encoder stamps naive datetimes as UTC, so the Python engine wrote a shifted `log_time` from any non-UTC process. PySpark reads a naive literal as local time, so the Spark change is explicit rather than a behaviour change.
- The two warnings that report an empty model-monitoring detection window name the model name and version the window was filtered on, so a mismatch like the loadtest's is visible in the job log. Empty windows stay a persisted, non-failing result.
- `read_log(model=...)` applied only the version filter (the two filters were joined with Python `and`) and compared an int against the STRING column; both filters now apply, the version is compared as a string, and the model object wins over an explicit name/version as documented. `read_log(filter=Logic)` recursed with the wrong arguments and read attributes `Logic` does not expose; fixed.

Depends on FSTORE-2111 (#1157, merged). Companion loadtest PR: logicalclocks/loadtest FSTORE-2112.

## Test plan
- [x] `pytest tests/core/test_feature_monitoring_config_engine.py tests/core/test_feature_view_engine.py tests/core/test_monitoring_window_config_engine.py` (new: model-filter warnings with caplog, requested-feature filter on merged statistics, `read_log` model/explicit/Logic filters)
- [x] `pytest tests/engine/test_python.py -k logging`, `pytest tests/engine/test_spark.py -k feature_logging` (new: UTC `log_time` for both engines)
- [x] ruff, docsig
- [x] Loadtest external twin `test_deploy_and_predict_python_model_with_model_monitoring` on javier-loadtest with the `spark-feature-pipeline` job image overlaid with this branch and `requirements.txt` pinned to it: three FM jobs FINISHED with non-empty detection and reference windows and a PSI difference on every compared feature. Without the requested-feature filter the second per-feature config fails on the same commit.

## Observations left out of scope
- `read_log` returns `model_version` as an int although the column is STRING: the offline read infers the partition value from the directory name.
- Per-model detection statistics share one feature-group statistics row per commit across configs and models (same feature name overwrites); only lookups are skipped for model filters.
- A Python-engine training dataset has no histograms, so a PSI reference against it is near-uniform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)