### PR TITLE
[FSTORE-1903] Backwards compatibility and upgrade tests for Feature Logging

### DIFF
--- a/python/hopsworks_common/constants.py
+++ b/python/hopsworks_common/constants.py
@@ -308,6 +308,10 @@ class FEATURE_LOGGING:
     PREFIX_PREDICTIONS = "predicted_"
     EMPTY_REQUEST_PARAMETER_COLUMN_VALUE = "{}"
 
+    # Model identity column of logging feature groups created before FSTORE-1871
+    # combined them and split the column into model_name and model_version.
+    LEGACY_MODEL_COLUMN_NAME = "hsml_model"
+
     LOGGING_METADATA_COLUMNS = [
         LOG_ID_COLUMN_NAME,
         TRAINING_DATASET_VERSION_COLUMN_NAME,

--- a/python/hopsworks_common/core/type_systems.py
+++ b/python/hopsworks_common/core/type_systems.py
@@ -22,13 +22,13 @@ import decimal
 from typing import TYPE_CHECKING, Literal, NewType
 
 import pytz
+from hopsworks_common.client.exceptions import FeatureStoreException
 from hopsworks_common.core.constants import (
     HAS_PANDAS,
     HAS_POLARS,
     HAS_PYARROW,
 )
 from hopsworks_common.decorators import _uses_polars
-from hsfs.client.exceptions import FeatureStoreException
 
 
 if TYPE_CHECKING:

--- a/python/hsfs/core/feature_logging.py
+++ b/python/hsfs/core/feature_logging.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import humps
 from hopsworks_apigen import public
+from hopsworks_common import constants
 from hsfs import feature_group, util
 from hsfs.feature import Feature
 
@@ -104,6 +105,46 @@ class FeatureLogging:
     @property
     def extra_logging_columns(self) -> list[Feature] | None:
         return self._extra_logging_columns
+
+    @property
+    def _is_legacy(self) -> bool:
+        """Whether this logging row predates FSTORE-1871, i.e. still carries a separate transformed feature group."""
+        return self._transformed_features is not None
+
+    @staticmethod
+    def _uses_legacy_model_column(feature_names: set[str] | list[str]) -> bool:
+        """Whether a logging feature group stores the model identity in the pre-FSTORE-1871 hsml_model column.
+
+        A feature group that carries both hsml_model and model_name classifies as current schema, so
+        corrupted combined feature groups are never written to as if they were legacy.
+        """
+        return (
+            constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME in feature_names
+            and constants.FEATURE_LOGGING.MODEL_COLUMN_NAME not in feature_names
+        )
+
+    @staticmethod
+    def _prediction_column_names(
+        prediction_feature_names: list[str],
+        logging_feature_group_feature_names: list[str],
+    ) -> dict[str, str]:
+        """Map each label column to the column name it takes in the logging feature group.
+
+        Current logging feature groups store predictions under predicted_<label>; legacy
+        (pre-FSTORE-1871) ones store them under the bare label name. Mixed schemas resolve
+        to the prefixed name so corrupted feature groups are treated as current schema.
+        """
+        mapping = {}
+        for feature_name in prediction_feature_names:
+            prefixed_name = constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + feature_name
+            if (
+                prefixed_name not in logging_feature_group_feature_names
+                and feature_name in logging_feature_group_feature_names
+            ):
+                mapping[feature_name] = feature_name
+            else:
+                mapping[feature_name] = prefixed_name
+        return mapping
 
     @public
     def get_feature_group(

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -2109,19 +2109,20 @@ class FeatureViewEngine:
                 )
         if model_name:
             if legacy_model_column:
-                if model_version:
-                    query = query.filter(
-                        fg.get_feature(
-                            constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME
-                        )
-                        == f"{model_name}_{model_version}"
+                # A LIKE prefix match on the concatenated value cannot express "this name,
+                # any version": `_` is a wildcard and sibling names share the prefix.
+                if not model_version:
+                    raise FeatureStoreException(
+                        "This logging feature group predates the model_name/model_version columns and "
+                        "stores the model as a single `<name>_<version>` value, so filtering by model_name "
+                        "alone is not supported. Pass `model_version` as well, or `model`."
                     )
-                else:
-                    query = query.filter(
-                        fg.get_feature(
-                            constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME
-                        ).like(f"{model_name}_%")
+                query = query.filter(
+                    fg.get_feature(constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME)
+                    == self._get_hsml_model_value(
+                        None, model_name=model_name, model_version=model_version
                     )
+                )
             else:
                 query = query.filter(
                     fg.get_feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME)

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -1675,6 +1675,28 @@ class FeatureViewEngine:
 
         # FSTORE-1871 combines the untransformed and transformed logging feature groups.
         # Transformed and untransformed logging features groups are retrived here to maintain backwards compatibility.
+        # Legacy rows (still carrying both feature groups) route per data kind like the
+        # pre-FSTORE-1871 client did: the transformed feature group only receives rows when
+        # transformed data was actually supplied, instead of a copy of every logged row.
+        if feature_logging._is_legacy:
+            logging_meta_data = getattr(logs, "hopsworks_logging_metadata", None)
+            has_transformed_data = transformed_features is not None or (
+                logging_meta_data is not None
+                and bool(logging_meta_data.transformed_features)
+            )
+            has_untransformed_data = (
+                logs is not None
+                or untransformed_features is not None
+                or (
+                    logging_meta_data is not None
+                    and bool(logging_meta_data.untransformed_features)
+                )
+                or not has_transformed_data
+            )
+        else:
+            has_untransformed_data = True
+            has_transformed_data = True
+
         if logger:
             logger.log(
                 **{
@@ -1698,28 +1720,30 @@ class FeatureViewEngine:
                             model_version=model_version,
                             return_list=True,
                         )
-                        if fg
+                        if fg and has_data
                         else None
                     )
-                    for key, fg in [
+                    for key, fg, has_data in [
                         (
                             constants.FEATURE_LOGGING.UNTRANSFORMED_FEATURES,
                             feature_logging.untransformed_features,
+                            has_untransformed_data,
                         ),
                         (
                             constants.FEATURE_LOGGING.TRANSFORMED_FEATURES,
                             feature_logging.transformed_features,
+                            has_transformed_data,
                         ),
                     ]
                 }
             )
 
         else:
-            for fg in [
-                feature_logging.untransformed_features,
-                feature_logging.transformed_features,
+            for fg, has_data in [
+                (feature_logging.untransformed_features, has_untransformed_data),
+                (feature_logging.transformed_features, has_transformed_data),
             ]:
-                if fg:
+                if fg and has_data:
                     logging_df = self._get_feature_logging_data(
                         fv=fv,
                         logging_feature_group=fg,
@@ -1869,11 +1893,6 @@ class FeatureViewEngine:
         logging_feature_group_feature_names = [
             feature.name for feature in logging_feature_group_features
         ]
-        logging_features = [
-            feature_name
-            for feature_name in logging_feature_group_feature_names
-            if feature_name not in constants.FEATURE_LOGGING.LOGGING_METADATA_COLUMNS
-        ]
         model_name = (
             model_name if model_name else hsml_model.name if hsml_model else None
         )
@@ -1884,6 +1903,29 @@ class FeatureViewEngine:
             if hsml_model
             else None
         )
+
+        # Logging feature groups created before FSTORE-1871 store the model identity in a single
+        # hsml_model column instead of model_name/model_version. Write that column (with the
+        # concatenated value the old schema used) so the model identity is not silently dropped.
+        model_col_name = constants.FEATURE_LOGGING.MODEL_COLUMN_NAME
+        if FeatureLogging._uses_legacy_model_column(
+            logging_feature_group_feature_names
+        ):
+            model_col_name = constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME
+            if model_name is not None:
+                model_name = (
+                    f"{model_name}_{model_version}"
+                    if model_version is not None
+                    else model_name
+                )
+
+        metadata_column_names = set(constants.FEATURE_LOGGING.LOGGING_METADATA_COLUMNS)
+        metadata_column_names.add(model_col_name)
+        logging_features = [
+            feature_name
+            for feature_name in logging_feature_group_feature_names
+            if feature_name not in metadata_column_names
+        ]
 
         if return_list:
             logging_data, additional_logging_features, missing_logging_features = (
@@ -1935,7 +1977,7 @@ class FeatureViewEngine:
                     ),
                     td_col_name=constants.FEATURE_LOGGING.TRAINING_DATASET_VERSION_COLUMN_NAME,
                     time_col_name=constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME,
-                    model_col_name=constants.FEATURE_LOGGING.MODEL_COLUMN_NAME,
+                    model_col_name=model_col_name,
                     training_dataset_version=training_dataset_version,
                     model_name=model_name,
                     model_version=model_version,
@@ -1991,7 +2033,7 @@ class FeatureViewEngine:
                     ),
                     td_col_name=constants.FEATURE_LOGGING.TRAINING_DATASET_VERSION_COLUMN_NAME,
                     time_col_name=constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME,
-                    model_col_name=constants.FEATURE_LOGGING.MODEL_COLUMN_NAME,
+                    model_col_name=model_col_name,
                     training_dataset_version=training_dataset_version,
                     model_name=model_name,
                     model_version=model_version,
@@ -2041,27 +2083,62 @@ class FeatureViewEngine:
                 )
                 == training_dataset_version
             )
+        # Logging feature groups created before FSTORE-1871 store the model identity in a single
+        # hsml_model column ("<name>_<version>") instead of model_name/model_version.
+        legacy_model_column = FeatureLogging._uses_legacy_model_column(
+            {feature.name for feature in fg.columns}
+        )
         if hsml_model:
-            query = query.filter(
-                (
-                    fg.get_feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME)
-                    == hsml_model.name
+            if legacy_model_column:
+                query = query.filter(
+                    fg.get_feature(constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME)
+                    == self._get_hsml_model_value(hsml_model)
                 )
-                and (
-                    fg.get_feature(constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME)
-                    == hsml_model.version
+            else:
+                query = query.filter(
+                    (
+                        fg.get_feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME)
+                        == hsml_model.name
+                    )
+                    & (
+                        fg.get_feature(
+                            constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME
+                        )
+                        == hsml_model.version
+                    )
                 )
-            )
         if model_name:
-            query = query.filter(
-                fg.get_feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME)
-                == model_name
-            )
+            if legacy_model_column:
+                if model_version:
+                    query = query.filter(
+                        fg.get_feature(
+                            constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME
+                        )
+                        == f"{model_name}_{model_version}"
+                    )
+                else:
+                    query = query.filter(
+                        fg.get_feature(
+                            constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME
+                        ).like(f"{model_name}_%")
+                    )
+            else:
+                query = query.filter(
+                    fg.get_feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME)
+                    == model_name
+                )
         if model_version:
-            query = query.filter(
-                fg.get_feature(constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME)
-                == model_version
-            )
+            if legacy_model_column:
+                if not model_name and not hsml_model:
+                    raise FeatureStoreException(
+                        "This logging feature group predates the model_name/model_version columns, so "
+                        "filtering by model_version alone is not supported. Pass `model` or `model_name` as well."
+                    )
+            else:
+                query = query.filter(
+                    fg.get_feature(constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME)
+                    == model_version
+                )
         if filter:
             query = query.filter(
                 self._convert_to_log_fg_filter(fg, fv, filter, fv_feat_name_map)

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -95,7 +95,7 @@ from hsfs.core.constants import (
     HAS_PYARROW,
     HAS_SQLALCHEMY,
 )
-from hsfs.core.feature_logging import LoggingMetaData
+from hsfs.core.feature_logging import FeatureLogging, LoggingMetaData
 from hsfs.core.type_systems import PYARROW_HOPSWORKS_DTYPE_MAPPING
 from hsfs.core.vector_db_client import VectorDbClient
 from hsfs.feature_group import ExternalFeatureGroup, FeatureGroup
@@ -2552,16 +2552,20 @@ class Engine:
                         # Higher precedence is given if the user explicitly passed the logging component.
                         logging_df[col] = df[col]
 
-        # Rename prediction columns
+        # Rename prediction columns to the name they take in the logging feature group
+        # (predicted_<label>, or the bare label name for legacy pre-FSTORE-1871 feature groups).
         _, predictions_feature_names, _ = predictions
         if predictions_feature_names:
-            for feature_name in predictions_feature_names:
-                logging_df = logging_df.rename(
-                    columns={
-                        feature_name: constants.FEATURE_LOGGING.PREFIX_PREDICTIONS
-                        + feature_name
-                    }
-                )
+            prediction_column_names = FeatureLogging._prediction_column_names(
+                predictions_feature_names, logging_feature_group_feature_names
+            )
+            logging_df = logging_df.rename(
+                columns={
+                    feature_name: target_name
+                    for feature_name, target_name in prediction_column_names.items()
+                    if target_name != feature_name
+                }
+            )
 
         # Creating a json column for request parameters
         request_parameter_data, request_parameter_columns, _ = request_parameters
@@ -2797,6 +2801,11 @@ class Engine:
             A list of dictionaries with all the logging components
         """
         _, label_columns, _ = predictions
+        # Name each label column takes in the logging feature group (predicted_<label>, or the bare
+        # label name for legacy pre-FSTORE-1871 feature groups).
+        prediction_column_names = FeatureLogging._prediction_column_names(
+            label_columns or [], logging_feature_group_feature_names
+        )
         # If any of the logging components is a dataframe, we use the _get_feature_logging_df function to get a dataframe and then _convert it to a list of dictionaries.
         if any(
             (HAS_PANDAS and isinstance(data, pd.DataFrame))
@@ -2861,7 +2870,9 @@ class Engine:
             if not data:
                 if log_component_name == constants.FEATURE_LOGGING.PREDICTIONS:
                     feature_names = [
-                        constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + name
+                        prediction_column_names.get(
+                            name, constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + name
+                        )
                         for name in feature_names
                     ]
                 all_missing_columns.update(set(feature_names))
@@ -2891,7 +2902,7 @@ class Engine:
                             else {
                                 col
                                 if col not in label_columns
-                                else constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + col
+                                else prediction_column_names[col]
                                 for col in row
                             }
                         )
@@ -2957,10 +2968,9 @@ class Engine:
         if predictions_feature_names:
             for log_vector in log_vectors:
                 for feature_name in predictions_feature_names:
-                    if feature_name in log_vector:
-                        log_vector[
-                            constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + feature_name
-                        ] = log_vector.pop(feature_name)
+                    target_name = prediction_column_names[feature_name]
+                    if feature_name in log_vector and target_name != feature_name:
+                        log_vector[target_name] = log_vector.pop(feature_name)
 
         # Create a json column for request parameters
         request_parameter_data, request_parameter_names, _ = request_parameters

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -2344,14 +2344,17 @@ class Engine:
                 for _ in range(size)
             ],
             model_col_name: [model_name for _ in range(size)],
-            constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME: [
-                str(model_version) for _ in range(size)
-            ],
             time_col_name: pd.Series([now for _ in range(size)]),
             constants.FEATURE_LOGGING.LOG_ID_COLUMN_NAME: [
                 str(uuid.uuid4()) for _ in range(size)
             ],
         }
+        # Legacy (pre-FSTORE-1871) logging feature groups carry the version inside the
+        # hsml_model value and have no model_version column to receive it.
+        if model_col_name != constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME:
+            metadata[constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME] = [
+                str(model_version) for _ in range(size)
+            ]
 
         if not batch:
             for k, v in metadata.items():

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -126,7 +126,7 @@ from hsfs.core import (
     transformation_function_engine,
 )
 from hsfs.core.constants import GE_MAJOR, HAS_AVRO, HAS_GREAT_EXPECTATIONS
-from hsfs.core.feature_logging import LoggingMetaData
+from hsfs.core.feature_logging import FeatureLogging, LoggingMetaData
 from hsfs.decorators import _uses_great_expectations
 from hsfs.storage_connector import StorageConnector
 from hsfs.training_dataset_split import TrainingDatasetSplit
@@ -2743,13 +2743,17 @@ class Engine:
                     col for col in df.columns if col != TEMP_JOIN_KEY
                 ]
 
-        # Renaming prediction columns
+        # Renaming prediction columns to the name they take in the logging feature group
+        # (predicted_<label>, or the bare label name for legacy pre-FSTORE-1871 feature groups).
         _, predictions_feature_names, _ = predictions
-        for prediction_feature_name in predictions_feature_names:
-            logging_df = logging_df.withColumnRenamed(
-                prediction_feature_name,
-                constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + prediction_feature_name,
-            )
+        prediction_column_names = FeatureLogging._prediction_column_names(
+            predictions_feature_names or [], logging_feature_group_feature_names
+        )
+        for prediction_feature_name, target_name in prediction_column_names.items():
+            if target_name != prediction_feature_name:
+                logging_df = logging_df.withColumnRenamed(
+                    prediction_feature_name, target_name
+                )
 
         # Creating a json column for request parameters
         missing_request_parameters = []

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -2808,10 +2808,13 @@ class Engine:
         logging_df = logging_df.withColumn(
             model_col_name, lit(model_name).cast(StringType())
         )
-        logging_df = logging_df.withColumn(
-            constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME,
-            lit(model_version).cast(StringType()),
-        )
+        # Legacy (pre-FSTORE-1871) logging feature groups carry the version inside the
+        # hsml_model value and have no model_version column to receive it.
+        if model_col_name != constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME:
+            logging_df = logging_df.withColumn(
+                constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME,
+                lit(model_version).cast(StringType()),
+            )
         now = datetime.now()
         logging_df = logging_df.withColumn(
             time_col_name, lit(now).cast(TimestampType())

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -5230,6 +5230,42 @@ class FeatureView:
                 )
             )
             self.enable_logging(extra_log_columns=logging_features)
+
+        if (
+            logging_data is not None
+            and untransformed_features is not None
+            and transformed_features is None
+            and self._looks_like_prediction_data(untransformed_features)
+        ):
+            if self.feature_logging is not None and self.feature_logging._is_legacy:
+                # Pre-FSTORE-1871 call style log(features, predictions[, transformed_features]):
+                # the current signature prepends logging_data, shifting every positional argument
+                # by one. The legacy dual-feature-group row is proof the calling code predates the
+                # shift, so re-bind the arguments to the old order.
+                _logger.info(
+                    "Detected the pre-4.x `log(features, predictions)` call style on a feature view "
+                    "with legacy logging feature groups. Re-binding the arguments accordingly. "
+                    "Update the call to `log(features, predictions=...)` to silence this message."
+                )
+                (
+                    untransformed_features,
+                    predictions,
+                    transformed_features,
+                    logging_data,
+                ) = (
+                    logging_data,
+                    untransformed_features,
+                    predictions,
+                    None,
+                )
+            else:
+                warnings.warn(
+                    "The second positional argument of `log()` is `untransformed_features`, but the "
+                    "passed value matches this feature view's label schema. If you meant to log "
+                    "predictions (pre-4.x call style `log(features, predictions)`), pass them "
+                    "explicitly as `log(features, predictions=...)`.",
+                    stacklevel=1,
+                )
         return self._feature_view_engine._log_features(
             self,
             feature_logging=self.feature_logging,
@@ -6235,3 +6271,34 @@ class FeatureView:
                 else []
             )
         return self.__extra_logging_column_names
+
+    def _looks_like_prediction_data(self, data) -> bool:
+        """Whether `data` matches this feature view's label schema.
+
+        Used to detect the pre-4.x positional call style `log(features, predictions)`, whose second
+        positional argument binds to `untransformed_features` in the current signature.
+        """
+        label_names = self._label_column_names
+        if not label_names:
+            return False
+        columns = getattr(data, "columns", None)
+        if columns is not None:
+            return set(columns) == set(label_names)
+        if isinstance(data, dict):
+            return set(data.keys()) == set(label_names)
+        if isinstance(data, pd.Series) or (HAS_POLARS and isinstance(data, pl.Series)):
+            return len(label_names) == 1
+        if isinstance(data, (list, tuple)) or (
+            HAS_NUMPY and isinstance(data, np.ndarray)
+        ):
+            if len(data) == 0:
+                return False
+            first_row = data[0]
+            if isinstance(first_row, dict):
+                return set(first_row.keys()) == set(label_names)
+            if isinstance(first_row, (list, tuple)) or (
+                HAS_NUMPY and isinstance(first_row, np.ndarray)
+            ):
+                return len(first_row) == len(label_names)
+            return len(label_names) == 1
+        return False

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -5243,7 +5243,7 @@ class FeatureView:
                 # by one. The legacy dual-feature-group row is proof the calling code predates the
                 # shift, so re-bind the arguments to the old order.
                 _logger.info(
-                    "Detected the pre-4.x `log(features, predictions)` call style on a feature view "
+                    "Detected the pre-4.6 `log(features, predictions)` call style on a feature view "
                     "with legacy logging feature groups. Re-binding the arguments accordingly. "
                     "Update the call to `log(features, predictions=...)` to silence this message."
                 )
@@ -5262,7 +5262,7 @@ class FeatureView:
                 warnings.warn(
                     "The second positional argument of `log()` is `untransformed_features`, but the "
                     "passed value matches this feature view's label schema. If you meant to log "
-                    "predictions (pre-4.x call style `log(features, predictions)`), pass them "
+                    "predictions (pre-4.6 call style `log(features, predictions)`), pass them "
                     "explicitly as `log(features, predictions=...)`.",
                     stacklevel=1,
                 )
@@ -6275,7 +6275,7 @@ class FeatureView:
     def _looks_like_prediction_data(self, data) -> bool:
         """Whether `data` matches this feature view's label schema.
 
-        Used to detect the pre-4.x positional call style `log(features, predictions)`, whose second
+        Used to detect the pre-4.6 positional call style `log(features, predictions)`, whose second
         positional argument binds to `untransformed_features` in the current signature.
         """
         label_names = self._label_column_names

--- a/python/tests/core/test_feature_view_engine.py
+++ b/python/tests/core/test_feature_view_engine.py
@@ -5047,7 +5047,7 @@ class TestFeatureViewEngine:
         assert applied_filter._condition == "EQUALS"
         assert applied_filter._value == "test_model_2"
 
-    def test_read_feature_logs_legacy_model_name_like_filter(self, mocker):
+    def test_read_feature_logs_legacy_model_name_and_version_filter(self, mocker):
         # Arrange
         mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
         mocked_engine = mocker.Mock()
@@ -5065,14 +5065,87 @@ class TestFeatureViewEngine:
             feature_group.FeatureGroup, "select_all", return_value=query
         )
 
-        # Act: name-only filter falls back to a prefix match on the concatenated value.
-        fv_engine._read_feature_logs(fv=mocker.Mock(), model_name="test_model")
+        # Act
+        fv_engine._read_feature_logs(
+            fv=mocker.Mock(), model_name="test_model", model_version=3
+        )
 
-        # Assert
+        # Assert: one exact-match filter on the concatenated value.
+        assert query.filter.call_count == 1
         applied_filter = query.filter.call_args[0][0]
         assert applied_filter._feature.name == "hsml_model"
-        assert applied_filter._condition == "LIKE"
-        assert applied_filter._value == "test_model_%"
+        assert applied_filter._condition == "EQUALS"
+        assert applied_filter._value == "test_model_3"
+
+    def test_read_feature_logs_legacy_model_name_only_raises(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        mocked_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=mocked_engine)
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+
+        legacy_logging_fg = self._legacy_logging_fg()
+        mocker.patch.object(
+            fv_engine, "_get_logging_fg", return_value=legacy_logging_fg
+        )
+        mocker.patch.object(fv_engine, "_get_fv_feature_name_map", return_value={})
+        query = MagicMock()
+        query.filter.return_value = query
+        mocker.patch.object(
+            feature_group.FeatureGroup, "select_all", return_value=query
+        )
+
+        # Act + Assert: a LIKE prefix match would return sibling models, so refuse.
+        with pytest.raises(FeatureStoreException, match="model_name alone"):
+            fv_engine._read_feature_logs(fv=mocker.Mock(), model_name="test_model")
+
+    def test_read_feature_logs_combined_model_filter_applies_both_columns(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        mocked_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=mocked_engine)
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+
+        combined_logging_fg = feature_group.FeatureGroup(
+            name="fv_name_1_log",
+            version=1,
+            featurestore_id=99,
+            primary_key=["log_id"],
+            partition_key=[],
+            features=[
+                feature.Feature("log_id", primary=True, type="string"),
+                feature.Feature("model_name", type="string"),
+                feature.Feature("model_version", type="string"),
+                feature.Feature("feature_1", type="double"),
+                feature.Feature("predicted_label", type="bigint"),
+            ],
+            id=13,
+            stream=False,
+            featurestore_name="test_fs",
+        )
+        mocker.patch.object(
+            fv_engine, "_get_logging_fg", return_value=combined_logging_fg
+        )
+        mocker.patch.object(fv_engine, "_get_fv_feature_name_map", return_value={})
+        query = MagicMock()
+        query.filter.return_value = query
+        mocker.patch.object(
+            feature_group.FeatureGroup, "select_all", return_value=query
+        )
+        mock_hsml_model = mocker.Mock()
+        mock_hsml_model.name = "test_model"
+        mock_hsml_model.version = 2
+
+        # Act
+        fv_engine._read_feature_logs(fv=mocker.Mock(), hsml_model=mock_hsml_model)
+
+        # Assert: both conditions survive (Python `and` would keep only the right one).
+        applied = query.filter.call_args[0][0]
+        assert applied._type == "AND"
+        left = applied.get_left_filter_or_logic()
+        right = applied.get_right_filter_or_logic()
+        assert (left._feature.name, str(left._value)) == ("model_name", "test_model")
+        assert (right._feature.name, str(right._value)) == ("model_version", "2")
 
     def test_read_feature_logs_legacy_model_version_only_raises(self, mocker):
         # Arrange

--- a/python/tests/core/test_feature_view_engine.py
+++ b/python/tests/core/test_feature_view_engine.py
@@ -38,7 +38,7 @@ from hsfs.core import (
 )
 from hsfs.core import data_source as ds
 from hsfs.core.feature_descriptive_statistics import FeatureDescriptiveStatistics
-from hsfs.core.feature_logging import LoggingMetaData
+from hsfs.core.feature_logging import FeatureLogging, LoggingMetaData
 from hsfs.hopsworks_udf import udf
 from hsfs.serving_key import ServingKey
 from hsfs.storage_connector import BigQueryConnector, StorageConnector
@@ -4838,6 +4838,263 @@ class TestFeatureViewEngine:
         transformed_names.assert_called_once_with(5)
         untransformed_names.assert_called_once_with(5)
         label_names.assert_called_once_with(5)
+
+    def test_feature_logging_legacy_classification(self):
+        legacy_fg = MagicMock()
+        combined_fg = MagicMock()
+
+        assert FeatureLogging(1, legacy_fg, combined_fg)._is_legacy
+        assert not FeatureLogging(1, None, combined_fg)._is_legacy
+
+        legacy_names = ["log_id", "td_version", "log_time", "hsml_model", "label"]
+        new_names = ["log_id", "model_name", "model_version", "predicted_label"]
+        corrupted_names = ["log_id", "model_name", "model_version", "hsml_model"]
+        assert FeatureLogging._uses_legacy_model_column(legacy_names)
+        assert not FeatureLogging._uses_legacy_model_column(new_names)
+        # Fail closed: a feature group with both model columns is treated as current schema.
+        assert not FeatureLogging._uses_legacy_model_column(corrupted_names)
+
+        assert FeatureLogging._prediction_column_names(["label"], legacy_names) == {
+            "label": "label"
+        }
+        assert FeatureLogging._prediction_column_names(["label"], new_names) == {
+            "label": "predicted_label"
+        }
+        # Fail closed: both the bare and prefixed columns present resolves to the prefixed name.
+        assert FeatureLogging._prediction_column_names(
+            ["label"], ["label", "predicted_label"]
+        ) == {"label": "predicted_label"}
+
+    def _legacy_logging_fg(self):
+        return feature_group.FeatureGroup(
+            name="fv_name_1_logging_untransformed",
+            version=1,
+            featurestore_id=99,
+            primary_key=["log_id"],
+            partition_key=[],
+            features=[
+                feature.Feature("log_id", primary=True, type="string"),
+                feature.Feature("td_version", type="bigint"),
+                feature.Feature("log_time", type="timestamp"),
+                feature.Feature("hsml_model", type="string"),
+                feature.Feature("feature_1", type="double"),
+                feature.Feature("feature_2", type="double"),
+                feature.Feature("label", type="bigint"),
+            ],
+            id=12,
+            stream=False,
+            featurestore_name="test_fs",
+        )
+
+    def test_get_feature_logging_data_legacy_model_column(self, mocker):
+        # Arrange
+        feature_store_id = 99
+
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        mocked_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=mocked_engine)
+        mocked_engine._get_feature_logging_df.return_value = (pd.DataFrame, None, None)
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+
+        fv_engine = feature_view_engine.FeatureViewEngine(
+            feature_store_id=feature_store_id
+        )
+
+        fg = feature_group.FeatureGroup(
+            name="test1",
+            version=1,
+            featurestore_id=99,
+            primary_key=["primary_key"],
+            event_time="event_time",
+            partition_key=[],
+            features=[
+                feature.Feature("primary_key", primary=True, type="bigint"),
+                feature.Feature("event_time", type="timestamp"),
+                feature.Feature("feature_1", type="float"),
+                feature.Feature("feature_2", type="float"),
+            ],
+            id=11,
+            stream=False,
+            featurestore_name="test_fs",
+        )
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            version=1,
+            featurestore_id=feature_store_id,
+            query=fg.select_all(),
+        )
+        fv.schema = [
+            TrainingDatasetFeature("feature_1", type="double"),
+            TrainingDatasetFeature("feature_2", type="double"),
+            TrainingDatasetFeature(name="label", type="bigint", label=True),
+        ]
+        fv._serving_keys = []
+        fv._FeatureView__extra_logging_column_names = []
+
+        legacy_logging_fg = self._legacy_logging_fg()
+
+        # Act
+        fv_engine._get_feature_logging_data(
+            fv=fv,
+            logging_feature_group=legacy_logging_fg,
+            untransformed_features=pd.DataFrame(
+                {"feature_1": [0.1], "feature_2": [0.2]}
+            ),
+            predictions=pd.DataFrame({"label": [1]}),
+            model_name="test_model",
+            model_version=1,
+            return_list=False,
+        )
+
+        # Assert: the legacy hsml_model column receives the concatenated model identity.
+        call_args = mocked_engine._get_feature_logging_df.call_args
+        assert call_args[1]["model_col_name"] == "hsml_model"
+        assert call_args[1]["model_name"] == "test_model_1"
+        # hsml_model is metadata, not an expected user data column.
+        assert "hsml_model" not in call_args[1]["logging_features"]
+
+    def test_log_features_legacy_per_kind_targeting_untransformed(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+        mocker.patch.object(
+            fv_engine, "_get_feature_logging_data", return_value=pd.DataFrame()
+        )
+        untransformed_fg = MagicMock()
+        transformed_fg = MagicMock()
+        legacy_feature_logging = FeatureLogging(1, transformed_fg, untransformed_fg)
+
+        # Act: only untransformed-kind data supplied.
+        fv_engine._log_features(
+            fv=mocker.Mock(),
+            feature_logging=legacy_feature_logging,
+            untransformed_features=pd.DataFrame({"feature_1": [0.1]}),
+        )
+
+        # Assert: the transformed feature group receives no row.
+        assert untransformed_fg.insert.call_count == 1
+        transformed_fg.insert.assert_not_called()
+
+    def test_log_features_legacy_per_kind_targeting_transformed(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+        mocker.patch.object(
+            fv_engine, "_get_feature_logging_data", return_value=pd.DataFrame()
+        )
+        untransformed_fg = MagicMock()
+        transformed_fg = MagicMock()
+        legacy_feature_logging = FeatureLogging(1, transformed_fg, untransformed_fg)
+
+        # Act: only transformed data supplied.
+        fv_engine._log_features(
+            fv=mocker.Mock(),
+            feature_logging=legacy_feature_logging,
+            transformed_features=pd.DataFrame({"min_max_scaler_feature_1": [0.1]}),
+        )
+
+        # Assert: the untransformed feature group receives no row.
+        transformed_fg.insert.assert_called_once()
+        untransformed_fg.insert.assert_not_called()
+
+    def test_log_features_combined_fg_unaffected_by_targeting(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+        mocker.patch.object(
+            fv_engine, "_get_feature_logging_data", return_value=pd.DataFrame()
+        )
+        combined_fg = MagicMock()
+        combined_feature_logging = FeatureLogging(1, None, combined_fg)
+
+        # Act: transformed-only data on a combined feature group still lands there.
+        fv_engine._log_features(
+            fv=mocker.Mock(),
+            feature_logging=combined_feature_logging,
+            transformed_features=pd.DataFrame({"min_max_scaler_feature_1": [0.1]}),
+        )
+
+        # Assert
+        combined_fg.insert.assert_called_once()
+
+    def test_read_feature_logs_legacy_model_filter(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        mocked_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=mocked_engine)
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+
+        legacy_logging_fg = self._legacy_logging_fg()
+        mocker.patch.object(
+            fv_engine, "_get_logging_fg", return_value=legacy_logging_fg
+        )
+        mocker.patch.object(fv_engine, "_get_fv_feature_name_map", return_value={})
+        query = MagicMock()
+        query.filter.return_value = query
+        mocker.patch.object(
+            feature_group.FeatureGroup, "select_all", return_value=query
+        )
+
+        # Act: model object filters on the concatenated hsml_model value.
+        mock_hsml_model = mocker.Mock()
+        mock_hsml_model.name = "test_model"
+        mock_hsml_model.version = 2
+        fv_engine._read_feature_logs(fv=mocker.Mock(), hsml_model=mock_hsml_model)
+
+        # Assert
+        applied_filter = query.filter.call_args[0][0]
+        assert applied_filter._feature.name == "hsml_model"
+        assert applied_filter._condition == "EQUALS"
+        assert applied_filter._value == "test_model_2"
+
+    def test_read_feature_logs_legacy_model_name_like_filter(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        mocked_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=mocked_engine)
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+
+        legacy_logging_fg = self._legacy_logging_fg()
+        mocker.patch.object(
+            fv_engine, "_get_logging_fg", return_value=legacy_logging_fg
+        )
+        mocker.patch.object(fv_engine, "_get_fv_feature_name_map", return_value={})
+        query = MagicMock()
+        query.filter.return_value = query
+        mocker.patch.object(
+            feature_group.FeatureGroup, "select_all", return_value=query
+        )
+
+        # Act: name-only filter falls back to a prefix match on the concatenated value.
+        fv_engine._read_feature_logs(fv=mocker.Mock(), model_name="test_model")
+
+        # Assert
+        applied_filter = query.filter.call_args[0][0]
+        assert applied_filter._feature.name == "hsml_model"
+        assert applied_filter._condition == "LIKE"
+        assert applied_filter._value == "test_model_%"
+
+    def test_read_feature_logs_legacy_model_version_only_raises(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
+        mocked_engine = mocker.Mock()
+        mocker.patch("hsfs.engine._get_instance", return_value=mocked_engine)
+        fv_engine = feature_view_engine.FeatureViewEngine(feature_store_id=99)
+
+        legacy_logging_fg = self._legacy_logging_fg()
+        mocker.patch.object(
+            fv_engine, "_get_logging_fg", return_value=legacy_logging_fg
+        )
+        mocker.patch.object(fv_engine, "_get_fv_feature_name_map", return_value={})
+        query = MagicMock()
+        query.filter.return_value = query
+        mocker.patch.object(
+            feature_group.FeatureGroup, "select_all", return_value=query
+        )
+
+        # Act + Assert
+        with pytest.raises(FeatureStoreException, match="model_version alone"):
+            fv_engine._read_feature_logs(fv=mocker.Mock(), model_version=2)
 
 
 class TestFeatureLoggingWithoutEventTime:

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -10279,10 +10279,14 @@ class TestPython:
         )
 
         # Act
-        logging_dataframe, _, _ = python_engine._get_feature_logging_df(**args)
+        logging_dataframe, additional_logging_features, _ = (
+            python_engine._get_feature_logging_df(**args)
+        )
 
-        # Assert: predictions stay under the bare label name and the model identity
-        # lands in the legacy hsml_model column.
+        # Assert: predictions stay under the bare label name, the model identity lands
+        # in the legacy hsml_model column, and no current-schema metadata column is
+        # reported as additional (that report is a per-write user warning).
+        assert not additional_logging_features
         assert list(logging_dataframe.columns) == [
             feat.name for feat in logging_feature_group_features
         ]

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -10208,3 +10208,175 @@ class TestPython:
                 self._get_val_multi(result, {"user_id": 1, "item_id": 10}, "val")
                 == "new"
             )
+
+    @staticmethod
+    def _legacy_logging_fg_features():
+        return [
+            feature.Feature(
+                constants.FEATURE_LOGGING.LOG_ID_COLUMN_NAME,
+                primary=True,
+                type="string",
+            ),
+            feature.Feature(
+                constants.FEATURE_LOGGING.TRAINING_DATASET_VERSION_COLUMN_NAME,
+                type="int",
+            ),
+            feature.Feature(
+                constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME, type="timestamp"
+            ),
+            feature.Feature(
+                constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME, type="string"
+            ),
+            feature.Feature("feature_1", type="double"),
+            feature.Feature("feature_2", type="double"),
+            feature.Feature("label", type="string"),
+        ]
+
+    @staticmethod
+    def _legacy_logging_arguments(logging_feature_group_features, **data_kwargs):
+        column_names = {
+            "untransformed_features": ["feature_1", "feature_2"],
+            "transformed_features": ["feature_1", "feature_2"],
+            "predictions": ["label"],
+            "serving_keys": [],
+            "helper_columns": [],
+            "request_parameters": [],
+            "event_time": [],
+            "request_id": [],
+            "extra_logging_features": [],
+        }
+        args = TestPython.get_logging_arguments(
+            column_names=column_names,
+            logging_feature_group_features=logging_feature_group_features,
+            **data_kwargs,
+        )
+        # Mirror the shared layer's legacy handling: hsml_model is the metadata model
+        # column and never an expected user data column.
+        args["model_col_name"] = constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME
+        args["model_name"] = "test_model_1"
+        args["logging_features"] = [
+            name
+            for name in args["logging_features"]
+            if name != constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME
+        ]
+        return args
+
+    def test_get_feature_logging_df_legacy_feature_group(self, mocker):
+        # Prepare
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        python_engine = python.Engine()
+
+        logging_feature_group_features = TestPython._legacy_logging_fg_features()
+        untransformed_df = pd.DataFrame(
+            {"feature_1": [0.1, 0.2], "feature_2": [0.3, 0.4]}
+        )
+        predictions_df = pd.DataFrame({"label": ["a", "b"]})
+        args = TestPython._legacy_logging_arguments(
+            logging_feature_group_features,
+            untransformed_features=untransformed_df,
+            predictions=predictions_df,
+        )
+
+        # Act
+        logging_dataframe, _, _ = python_engine._get_feature_logging_df(**args)
+
+        # Assert: predictions stay under the bare label name and the model identity
+        # lands in the legacy hsml_model column.
+        assert list(logging_dataframe.columns) == [
+            feat.name for feat in logging_feature_group_features
+        ]
+        assert logging_dataframe["label"].tolist() == ["a", "b"]
+        assert logging_dataframe[
+            constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME
+        ].tolist() == ["test_model_1", "test_model_1"]
+
+    def test_get_feature_logging_df_corrupted_feature_group_fails_closed(self, mocker):
+        # Prepare
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        python_engine = python.Engine()
+
+        # A combined feature group polluted with a stray hsml_model column: predictions
+        # must still be written to predicted_<label> (current schema wins).
+        logging_feature_group_features = [
+            feature.Feature(
+                constants.FEATURE_LOGGING.LOG_ID_COLUMN_NAME,
+                primary=True,
+                type="string",
+            ),
+            feature.Feature(
+                constants.FEATURE_LOGGING.TRAINING_DATASET_VERSION_COLUMN_NAME,
+                type="int",
+            ),
+            feature.Feature(
+                constants.FEATURE_LOGGING.LOG_TIME_COLUMN_NAME, type="timestamp"
+            ),
+            feature.Feature(constants.FEATURE_LOGGING.MODEL_COLUMN_NAME, type="string"),
+            feature.Feature(
+                constants.FEATURE_LOGGING.MODEL_VERSION_COLUMN_NAME, type="string"
+            ),
+            feature.Feature(
+                constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME, type="string"
+            ),
+            feature.Feature("feature_1", type="double"),
+            feature.Feature("feature_2", type="double"),
+            feature.Feature(
+                constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + "label", type="string"
+            ),
+        ]
+        column_names = {
+            "untransformed_features": ["feature_1", "feature_2"],
+            "transformed_features": ["feature_1", "feature_2"],
+            "predictions": ["label"],
+            "serving_keys": [],
+            "helper_columns": [],
+            "request_parameters": [],
+            "event_time": [],
+            "request_id": [],
+            "extra_logging_features": [],
+        }
+        args = TestPython.get_logging_arguments(
+            column_names=column_names,
+            logging_feature_group_features=logging_feature_group_features,
+            untransformed_features=pd.DataFrame(
+                {"feature_1": [0.1, 0.2], "feature_2": [0.3, 0.4]}
+            ),
+            predictions=pd.DataFrame({"label": ["a", "b"]}),
+        )
+
+        # Act
+        logging_dataframe, _, _ = python_engine._get_feature_logging_df(**args)
+
+        # Assert
+        assert logging_dataframe[
+            constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + "label"
+        ].tolist() == ["a", "b"]
+        assert (
+            logging_dataframe[constants.FEATURE_LOGGING.LEGACY_MODEL_COLUMN_NAME]
+            .isna()
+            .all()
+        )
+
+    def test_get_feature_logging_list_legacy_feature_group(self, mocker):
+        # Prepare
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        python_engine = python.Engine()
+
+        logging_feature_group_features = TestPython._legacy_logging_fg_features()
+        args = TestPython._legacy_logging_arguments(
+            logging_feature_group_features,
+            untransformed_features=[[0.1, 0.3], [0.2, 0.4]],
+            predictions=[["a"], ["b"]],
+        )
+
+        # Act
+        log_vectors, _, _ = python_engine._get_feature_logging_list(**args)
+
+        # Assert: rows keep the bare label key instead of predicted_<label>.
+        assert [row["label"] for row in log_vectors] == ["a", "b"]
+        assert all(
+            constants.FEATURE_LOGGING.PREFIX_PREDICTIONS + "label" not in row
+            for row in log_vectors
+        )

--- a/python/tests/test_feature_view.py
+++ b/python/tests/test_feature_view.py
@@ -699,7 +699,7 @@ class TestFeatureView:
         features_df = pd.DataFrame({"fg1_feature": [0.1, 0.2]})
         predictions_df = pd.DataFrame({"label": ["a", "b"]})
 
-        # Act: pre-4.x call style log(features, predictions) on a legacy feature view.
+        # Act: pre-4.6 call style log(features, predictions) on a legacy feature view.
         fv.log(features_df, predictions_df)
 
         # Assert: arguments are re-bound to the old positional order.
@@ -716,7 +716,7 @@ class TestFeatureView:
         predictions_df = pd.DataFrame({"label": ["a", "b"]})
         transformed_df = pd.DataFrame({"fg1_feature": [0.5, 0.6]})
 
-        # Act: pre-4.x call style log(features, predictions, transformed_features).
+        # Act: pre-4.6 call style log(features, predictions, transformed_features).
         fv.log(features_df, predictions_df, transformed_df)
 
         # Assert

--- a/python/tests/test_feature_view.py
+++ b/python/tests/test_feature_view.py
@@ -16,12 +16,14 @@
 import json
 import warnings
 
+import pandas as pd
 import pytest
 from hopsworks_common import version
 from hopsworks_common.client.exceptions import FeatureStoreException
 from hsfs import feature, feature_group, feature_view, training_dataset_feature
 from hsfs.builtin_transformations import one_hot_encoder
 from hsfs.constructor import query
+from hsfs.core.feature_logging import FeatureLogging
 from hsfs.feature_store import FeatureStore
 from hsfs.hopsworks_udf import udf
 from hsfs.serving_key import ServingKey
@@ -663,6 +665,97 @@ class TestFeatureView:
 
         # Assert
         assert fv.logging_enabled is True
+
+    def _logging_feature_view(self, mocker, legacy):
+        mocker.patch("hopsworks_common.client._get_instance")
+        mocker.patch("hsfs.engine._get_type", return_value="python")
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine")
+        fv = feature_view.FeatureView(
+            name="fv_name",
+            query=fg1.select_features(),
+            featurestore_id=99,
+            featurestore_name="test_fs",
+            labels=["label"],
+        )
+        fv.logging_enabled = True
+        mocker.patch.object(
+            feature_view.FeatureView,
+            "_label_column_names",
+            new_callable=mocker.PropertyMock,
+            return_value={"label"},
+        )
+        transformed_fg = mocker.MagicMock() if legacy else None
+        mocker.patch.object(
+            feature_view.FeatureView,
+            "feature_logging",
+            new_callable=mocker.PropertyMock,
+            return_value=FeatureLogging(1, transformed_fg, mocker.MagicMock()),
+        )
+        return fv
+
+    def test_log_positional_predictions_reroute_on_legacy(self, mocker):
+        # Arrange
+        fv = self._logging_feature_view(mocker, legacy=True)
+        features_df = pd.DataFrame({"fg1_feature": [0.1, 0.2]})
+        predictions_df = pd.DataFrame({"label": ["a", "b"]})
+
+        # Act: pre-4.x call style log(features, predictions) on a legacy feature view.
+        fv.log(features_df, predictions_df)
+
+        # Assert: arguments are re-bound to the old positional order.
+        call_kwargs = fv._feature_view_engine._log_features.call_args[1]
+        assert call_kwargs["logs"] is None
+        assert call_kwargs["untransformed_features"] is features_df
+        assert call_kwargs["predictions"] is predictions_df
+        assert call_kwargs["transformed_features"] is None
+
+    def test_log_positional_predictions_reroute_on_legacy_three_args(self, mocker):
+        # Arrange
+        fv = self._logging_feature_view(mocker, legacy=True)
+        features_df = pd.DataFrame({"fg1_feature": [0.1, 0.2]})
+        predictions_df = pd.DataFrame({"label": ["a", "b"]})
+        transformed_df = pd.DataFrame({"fg1_feature": [0.5, 0.6]})
+
+        # Act: pre-4.x call style log(features, predictions, transformed_features).
+        fv.log(features_df, predictions_df, transformed_df)
+
+        # Assert
+        call_kwargs = fv._feature_view_engine._log_features.call_args[1]
+        assert call_kwargs["logs"] is None
+        assert call_kwargs["untransformed_features"] is features_df
+        assert call_kwargs["predictions"] is predictions_df
+        assert call_kwargs["transformed_features"] is transformed_df
+
+    def test_log_positional_predictions_warns_on_combined(self, mocker):
+        # Arrange
+        fv = self._logging_feature_view(mocker, legacy=False)
+        features_df = pd.DataFrame({"fg1_feature": [0.1, 0.2]})
+        predictions_df = pd.DataFrame({"label": ["a", "b"]})
+
+        # Act: same call style on a combined feature group warns but is not re-routed.
+        with pytest.warns(UserWarning, match="label schema"):
+            fv.log(features_df, predictions_df)
+
+        # Assert
+        call_kwargs = fv._feature_view_engine._log_features.call_args[1]
+        assert call_kwargs["logs"] is features_df
+        assert call_kwargs["untransformed_features"] is predictions_df
+        assert call_kwargs["predictions"] is None
+
+    def test_log_new_style_not_rerouted_on_legacy(self, mocker):
+        # Arrange
+        fv = self._logging_feature_view(mocker, legacy=True)
+        features_df = pd.DataFrame({"fg1_feature": [0.1, 0.2]})
+        untransformed_df = pd.DataFrame({"fg1_feature": [0.3, 0.4]})
+
+        # Act: second argument does not match the label schema, so nothing is re-bound.
+        fv.log(features_df, untransformed_df)
+
+        # Assert
+        call_kwargs = fv._feature_view_engine._log_features.call_args[1]
+        assert call_kwargs["logs"] is features_df
+        assert call_kwargs["untransformed_features"] is untransformed_df
+        assert call_kwargs["predictions"] is None
 
     def test_label_column_name(self, mocker):
         # Arrange


### PR DESCRIPTION
## Summary
FSTORE-1871 combined the logging feature groups, renamed label columns to `predicted_<label>` and replaced `hsml_model` with `model_name` / `model_version`. Model deployments and batch services already running a pre-4.6 Hopsworks client must keep logging against an upgraded backend without any code change, and current clients must read and write the logging feature groups those old clients created.

This repo makes the client adapt to whichever layout it finds:
- Writes against a pre-upgrade feature view put predictions and model identity in the legacy columns instead of dropping them.
- Old-style positional `log()` calls keep working on legacy feature views.
- Reading logs filtered by model resolves on both layouts.
- Enabling logging on a *new* feature view from an old client is documented as unsupported, and fails cleanly rather than writing incomplete rows.

## Test plan
- [x] Python suite: 4300 passed, 13 skipped. The 5 `test_spark.py` avro failures are pre-existing on `main` and unrelated.
- [x] Cluster, 5.1 with this branch installed in the loadtest image: feature-store Python feature-logging suite 8/8, including the old-client compatibility test, whose markers pin the documented contract (`MARKER_ENABLE_OK`, `MARKER_TRANSFORMED_SLOT_EMPTY`, `MARKER_LOG_FAILED KeyError [...]` on a 4.4.4 client).
- [x] Cluster, a real 4.4.2 → 5.0.9 upgrade (this change backported as `FSTORE-1903-5.0`): with the upgraded backend, this client wrote into the legacy pair, read it back through the customer's own export filter (98,538 rows) and a model filter, saw the original `hsml_model` values intact and the transformed slot still empty, then converted the pair with `delete_log()` — 13/13 checks.
- [ ] Not covered: a Spark job running the old client (out of scope for this ticket).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxdV8jEhUKSKssaLexdYSQ
