### PR TITLE
[HWORKS-3238] FeatureView docstrings no longer link to the removed ArrowFlight docs page

### DIFF
--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -1990,7 +1990,7 @@ class FeatureView:
 
                 When using the `python` engine, write_options can contain the following entries:
 
-                - key `use_spark` and value `True` to materialize training dataset with Spark instead of [Hopsworks Feature Query Service][arrowflight-server-with-duckdb].
+                - key `use_spark` and value `True` to materialize training dataset with Spark instead of the Hopsworks Feature Query Service.
                 - key `spark` and value an object of type [hsfs.core.job_configuration.JobConfiguration][hsfs.core.job_configuration.JobConfiguration] to configure the Hopsworks Job used to compute the training dataset.
                 - key `wait_for_job` and value `True` or `False` to configure whether or not to the save call should return only after the Hopsworks Job has finished.
                   By default it waits.
@@ -2285,7 +2285,7 @@ class FeatureView:
                 When using the `python` engine, write_options can contain the
                 following entries:
                 * key `use_spark` and value `True` to materialize training dataset
-                  with Spark instead of [Hopsworks Feature Query Service][arrowflight-server-with-duckdb].
+                  with Spark instead of the Hopsworks Feature Query Service.
                 * key `spark` and value an object of type
                 [hsfs.core.job_configuration.JobConfiguration][hsfs.core.job_configuration.JobConfiguration]
                   to configure the Hopsworks Job used to compute the training dataset.
@@ -2578,7 +2578,7 @@ class FeatureView:
                 When using the `python` engine, write_options can contain the
                 following entries:
                 * key `use_spark` and value `True` to materialize training dataset
-                  with Spark instead of [Hopsworks Feature Query Service][arrowflight-server-with-duckdb].
+                  with Spark instead of the Hopsworks Feature Query Service.
                 * key `spark` and value an object of type
                 [hsfs.core.job_configuration.JobConfiguration][hsfs.core.job_configuration.JobConfiguration]
                   to configure the Hopsworks Job used to compute the training dataset.
@@ -2711,7 +2711,7 @@ class FeatureView:
                 When using the `python` engine, write_options can contain the
                 following entries:
                 * key `use_spark` and value `True` to materialize training dataset
-                  with Spark instead of [Hopsworks Feature Query Service][arrowflight-server-with-duckdb].
+                  with Spark instead of the Hopsworks Feature Query Service.
                 * key `spark` and value an object of type
                 [hsfs.core.job_configuration.JobConfiguration][hsfs.core.job_configuration.JobConfiguration]
                   to configure the Hopsworks Job used to compute the training dataset.


### PR DESCRIPTION
Docs-only change, no behaviour.

- The docs removed the "ArrowFlight Server with DuckDB" setup page (service is enabled by default).
- Four `FeatureView` docstrings (`create_training_data`, `create_train_test_split`, `create_train_validation_test_split`, `recreate_training_dataset`) still cross-referenced it, which fails the strict docs build once the API is installed from `main`.
- The cross-reference becomes the plain name the same docstrings already use, "the Hopsworks Feature Query Service".

Jira: https://hopsworks.atlassian.net/browse/HWORKS-3238
